### PR TITLE
Fix reticulumd interface mutation handling

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap.rs
@@ -302,7 +302,7 @@ pub(super) async fn bootstrap(args: Args) -> BootstrapContext {
                         Ok(()) => {
                             mark_interface_startup_status(
                                 &mut configured_interfaces[index],
-                                "active",
+                                "validated_startup_only",
                                 None,
                                 None,
                             );
@@ -358,6 +358,7 @@ pub(super) async fn bootstrap(args: Args) -> BootstrapContext {
                 None,
                 Some(runtime_iface.as_str()),
             );
+            mark_interface_runtime_managed(&mut server_record, "daemon_transport");
             configured_interfaces.push(server_record);
         }
 
@@ -488,6 +489,32 @@ pub(super) fn mark_interface_startup_status(
     startup_error: Option<&str>,
     runtime_iface: Option<&str>,
 ) {
+    with_interface_runtime_metadata(record, |runtime| {
+        runtime.insert("startup_status".to_string(), JsonValue::String(status.to_string()));
+        if let Some(startup_error) = startup_error {
+            runtime
+                .insert("startup_error".to_string(), JsonValue::String(startup_error.to_string()));
+        } else {
+            runtime.remove("startup_error");
+        }
+        if let Some(runtime_iface) = runtime_iface {
+            runtime.insert("iface".to_string(), JsonValue::String(runtime_iface.to_string()));
+        } else {
+            runtime.remove("iface");
+        }
+    });
+}
+
+pub(super) fn mark_interface_runtime_managed(record: &mut InterfaceRecord, managed_by: &str) {
+    with_interface_runtime_metadata(record, |runtime| {
+        runtime.insert("managed_by".to_string(), JsonValue::String(managed_by.to_string()));
+    });
+}
+
+fn with_interface_runtime_metadata(
+    record: &mut InterfaceRecord,
+    update: impl FnOnce(&mut JsonMap<String, JsonValue>),
+) {
     let mut settings = match record.settings.take() {
         Some(JsonValue::Object(existing)) => existing,
         Some(other) => {
@@ -498,16 +525,19 @@ pub(super) fn mark_interface_startup_status(
         None => JsonMap::new(),
     };
 
-    let mut runtime = JsonMap::new();
-    runtime.insert("startup_status".to_string(), JsonValue::String(status.to_string()));
-    if let Some(startup_error) = startup_error {
-        runtime.insert("startup_error".to_string(), JsonValue::String(startup_error.to_string()));
-    }
-    if let Some(runtime_iface) = runtime_iface {
-        runtime.insert("iface".to_string(), JsonValue::String(runtime_iface.to_string()));
-    }
-
-    settings.insert("_runtime".to_string(), JsonValue::Object(runtime));
+    let runtime_value =
+        settings.entry("_runtime".to_string()).or_insert_with(|| JsonValue::Object(JsonMap::new()));
+    let runtime = match runtime_value {
+        JsonValue::Object(existing) => existing,
+        other => {
+            *other = JsonValue::Object(JsonMap::new());
+            match other {
+                JsonValue::Object(existing) => existing,
+                _ => unreachable!("runtime metadata must be an object"),
+            }
+        }
+    };
+    update(runtime);
     record.settings = Some(JsonValue::Object(settings));
 }
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/serial.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/serial.rs
@@ -10,6 +10,9 @@ pub(crate) fn build_adapter(iface: &InterfaceConfig) -> Result<SerialInterface, 
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "serial.device is required".to_string())?;
     let baud_rate = iface.baud_rate.ok_or_else(|| "serial.baud_rate is required".to_string())?;
+    if baud_rate == 0 {
+        return Err("serial.baud_rate must be > 0".to_string());
+    }
 
     let reconnect_backoff_ms = iface.reconnect_backoff_ms.unwrap_or(500).max(50);
     let max_reconnect_backoff_ms = iface

--- a/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
@@ -1,6 +1,6 @@
 use crate::bootstrap::{
-    enforce_startup_policy, mark_interface_runtime_fields, mark_interface_startup_status,
-    InterfaceStartupFailure,
+    enforce_startup_policy, mark_interface_runtime_fields, mark_interface_runtime_managed,
+    mark_interface_startup_status, InterfaceStartupFailure,
 };
 use crate::bridge_helpers::opportunistic_payload;
 use crate::interfaces::{lora, serial};
@@ -68,6 +68,19 @@ fn serial_builder_rejects_missing_required_fields() {
     assert!(result.is_err(), "missing device/baud should fail");
     let err = result.err().unwrap_or_default();
     assert!(err.contains("serial.device"));
+}
+
+#[test]
+fn serial_builder_rejects_zero_baud_rate() {
+    let iface = InterfaceConfig {
+        kind: "serial".to_string(),
+        enabled: Some(true),
+        device: Some("/dev/ttyUSB0".to_string()),
+        baud_rate: Some(0),
+        ..InterfaceConfig::default()
+    };
+    let err = serial::build_adapter(&iface).err().expect("zero baud rate should fail");
+    assert!(err.contains("serial.baud_rate must be > 0"));
 }
 
 #[test]
@@ -148,6 +161,32 @@ fn runtime_status_metadata_is_embedded_in_interface_settings() {
     assert_eq!(runtime.get("runtime_status").and_then(|value| value.as_str()), Some("running"));
     assert_eq!(runtime.get("reconnect_attempts").and_then(|value| value.as_u64()), Some(0));
     assert_eq!(runtime.get("iface").and_then(|value| value.as_str()), Some("beefcafe"));
+}
+
+#[test]
+fn runtime_managed_metadata_survives_startup_status_updates() {
+    let mut record = InterfaceRecord {
+        kind: "tcp_server".to_string(),
+        enabled: true,
+        host: Some("127.0.0.1".to_string()),
+        port: Some(4242),
+        name: Some("daemon-transport".to_string()),
+        settings: None,
+    };
+
+    mark_interface_runtime_managed(&mut record, "daemon_transport");
+    mark_interface_startup_status(&mut record, "active", None, Some("feedbeef"));
+
+    let settings = record.settings.expect("settings should be present");
+    let runtime = settings
+        .get("_runtime")
+        .and_then(|value| value.as_object())
+        .expect("runtime metadata should be present");
+    assert_eq!(
+        runtime.get("managed_by").and_then(|value| value.as_str()),
+        Some("daemon_transport")
+    );
+    assert_eq!(runtime.get("iface").and_then(|value| value.as_str()), Some("feedbeef"));
 }
 
 #[test]

--- a/crates/apps/reticulumd/src/config.rs
+++ b/crates/apps/reticulumd/src/config.rs
@@ -229,6 +229,9 @@ impl InterfaceConfig {
         if self.baud_rate.is_none() {
             return Err(format!("interfaces[{index}].baud_rate is required for serial"));
         }
+        if self.baud_rate == Some(0) {
+            return Err(format!("interfaces[{index}].baud_rate must be > 0 for serial"));
+        }
         if let Some(data_bits) = self.data_bits {
             if !(5..=8).contains(&data_bits) {
                 return Err(format!(

--- a/crates/apps/reticulumd/tests/config.rs
+++ b/crates/apps/reticulumd/tests/config.rs
@@ -76,6 +76,21 @@ interfaces = [
 }
 
 #[test]
+fn rejects_zero_serial_baud_rate() {
+    let input = r#"
+interfaces = [
+  { type = "serial", enabled = true, device = "/dev/ttyUSB0", baud_rate = 0 }
+]
+"#;
+    let err = DaemonConfig::from_toml(input).expect_err("zero baud rate should fail");
+    let message = err.to_string();
+    assert!(
+        message.contains("baud_rate must be > 0 for serial"),
+        "unexpected parse error: {message}"
+    );
+}
+
+#[test]
 fn rejects_enabled_ble_interface_missing_required_fields() {
     let input = r#"
 interfaces = [

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -81,8 +81,10 @@ impl RpcDaemon {
                 })?;
                 let parsed: SetInterfacesParams = serde_json::from_value(params)
                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+                let mut requested_interfaces = parsed.interfaces;
+                Self::strip_runtime_metadata_from_interfaces(&mut requested_interfaces);
 
-                for iface in &parsed.interfaces {
+                for iface in &requested_interfaces {
                     if iface.kind.trim().is_empty() {
                         return Err(std::io::Error::new(
                             std::io::ErrorKind::InvalidInput,
@@ -102,8 +104,7 @@ impl RpcDaemon {
                         ));
                     }
                 }
-                let blocked = parsed
-                    .interfaces
+                let blocked = requested_interfaces
                     .iter()
                     .enumerate()
                     .filter(|(_, iface)| !Self::is_legacy_hot_apply_kind(iface.kind.as_str()))
@@ -117,12 +118,15 @@ impl RpcDaemon {
                     ));
                 }
 
+                let current_interfaces =
+                    self.interfaces.lock().expect("interfaces mutex poisoned").clone();
+                let merged_interfaces =
+                    Self::merge_with_runtime_managed_interfaces(&current_interfaces, &requested_interfaces);
                 {
                     let mut guard = self.interfaces.lock().expect("interfaces mutex poisoned");
-                    *guard = parsed.interfaces.clone();
+                    *guard = merged_interfaces.clone();
                 }
-                let applied_interfaces = parsed
-                    .interfaces
+                let applied_interfaces = requested_interfaces
                     .iter()
                     .enumerate()
                     .map(|(index, iface)| Self::interface_identifier(iface, index))
@@ -130,7 +134,7 @@ impl RpcDaemon {
 
                 let event = RpcEvent {
                     event_type: "interfaces_updated".into(),
-                    payload: json!({ "interfaces": parsed.interfaces }),
+                    payload: json!({ "interfaces": merged_interfaces }),
                 };
                 self.publish_event(event);
 
@@ -149,7 +153,9 @@ impl RpcDaemon {
                     let parsed: ReloadConfigParams = serde_json::from_value(params).map_err(|err| {
                         std::io::Error::new(std::io::ErrorKind::InvalidInput, err)
                     })?;
-                    for iface in &parsed.interfaces {
+                    let mut requested_interfaces = parsed.interfaces;
+                    Self::strip_runtime_metadata_from_interfaces(&mut requested_interfaces);
+                    for iface in &requested_interfaces {
                         if iface.kind.trim().is_empty() {
                             return Err(std::io::Error::new(
                                 std::io::ErrorKind::InvalidInput,
@@ -172,35 +178,15 @@ impl RpcDaemon {
                         }
                     }
 
-                    let current = self.interfaces.lock().expect("interfaces mutex poisoned").clone();
-                    if !Self::is_reload_hot_apply_compatible(&current, &parsed.interfaces) {
-                        let mut affected = parsed
-                            .interfaces
-                            .iter()
-                            .enumerate()
-                            .filter(|(_, iface)| {
-                                !Self::is_legacy_hot_apply_kind(iface.kind.as_str())
-                            })
-                            .map(|(index, iface)| Self::interface_identifier(iface, index))
-                            .collect::<Vec<_>>();
-                        if affected.is_empty() {
-                            affected = parsed
-                                .interfaces
-                                .iter()
-                                .enumerate()
-                                .map(|(index, iface)| Self::interface_identifier(iface, index))
-                                .collect::<Vec<_>>();
-                        }
-                        if affected.is_empty() {
-                            affected = current
-                                .iter()
-                                .enumerate()
-                                .map(|(index, iface)| Self::interface_identifier(iface, index))
-                                .collect::<Vec<_>>();
-                        }
-                        if affected.is_empty() {
-                            affected.push("interfaces".to_string());
-                        }
+                    let current_snapshot =
+                        self.interfaces.lock().expect("interfaces mutex poisoned").clone();
+                    let current_interfaces =
+                        Self::config_managed_interfaces(&current_snapshot);
+                    if !Self::is_reload_hot_apply_compatible(&current_interfaces, &requested_interfaces) {
+                        let affected = Self::restart_required_affected_interfaces(
+                            &current_interfaces,
+                            &requested_interfaces,
+                        );
                         return Ok(Self::restart_required_response(
                             request.id,
                             "reload_config",
@@ -208,13 +194,17 @@ impl RpcDaemon {
                         ));
                     }
 
+                    let merged_interfaces = Self::merge_with_runtime_managed_interfaces(
+                        &current_snapshot,
+                        &requested_interfaces,
+                    );
                     {
                         let mut guard = self.interfaces.lock().expect("interfaces mutex poisoned");
-                        *guard = parsed.interfaces.clone();
+                        *guard = merged_interfaces.clone();
                     }
                     let update_event = RpcEvent {
                         event_type: "interfaces_updated".into(),
-                        payload: json!({ "interfaces": parsed.interfaces }),
+                        payload: json!({ "interfaces": merged_interfaces }),
                     };
                     self.publish_event(update_event);
                 }
@@ -463,6 +453,105 @@ impl RpcDaemon {
             .filter(|value| !value.is_empty())
             .map(ToOwned::to_owned)
             .unwrap_or_else(|| format!("{}[{index}]", iface.kind))
+    }
+
+    fn strip_runtime_metadata_from_interfaces(interfaces: &mut [InterfaceRecord]) {
+        for iface in interfaces {
+            Self::strip_runtime_metadata(iface);
+        }
+    }
+
+    fn strip_runtime_metadata(iface: &mut InterfaceRecord) {
+        let Some(JsonValue::Object(settings)) = iface.settings.as_mut() else {
+            return;
+        };
+        settings.remove("_runtime");
+        if settings.is_empty() {
+            iface.settings = None;
+        }
+    }
+
+    fn is_runtime_managed_interface(iface: &InterfaceRecord) -> bool {
+        iface
+            .settings
+            .as_ref()
+            .and_then(JsonValue::as_object)
+            .and_then(|settings| settings.get("_runtime"))
+            .and_then(JsonValue::as_object)
+            .and_then(|runtime| runtime.get("managed_by"))
+            .and_then(JsonValue::as_str)
+            .is_some_and(|managed_by| managed_by == "daemon_transport")
+    }
+
+    fn config_managed_interfaces(interfaces: &[InterfaceRecord]) -> Vec<InterfaceRecord> {
+        interfaces
+            .iter()
+            .filter(|iface| !Self::is_runtime_managed_interface(iface))
+            .cloned()
+            .collect()
+    }
+
+    fn merge_with_runtime_managed_interfaces(
+        current: &[InterfaceRecord],
+        next: &[InterfaceRecord],
+    ) -> Vec<InterfaceRecord> {
+        let mut merged = next.to_vec();
+        merged.extend(current.iter().filter(|iface| Self::is_runtime_managed_interface(iface)).cloned());
+        merged
+    }
+
+    fn restart_required_affected_interfaces(
+        current: &[InterfaceRecord],
+        next: &[InterfaceRecord],
+    ) -> Vec<String> {
+        let mut affected = Vec::new();
+        Self::push_unique_interface_identifiers(
+            &mut affected,
+            next.iter()
+                .enumerate()
+                .filter(|(_, iface)| !Self::is_legacy_hot_apply_kind(iface.kind.as_str()))
+                .map(|(index, iface)| Self::interface_identifier(iface, index)),
+        );
+        Self::push_unique_interface_identifiers(
+            &mut affected,
+            current
+                .iter()
+                .enumerate()
+                .filter(|(_, iface)| !Self::is_legacy_hot_apply_kind(iface.kind.as_str()))
+                .map(|(index, iface)| Self::interface_identifier(iface, index)),
+        );
+        if affected.is_empty() {
+            Self::push_unique_interface_identifiers(
+                &mut affected,
+                next.iter()
+                    .enumerate()
+                    .map(|(index, iface)| Self::interface_identifier(iface, index)),
+            );
+        }
+        if affected.is_empty() {
+            Self::push_unique_interface_identifiers(
+                &mut affected,
+                current
+                    .iter()
+                    .enumerate()
+                    .map(|(index, iface)| Self::interface_identifier(iface, index)),
+            );
+        }
+        if affected.is_empty() {
+            affected.push("interfaces".to_string());
+        }
+        affected
+    }
+
+    fn push_unique_interface_identifiers<I>(target: &mut Vec<String>, identifiers: I)
+    where
+        I: IntoIterator<Item = String>,
+    {
+        for identifier in identifiers {
+            if !target.iter().any(|existing| existing == &identifier) {
+                target.push(identifier);
+            }
+        }
     }
 
     fn is_reload_hot_apply_compatible(current: &[InterfaceRecord], next: &[InterfaceRecord]) -> bool {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/interface_mutation_policy.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/interface_mutation_policy.rs
@@ -9,6 +9,37 @@
         }
     }
 
+    fn runtime_managed_transport_listener() -> InterfaceRecord {
+        InterfaceRecord {
+            kind: "tcp_server".to_string(),
+            enabled: true,
+            host: Some("127.0.0.1".to_string()),
+            port: Some(4242),
+            name: Some("daemon-transport".to_string()),
+            settings: Some(json!({
+                "_runtime": {
+                    "startup_status": "active",
+                    "iface": "deadbeef",
+                    "managed_by": "daemon_transport"
+                }
+            })),
+        }
+    }
+
+    fn lora_interface(name: &str) -> InterfaceRecord {
+        InterfaceRecord {
+            kind: "lora".to_string(),
+            enabled: true,
+            host: None,
+            port: None,
+            name: Some(name.to_string()),
+            settings: Some(json!({
+                "region": "US915",
+                "state_path": "var/lora-state.json"
+            })),
+        }
+    }
+
     #[test]
     fn set_interfaces_rejects_startup_only_interface_kinds() {
         let daemon = RpcDaemon::test_instance();
@@ -54,6 +85,7 @@
     #[test]
     fn set_interfaces_updates_legacy_tcp_entries() {
         let daemon = RpcDaemon::test_instance();
+        daemon.replace_interfaces(vec![runtime_managed_transport_listener()]);
 
         let response = daemon
             .handle_rpc(rpc_request(
@@ -77,10 +109,11 @@
         assert_eq!(response.result.expect("result")["updated"], json!(true));
 
         let interfaces = daemon.interfaces.lock().expect("interfaces mutex poisoned").clone();
-        assert_eq!(interfaces.len(), 1);
+        assert_eq!(interfaces.len(), 2);
         assert_eq!(interfaces[0].kind, "tcp_client");
         assert_eq!(interfaces[0].host.as_deref(), Some("rmap.world"));
         assert_eq!(interfaces[0].port, Some(4242));
+        assert_eq!(interfaces[1], runtime_managed_transport_listener());
     }
 
     #[test]
@@ -124,7 +157,10 @@
     #[test]
     fn reload_config_hot_applies_legacy_tcp_only_diff() {
         let daemon = RpcDaemon::test_instance();
-        daemon.replace_interfaces(vec![tcp_interface("primary", "127.0.0.1", 4242)]);
+        daemon.replace_interfaces(vec![
+            tcp_interface("primary", "127.0.0.1", 4242),
+            runtime_managed_transport_listener(),
+        ]);
 
         let response = daemon
             .handle_rpc(rpc_request(
@@ -151,6 +187,7 @@
 
         let interfaces = daemon.interfaces.lock().expect("interfaces mutex poisoned").clone();
         assert_eq!(interfaces[0].port, Some(4248));
+        assert_eq!(interfaces[1], runtime_managed_transport_listener());
     }
 
     #[test]
@@ -183,4 +220,48 @@
 
         let interfaces = daemon.interfaces.lock().expect("interfaces mutex poisoned").clone();
         assert_eq!(interfaces, vec![tcp_interface("primary", "127.0.0.1", 4242)]);
+    }
+
+    #[test]
+    fn reload_config_reports_removed_startup_only_interface_names() {
+        let daemon = RpcDaemon::test_instance();
+        daemon.replace_interfaces(vec![
+            tcp_interface("primary", "127.0.0.1", 4242),
+            lora_interface("lora-main"),
+        ]);
+
+        let response = daemon
+            .handle_rpc(rpc_request(
+                6,
+                "reload_config",
+                json!({
+                    "interfaces": [
+                        {
+                            "type": "tcp_client",
+                            "enabled": true,
+                            "host": "127.0.0.1",
+                            "port": 4248,
+                            "name": "primary"
+                        }
+                    ]
+                }),
+            ))
+            .expect("reload_config response");
+
+        let error = response.error.expect("expected restart-required error");
+        let details = error.details.expect("details must be present");
+        let affected = details
+            .get("affected_interfaces")
+            .and_then(|value| value.as_array())
+            .expect("affected interfaces array");
+        assert!(
+            affected.iter().any(|item| item.as_str() == Some("lora-main")),
+            "removed startup-only interface should be named in affected_interfaces"
+        );
+
+        let interfaces = daemon.interfaces.lock().expect("interfaces mutex poisoned").clone();
+        assert_eq!(
+            interfaces,
+            vec![tcp_interface("primary", "127.0.0.1", 4242), lora_interface("lora-main")]
+        );
     }

--- a/docs/contracts/rpc-contract.md
+++ b/docs/contracts/rpc-contract.md
@@ -71,9 +71,10 @@ All methods below are required for full CLI feature coverage.
 `list_interfaces` response notes:
 
 - `interfaces[*].settings` may include a runtime metadata envelope at `_runtime` with fields:
-  `startup_status`, optional `startup_error`, and optional `iface` (runtime interface id).
+  `startup_status`, optional `startup_error`, optional `iface` (runtime interface id), and
+  optional `managed_by` for daemon-owned synthetic records.
 - Known `startup_status` values include: `disabled`, `inactive_transport_disabled`, `failed`,
-  `spawned`, and `active`.
+  `spawned`, `active`, and `validated_startup_only`.
 - This metadata is additive and intended for startup/degraded-mode observability.
 
 Startup policy notes:

--- a/docs/runbooks/reticulumd-lora-interface.md
+++ b/docs/runbooks/reticulumd-lora-interface.md
@@ -94,6 +94,7 @@ Failure log:
 Runtime status visibility:
 
 - `list_interfaces` includes `_runtime.startup_status`.
+- Successful startup-only validation is reported as `_runtime.startup_status = "validated_startup_only"`.
 - Failed interfaces include `_runtime.startup_error`.
 
 ## Verification Commands


### PR DESCRIPTION
## Summary
- preserve daemon-managed transport listener records during set_interfaces and eload_config, and strip client-supplied runtime metadata before hot-apply comparisons
- reject serial configs with aud_rate = 0 during config validation and adapter construction
- report LoRa startup-only checks as alidated_startup_only, with tests and RPC contract updates for runtime metadata

## Validation
- cargo check --workspace --tests
- cargo test -p reticulumd --test config rejects_zero_serial_baud_rate -- --exact *(fails locally because this Windows environment is missing sqlite3.lib at link time)*