### PR TITLE
feat: add sdk app delivery helpers

### DIFF
--- a/crates/libs/lxmf-sdk/src/app/config.rs
+++ b/crates/libs/lxmf-sdk/src/app/config.rs
@@ -1,0 +1,68 @@
+use super::delivery::DeliveryPlan;
+use super::node::{Config, Profile};
+use crate::SdkConfig;
+
+impl Config {
+    pub fn from_profile(profile: Profile) -> Self {
+        match profile {
+            Profile::MobileDefault => Self {
+                profile,
+                sdk_config: SdkConfig::desktop_local_default(),
+                supported_contract_versions: vec![2],
+                requested_capabilities: Vec::new(),
+                event_batch_size: Some(32),
+            },
+            Profile::DesktopDefault => Self {
+                profile,
+                sdk_config: SdkConfig::desktop_full_default(),
+                supported_contract_versions: vec![2],
+                requested_capabilities: Vec::new(),
+                event_batch_size: Some(64),
+            },
+            Profile::EmbeddedDefault => Self {
+                profile,
+                sdk_config: SdkConfig::embedded_alloc_default(),
+                supported_contract_versions: vec![2],
+                requested_capabilities: Vec::new(),
+                event_batch_size: Some(16),
+            },
+            Profile::TestingDefault => {
+                let mut sdk_config = SdkConfig::desktop_local_default();
+                sdk_config.event_stream.max_poll_events = 32;
+                Self {
+                    profile,
+                    sdk_config,
+                    supported_contract_versions: vec![2],
+                    requested_capabilities: Vec::new(),
+                    event_batch_size: Some(16),
+                }
+            }
+        }
+    }
+
+    pub fn delivery_plan(&self) -> DeliveryPlan {
+        let mut plan = self.profile.defaults();
+        plan.default_event_batch_size =
+            self.event_batch_size.unwrap_or(plan.default_event_batch_size);
+        plan.redaction_enabled = self.sdk_config.redaction.enabled;
+        plan
+    }
+
+    pub fn with_event_batch_size(mut self, event_batch_size: usize) -> Self {
+        self.event_batch_size = Some(event_batch_size.max(1));
+        self
+    }
+
+    pub fn with_supported_contract_version(mut self, contract_version: u16) -> Self {
+        self.supported_contract_versions = vec![contract_version];
+        self
+    }
+
+    pub fn with_supported_contract_versions(
+        mut self,
+        contract_versions: impl IntoIterator<Item = u16>,
+    ) -> Self {
+        self.supported_contract_versions = contract_versions.into_iter().collect();
+        self
+    }
+}

--- a/crates/libs/lxmf-sdk/src/app/delivery.rs
+++ b/crates/libs/lxmf-sdk/src/app/delivery.rs
@@ -1,0 +1,220 @@
+use super::errors::{Error, ErrorCategory, ErrorCode};
+use super::node::{Profile, SendReceipt};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct BackoffSchedule {
+    pub initial_delay_ms: u64,
+    pub multiplier: u32,
+    pub max_delay_ms: u64,
+}
+
+impl BackoffSchedule {
+    pub const fn fixed(delay_ms: u64) -> Self {
+        Self { initial_delay_ms: delay_ms, multiplier: 1, max_delay_ms: delay_ms }
+    }
+
+    pub const fn exponential(initial_delay_ms: u64, multiplier: u32, max_delay_ms: u64) -> Self {
+        Self { initial_delay_ms, multiplier, max_delay_ms }
+    }
+
+    pub fn delay_for_attempt(&self, attempt: u32) -> u64 {
+        if attempt <= 1 {
+            return self.initial_delay_ms.min(self.max_delay_ms);
+        }
+        let mut delay = self.initial_delay_ms.max(1);
+        for _ in 1..attempt {
+            delay = delay.saturating_mul(u64::from(self.multiplier.max(1)));
+            if delay >= self.max_delay_ms {
+                return self.max_delay_ms;
+            }
+        }
+        delay.min(self.max_delay_ms)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum QueuePressureStrategy {
+    FailFast,
+    Retry,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RetryPolicy {
+    pub max_attempts: u32,
+    pub backoff: BackoffSchedule,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ReconnectPolicy {
+    pub enabled: bool,
+    pub max_attempts: Option<u32>,
+    pub backoff: BackoffSchedule,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct QueuePressurePolicy {
+    pub strategy: QueuePressureStrategy,
+    pub max_attempts: u32,
+    pub backoff: BackoffSchedule,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct TimeoutPolicy {
+    pub send_timeout_ms: Option<u64>,
+    pub event_next_timeout_ms: Option<u64>,
+    pub reconnect_grace_ms: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DeliveryPlan {
+    pub profile: Profile,
+    pub retry: RetryPolicy,
+    pub reconnect: ReconnectPolicy,
+    pub queue_pressure: QueuePressurePolicy,
+    pub timeout: TimeoutPolicy,
+    pub durable_queueing: bool,
+    pub restart_recovery: bool,
+    pub default_event_batch_size: usize,
+    pub redaction_enabled: bool,
+}
+
+impl DeliveryPlan {
+    pub(crate) fn resolve(&self, options: &DeliveryOptions) -> ResolvedSendPolicy {
+        ResolvedSendPolicy {
+            max_attempts: options.max_attempts.unwrap_or(self.retry.max_attempts).max(1),
+            timeout_ms: options.timeout_ms.or(self.timeout.send_timeout_ms),
+            retry_backoff: self.retry.backoff.clone(),
+            queue_pressure_max_attempts: options
+                .max_attempts
+                .unwrap_or(self.queue_pressure.max_attempts)
+                .max(1),
+            queue_pressure_strategy: options
+                .queue_pressure_strategy
+                .clone()
+                .unwrap_or(self.queue_pressure.strategy.clone()),
+            queue_pressure_backoff: self.queue_pressure.backoff.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct DeliveryOptions {
+    pub max_attempts: Option<u32>,
+    pub timeout_ms: Option<u64>,
+    pub queue_pressure_strategy: Option<QueuePressureStrategy>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AttemptDisposition {
+    Retried,
+    Failed,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DeliveryAttempt {
+    pub attempt: u32,
+    pub disposition: AttemptDisposition,
+    pub error_code: String,
+    pub retryable: bool,
+    pub queue_pressure: bool,
+    pub scheduled_delay_ms: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
+pub struct SendReport {
+    pub receipt: SendReceipt,
+    pub attempts: Vec<DeliveryAttempt>,
+    pub total_delay_ms: u64,
+    pub plan: DeliveryPlan,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ResolvedSendPolicy {
+    pub max_attempts: u32,
+    pub timeout_ms: Option<u64>,
+    pub retry_backoff: BackoffSchedule,
+    pub queue_pressure_max_attempts: u32,
+    pub queue_pressure_strategy: QueuePressureStrategy,
+    pub queue_pressure_backoff: BackoffSchedule,
+}
+
+impl ResolvedSendPolicy {
+    pub(crate) fn classify_failure(
+        &self,
+        attempt: u32,
+        err: &Error,
+        elapsed_ms: u64,
+    ) -> AttemptDecision {
+        if let Some(timeout_ms) = self.timeout_ms {
+            if elapsed_ms >= timeout_ms {
+                return AttemptDecision::Timeout(Error {
+                    code: ErrorCode::TimeoutOperationExpired,
+                    category: ErrorCategory::Timeout,
+                    retryable: false,
+                    terminal: true,
+                    user_action_required: false,
+                    message: format!("send helper exceeded timeout budget of {timeout_ms}ms"),
+                    details: [("timeout_ms".to_owned(), serde_json::Value::from(timeout_ms))]
+                        .into_iter()
+                        .collect(),
+                    cause_code: Some(root_cause_code(err)),
+                });
+            }
+        }
+
+        if matches!(err.code, ErrorCode::DeliveryQueuePressure) {
+            if self.queue_pressure_strategy == QueuePressureStrategy::Retry
+                && attempt < self.queue_pressure_max_attempts
+            {
+                return AttemptDecision::Retry(self.queue_pressure_backoff.delay_for_attempt(attempt));
+            }
+            return AttemptDecision::Stop(err.clone());
+        }
+
+        if err.retryable && attempt < self.max_attempts {
+            return AttemptDecision::Retry(self.retry_backoff.delay_for_attempt(attempt));
+        }
+
+        if err.retryable && attempt >= self.max_attempts {
+            return AttemptDecision::Stop(Error {
+                code: ErrorCode::DeliveryRetryExhausted,
+                category: ErrorCategory::Delivery,
+                retryable: false,
+                terminal: true,
+                user_action_required: false,
+                message: format!("send helper exhausted retry policy after {attempt} attempts"),
+                details: [("attempts".to_owned(), serde_json::Value::from(attempt))]
+                    .into_iter()
+                    .collect(),
+                cause_code: Some(root_cause_code(err)),
+            });
+        }
+
+        AttemptDecision::Stop(err.clone())
+    }
+}
+
+fn root_cause_code(err: &Error) -> String {
+    err.cause_code.clone().unwrap_or_else(|| err.code.as_str().to_owned())
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum AttemptDecision {
+    Retry(u64),
+    Stop(Error),
+    Timeout(Error),
+}

--- a/crates/libs/lxmf-sdk/src/app/mod.rs
+++ b/crates/libs/lxmf-sdk/src/app/mod.rs
@@ -1,9 +1,17 @@
 mod capabilities;
+mod config;
+mod delivery;
 mod errors;
 mod events;
 mod node;
+mod profiles;
 
 pub use capabilities::CapabilitySummary;
+pub use delivery::{
+    AttemptDisposition, BackoffSchedule, DeliveryAttempt, DeliveryOptions, DeliveryPlan,
+    QueuePressurePolicy, QueuePressureStrategy, ReconnectPolicy, RetryPolicy, SendReport,
+    TimeoutPolicy,
+};
 pub use errors::{Error, ErrorCategory, ErrorCode};
 pub use events::{Event, EventBatch, EventKind, EventMetadata, Severity, StreamGapDetails, SubscriptionStart};
 pub use node::{Client, Config, DeliveryState, DeliveryStatus, Handle, Profile, RunState, RuntimeStatus, SendReceipt, SendRequest};

--- a/crates/libs/lxmf-sdk/src/app/node.rs
+++ b/crates/libs/lxmf-sdk/src/app/node.rs
@@ -1,4 +1,8 @@
 use super::capabilities::CapabilitySummary;
+use super::delivery::{
+    AttemptDecision, AttemptDisposition, DeliveryAttempt, DeliveryOptions, DeliveryPlan,
+    SendReport,
+};
 use super::errors::Error;
 #[cfg(feature = "sdk-async")]
 use super::events::{
@@ -15,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -58,45 +63,19 @@ pub struct Config {
 
 impl Config {
     pub fn mobile_default() -> Self {
-        Self {
-            profile: Profile::MobileDefault,
-            sdk_config: SdkConfig::desktop_local_default(),
-            supported_contract_versions: vec![2],
-            requested_capabilities: Vec::new(),
-            event_batch_size: Some(32),
-        }
+        Self::from_profile(Profile::MobileDefault)
     }
 
     pub fn desktop_default() -> Self {
-        Self {
-            profile: Profile::DesktopDefault,
-            sdk_config: SdkConfig::desktop_full_default(),
-            supported_contract_versions: vec![2],
-            requested_capabilities: Vec::new(),
-            event_batch_size: Some(64),
-        }
+        Self::from_profile(Profile::DesktopDefault)
     }
 
     pub fn embedded_default() -> Self {
-        Self {
-            profile: Profile::EmbeddedDefault,
-            sdk_config: SdkConfig::embedded_alloc_default(),
-            supported_contract_versions: vec![2],
-            requested_capabilities: Vec::new(),
-            event_batch_size: Some(16),
-        }
+        Self::from_profile(Profile::EmbeddedDefault)
     }
 
     pub fn testing_default() -> Self {
-        let mut sdk_config = SdkConfig::desktop_local_default();
-        sdk_config.event_stream.max_poll_events = 32;
-        Self {
-            profile: Profile::TestingDefault,
-            sdk_config,
-            supported_contract_versions: vec![2],
-            requested_capabilities: Vec::new(),
-            event_batch_size: Some(16),
-        }
+        Self::from_profile(Profile::TestingDefault)
     }
 
     pub fn with_requested_capability(mut self, capability: impl Into<String>) -> Self {
@@ -187,6 +166,11 @@ impl SendRequest {
 
     pub fn with_correlation_id(mut self, correlation_id: impl Into<String>) -> Self {
         self.correlation_id = Some(correlation_id.into());
+        self
+    }
+
+    pub fn with_extension(mut self, key: impl Into<String>, value: JsonValue) -> Self {
+        self.extensions.insert(key.into(), value);
         self
     }
 
@@ -332,6 +316,19 @@ impl<B: SdkBackend> Client<B> {
         Self { backend, state: Mutex::new(State::default()) }
     }
 
+    fn active_config(&self) -> Result<Config, Error> {
+        let state = self.state.lock().expect("app client mutex poisoned");
+        let Some(session) = state.session.as_ref() else {
+            return Err(Error::not_started());
+        };
+        let session = session.lock().expect("app session mutex poisoned");
+        Ok(session.config.clone())
+    }
+
+    pub fn delivery_plan(&self) -> Result<DeliveryPlan, Error> {
+        Ok(self.active_config()?.delivery_plan())
+    }
+
     pub fn start(&self, config: Config) -> Result<Handle, Error> {
         let mut state = self.state.lock().expect("app client mutex poisoned");
         if state.client.is_none() && state.session.is_some() {
@@ -398,6 +395,73 @@ impl<B: SdkBackend> Client<B> {
             profile: session.config.profile.clone(),
             correlation_id,
         })
+    }
+
+    pub fn send_with_profile_defaults(&self, request: SendRequest) -> Result<SendReport, Error> {
+        self.send_with_options(request, DeliveryOptions::default())
+    }
+
+    pub fn send_with_options(
+        &self,
+        request: SendRequest,
+        options: DeliveryOptions,
+    ) -> Result<SendReport, Error> {
+        let plan = self.delivery_plan()?;
+        let resolved = plan.resolve(&options);
+        let started = Instant::now();
+        let mut attempts: Vec<DeliveryAttempt> = Vec::new();
+        let mut request = request;
+
+        loop {
+            let attempt_no = attempts.len() as u32 + 1;
+            match self.send(request.clone()) {
+                Ok(receipt) => {
+                    let total_delay_ms =
+                        attempts
+                            .iter()
+                            .filter_map(|attempt: &DeliveryAttempt| attempt.scheduled_delay_ms)
+                            .sum::<u64>();
+                    return Ok(SendReport { receipt, attempts, total_delay_ms, plan });
+                }
+                Err(err) => match resolved.classify_failure(
+                    attempt_no,
+                    &err,
+                    started.elapsed().as_millis() as u64,
+                ) {
+                    AttemptDecision::Retry(delay_ms) => {
+                        attempts.push(DeliveryAttempt {
+                            attempt: attempt_no,
+                            disposition: AttemptDisposition::Retried,
+                            error_code: err.code.as_str().to_owned(),
+                            retryable: err.retryable,
+                            queue_pressure: matches!(
+                                err.code,
+                                super::errors::ErrorCode::DeliveryQueuePressure
+                            ),
+                            scheduled_delay_ms: Some(delay_ms),
+                        });
+                        if delay_ms > 0 {
+                            std::thread::sleep(Duration::from_millis(delay_ms));
+                        }
+                        request = request.clone();
+                    }
+                    AttemptDecision::Stop(stop_err) | AttemptDecision::Timeout(stop_err) => {
+                        attempts.push(DeliveryAttempt {
+                            attempt: attempt_no,
+                            disposition: AttemptDisposition::Failed,
+                            error_code: err.code.as_str().to_owned(),
+                            retryable: err.retryable,
+                            queue_pressure: matches!(
+                                err.code,
+                                super::errors::ErrorCode::DeliveryQueuePressure
+                            ),
+                            scheduled_delay_ms: None,
+                        });
+                        return Err(stop_err);
+                    }
+                },
+            }
+        }
     }
 
     pub fn delivery_status(
@@ -583,6 +647,7 @@ mod tests {
     use super::{
         Client, Config, DeliveryState, Profile, RunState, SendRequest, SubscriptionStart,
     };
+    use crate::app::DeliveryOptions;
     use crate::error::{code, ErrorCategory as SdkErrorCategory, SdkError};
     use crate::event::{
         EventBatch as RawEventBatch, EventCursor, EventSubscription, SdkEvent,
@@ -603,6 +668,7 @@ mod tests {
         runtime_seq: AtomicUsize,
         send_seq: AtomicUsize,
         poll_batches: Mutex<VecDeque<RawEventBatch>>,
+        send_results: Mutex<VecDeque<Result<crate::MessageId, SdkError>>>,
         shutdown_calls: AtomicUsize,
         shutdown_results: Mutex<VecDeque<Result<Ack, SdkError>>>,
     }
@@ -613,6 +679,7 @@ mod tests {
                 runtime_seq: AtomicUsize::new(1),
                 send_seq: AtomicUsize::new(1),
                 poll_batches: Mutex::new(VecDeque::new()),
+                send_results: Mutex::new(VecDeque::new()),
                 shutdown_calls: AtomicUsize::new(0),
                 shutdown_results: Mutex::new(VecDeque::new()),
             }
@@ -624,6 +691,10 @@ mod tests {
 
         fn queue_shutdown_result(&self, result: Result<Ack, SdkError>) {
             self.shutdown_results.lock().expect("shutdown results").push_back(result);
+        }
+
+        fn queue_send_result(&self, result: Result<crate::MessageId, SdkError>) {
+            self.send_results.lock().expect("send results").push_back(result);
         }
     }
 
@@ -657,7 +728,16 @@ mod tests {
         }
 
         fn send(&self, _req: RawSendRequest) -> Result<crate::MessageId, SdkError> {
-            Ok(crate::MessageId(format!("msg-{}", self.send_seq.fetch_add(1, Ordering::Relaxed))))
+            self.send_results
+                .lock()
+                .expect("send results")
+                .pop_front()
+                .unwrap_or_else(|| {
+                    Ok(crate::MessageId(format!(
+                        "msg-{}",
+                        self.send_seq.fetch_add(1, Ordering::Relaxed)
+                    )))
+                })
         }
 
         fn cancel(&self, _id: crate::MessageId) -> Result<CancelResult, SdkError> {
@@ -888,5 +968,89 @@ mod tests {
             .restart(Config::desktop_default())
             .expect_err("restart should fail when stop fails");
         assert_eq!(err.code.as_str(), "SDK_APP_INTERNAL_UNEXPECTED_FAILURE");
+    }
+
+    #[test]
+    fn delivery_plan_tracks_profile_defaults() {
+        let config = Config::desktop_default();
+        let plan = config.delivery_plan();
+
+        assert_eq!(plan.profile, Profile::DesktopDefault);
+        assert_eq!(plan.retry.max_attempts, 5);
+        assert!(plan.reconnect.enabled);
+        assert_eq!(plan.default_event_batch_size, 64);
+        assert!(plan.redaction_enabled);
+    }
+
+    #[test]
+    fn send_with_profile_defaults_retries_queue_pressure() {
+        let backend = MockBackend::new();
+        backend.queue_send_result(Err(SdkError::new(
+            "SDK_RUNTIME_STORE_FORWARD_CAPACITY_REACHED",
+            SdkErrorCategory::Runtime,
+            "full",
+        )
+        .with_retryable(true)));
+        let app = Client::new(backend);
+        app.start(Config::desktop_default()).expect("start");
+
+        let report = app
+            .send_with_profile_defaults(SendRequest::new("src", "dst", json!({ "body": "hello" })))
+            .expect("report");
+
+        assert_eq!(report.attempts.len(), 1);
+        assert_eq!(report.attempts[0].disposition, super::super::delivery::AttemptDisposition::Retried);
+        assert!(report.attempts[0].queue_pressure);
+        assert_eq!(report.receipt.profile, Profile::DesktopDefault);
+    }
+
+    #[test]
+    fn send_with_options_can_fail_fast_on_queue_pressure() {
+        let backend = MockBackend::new();
+        backend.queue_send_result(Err(SdkError::new(
+            "SDK_RUNTIME_STORE_FORWARD_CAPACITY_REACHED",
+            SdkErrorCategory::Runtime,
+            "full",
+        )
+        .with_retryable(true)));
+        let app = Client::new(backend);
+        app.start(Config::desktop_default()).expect("start");
+
+        let err = app
+            .send_with_options(
+                SendRequest::new("src", "dst", json!({ "body": "hello" })),
+                super::super::delivery::DeliveryOptions {
+                    queue_pressure_strategy: Some(super::super::delivery::QueuePressureStrategy::FailFast),
+                    ..Default::default()
+                },
+            )
+            .expect_err("queue pressure should fail fast");
+
+        assert_eq!(err.code.as_str(), "SDK_APP_DELIVERY_QUEUE_PRESSURE");
+    }
+
+    #[test]
+    fn send_with_options_maps_retry_exhaustion() {
+        let backend = MockBackend::new();
+        backend.queue_send_result(Err(
+            SdkError::new(code::INTERNAL, SdkErrorCategory::Internal, "temporary")
+                .with_retryable(true),
+        ));
+        backend.queue_send_result(Err(
+            SdkError::new(code::INTERNAL, SdkErrorCategory::Internal, "temporary")
+                .with_retryable(true),
+        ));
+        let app = Client::new(backend);
+        app.start(Config::testing_default()).expect("start");
+
+        let err = app
+            .send_with_options(
+                SendRequest::new("src", "dst", json!({ "body": "hello" })),
+                DeliveryOptions { max_attempts: Some(2), ..Default::default() },
+            )
+            .expect_err("retry exhaustion");
+
+        assert_eq!(err.code.as_str(), "SDK_APP_DELIVERY_RETRY_EXHAUSTED");
+        assert_eq!(err.cause_code.as_deref(), Some("SDK_INTERNAL_ERROR"));
     }
 }

--- a/crates/libs/lxmf-sdk/src/app/profiles.rs
+++ b/crates/libs/lxmf-sdk/src/app/profiles.rs
@@ -1,0 +1,117 @@
+use super::delivery::{
+    BackoffSchedule, DeliveryPlan, QueuePressurePolicy, QueuePressureStrategy, ReconnectPolicy,
+    RetryPolicy, TimeoutPolicy,
+};
+use super::node::Profile;
+
+impl Profile {
+    pub fn defaults(&self) -> DeliveryPlan {
+        match self {
+            Self::MobileDefault => DeliveryPlan {
+                profile: self.clone(),
+                retry: RetryPolicy {
+                    max_attempts: 3,
+                    backoff: BackoffSchedule::exponential(250, 2, 2_000),
+                },
+                reconnect: ReconnectPolicy {
+                    enabled: true,
+                    max_attempts: Some(5),
+                    backoff: BackoffSchedule::exponential(500, 2, 10_000),
+                },
+                queue_pressure: QueuePressurePolicy {
+                    strategy: QueuePressureStrategy::Retry,
+                    max_attempts: 3,
+                    backoff: BackoffSchedule::exponential(100, 2, 750),
+                },
+                timeout: TimeoutPolicy {
+                    send_timeout_ms: Some(5_000),
+                    event_next_timeout_ms: Some(1_000),
+                    reconnect_grace_ms: Some(15_000),
+                },
+                durable_queueing: false,
+                restart_recovery: false,
+                default_event_batch_size: 32,
+                redaction_enabled: true,
+            },
+            Self::DesktopDefault => DeliveryPlan {
+                profile: self.clone(),
+                retry: RetryPolicy {
+                    max_attempts: 5,
+                    backoff: BackoffSchedule::exponential(200, 2, 5_000),
+                },
+                reconnect: ReconnectPolicy {
+                    enabled: true,
+                    max_attempts: Some(10),
+                    backoff: BackoffSchedule::exponential(500, 2, 15_000),
+                },
+                queue_pressure: QueuePressurePolicy {
+                    strategy: QueuePressureStrategy::Retry,
+                    max_attempts: 4,
+                    backoff: BackoffSchedule::exponential(100, 2, 1_000),
+                },
+                timeout: TimeoutPolicy {
+                    send_timeout_ms: Some(10_000),
+                    event_next_timeout_ms: Some(2_000),
+                    reconnect_grace_ms: Some(30_000),
+                },
+                durable_queueing: false,
+                restart_recovery: false,
+                default_event_batch_size: 64,
+                redaction_enabled: true,
+            },
+            Self::EmbeddedDefault => DeliveryPlan {
+                profile: self.clone(),
+                retry: RetryPolicy {
+                    max_attempts: 2,
+                    backoff: BackoffSchedule::exponential(500, 2, 2_000),
+                },
+                reconnect: ReconnectPolicy {
+                    enabled: false,
+                    max_attempts: Some(1),
+                    backoff: BackoffSchedule::fixed(1_000),
+                },
+                queue_pressure: QueuePressurePolicy {
+                    strategy: QueuePressureStrategy::FailFast,
+                    max_attempts: 1,
+                    backoff: BackoffSchedule::fixed(0),
+                },
+                timeout: TimeoutPolicy {
+                    send_timeout_ms: Some(3_000),
+                    event_next_timeout_ms: Some(500),
+                    reconnect_grace_ms: None,
+                },
+                durable_queueing: false,
+                restart_recovery: false,
+                default_event_batch_size: 16,
+                redaction_enabled: true,
+            },
+            Self::TestingDefault => DeliveryPlan {
+                profile: self.clone(),
+                retry: RetryPolicy {
+                    max_attempts: 2,
+                    backoff: BackoffSchedule::fixed(10),
+                },
+                reconnect: ReconnectPolicy {
+                    enabled: true,
+                    max_attempts: Some(2),
+                    backoff: BackoffSchedule::fixed(25),
+                },
+                queue_pressure: QueuePressurePolicy {
+                    strategy: QueuePressureStrategy::FailFast,
+                    max_attempts: 1,
+                    backoff: BackoffSchedule::fixed(0),
+                },
+                timeout: TimeoutPolicy {
+                    send_timeout_ms: Some(500),
+                    event_next_timeout_ms: Some(100),
+                    reconnect_grace_ms: Some(250),
+                },
+                durable_queueing: false,
+                restart_recovery: false,
+                default_event_batch_size: 16,
+                redaction_enabled: true,
+            },
+        }
+    }
+}
+

--- a/docs/contracts/sdk-app-api-v1.md
+++ b/docs/contracts/sdk-app-api-v1.md
@@ -68,7 +68,8 @@ Optional additive helpers:
 - `restart(config)`
 - `flush(timeout)`
 - `reconnect()`
-- `send_with_policy(request, policy_override)`
+- `send_with_profile_defaults(request)`
+- `send_with_options(request, options)`
 
 ## Lifecycle State Machine
 
@@ -138,6 +139,7 @@ Rules:
 2. Wrappers may expose override hooks, but overrides must start from a known contract-defined default.
 3. Timeout behavior must be stable across languages.
 4. “Retryable” vs “terminal” failure classification must be part of the typed error model.
+5. The default Rust app surface may expose profile-derived delivery helpers that apply bounded retry and queue-pressure policy without requiring caller-owned retry loops.
 
 ## Persistence and Offline Recovery
 

--- a/docs/contracts/sdk-app-profiles-v1.md
+++ b/docs/contracts/sdk-app-profiles-v1.md
@@ -21,6 +21,14 @@ Required presets:
 - `embedded_default`
 - `testing_default`
 
+Current Rust reference surface:
+
+- `app::Profile::defaults() -> DeliveryPlan`
+- `Config::from_profile(profile)`
+- `Config::delivery_plan()`
+- `Client::send_with_profile_defaults(request)`
+- `Client::send_with_options(request, options)`
+
 Rules:
 
 1. Profiles are immutable for a running app-api session unless the contract explicitly allows a mutable subset.
@@ -102,6 +110,33 @@ Required defaults:
 - reduced jitter in retry/backoff policy
 - explicit failure visibility over silent auto-healing
 - diagnostics suitable for contract assertions
+
+## Reference Defaults
+
+The current Rust reference implementation freezes these defaults:
+
+- `mobile_default`
+  - retry attempts: `3`
+  - retry backoff: `250ms`, `x2`, capped at `2000ms`
+  - queue pressure: bounded retry, `3` attempts
+  - reconnect: enabled, bounded
+
+- `desktop_default`
+  - retry attempts: `5`
+  - retry backoff: `200ms`, `x2`, capped at `5000ms`
+  - queue pressure: bounded retry, `4` attempts
+  - reconnect: enabled, bounded
+
+- `embedded_default`
+  - retry attempts: `2`
+  - queue pressure: fail fast
+  - reconnect: disabled by default
+
+- `testing_default`
+  - retry attempts: `2`
+  - fixed `10ms` retry backoff
+  - queue pressure: fail fast
+  - reconnect: enabled with fixed `25ms` backoff
 
 ## Policy Defaults
 

--- a/docs/sdk/configuration-profiles.md
+++ b/docs/sdk/configuration-profiles.md
@@ -1,6 +1,24 @@
 # SDK Configuration and Profiles
 
 `SdkConfig` combines runtime policy, event buffering, redaction, and RPC transport controls.
+The app-facing layer in `lxmf_sdk::app` adds profile-derived policy helpers on top of that lower-level config surface.
+
+## App Profiles
+
+For most apps, start from the app-facing presets instead of constructing `SdkConfig` manually:
+
+- `app::Config::from_profile(app::Profile::MobileDefault)`
+- `app::Config::from_profile(app::Profile::DesktopDefault)`
+- `app::Config::from_profile(app::Profile::EmbeddedDefault)`
+- `app::Config::from_profile(app::Profile::TestingDefault)`
+
+The app layer also exposes:
+
+- `Config::delivery_plan()`
+- `Client::send_with_profile_defaults(request)`
+- `Client::send_with_options(request, options)`
+
+These helpers apply the profile’s bounded retry and queue-pressure policy so callers do not need their own default retry loops.
 
 ## Profile Selection
 


### PR DESCRIPTION
## Summary
- add app-layer profile policy and delivery planning types under 
- implement , , and bounded delivery helpers on 
- document the current app profile defaults and delivery helper entrypoints in the app contracts and SDK guide

## Testing
- cargo check -p lxmf-sdk --no-default-features --features std
- cargo test -p lxmf-sdk
- cargo test -p test-support sdk_conformance_app_mode -- --nocapture

Closes #30