### PR TITLE
Define SDK easy-mode contracts

### DIFF
--- a/docs/contracts/sdk-easy-api-v1.md
+++ b/docs/contracts/sdk-easy-api-v1.md
@@ -1,0 +1,202 @@
+# SDK Easy-Mode API v1
+
+Status: Draft, implementation target  
+Contract family: `sdk-easy`  
+Contract release: `v1`  
+Underlying core contract: `sdk-v2.5`
+
+## Purpose
+
+This document defines the default, app-facing SDK surface for clients that want the easiest possible integration path.
+
+The easy-mode API is:
+
+- event-first
+- profile-aware
+- policy-bearing
+- backend-neutral from the consumer perspective
+
+This contract is normative. Wrappers and language bindings must not invent their own lifecycle, retry, recovery, or ordering semantics.
+
+## Scope
+
+In scope:
+
+- app-facing lifecycle API
+- typed send and receive behavior
+- default delivery and recovery policy
+- callback and event-stream semantics
+- configuration presets and policy ownership
+- capability and version negotiation behavior
+
+Out of scope:
+
+- raw transport packet formats
+- low-level manual-tick mechanics as part of the default API
+- wrapper-specific syntax choices
+
+## Design Rules
+
+1. Easy mode is the default API surface for normal app consumers.
+2. Low-level polling, transport, wire, and manual-tick behavior are advanced-only.
+3. All first-party wrappers must implement semantically identical behavior by default.
+4. Policy belongs in SDK orchestration, not in each wrapper.
+5. If a platform cannot support the default semantics, the deviation must be profile-declared and capability-exposed.
+
+## Canonical App Model
+
+The default client model consists of:
+
+- `Node` or `Client`
+- `EasyConfig`
+- `SendRequest`
+- `SendReceipt`
+- `EventStream`
+- `SdkEasyError`
+- `RuntimeStatus`
+
+Default lifecycle methods:
+
+- `start(config) -> Result<Handle, SdkEasyError>`
+- `stop(mode) -> Result<(), SdkEasyError>`
+- `send(request) -> Result<SendReceipt, SdkEasyError>`
+- `subscribe_events(options) -> Result<EventStream, SdkEasyError>`
+- `status() -> Result<RuntimeStatus, SdkEasyError>`
+
+Optional additive helpers:
+
+- `restart(config)`
+- `flush(timeout)`
+- `reconnect()`
+- `send_with_policy(request, policy_override)`
+
+## Lifecycle State Machine
+
+Easy-mode runtime states:
+
+- `New`
+- `Starting`
+- `Running`
+- `Degraded`
+- `Stopping`
+- `Stopped`
+- `Failed`
+
+Rules:
+
+1. `start()` is legal in `New` and `Stopped`.
+2. `start()` in `Running` returns the existing active handle if the effective config is equivalent.
+3. `start()` in `Running` with a non-equivalent effective config fails with `EASY_RUNTIME_ALREADY_RUNNING_DIFFERENT_CONFIG`.
+4. `send()` is legal in `Running` and may be legal in `Degraded` only if the active profile explicitly permits queued offline delivery.
+5. `subscribe_events()` is legal in `Starting`, `Running`, `Degraded`, and `Stopping`.
+6. `stop()` is idempotent.
+7. `Failed` is terminal until explicit restart or fresh start semantics are invoked.
+
+## Threading and Callback Guarantees
+
+Bindings must document the execution context for callbacks/async streams, but semantic guarantees are fixed:
+
+1. Event order is stable regardless of callback mechanism.
+2. Default event delivery must not require consumer-managed locking to preserve SDK correctness.
+3. Callbacks must not be invoked concurrently for the same subscription unless the binding explicitly opts into concurrent delivery and documents that profile.
+4. `stop()` and `restart()` must deterministically wake blocked waiters/subscribers.
+5. Event stream closure is explicit and must not silently disappear.
+
+## Delivery Semantics
+
+Easy mode owns the default delivery policy.
+
+Required default behaviors:
+
+1. `send()` returns acceptance into the SDK-managed delivery pipeline, not final delivery proof.
+2. Terminal delivery outcome is communicated by typed events and status transitions.
+3. Retry scheduling, reconnect behavior, and queue-pressure policy are SDK-defined and profile-bound.
+4. Idempotency and deduplication behavior must be stable across wrappers.
+5. Receipts and events must remain correlatable across restart boundaries.
+
+## Queue Pressure and Backpressure
+
+Default consumers must not implement queue-pressure logic themselves.
+
+Rules:
+
+1. Queue pressure is surfaced as a typed easy-mode error.
+2. The default policy for queue pressure is profile-defined and may be:
+   - fail fast
+   - bounded retry with backoff
+   - queue-when-offline with durable admission
+3. Partial acceptance must never be hidden from the caller.
+4. If fanout helpers admit a subset of targets, that must be explicitly represented in the receipt and event stream. Silent partial success is forbidden.
+
+## Timeout and Retry Policy
+
+Default timeout and retry behavior must be centrally defined.
+
+Rules:
+
+1. Retry policy belongs to the SDK easy-mode layer.
+2. Wrappers may expose override hooks, but overrides must start from a known contract-defined default.
+3. Timeout behavior must be stable across languages.
+4. “Retryable” vs “terminal” failure classification must be part of the typed error model.
+
+## Persistence and Offline Recovery
+
+Easy mode must define whether caller-visible delivery survives restart and offline periods.
+
+Required contract fields:
+
+- durable queue support: `supported | unsupported`
+- restart recovery scope
+- offline send policy
+- event replay/recovery guarantees
+
+Rules:
+
+1. If durable queueing is unsupported for a profile, that must be explicit.
+2. If restart recovery is supported, queue, receipt, and event resumption semantics must be documented.
+3. Easy-mode defaults must not imply durability unless the profile guarantees it.
+
+## Capability and Version Negotiation
+
+Easy mode is layered on top of the broader SDK contract and may negotiate capabilities internally.
+
+Rules:
+
+1. Bindings must not require apps to reason about raw capability bits for the default path.
+2. Easy-mode startup fails fast if required semantics are unavailable.
+3. Unknown additive fields and unknown future capability flags must be ignored safely unless they are marked required-by-profile.
+4. The effective easy-mode profile and policy set are frozen for the active session after successful start.
+
+## Security and Identity Ownership
+
+Easy-mode integrations must not guess security behavior.
+
+Rules:
+
+1. The contract must define who owns identity material, token acquisition, and secure storage integration.
+2. Secrets must not appear in typed events or error payloads.
+3. Remote or shared-instance modes must require explicit secure auth posture.
+4. Default profiles must prefer least-privilege and redaction-enabled operation.
+
+## Advanced Escape Hatches
+
+The following are advanced-only:
+
+- raw transport/wire APIs
+- manual tick
+- raw low-level event or poll surfaces
+- profile bypasses that disable default policy behavior
+
+Rules:
+
+1. Advanced escape hatches must be clearly labeled non-default.
+2. Using advanced mode may void some easy-mode guarantees and must be documented as such.
+3. Wrappers should expose advanced surfaces separately from the default API.
+
+## Acceptance Standard
+
+This contract is complete when:
+
+- wrapper authors can implement the default API without guessing behavior
+- most apps do not need custom retry/reconnect/queue logic
+- semantics are stable enough to back a language-agnostic conformance suite

--- a/docs/contracts/sdk-easy-errors-v1.md
+++ b/docs/contracts/sdk-easy-errors-v1.md
@@ -1,0 +1,139 @@
+# SDK Easy-Mode Errors v1
+
+Status: Draft, implementation target  
+Contract family: `sdk-easy`  
+Contract release: `v1`
+
+## Purpose
+
+This document defines the typed error model for easy-mode consumers.
+
+Apps should not need to inspect low-level transport or runtime internals to decide what happened or what to do next.
+
+## Error Envelope
+
+All easy-mode errors must expose:
+
+- `code`
+- `category`
+- `retryable`
+- `terminal`
+- `user_action_required`
+- `message`
+- `details`
+- `cause_code` optional
+
+Rules:
+
+1. Unknown future errors must parse safely as `Unknown(code)`.
+2. Reusing an existing error code with different semantics is a breaking change.
+3. Error messages are descriptive only; behavior must be driven by typed fields.
+
+## Categories
+
+Required categories:
+
+- `Validation`
+- `Capability`
+- `Config`
+- `Policy`
+- `Delivery`
+- `Connectivity`
+- `Persistence`
+- `Security`
+- `Timeout`
+- `Runtime`
+- `Internal`
+
+## Required Easy-Mode Codes
+
+Minimum default set:
+
+- `EASY_VALIDATION_INVALID_ARGUMENT`
+- `EASY_VALIDATION_UNKNOWN_FIELD`
+- `EASY_CAPABILITY_UNSUPPORTED_PROFILE`
+- `EASY_CAPABILITY_REQUIRED_FEATURE_MISSING`
+- `EASY_CONFIG_INVALID`
+- `EASY_RUNTIME_INVALID_STATE`
+- `EASY_RUNTIME_ALREADY_RUNNING_DIFFERENT_CONFIG`
+- `EASY_RUNTIME_STREAM_DEGRADED`
+- `EASY_RUNTIME_NOT_STARTED`
+- `EASY_DELIVERY_QUEUE_PRESSURE`
+- `EASY_DELIVERY_PARTIAL_ACCEPTANCE`
+- `EASY_DELIVERY_RETRY_EXHAUSTED`
+- `EASY_DELIVERY_CANCELLED`
+- `EASY_CONNECTIVITY_DISCONNECTED`
+- `EASY_CONNECTIVITY_RECONNECT_FAILED`
+- `EASY_PERSISTENCE_UNAVAILABLE`
+- `EASY_PERSISTENCE_RECOVERY_REQUIRED`
+- `EASY_TIMEOUT_OPERATION_EXPIRED`
+- `EASY_SECURITY_AUTH_REQUIRED`
+- `EASY_SECURITY_AUTHZ_DENIED`
+- `EASY_SECURITY_REDACTION_REQUIRED`
+- `EASY_INTERNAL_UNEXPECTED_FAILURE`
+
+## Retryability Rules
+
+`retryable` is contract-governed.
+
+Rules:
+
+1. The same error code must not be `retryable=true` in one wrapper and `false` in another unless the profile explicitly declares that difference.
+2. Retryability reflects default SDK policy, not merely possibility in theory.
+3. If SDK policy will retry automatically, the error should usually be surfaced as an event or non-terminal status rather than an immediate terminal send failure.
+
+## Terminality Rules
+
+`terminal` refers to the current operation or delivery item, not necessarily the whole runtime.
+
+Rules:
+
+1. `EASY_DELIVERY_RETRY_EXHAUSTED` is terminal for that delivery item.
+2. `EASY_DELIVERY_QUEUE_PRESSURE` is not inherently terminal unless admission policy says fail-fast.
+3. `EASY_RUNTIME_STREAM_DEGRADED` is terminal for the affected subscription state until explicit recovery.
+4. `EASY_INTERNAL_UNEXPECTED_FAILURE` may be terminal for the runtime session.
+
+## User-Actionable Rules
+
+Apps often need to know whether to surface UI or let the SDK continue.
+
+Rules:
+
+1. `user_action_required=true` only when the caller or user must do something meaningful:
+   - re-authenticate
+   - change config
+   - free capacity
+   - explicitly recover stream state
+2. Automatic retries and reconnects should not be surfaced as user-actionable errors by default.
+
+## Queue Pressure and Partial Acceptance
+
+Easy mode must make fanout and pressure semantics explicit.
+
+Rules:
+
+1. Queue pressure must map to `EASY_DELIVERY_QUEUE_PRESSURE`.
+2. Partial acceptance must map to `EASY_DELIVERY_PARTIAL_ACCEPTANCE`.
+3. Partial success must never be hidden in a generic `Ok`.
+4. If a profile promises all-or-nothing admission for a helper, partial acceptance must not occur for that helper.
+
+## Recovery-Oriented Errors
+
+The following errors require explicit recovery logic, whether automatic or user-triggered:
+
+- `EASY_RUNTIME_STREAM_DEGRADED`
+- `EASY_PERSISTENCE_RECOVERY_REQUIRED`
+- `EASY_CONNECTIVITY_RECONNECT_FAILED`
+
+Rules:
+
+1. Recovery semantics must be profile-defined.
+2. Wrappers must not improvise different recovery behavior without a declared profile difference.
+
+## Security and Redaction
+
+Rules:
+
+1. Secrets must never appear in `message` or `details`.
+2. Sensitive identifiers must be redacted or transformed according to SDK policy.
+3. Raw payload or credential excerpts are forbidden in default easy-mode errors.

--- a/docs/contracts/sdk-easy-events-v1.md
+++ b/docs/contracts/sdk-easy-events-v1.md
@@ -1,0 +1,143 @@
+# SDK Easy-Mode Events v1
+
+Status: Draft, implementation target  
+Contract family: `sdk-easy`  
+Contract release: `v1`
+
+## Purpose
+
+This document defines the typed app-level event model for easy-mode consumers.
+
+The default event surface must hide raw transport and polling details. Advanced consumers may opt into lower-level streams separately.
+
+## Event Model
+
+Each event includes a stable envelope:
+
+- `event_id`
+- `runtime_id`
+- `seq_no`
+- `occurred_at_ms`
+- `event_type`
+- `severity`
+- `operation_id` optional
+- `message_id` optional
+- `correlation_id` optional
+- `profile_id`
+- `extensions` optional
+
+Rules:
+
+1. `seq_no` is strictly monotonic per runtime session.
+2. Duplicate delivery may occur only if the broader SDK contract allows at-least-once replay; duplicates must preserve `event_id`.
+3. Unknown future additive fields must be safely ignored.
+
+## Typed Easy-Mode Event Set
+
+Required app-level event types:
+
+- `RuntimeStarted`
+- `RuntimeStopped`
+- `RuntimeDegraded`
+- `RuntimeRecovered`
+- `MessageQueued`
+- `MessageDispatching`
+- `MessageSent`
+- `MessageDelivered`
+- `MessageFailed`
+- `MessageCancelled`
+- `InboundMessageReceived`
+- `QueuePressureRaised`
+- `RetryScheduled`
+- `ReconnectScheduled`
+- `StreamGapDetected`
+- `SecurityActionRequired`
+- `FatalErrorRaised`
+
+Wrappers should present these as typed domain events instead of exposing raw event-type strings by default.
+
+## Event Ordering Rules
+
+1. Runtime lifecycle events must preserve causal order.
+2. Delivery progression for a single `message_id` must be monotonic.
+3. A terminal delivery event must be the final delivery-state event for that message.
+4. `StreamGapDetected` must never be hidden or auto-healed silently.
+5. Reconnect and retry scheduling events must occur before the follow-up delivery attempt they describe.
+
+## Delivery-State Event Semantics
+
+Delivery progression states exposed to apps:
+
+- `queued`
+- `dispatching`
+- `sent`
+- `delivered`
+- `failed`
+- `cancelled`
+
+Rules:
+
+1. `send()` acceptance should produce `MessageQueued` or a documented equivalent initial state.
+2. `MessageSent` is not necessarily terminal.
+3. `MessageDelivered` is terminal success.
+4. `MessageFailed` and `MessageCancelled` are terminal failure states.
+5. If a profile cannot observe `delivered`, that limitation must be explicit in profile semantics.
+
+## Queue Pressure and Retry Events
+
+Easy-mode policy must be visible to the app in typed form.
+
+Required semantics:
+
+- `QueuePressureRaised`
+  - emitted when queue admission or pipeline pressure affects behavior
+- `RetryScheduled`
+  - emitted when the SDK schedules a retry
+- `ReconnectScheduled`
+  - emitted when the SDK schedules reconnection or session recovery
+
+Rules:
+
+1. These events are informational, not low-level transport trivia.
+2. They must include enough context for UI/telemetry without leaking secrets.
+3. The app must not need to infer retry behavior from generic error strings.
+
+## Stream Gap and Recovery Events
+
+Easy mode must not hide data-loss indicators.
+
+Required event:
+
+- `StreamGapDetected`
+
+Required fields:
+
+- `expected_seq_no`
+- `observed_seq_no`
+- `dropped_count`
+- `recovery_required`
+
+Rules:
+
+1. Silent gap healing is forbidden.
+2. If explicit consumer action is required, `recovery_required` must be true.
+3. Gap semantics must be identical across wrappers.
+
+## Callback and Subscription Semantics
+
+Bindings may use callbacks, async streams, observers, or channels, but semantics are fixed:
+
+1. Default subscriptions receive typed app-level events.
+2. Subscription closure is explicit.
+3. Blocking waits or async awaits must resolve deterministically on stop, restart, close, or fatal failure.
+4. The same event order must be preserved regardless of callback or async facade style.
+
+## Extension Behavior
+
+Easy-mode default consumers should rarely need extension events.
+
+Rules:
+
+1. Unknown extension events must not break parsing.
+2. Extension events are advanced-only unless promoted into the typed easy-mode set.
+3. Bindings should expose raw extension details separately from the default app event surface.

--- a/docs/contracts/sdk-easy-profiles-v1.md
+++ b/docs/contracts/sdk-easy-profiles-v1.md
@@ -1,0 +1,172 @@
+# SDK Easy-Mode Profiles v1
+
+Status: Draft, implementation target  
+Contract family: `sdk-easy`  
+Contract release: `v1`
+
+## Purpose
+
+This document defines the profile presets and policy defaults for easy-mode consumers.
+
+Profiles exist so most apps can adopt the SDK with minimal configuration and without encoding custom policy logic.
+
+## Profile Model
+
+Easy-mode profiles are named policy bundles.
+
+Required presets:
+
+- `mobile_default`
+- `desktop_default`
+- `embedded_default`
+- `testing_default`
+
+Rules:
+
+1. Profiles are immutable for a running easy-mode session unless the contract explicitly allows a mutable subset.
+2. Effective profile semantics are frozen at successful start.
+3. All wrappers must implement the same semantic meaning for a given profile name.
+
+## Profile Fields
+
+Each profile must define:
+
+- lifecycle posture
+- retry policy
+- reconnect policy
+- queue pressure policy
+- timeout policy
+- persistence/durability support
+- event buffering expectations
+- redaction/security defaults
+- capability assumptions
+
+## `mobile_default`
+
+Intended for:
+
+- user-facing mobile apps
+- intermittent connectivity
+- battery- and UX-sensitive runtimes
+
+Required defaults:
+
+- reconnect enabled with bounded backoff
+- retry enabled for retryable delivery failures
+- queue pressure policy favors bounded buffering or bounded retry over immediate failure when supported
+- redaction enabled
+- callback/event delivery safe for UI integration through binding-specific dispatch rules
+
+## `desktop_default`
+
+Intended for:
+
+- desktop apps
+- local agents
+- service-style host integrations
+
+Required defaults:
+
+- reconnect enabled
+- retry enabled with more generous resource assumptions than mobile
+- stronger event buffering than mobile
+- redaction enabled
+- richer diagnostics permitted within the default redaction policy
+
+## `embedded_default`
+
+Intended for:
+
+- constrained host-side integrations
+- lower-resource deployments
+- profiles closer to embedded/native runtime constraints
+
+Required defaults:
+
+- conservative buffering
+- conservative retry policy
+- explicit handling when durability is unsupported
+- capability assumptions may be narrower than desktop/mobile, but semantics must stay explicit
+
+## `testing_default`
+
+Intended for:
+
+- integration tests
+- deterministic harnesses
+- contract/conformance execution
+
+Required defaults:
+
+- deterministic timing knobs where possible
+- reduced jitter in retry/backoff policy
+- explicit failure visibility over silent auto-healing
+- diagnostics suitable for contract assertions
+
+## Policy Defaults
+
+### Retry
+
+Rules:
+
+1. Retry defaults are part of the profile, not wrapper-local behavior.
+2. Retry policy must define:
+   - eligible failure classes
+   - max attempts or exhaustion policy
+   - backoff strategy
+   - terminal exhaustion behavior
+
+### Reconnect
+
+Rules:
+
+1. Reconnect defaults are part of the profile.
+2. Reconnect behavior must define:
+   - whether auto-reconnect is enabled
+   - scheduling strategy
+   - escalation to degraded or failed state
+
+### Queue Pressure
+
+Rules:
+
+1. Queue pressure behavior must be explicit:
+   - fail fast
+   - bounded retry
+   - bounded buffering
+2. The chosen policy must be visible through typed events and errors.
+3. Apps should not need custom queue-pressure handling for normal use.
+
+### Timeout
+
+Rules:
+
+1. Operation timeouts must have profile-defined defaults.
+2. Wrappers may expose overrides, but default behavior must be consistent across languages.
+
+### Persistence and Durability
+
+Rules:
+
+1. Profiles must state whether durable queueing and restart recovery are supported.
+2. Durability must never be implied by default if unsupported by the runtime/profile.
+3. If durability is unsupported, the profile must define the failure or degradation semantics clearly.
+
+## Security Defaults
+
+Required baseline:
+
+- redaction enabled
+- least-privilege bind/auth posture
+- explicit secure auth requirements for remote/shared-instance use
+
+Rules:
+
+1. Profiles must not weaken security posture silently.
+2. Any profile-specific security tradeoff must be explicit.
+
+## Profile Evolution Rules
+
+1. Changing the semantic meaning of an existing profile is a contract change.
+2. Additive tunables are allowed if defaults preserve prior meaning.
+3. Breaking behavioral shifts require a new profile version or new profile identifier.

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -24,3 +24,10 @@ It complements the formal contracts under `docs/contracts/` with integration-foc
 - `docs/contracts/sdk-v2-events.md`
 - `docs/contracts/sdk-v2-errors.md`
 - `docs/contracts/sdk-v2-feature-matrix.md`
+
+Easy-mode roadmap contracts:
+
+- `docs/contracts/sdk-easy-api-v1.md`
+- `docs/contracts/sdk-easy-events-v1.md`
+- `docs/contracts/sdk-easy-errors-v1.md`
+- `docs/contracts/sdk-easy-profiles-v1.md`


### PR DESCRIPTION
## Summary
- add the first normative `sdk-easy` contract set for the app-facing easy-mode API
- define typed easy-mode lifecycle, event, error, and profile semantics before wrapper or facade implementation
- link the new contract family from the SDK guide for discoverability

## Scope
This PR is docs-only and covers issue #27.

New contract docs:
- `docs/contracts/sdk-easy-api-v1.md`
- `docs/contracts/sdk-easy-events-v1.md`
- `docs/contracts/sdk-easy-errors-v1.md`
- `docs/contracts/sdk-easy-profiles-v1.md`

## Notes
- The contract is explicitly layered on top of the existing `sdk-v2.5` contract family.
- It fixes the sequencing called out in roadmap review: contract semantics first, conformance next, implementation after that.

## Testing
- Not run (docs-only change)
