### PR TITLE
Restart managed daemon when display name changes

### DIFF
--- a/crates/lxmf/src/cli/commands_profile.rs
+++ b/crates/lxmf/src/cli/commands_profile.rs
@@ -101,16 +101,13 @@ pub fn run(cli: &Cli, command: &ProfileCommand, output: &Output) -> Result<()> {
             save_profile_settings(&profile)?;
 
             let supervisor = DaemonSupervisor::new(&name, profile.clone());
-            if profile.managed {
-                if did_display_name_change {
-                    if let Ok(status) = supervisor.status() {
-                        if status.running {
-                            if let Err(err) = supervisor.restart(None, Some(profile.managed), None)
-                            {
-                                eprintln!(
-                                    "warning: profile display name was updated but daemon restart failed: {err}"
-                                );
-                            }
+            if profile.managed && did_display_name_change {
+                if let Ok(status) = supervisor.status() {
+                    if status.running {
+                        if let Err(err) = supervisor.restart(None, Some(profile.managed), None) {
+                            eprintln!(
+                                "warning: profile display name was updated but daemon restart failed: {err}"
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
Fix profile rename flow so runtime announces new name immediately:

- In CLI profile name set path, detect when display name changed and daemon process is running
- Restart managed daemon after saving profile so announce/name propagation updates without stale state

This avoids needing manual daemon restart after a name update.