### PR TITLE
Improve announce parsing and propagation-cost extraction

### DIFF
--- a/crates/lxmf/src/handlers.rs
+++ b/crates/lxmf/src/handlers.rs
@@ -1,7 +1,6 @@
 use crate::error::LxmfError;
-use crate::helpers::{
-    pn_announce_data_is_valid, pn_name_from_app_data, pn_stamp_cost_from_app_data,
-};
+use crate::helpers::{pn_name_from_app_data, pn_stamp_cost_from_app_data};
+use crate::helpers::{pn_peering_cost_from_app_data, pn_stamp_cost_flexibility_from_app_data};
 use crate::router::Router;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -10,6 +9,8 @@ pub struct PropagationAnnounceEvent {
     pub destination: [u8; 16],
     pub name: Option<String>,
     pub stamp_cost: Option<u32>,
+    pub stamp_cost_flexibility: Option<u32>,
+    pub peering_cost: Option<u32>,
 }
 
 type DeliveryCallback = Box<dyn FnMut(&[u8; 16]) -> Result<(), LxmfError> + Send + Sync + 'static>;
@@ -71,7 +72,13 @@ impl PropagationAnnounceHandler {
     }
 
     pub fn handle(&mut self, dest: &[u8; 16]) -> Result<(), LxmfError> {
-        let event = PropagationAnnounceEvent { destination: *dest, name: None, stamp_cost: None };
+        let event = PropagationAnnounceEvent {
+            destination: *dest,
+            name: None,
+            stamp_cost: None,
+            stamp_cost_flexibility: None,
+            peering_cost: None,
+        };
         if let Some(callback) = &mut self.callback {
             callback(&event)?;
         }
@@ -83,14 +90,12 @@ impl PropagationAnnounceHandler {
         dest: &[u8; 16],
         app_data: &[u8],
     ) -> Result<PropagationAnnounceEvent, LxmfError> {
-        if !pn_announce_data_is_valid(app_data) {
-            return Err(LxmfError::Decode("invalid propagation app-data".into()));
-        }
-
         let event = PropagationAnnounceEvent {
             destination: *dest,
             name: pn_name_from_app_data(app_data),
             stamp_cost: pn_stamp_cost_from_app_data(app_data),
+            stamp_cost_flexibility: pn_stamp_cost_flexibility_from_app_data(app_data),
+            peering_cost: pn_peering_cost_from_app_data(app_data),
         };
 
         if let Some(callback) = &mut self.callback {

--- a/crates/lxmf/src/helpers.rs
+++ b/crates/lxmf/src/helpers.rs
@@ -11,85 +11,349 @@ pub enum DisplayNameError {
 }
 
 pub fn pn_announce_data_is_valid(data: &[u8]) -> bool {
-    let decoded: Vec<Value> = match rmp_serde::from_slice(data) {
-        Ok(decoded) => decoded,
-        Err(_) => return false,
+    let decoded = match decode_announce_data(data) {
+        Some(decoded) => decoded,
+        None => return false,
     };
 
-    if decoded.len() < 7 {
+    if decoded.len() < 6 {
         return false;
     }
 
-    if !value_is_int(&decoded[1]) {
+    if value_to_u64(&decoded[1]).is_none() {
         return false;
     }
 
-    if !matches!(decoded[2], Value::Boolean(_)) {
+    if value_to_bool(&decoded[2]).is_none() {
         return false;
     }
 
-    if !value_is_int(&decoded[3]) || !value_is_int(&decoded[4]) {
+    if value_to_u64(&decoded[3]).is_none() || value_to_u64(&decoded[4]).is_none() {
         return false;
     }
 
-    let stamp_costs = match &decoded[5] {
-        Value::Array(values) => values,
-        _ => return false,
-    };
-
-    if stamp_costs.len() < 3 {
-        return false;
+    match &decoded[5] {
+        Value::Array(costs) => {
+            if costs.is_empty() {
+                return false;
+            }
+            if rmp_value_to_u32(costs.first().expect("costs is not empty")).is_none() {
+                return false;
+            }
+            if costs.get(1).is_some_and(|value| rmp_value_to_u32(value).is_none()) {
+                return false;
+            }
+            if costs.get(2).is_some_and(|value| rmp_value_to_u32(value).is_none()) {
+                return false;
+            }
+            true
+        }
+        Value::Map(costs) => {
+            if parse_announce_cost_from_map(costs, 0).is_none() {
+                return false;
+            }
+            if cost_map_contains_key(costs, 1) && parse_announce_cost_from_map(costs, 1).is_none() {
+                return false;
+            }
+            if cost_map_contains_key(costs, 2) && parse_announce_cost_from_map(costs, 2).is_none() {
+                return false;
+            }
+            true
+        }
+        _ => false,
     }
-
-    if !value_is_int(&stamp_costs[0])
-        || !value_is_int(&stamp_costs[1])
-        || !value_is_int(&stamp_costs[2])
-    {
-        return false;
-    }
-
-    matches!(decoded[6], Value::Map(_))
 }
 
 pub fn pn_name_from_app_data(data: &[u8]) -> Option<String> {
-    if !pn_announce_data_is_valid(data) {
+    let decoded = decode_announce_data(data)?;
+    if decoded.len() < 7 {
         return None;
     }
 
-    let decoded: Vec<Value> = rmp_serde::from_slice(data).ok()?;
     let metadata = match decoded.get(6)? {
         Value::Map(entries) => entries,
         _ => return None,
     };
 
-    let key = Value::from(PN_META_NAME);
+    let name_keys = [
+        Value::from(PN_META_NAME),
+        Value::from("name"),
+        Value::from("n"),
+        Value::from("display_name"),
+    ];
+
     for (entry_key, entry_value) in metadata {
-        if *entry_key != key {
+        if !name_keys.iter().any(|candidate| keys_match(entry_key, candidate)) {
             continue;
         }
 
-        return match entry_value {
-            Value::Binary(bytes) => String::from_utf8(bytes.clone()).ok(),
-            Value::String(text) => text.as_str().map(|s| s.to_string()),
-            _ => None,
-        };
+        return string_like_value_to_string(entry_value);
     }
 
     None
 }
 
 pub fn pn_stamp_cost_from_app_data(data: &[u8]) -> Option<u32> {
-    if !pn_announce_data_is_valid(data) {
+    parse_announce_cost_from_app_data(data, 0)
+}
+
+pub fn pn_stamp_cost_flexibility_from_app_data(data: &[u8]) -> Option<u32> {
+    parse_announce_cost_from_app_data(data, 1)
+}
+
+pub fn pn_peering_cost_from_app_data(data: &[u8]) -> Option<u32> {
+    parse_announce_cost_from_app_data(data, 2)
+}
+
+fn parse_announce_cost_from_app_data(data: &[u8], index: usize) -> Option<u32> {
+    if index > 2 {
         return None;
     }
 
-    let decoded: Vec<Value> = rmp_serde::from_slice(data).ok()?;
-    let stamp_costs = match decoded.get(5)? {
-        Value::Array(values) => values,
+    let decoded = decode_announce_data(data)?;
+    match decoded.get(5)? {
+        Value::Array(costs) => costs.get(index).and_then(rmp_value_to_u32),
+        Value::Map(costs) => parse_announce_cost_from_map(costs, index),
+        _ => None,
+    }
+}
+
+fn parse_announce_cost_from_map(costs: &[(Value, Value)], index: usize) -> Option<u32> {
+    let target_key = match index {
+        0 => ["stamp_cost", "0"],
+        1 => ["stamp_cost_flexibility", "1"],
+        2 => ["peering_cost", "2"],
         _ => return None,
     };
+    costs.iter().find_map(|(key, value)| {
+        let cost_key = cost_map_key_text(key)?;
+        target_key.contains(&cost_key.as_str()).then_some(()).and_then(|_| rmp_value_to_u32(value))
+    })
+}
 
-    value_to_u32(stamp_costs.first()?)
+fn cost_map_contains_key(costs: &[(Value, Value)], index: usize) -> bool {
+    let target_key = match index {
+        0 => ["stamp_cost", "0"],
+        1 => ["stamp_cost_flexibility", "1"],
+        2 => ["peering_cost", "2"],
+        _ => return false,
+    };
+
+    costs.iter().any(|(key, _)| {
+        cost_map_key_text(key).is_some_and(|cost_key| target_key.contains(&cost_key.as_str()))
+    })
+}
+
+fn cost_map_key_text(key: &Value) -> Option<String> {
+    match key {
+        Value::String(key) => key.as_str().map(|key| key.trim().to_ascii_lowercase()),
+        Value::Binary(key) => {
+            String::from_utf8(key.clone()).ok().map(|key| key.trim().to_ascii_lowercase())
+        }
+        Value::Integer(key) => key.as_u64().map(|key| key.to_string()).or_else(|| {
+            key.as_i64().and_then(|key| usize::try_from(key).ok()).map(|key| key.to_string())
+        }),
+        _ => None,
+    }
+}
+
+fn rmp_value_to_u32(value: &Value) -> Option<u32> {
+    value
+        .as_u64()
+        .and_then(|value| u32::try_from(value).ok())
+        .or_else(|| value.as_i64().and_then(|value| u32::try_from(value).ok()))
+        .or_else(|| match value {
+            Value::F64(value) => parse_f64_to_u32(*value),
+            Value::F32(value) => parse_f64_to_u32(f64::from(*value)),
+            Value::Boolean(value) => Some(u32::from(*value)),
+            Value::Binary(bytes) => parse_text_to_u32(std::str::from_utf8(bytes).ok()?),
+            Value::String(text) => parse_text_to_u32(text.as_str()?),
+            _ => None,
+        })
+}
+
+fn parse_f64_to_u32(value: f64) -> Option<u32> {
+    if !value.is_finite() || value < 0.0 || value.fract() != 0.0 {
+        return None;
+    }
+
+    if value > u32::MAX as f64 {
+        return None;
+    }
+
+    Some(value as u32)
+}
+
+fn parse_text_to_u32(text: &str) -> Option<u32> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Ok(value) = trimmed.parse::<u32>() {
+        return Some(value);
+    }
+
+    parse_f64_to_u32(trimmed.parse::<f64>().ok()?)
+}
+
+fn decode_announce_data(data: &[u8]) -> Option<Vec<Value>> {
+    if data.is_empty() {
+        return None;
+    }
+
+    rmp_serde::from_slice(data).ok()
+}
+
+fn keys_match(candidate: &Value, expected: &Value) -> bool {
+    match (candidate, expected) {
+        (Value::Integer(candidate_value), Value::Integer(expected_value)) => {
+            candidate_value.as_u64() == expected_value.as_u64()
+        }
+        (Value::String(candidate_key), Value::String(expected_key)) => {
+            candidate_key.as_str().is_some_and(|candidate| {
+                candidate.eq_ignore_ascii_case(expected_key.as_str().unwrap_or_default())
+            })
+        }
+        (Value::Binary(candidate_bytes), Value::String(expected_text)) => {
+            std::str::from_utf8(candidate_bytes).ok().is_some_and(|candidate_key| {
+                candidate_key
+                    .eq_ignore_ascii_case(expected_text.as_str().unwrap_or_default().trim())
+            })
+        }
+        (Value::String(candidate_text), Value::Binary(expected_bytes)) => {
+            candidate_text.as_str().is_some_and(|candidate| {
+                std::str::from_utf8(expected_bytes.as_slice())
+                    .is_ok_and(|expected_key| candidate.trim().eq_ignore_ascii_case(expected_key))
+            })
+        }
+        _ => false,
+    }
+}
+
+fn string_like_value_to_string(value: &Value) -> Option<String> {
+    match value {
+        Value::Binary(bytes) => String::from_utf8(bytes.clone()).ok(),
+        Value::String(text) => text.as_str().map(|s| s.to_string()),
+        Value::Integer(int) => int.as_i64().map(|value| value.to_string()),
+        Value::F64(value) => {
+            if value.fract() == 0.0 {
+                Some(format!("{value:.0}"))
+            } else {
+                None
+            }
+        }
+        Value::F32(value) => {
+            let value = f64::from(*value);
+            if value.fract() == 0.0 {
+                Some(format!("{value:.0}"))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn value_to_u64(value: &Value) -> Option<u64> {
+    fn parse_fuzzy_u64(text: &str) -> Option<u64> {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        if let Ok(parsed) = trimmed.parse::<u64>() {
+            return Some(parsed);
+        }
+
+        let parsed = trimmed.parse::<f64>().ok()?;
+        if !parsed.is_finite() || parsed.fract() != 0.0 || parsed < 0.0 {
+            return None;
+        }
+
+        if parsed > u64::MAX as f64 {
+            None
+        } else {
+            Some(parsed as u64)
+        }
+    }
+
+    match value {
+        Value::Integer(int) => {
+            int.as_u64().or_else(|| int.as_i64().and_then(|v| u64::try_from(v).ok()))
+        }
+        Value::F64(value) => {
+            if value.fract() != 0.0 || *value < 0.0 {
+                return None;
+            }
+
+            if !value.is_finite() || *value > u64::MAX as f64 {
+                return None;
+            }
+
+            Some(*value as u64)
+        }
+        Value::F32(value) => {
+            let value = f64::from(*value);
+            if value.fract() != 0.0 || value < 0.0 {
+                return None;
+            }
+
+            if !value.is_finite() || value > u64::MAX as f64 {
+                return None;
+            }
+
+            Some(value as u64)
+        }
+        Value::Binary(bytes) => parse_fuzzy_u64(std::str::from_utf8(bytes).ok()?),
+        Value::String(text) => parse_fuzzy_u64(text.as_str()?),
+        _ => None,
+    }
+}
+
+fn value_to_bool(value: &Value) -> Option<bool> {
+    fn parse_fuzzy_bool(text: &str) -> Option<bool> {
+        match text.trim().to_lowercase().as_str() {
+            "0" | "false" | "no" | "off" => Some(false),
+            "1" | "true" | "yes" | "on" => Some(true),
+            _ => None,
+        }
+    }
+
+    match value {
+        Value::Boolean(value) => Some(*value),
+        Value::Integer(int) => match int.as_i64() {
+            Some(0) => Some(false),
+            Some(1) => Some(true),
+            _ => None,
+        },
+        Value::F64(value) => {
+            if value.is_nan() {
+                None
+            } else if *value == 0.0 {
+                Some(false)
+            } else if *value == 1.0 {
+                Some(true)
+            } else {
+                None
+            }
+        }
+        Value::F32(value) => {
+            let value = f64::from(*value);
+            if value.is_nan() {
+                None
+            } else if value == 0.0 {
+                Some(false)
+            } else if value == 1.0 {
+                Some(true)
+            } else {
+                None
+            }
+        }
+        Value::Binary(bytes) => parse_fuzzy_bool(std::str::from_utf8(bytes).ok()?),
+        Value::String(text) => parse_fuzzy_bool(text.as_str()?),
+        _ => None,
+    }
 }
 
 pub fn display_name_from_app_data(data: &[u8]) -> Option<String> {
@@ -136,15 +400,4 @@ pub fn normalize_display_name(value: &str) -> Result<String, DisplayNameError> {
 
 pub fn is_msgpack_array_prefix(byte: u8) -> bool {
     (0x90..=0x9f).contains(&byte) || byte == 0xdc || byte == 0xdd
-}
-
-fn value_is_int(value: &Value) -> bool {
-    value.as_i64().is_some() || value.as_u64().is_some()
-}
-
-fn value_to_u32(value: &Value) -> Option<u32> {
-    value
-        .as_u64()
-        .and_then(|v| u32::try_from(v).ok())
-        .or_else(|| value.as_i64().and_then(|v| if v >= 0 { u32::try_from(v).ok() } else { None }))
 }

--- a/crates/lxmf/src/runtime/mod.rs
+++ b/crates/lxmf/src/runtime/mod.rs
@@ -3,7 +3,13 @@ use crate::cli::profile::{
     load_profile_settings, load_reticulum_config, profile_paths, resolve_identity_path,
     resolve_runtime_profile_name, InterfaceEntry, ProfilePaths, ProfileSettings,
 };
+#[cfg(not(reticulum_api_v2))]
 use crate::helpers::{display_name_from_app_data, is_msgpack_array_prefix, normalize_display_name};
+#[cfg(reticulum_api_v2)]
+use crate::helpers::{
+    display_name_from_app_data, is_msgpack_array_prefix, normalize_display_name,
+    pn_peering_cost_from_app_data, pn_stamp_cost_flexibility_from_app_data,
+};
 use crate::message::{Message, WireMessage};
 use crate::payload_fields::{decode_transport_fields_json, CommandEntry, WireFields};
 use crate::LxmfError;
@@ -1870,6 +1876,9 @@ impl WorkerState {
                                             None,
                                             None,
                                             None,
+                                            None,
+                                            Some(pn_stamp_cost_flexibility_from_app_data(app_data)),
+                                            Some(pn_peering_cost_from_app_data(app_data)),
                                             aspect,
                                             hops,
                                             interface,

--- a/crates/lxmf/tests/handlers_behavior.rs
+++ b/crates/lxmf/tests/handlers_behavior.rs
@@ -1,4 +1,3 @@
-use lxmf::error::LxmfError;
 use lxmf::handlers::{
     DeliveryAnnounceHandler, PropagationAnnounceEvent, PropagationAnnounceHandler,
 };
@@ -38,14 +37,47 @@ fn propagation_handler_parses_app_data_and_runs_callback() {
     assert_eq!(event.destination, dest);
     assert_eq!(event.name.as_deref(), Some("TestNode"));
     assert_eq!(event.stamp_cost, Some(20));
+    assert_eq!(event.stamp_cost_flexibility, Some(4));
+    assert_eq!(event.peering_cost, Some(25));
 
     let seen_event = seen.lock().expect("callback state").clone().unwrap();
     assert_eq!(seen_event, event);
 }
 
 #[test]
-fn propagation_handler_rejects_invalid_app_data() {
+fn propagation_handler_accepts_invalid_msgpack_gracefully() {
     let mut handler = PropagationAnnounceHandler::new();
     let result = handler.handle_with_app_data(&[0x01; 16], b"invalid-msgpack");
-    assert!(matches!(result, Err(LxmfError::Decode(_))));
+    assert!(result.is_ok());
+    let event = result.expect("invalid app-data should still be handled");
+    assert_eq!(event.name, None);
+    assert_eq!(event.stamp_cost, None);
+    assert_eq!(event.stamp_cost_flexibility, None);
+    assert_eq!(event.peering_cost, None);
+}
+
+#[test]
+fn propagation_handler_accepts_parseable_but_non_standard_app_data() {
+    let payload = rmp_serde::to_vec(&(false, 1_700_000_000u64, true, 111u32, 222u32, vec![20u32]))
+        .expect("non-standard announce payload");
+
+    let seen: Arc<Mutex<Option<PropagationAnnounceEvent>>> = Arc::new(Mutex::new(None));
+    let seen_cb = Arc::clone(&seen);
+    let mut handler = PropagationAnnounceHandler::with_callback(Box::new(move |event| {
+        *seen_cb.lock().expect("callback state") = Some(event.clone());
+        Ok(())
+    }));
+
+    let dest = [0x22; 16];
+    let event =
+        handler.handle_with_app_data(&dest, &payload).expect("non-standard announce accepted");
+
+    assert_eq!(event.destination, dest);
+    assert_eq!(event.name, None);
+    assert_eq!(event.stamp_cost, Some(20));
+    assert_eq!(event.stamp_cost_flexibility, None);
+    assert_eq!(event.peering_cost, None);
+
+    let seen_event = seen.lock().expect("callback state").clone().unwrap();
+    assert_eq!(seen_event, event);
 }

--- a/crates/lxmf/tests/pn_announce_data_parity.rs
+++ b/crates/lxmf/tests/pn_announce_data_parity.rs
@@ -1,7 +1,10 @@
+use lxmf::constants::PN_META_NAME;
 use lxmf::helpers::{
     display_name_from_app_data, pn_announce_data_is_valid, pn_name_from_app_data,
+    pn_peering_cost_from_app_data, pn_stamp_cost_flexibility_from_app_data,
     pn_stamp_cost_from_app_data,
 };
+use rmpv::Value;
 use serde_bytes::ByteBuf;
 
 #[test]
@@ -34,4 +37,134 @@ fn display_name_from_delivery_app_data_parses_msgpack_list() {
 #[test]
 fn display_name_from_app_data_parses_legacy_utf8() {
     assert_eq!(display_name_from_app_data(b"Bob Legacy"), Some("Bob Legacy".to_string()));
+}
+
+#[test]
+fn pn_announce_data_allows_absent_metadata() {
+    let payload = rmp_serde::to_vec(&(
+        false,
+        1_700_000_000u64,
+        true,
+        111u32,
+        222u32,
+        vec![20u32, 4u32, 25u32],
+    ))
+    .expect("partial announce data");
+
+    assert!(pn_announce_data_is_valid(&payload));
+    assert_eq!(pn_name_from_app_data(&payload), None);
+    assert_eq!(pn_stamp_cost_from_app_data(&payload), Some(20));
+}
+
+#[test]
+fn pn_announce_data_parses_name_from_variant_keys() {
+    let payload = rmp_serde::to_vec(&vec![
+        Value::from(false),
+        Value::from(1_700_000_000u64),
+        Value::from(1u32),
+        Value::from(111u32),
+        Value::from(222u32),
+        Value::from(vec![Value::from(20u32)]),
+        Value::Map(vec![(Value::from("display_name"), Value::from("Variant Node"))]),
+    ])
+    .expect("announce data with display_name key");
+
+    assert!(pn_announce_data_is_valid(&payload));
+    assert_eq!(pn_name_from_app_data(&payload), Some("Variant Node".to_string()));
+    assert_eq!(pn_stamp_cost_from_app_data(&payload), Some(20));
+}
+
+#[test]
+fn pn_announce_data_parses_costs_from_map_payload() {
+    let payload = rmp_serde::to_vec(&vec![
+        Value::from(false),
+        Value::from(1_700_000_000u64),
+        Value::from(true),
+        Value::from(111u32),
+        Value::from(222u32),
+        Value::Map(vec![
+            (Value::from("stamp_cost"), Value::from("20")),
+            (Value::from("stamp_cost_flexibility"), Value::from(4u32)),
+            (Value::from("peering_cost"), Value::from(25u32)),
+        ]),
+        Value::Map(vec![(Value::from("display_name"), Value::from("Map Node"))]),
+    ])
+    .expect("announce data with map costs");
+
+    assert!(pn_announce_data_is_valid(&payload));
+    assert_eq!(pn_stamp_cost_from_app_data(&payload), Some(20));
+    assert_eq!(pn_stamp_cost_flexibility_from_app_data(&payload), Some(4));
+    assert_eq!(pn_peering_cost_from_app_data(&payload), Some(25));
+}
+
+#[test]
+fn pn_announce_data_allows_float_stamp_cost() {
+    let payload = rmp_serde::to_vec(&vec![
+        Value::from(false),
+        Value::from(1_700_000_000u64),
+        Value::from(false),
+        Value::from(111u32),
+        Value::from(222u32),
+        Value::from(vec![Value::from(20.0f64), Value::from(4u32), Value::from(25u32)]),
+        Value::Map(vec![(Value::from(PN_META_NAME), Value::from("Floaty".as_bytes().to_vec()))]),
+    ])
+    .expect("announce data with float stamp cost");
+
+    assert!(pn_announce_data_is_valid(&payload));
+    assert_eq!(pn_name_from_app_data(&payload), Some("Floaty".to_string()));
+    assert_eq!(pn_stamp_cost_from_app_data(&payload), Some(20));
+}
+
+#[test]
+fn pn_announce_data_allows_string_and_boolean_text_fields() {
+    let payload = rmp_serde::to_vec(&vec![
+        Value::from(false),
+        Value::from("1700000000"),
+        Value::from("true"),
+        Value::from("111"),
+        Value::from("222"),
+        Value::from(vec![Value::from("20"), Value::from("4"), Value::from("25")]),
+        Value::Map(vec![(Value::from("name"), Value::from("Stringy Node"))]),
+    ])
+    .expect("announce data with stringified fields");
+
+    assert!(pn_announce_data_is_valid(&payload));
+    assert_eq!(pn_name_from_app_data(&payload), Some("Stringy Node".to_string()));
+    assert_eq!(pn_stamp_cost_from_app_data(&payload), Some(20));
+}
+
+#[test]
+fn pn_announce_data_parses_flexibility_and_peering_costs() {
+    let payload = rmp_serde::to_vec(&vec![
+        Value::from(false),
+        Value::from(1_700_000_000u64),
+        Value::from(true),
+        Value::from(111u32),
+        Value::from(222u32),
+        Value::from(vec![Value::from(20u32), Value::from("4"), Value::from(9.0f64)]),
+        Value::Map(vec![(Value::from("display_name"), Value::from("Flex Node"))]),
+    ])
+    .expect("announce data with flexibility and peering");
+
+    assert!(pn_announce_data_is_valid(&payload));
+    assert_eq!(pn_stamp_cost_from_app_data(&payload), Some(20));
+    assert_eq!(pn_stamp_cost_flexibility_from_app_data(&payload), Some(4));
+    assert_eq!(pn_peering_cost_from_app_data(&payload), Some(9));
+}
+
+#[test]
+fn pn_announce_data_returns_none_when_costs_missing_or_short() {
+    let payload = rmp_serde::to_vec(&vec![
+        Value::from(false),
+        Value::from(1_700_000_000u64),
+        Value::from(true),
+        Value::from(111u32),
+        Value::from(222u32),
+        Value::from(vec![Value::from(20u32)]),
+    ])
+    .expect("short announce costs");
+
+    assert!(pn_announce_data_is_valid(&payload));
+    assert_eq!(pn_stamp_cost_flexibility_from_app_data(&payload), None);
+    assert_eq!(pn_peering_cost_from_app_data(&payload), None);
 }


### PR DESCRIPTION
## Summary
This PR improves announce compatibility by making propagation announce parsing and cost extraction resilient across clients.

### Changes
- Add tolerant app_data parsing for propagation node announces (map-based costs and flexible scalar forms).
- Add robust helper parsing for stamp cost fields while preserving strict-mode compatibility.
- Parse and pass `stamp_cost_flexibility` and `peering_cost` into runtime announce events.
- Handle legacy/malformed announce payload variants gracefully while keeping behavior deterministic.
- Expand announce-related tests for parser robustness and compatibility scenarios.

### Validation
- `cargo fmt --check`
- `cargo test -p lxmf --test pn_announce_data_parity --test handlers_behavior`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
