### PR TITLE
Bump rusqlite to 0.37.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ loom = "0.7"
 serde_bytes = "0.11"
 rmp-serde = "1.3.0"
 rmpv = "1.3.0"
-rusqlite = { version = "0.31.0", features = ["bundled"] }
+rusqlite = { version = "0.37.0", features = ["bundled"] }
 time = "0.3.45"
 tokio-util = "0.7.15"
 bzip2 = "0.4"


### PR DESCRIPTION
## Summary

Bumps `rusqlite` from 0.31.0 → 0.37.0 in the workspace's dependency list. One line in `Cargo.toml`, no code changes required.

## Motivation

Cargo enforces a hard single-copy constraint on any crate declaring `links = "sqlite3"` (which `libsqlite3-sys` does). When a downstream workspace wants to compose `reticulum-rs-transport` with other crates already on `rusqlite 0.37` — notably Holochain's `holo_hash` and `holochain_sqlite` — `cargo metadata` refuses to resolve the graph because two `libsqlite3-sys` versions would end up linked.

This blocks the transport from being adopted in any workspace that uses recent Holochain (or more broadly, any workspace that's moved to rusqlite 0.37), even when the transport is gated behind an optional feature — the conflict is caught at resolution time, before feature selection.

## Verification

- No rusqlite API changes between 0.31 and 0.37 in the surface this crate uses (`Connection`, `execute`, `prepare`, `params!`, `Row::get`).
- `cargo test --workspace --lib` passes (133 tests) against the bumped version.
- Downstream consumers on rusqlite 0.37 can now include this crate without patching.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace --lib`
- [ ] CI green

We've been carrying this as a `[patch.crates-io]` override on a fork branch in the [lightningrodlabs/kitsune2](https://github.com/lightningrodlabs/kitsune2) fork's Reticulum transport work. Would be great to retire the patch once this lands in a release.