### PR TITLE
Fix daemon LXMF and RNS runtime findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/apps/lxmf-cli/src/bin/lxmd/config.rs
+++ b/crates/apps/lxmf-cli/src/bin/lxmd/config.rs
@@ -479,11 +479,7 @@ pub(crate) fn parse_python_reticulum_interfaces(input: &str) -> Vec<crate::Singl
             "target_port" | "listen_port" | "port" => {
                 current.port = value.parse::<u16>().ok();
             }
-            "listen_ip" => {
-                if !value.is_empty() {
-                    current.host = Some(value.to_string());
-                }
-            }
+            "listen_ip" if !value.is_empty() => current.host = Some(value.to_string()),
             _ => {}
         }
     }

--- a/crates/apps/lxmf-cli/src/bin/lxmd/query.rs
+++ b/crates/apps/lxmf-cli/src/bin/lxmd/query.rs
@@ -174,7 +174,7 @@ fn print_remote_peer_summary(status: &serde_json::Value) {
     }
 
     let mut rows: Vec<_> = peers.iter().collect();
-    rows.sort_by(|(left, _), (right, _)| left.cmp(right));
+    rows.sort_by_key(|(peer, _)| *peer);
     for (peer, details) in rows {
         let name = details.get("name").and_then(|value| value.as_str()).unwrap_or("");
         let last_heard = details.get("last_heard").and_then(|value| value.as_i64()).unwrap_or(0);

--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap.rs
@@ -150,8 +150,11 @@ pub(super) async fn bootstrap(args: Args) -> BootstrapContext {
         panic!("{policy_error}");
     }
 
-    let transport_summary =
-        selected_tcp_server.bind_addr.clone().unwrap_or_else(|| "disabled".to_string());
+    let transport_summary = if transport.is_some() {
+        selected_tcp_server.bind_addr.clone().unwrap_or_else(|| "configured interfaces".to_string())
+    } else {
+        "disabled".to_string()
+    };
     println!(
         "{}",
         pretty_boot_line(

--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport.rs
@@ -75,7 +75,10 @@ pub(super) async fn start_transport_and_interfaces(
         Ok(selection) => selection,
         Err(err) => panic!("{err}"),
     };
-    let transport_required = selected_tcp_server.bind_addr.is_some();
+    let has_enabled_configured_interface =
+        daemon_config.is_some_and(|config| config.interfaces.iter().any(|iface| iface.enabled()));
+    let transport_required =
+        selected_tcp_server.bind_addr.is_some() || has_enabled_configured_interface;
 
     let mut transport: Option<Arc<Transport>> = None;
     let peer_crypto: Arc<Mutex<HashMap<String, PeerCrypto>>> = Arc::new(Mutex::new(HashMap::new()));

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
@@ -30,16 +30,23 @@ impl TransportBridge {
             .transpose()?;
         let request_identity = identity_override.unwrap_or_else(|| self.signer.clone());
         let timeout = Duration::from_secs_f64(timeout_secs.max(0.1));
+        let path = path.to_string();
         let transport = self.transport.clone();
         let identity_cache = self.outbound_propagation_identities.clone();
 
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async move {
+        std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|err| {
+                    std::io::Error::other(format!("failed to build remote control runtime: {err}"))
+                })?;
+            runtime.block_on(async move {
                 let result = remote_control_request(
                     transport.as_ref(),
                     &request_identity,
                     &remote,
-                    path,
+                    &path,
                     data,
                     timeout,
                 )
@@ -52,6 +59,8 @@ impl TransportBridge {
                 result.map(|(json, _)| json)
             })
         })
+        .join()
+        .map_err(|_| std::io::Error::other("remote control helper thread panicked"))?
     }
 }
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker.rs
@@ -4,24 +4,26 @@ use super::bridge_helpers::{diagnostics_enabled, payload_preview};
 mod control;
 #[path = "inbound_propagation.rs"]
 mod propagation;
-use lxmf::inbound_decode::InboundPayloadMode;
+use lxmf::{inbound_decode::InboundPayloadMode, WireMessage};
 use reticulum_daemon::inbound_delivery::{
     annotate_inbound_record_stamp_status, decode_inbound_payload,
     decode_inbound_payload_with_diagnostics, evaluate_inbound_stamp_policy,
 };
 use reticulum_daemon::receipt_bridge::ReceiptEvent;
-use rns_rpc::{RpcDaemon, RpcRequest};
+use rns_rpc::{MessageRecord, RpcDaemon, RpcRequest};
 use rns_transport::destination::link::{Link, LinkEvent};
 use rns_transport::destination::{DestinationDesc, DestinationName, SingleInputDestination};
 use rns_transport::hash::AddressHash;
 use rns_transport::identity::{DecryptIdentity, Identity};
+use rns_transport::identity_bridge::to_core_identity;
 use rns_transport::packet::{
     ContextFlag, DestinationType, Header, HeaderType, IfacFlag, Packet, PacketContext,
     PacketDataBuffer, PacketType, PropagationType,
 };
 use rns_transport::resource::ResourceEventKind;
 use rns_transport::transport::{ReceivedPayloadMode, Transport};
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
@@ -41,6 +43,80 @@ fn inbound_payload_mode(mode: ReceivedPayloadMode) -> InboundPayloadMode {
         ReceivedPayloadMode::FullWire => InboundPayloadMode::FullWire,
         ReceivedPayloadMode::DestinationStripped => InboundPayloadMode::DestinationStripped,
     }
+}
+
+async fn annotate_inbound_signature_status(
+    transport: &Transport,
+    record: &mut MessageRecord,
+    destination: [u8; 16],
+    payload: &[u8],
+    mode: InboundPayloadMode,
+) {
+    let wire = match mode {
+        InboundPayloadMode::FullWire => Cow::Borrowed(payload),
+        InboundPayloadMode::DestinationStripped => {
+            let mut with_destination = Vec::with_capacity(16 + payload.len());
+            with_destination.extend_from_slice(&destination);
+            with_destination.extend_from_slice(payload);
+            Cow::Owned(with_destination)
+        }
+    };
+
+    let mut checked = false;
+    let mut valid = false;
+    let mut reason = "source_identity_unknown".to_string();
+
+    match WireMessage::unpack(wire.as_ref()) {
+        Ok(message) => {
+            let source_hash = AddressHash::new(message.source);
+            if let Some(identity) = transport.destination_identity(&source_hash).await {
+                checked = true;
+                match message.verify(&to_core_identity(&identity)) {
+                    Ok(true) => {
+                        valid = true;
+                        reason = "verified".to_string();
+                    }
+                    Ok(false) => {
+                        reason = "signature_invalid".to_string();
+                    }
+                    Err(error) => {
+                        reason = format!("verification_error: {error}");
+                    }
+                }
+            }
+        }
+        Err(error) => {
+            reason = format!("decode_error: {error}");
+        }
+    }
+
+    annotate_lxmf_metadata(record, |lxmf| {
+        lxmf.insert("signature_checked".to_string(), Value::Bool(checked));
+        lxmf.insert("signature_valid".to_string(), Value::Bool(valid));
+        lxmf.insert("signature_status".to_string(), Value::String(reason));
+    });
+}
+
+fn annotate_lxmf_metadata(
+    record: &mut MessageRecord,
+    update: impl FnOnce(&mut Map<String, Value>),
+) {
+    let mut root = match record.fields.take() {
+        Some(Value::Object(map)) => map,
+        Some(other) => {
+            let mut map = Map::new();
+            map.insert("_fields_raw".to_string(), other);
+            map
+        }
+        None => Map::new(),
+    };
+    let mut lxmf = match root.remove("_lxmf") {
+        Some(Value::Object(map)) => map,
+        _ => Map::new(),
+    };
+    update(&mut lxmf);
+    root.insert("_lxmf".to_string(), Value::Object(lxmf));
+    record.fields = Some(Value::Object(root));
 }
 
 pub(super) fn spawn_inbound_worker(
@@ -93,6 +169,14 @@ pub(super) fn spawn_inbound_worker(
                                             &mut record,
                                             stamp_status,
                                         );
+                                        annotate_inbound_signature_status(
+                                            transport.as_ref(),
+                                            &mut record,
+                                            destination,
+                                            &complete.data,
+                                            InboundPayloadMode::FullWire,
+                                        )
+                                        .await;
                                         let _ =
                                             daemon.accept_inbound_with_raw(record, &complete.data);
                                     }
@@ -294,6 +378,14 @@ fn spawn_packet_inbound_worker(
                                 if let Some(stamp_status) = stamp_status {
                                     annotate_inbound_record_stamp_status(&mut record, stamp_status);
                                 }
+                                annotate_inbound_signature_status(
+                                    inbound_transport.as_ref(),
+                                    &mut record,
+                                    destination,
+                                    data,
+                                    payload_mode,
+                                )
+                                .await;
                                 daemon_inbound
                                     .record_inbound_peer_activity(&record.source, data.len());
                                 let _ = daemon_inbound.accept_inbound_with_raw(record, data);

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop.rs
@@ -353,10 +353,8 @@ fn build_tls_server_config(config: &RpcTlsConfig) -> io::Result<std::sync::Arc<S
     let builder = ServerConfig::builder();
     let server_config = if let Some(client_ca_path) = config.client_ca_path.as_ref() {
         let roots = load_root_store(client_ca_path.as_path())?;
-        let verifier = WebPkiClientVerifier::builder(std::sync::Arc::new(roots))
-            .allow_unauthenticated()
-            .build()
-            .map_err(|err| {
+        let verifier =
+            WebPkiClientVerifier::builder(std::sync::Arc::new(roots)).build().map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::InvalidInput,
                     format!(

--- a/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
@@ -528,7 +528,7 @@ fn select_tcp_server_bind_rejects_multiple_enabled_servers_without_override() {
 }
 
 #[test]
-fn bootstrap_best_effort_marks_interfaces_inactive_when_transport_is_disabled() {
+fn bootstrap_best_effort_starts_configured_interfaces_without_transport_flag() {
     let temp = TempDir::new().expect("temp dir");
     let db_path = temp.path().join("reticulum.db");
     let config_path = temp.path().join("daemon.toml");
@@ -566,7 +566,7 @@ interfaces = [
             .and_then(|value| value.get("_runtime"))
             .and_then(|value| value.get("startup_status"))
             .and_then(|value| value.as_str()),
-        Some("inactive_transport_disabled")
+        Some("spawned")
     );
 }
 

--- a/crates/libs/lxmf-runtime/src/lib.rs
+++ b/crates/libs/lxmf-runtime/src/lib.rs
@@ -60,7 +60,10 @@ impl RuntimeHandle {
     }
 
     pub fn send_message(&self, _request: SendMessageRequest) -> SendMessageResponse {
-        SendMessageResponse { ok: true, reason: None }
+        SendMessageResponse {
+            ok: false,
+            reason: Some("lxmf-runtime boundary has no transport adapter attached".to_string()),
+        }
     }
 
     pub fn events_probe_report(&self) -> EventsProbeReport {

--- a/crates/libs/lxmf-sdk/src/messaging.rs
+++ b/crates/libs/lxmf-sdk/src/messaging.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -157,7 +158,7 @@ impl MessagingStore {
 
     pub fn list_announces(&self) -> Vec<AnnounceRecord> {
         let mut records = self.announce_records.values().cloned().collect::<Vec<_>>();
-        records.sort_by(|left, right| right.received_at_ms.cmp(&left.received_at_ms));
+        records.sort_by_key(|record| Reverse(record.received_at_ms));
         records
     }
 
@@ -245,7 +246,7 @@ impl MessagingStore {
             }
         }
 
-        peers.sort_by(|left, right| right.last_seen_at_ms.cmp(&left.last_seen_at_ms));
+        peers.sort_by_key(|peer| Reverse(peer.last_seen_at_ms));
         peers
     }
 
@@ -356,7 +357,7 @@ impl MessagingStore {
         }
 
         let mut out = by_conversation.into_values().collect::<Vec<_>>();
-        out.sort_by(|left, right| right.last_message_at_ms.cmp(&left.last_message_at_ms));
+        out.sort_by_key(|conversation| Reverse(conversation.last_message_at_ms));
         out
     }
 

--- a/crates/libs/rns-embedded-runtime/src/lib.rs
+++ b/crates/libs/rns-embedded-runtime/src/lib.rs
@@ -310,10 +310,7 @@ impl EmbeddedNodeRuntime {
             return Ok(());
         }
 
-        loop {
-            let Some(frame) = self.outbound.front().cloned() else {
-                break;
-            };
+        while let Some(frame) = self.outbound.front().cloned() {
             match transport.send_frame(&frame) {
                 Ok(()) => {
                     self.outbound.pop_front();

--- a/crates/libs/rns-transport/src/transport/core.rs
+++ b/crates/libs/rns-transport/src/transport/core.rs
@@ -1,14 +1,21 @@
 use super::jobs::manage_transport;
 use super::*;
 
+const TRANSPORT_EVENT_CHANNEL_CAPACITY: usize = 1024;
+
 impl Transport {
     pub fn new(config: TransportConfig) -> Self {
-        let (announce_tx, _) = tokio::sync::broadcast::channel(16);
-        let (link_in_event_tx, _) = tokio::sync::broadcast::channel(16);
-        let (link_out_event_tx, _) = tokio::sync::broadcast::channel(16);
-        let (received_data_tx, _) = tokio::sync::broadcast::channel(16);
-        let (iface_messages_tx, _) = tokio::sync::broadcast::channel(16);
-        let (resource_events_tx, _) = tokio::sync::broadcast::channel(16);
+        let (announce_tx, _) = tokio::sync::broadcast::channel(TRANSPORT_EVENT_CHANNEL_CAPACITY);
+        let (link_in_event_tx, _) =
+            tokio::sync::broadcast::channel(TRANSPORT_EVENT_CHANNEL_CAPACITY);
+        let (link_out_event_tx, _) =
+            tokio::sync::broadcast::channel(TRANSPORT_EVENT_CHANNEL_CAPACITY);
+        let (received_data_tx, _) =
+            tokio::sync::broadcast::channel(TRANSPORT_EVENT_CHANNEL_CAPACITY);
+        let (iface_messages_tx, _) =
+            tokio::sync::broadcast::channel(TRANSPORT_EVENT_CHANNEL_CAPACITY);
+        let (resource_events_tx, _) =
+            tokio::sync::broadcast::channel(TRANSPORT_EVENT_CHANNEL_CAPACITY);
 
         let iface_manager = InterfaceManager::new(128);
 

--- a/xtask/src/client_codegen.rs
+++ b/xtask/src/client_codegen.rs
@@ -2088,41 +2088,13 @@ fn validate_json_value(name: &str, value: &Value, schema: &Value) -> Result<()> 
             return Ok(());
         }
         match value_type {
-            "object" => {
-                if !value.is_object() {
-                    bail!("{name} must be object");
-                }
-            }
-            "array" => {
-                if !value.is_array() {
-                    bail!("{name} must be array");
-                }
-            }
-            "string" => {
-                if !value.is_string() {
-                    bail!("{name} must be string");
-                }
-            }
-            "number" => {
-                if !value.is_number() {
-                    bail!("{name} must be number");
-                }
-            }
-            "integer" => {
-                if !(value.is_i64() || value.is_u64()) {
-                    bail!("{name} must be integer");
-                }
-            }
-            "boolean" => {
-                if !value.is_boolean() {
-                    bail!("{name} must be boolean");
-                }
-            }
-            "null" => {
-                if !value.is_null() {
-                    bail!("{name} must be null");
-                }
-            }
+            "object" if !value.is_object() => bail!("{name} must be object"),
+            "array" if !value.is_array() => bail!("{name} must be array"),
+            "string" if !value.is_string() => bail!("{name} must be string"),
+            "number" if !value.is_number() => bail!("{name} must be number"),
+            "integer" if !(value.is_i64() || value.is_u64()) => bail!("{name} must be integer"),
+            "boolean" if !value.is_boolean() => bail!("{name} must be boolean"),
+            "null" if !value.is_null() => bail!("{name} must be null"),
             _ => {}
         }
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4177,7 +4177,7 @@ fn capture_platform_descriptor() -> Result<String> {
         });
         let arch = std::env::var("PROCESSOR_ARCHITECTURE")
             .unwrap_or_else(|_| std::env::consts::ARCH.to_string());
-        return Ok(format!("{release}; arch={arch}"));
+        Ok(format!("{release}; arch={arch}"))
     }
 
     #[cfg(not(target_family = "windows"))]


### PR DESCRIPTION
## Summary
- rebases the daemon LXMF/RNS runtime fixes onto current main
- starts reticulumd transport when any configured interface is enabled, not only when a TCP server bind is selected
- runs propagation remote-control requests on a helper thread with an owned Tokio current-thread runtime
- annotates inbound LXMF records with signature verification metadata when source identity is known
- requires client certificates when an RPC client CA is configured, increases transport event channel capacity, and preserves queued embedded-runtime sends when the transport is unavailable
- temporarily includes PR #152's CI/security cleanup so this draft branch can pass checks before #152 lands; once #152 is merged, that overlap should disappear from this PR's effective diff

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
- cargo check -p reticulumd
- cargo test -p reticulumd
- cargo audit --ignore RUSTSEC-2024-0421 --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2026-0009 --ignore RUSTSEC-2025-0134