### PR TITLE
udp multicast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,8 +1075,14 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "ahash",
+ "foldhash",
 ]
 
 [[package]]
@@ -1081,11 +1093,11 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1321,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1960,6 +1972,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sha2",
+ "socket2 0.5.10",
  "tempfile",
  "tokio",
  "tokio-serial",
@@ -2108,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.31.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator",
@@ -2391,6 +2404,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -2592,7 +2615,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/native.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/native.rs
@@ -11,7 +11,7 @@ use reticulum_daemon::config::InterfaceConfig;
 use rns_transport::buffer::{InputBuffer, OutputBuffer};
 use rns_transport::hash::AddressHash;
 use rns_transport::iface::hdlc::Hdlc;
-use rns_transport::iface::{Interface, InterfaceContext, InterfaceManager, RxMessage};
+use rns_transport::iface::{IfaceSource, Interface, InterfaceContext, InterfaceManager, RxMessage};
 use rns_transport::packet::Packet;
 use rns_transport::serde::Serialize;
 use std::pin::Pin;
@@ -139,7 +139,7 @@ impl BleGattInterface {
                                     let mut output = OutputBuffer::new(&mut hdlc_rx_buffer);
                                     if Hdlc::decode(frame, &mut output).is_ok() {
                                         if let Ok(packet) = Packet::deserialize(&mut InputBuffer::new(output.as_slice())) {
-                                            let _ = rx_channel.send(RxMessage { address: iface_address, packet }).await;
+                                            let _ = rx_channel.send(RxMessage { address: iface_address, packet, source: IfaceSource::None }).await;
                                         }
                                     }
                                     frame_buffer.drain(..=end);

--- a/crates/libs/rns-transport/Cargo.toml
+++ b/crates/libs/rns-transport/Cargo.toml
@@ -33,6 +33,7 @@ serde_json.workspace = true
 sha2.workspace = true
 log.workspace = true
 hex.workspace = true
+socket2 = { version = "0.5", features = ["all"] }
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 tokio-serial = { workspace = true }

--- a/crates/libs/rns-transport/src/iface.rs
+++ b/crates/libs/rns-transport/src/iface.rs
@@ -5,6 +5,7 @@ pub mod tcp_client;
 pub mod tcp_server;
 pub mod udp;
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::OnceLock;
@@ -45,10 +46,46 @@ pub struct TxDispatchTrace {
     pub failed_ifaces: usize,
 }
 
+/// Where a received packet came from at the wire level.
+///
+/// Packets arriving over a stream/serial medium have `None`; UDP packets
+/// carry the sender's socket address so the transport can route replies
+/// back unicast instead of re-broadcasting them onto a multicast group.
+#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
+pub enum IfaceSource {
+    #[default]
+    None,
+    Udp(SocketAddr),
+}
+
+/// Tags an interface's transmit semantics.
+///
+/// - `Unicast` (default): TCP / serial / point-to-point UDP. Carries
+///   both `Broadcast` and `Direct` tx.
+/// - `Multicast`: shared-group UDP. Carries `Broadcast` tx; `Direct` tx
+///   addressed at the iface itself is dropped by the tx-guard in
+///   `iface::udp` (nonsensical — multicast sockets broadcast every tx).
+///   Per-peer unicast traffic on this medium goes via `VirtualUnicast`
+///   siblings that share the host multicast socket.
+/// - `VirtualUnicast`: a *virtual* iface pinned to one peer over a host
+///   multicast iface. Registered via
+///   `InterfaceManager::register_virtual_iface`; shares its tx channel
+///   with the host iface so the host iface's tx task routes by
+///   destination. Skipped on `Broadcast` tx — the host iface already
+///   delivers broadcasts for the whole group.
+#[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
+pub enum IfaceRole {
+    #[default]
+    Unicast,
+    Multicast,
+    VirtualUnicast,
+}
+
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct RxMessage {
     pub address: AddressHash,
     pub packet: Packet,
+    pub source: IfaceSource,
 }
 
 pub struct InterfaceChannel {
@@ -93,6 +130,7 @@ struct LocalInterface {
     address: AddressHash,
     tx_send: InterfaceTxSender,
     stop: CancellationToken,
+    role: IfaceRole,
 }
 
 pub struct InterfaceContext<T: Interface> {
@@ -137,6 +175,10 @@ impl InterfaceManager {
     }
 
     pub fn new_channel(&mut self, tx_cap: usize) -> InterfaceChannel {
+        self.new_channel_with_role(tx_cap, IfaceRole::default())
+    }
+
+    pub fn new_channel_with_role(&mut self, tx_cap: usize, role: IfaceRole) -> InterfaceChannel {
         self.counter += 1;
 
         let counter_bytes = self.counter.to_le_bytes();
@@ -144,20 +186,26 @@ impl InterfaceManager {
 
         let (tx_send, tx_recv) = InterfaceChannel::make_tx_channel(tx_cap);
 
-        log::debug!("iface: create channel {}", address);
+        log::debug!("iface: create channel {} role={:?}", address, role);
 
         let stop = CancellationToken::new();
 
-        self.ifaces.push(LocalInterface { address, tx_send, stop: stop.clone() });
+        self.ifaces.push(LocalInterface { address, tx_send, stop: stop.clone(), role });
 
         InterfaceChannel { rx_channel: self.rx_send.clone(), tx_channel: tx_recv, address, stop }
     }
 
     pub fn new_context<T: Interface>(&mut self, inner: T) -> InterfaceContext<T> {
-        let channel = self.new_channel(DEFAULT_IFACE_TX_QUEUE_CAPACITY);
+        self.new_context_with_role(inner, IfaceRole::default())
+    }
 
+    pub fn new_context_with_role<T: Interface>(
+        &mut self,
+        inner: T,
+        role: IfaceRole,
+    ) -> InterfaceContext<T> {
+        let channel = self.new_channel_with_role(DEFAULT_IFACE_TX_QUEUE_CAPACITY, role);
         let inner = Arc::new(Mutex::new(inner));
-
         InterfaceContext::<T> { inner: inner.clone(), channel, cancel: self.cancel.clone() }
     }
 
@@ -167,12 +215,64 @@ impl InterfaceManager {
         R: std::future::Future<Output = ()> + Send + 'static,
         R::Output: Send + 'static,
     {
-        let context = self.new_context(inner);
+        self.spawn_as(inner, worker, IfaceRole::default())
+    }
+
+    pub fn spawn_as<T: Interface, F, R>(
+        &mut self,
+        inner: T,
+        worker: F,
+        role: IfaceRole,
+    ) -> AddressHash
+    where
+        F: FnOnce(InterfaceContext<T>) -> R,
+        R: std::future::Future<Output = ()> + Send + 'static,
+        R::Output: Send + 'static,
+    {
+        let context = self.new_context_with_role(inner, role);
         let address = *context.channel.address();
 
         task::spawn(worker(context));
 
         address
+    }
+
+    pub fn role(&self, address: &AddressHash) -> Option<IfaceRole> {
+        self.ifaces.iter().find(|i| i.address == *address).map(|i| i.role)
+    }
+
+    /// Register a virtual iface that shares its tx channel with an
+    /// existing host iface. Used by the UDP multicast iface to pin
+    /// per-peer point-to-point routes without spawning additional
+    /// sockets. Returns `None` if `host` is not registered.
+    ///
+    /// The returned `AddressHash` is used by the transport's routing
+    /// tables (path_table, link ingress_iface) so `Direct` tx
+    /// targeting this address is delivered into the host iface's tx
+    /// task, which then sends the packet unicast to the pinned peer
+    /// via its own socket.
+    pub fn register_virtual_iface(
+        &mut self,
+        host: AddressHash,
+        role: IfaceRole,
+    ) -> Option<AddressHash> {
+        let host_tx = self.ifaces.iter().find(|i| i.address == host).map(|i| i.tx_send.clone())?;
+
+        // Virtual iface gets its own CancellationToken so it can be
+        // stopped (and GC'd by `cleanup()`) independently of the host.
+        // A cloned token would share cancel state with the host,
+        // meaning stopping one would tear down the other.
+        let stop = CancellationToken::new();
+
+        self.counter += 1;
+        let counter_bytes = self.counter.to_le_bytes();
+        let address = AddressHash::new_from_hash(&Hash::new_from_slice(&counter_bytes[..]));
+
+        log::debug!("iface: register virtual iface {} on host {} role={:?}", address, host, role);
+
+        self.ifaces.push(LocalInterface { address, tx_send: host_tx, stop, role });
+
+        Some(address)
     }
 
     pub fn receiver(&self) -> Arc<tokio::sync::Mutex<InterfaceRxReceiver>> {
@@ -195,17 +295,36 @@ impl InterfaceManager {
         stopped
     }
 
+    /// Test-only: returns the number of tracked ifaces (live or stopped).
+    #[cfg(test)]
+    pub fn iface_count(&self) -> usize {
+        self.ifaces.len()
+    }
+
+    /// Test-only: returns true if any tracked iface has the given role.
+    #[cfg(test)]
+    pub fn has_role(&self, role: IfaceRole) -> bool {
+        self.ifaces.iter().any(|i| i.role == role)
+    }
+
     pub async fn send(&self, message: TxMessage) -> TxDispatchTrace {
         let mut trace = TxDispatchTrace::default();
         for iface in &self.ifaces {
             let should_send = match message.tx_type {
                 TxMessageType::Broadcast(address) => {
-                    let mut should_send = true;
-                    if let Some(address) = address {
-                        should_send = address != iface.address;
+                    // VirtualUnicast ifaces share their tx channel with a
+                    // host (multicast) iface, so broadcasting to both
+                    // would double-enqueue each packet. Skip them — the
+                    // host iface will carry the broadcast.
+                    if iface.role == IfaceRole::VirtualUnicast {
+                        false
+                    } else {
+                        let mut should_send = true;
+                        if let Some(address) = address {
+                            should_send = address != iface.address;
+                        }
+                        should_send
                     }
-
-                    should_send
                 }
                 TxMessageType::Direct(address) => address == iface.address,
             };
@@ -264,5 +383,72 @@ impl InterfaceManager {
         }
 
         trace
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A zero-sized Interface impl for tests that only exercise the
+    // manager's bookkeeping (registration, role tagging, lookup). No
+    // actual worker task is spawned by these tests; we only drive
+    // `new_channel_with_role` and the `role`/`stop_interface`/`cleanup`
+    // helpers.
+
+    #[test]
+    fn new_channel_defaults_to_unicast_role() {
+        let mut mgr = InterfaceManager::new(16);
+        let channel = mgr.new_channel(16);
+        assert_eq!(mgr.role(channel.address()), Some(IfaceRole::Unicast));
+    }
+
+    #[test]
+    fn new_channel_with_role_records_multicast_tag() {
+        let mut mgr = InterfaceManager::new(16);
+        let channel = mgr.new_channel_with_role(16, IfaceRole::Multicast);
+        assert_eq!(mgr.role(channel.address()), Some(IfaceRole::Multicast));
+        assert!(mgr.has_role(IfaceRole::Multicast));
+    }
+
+    #[test]
+    fn role_returns_none_for_unknown_address() {
+        let mgr = InterfaceManager::new(16);
+        let fake = AddressHash::new_from_hash(&Hash::new_from_slice(&[0u8; 32]));
+        assert_eq!(mgr.role(&fake), None);
+    }
+
+    #[test]
+    fn each_new_channel_gets_a_unique_address_hash() {
+        let mut mgr = InterfaceManager::new(16);
+        let a = *mgr.new_channel(16).address();
+        let b = *mgr.new_channel(16).address();
+        let c = *mgr.new_channel_with_role(16, IfaceRole::Multicast).address();
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(b, c);
+    }
+
+    #[test]
+    fn stop_interface_marks_iface_stopped_and_cleanup_removes_it() {
+        let mut mgr = InterfaceManager::new(16);
+        let channel = mgr.new_channel_with_role(16, IfaceRole::Multicast);
+        let addr = *channel.address();
+        assert_eq!(mgr.iface_count(), 1);
+        assert!(mgr.stop_interface(addr));
+        // stop_interface also calls cleanup() which prunes cancelled ifaces.
+        assert_eq!(mgr.iface_count(), 0);
+    }
+
+    #[test]
+    fn iface_source_default_is_none() {
+        let src = IfaceSource::default();
+        assert_eq!(src, IfaceSource::None);
+    }
+
+    #[test]
+    fn iface_role_default_is_unicast() {
+        let role = IfaceRole::default();
+        assert_eq!(role, IfaceRole::Unicast);
     }
 }

--- a/crates/libs/rns-transport/src/iface/serial.rs
+++ b/crates/libs/rns-transport/src/iface/serial.rs
@@ -7,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::buffer::{InputBuffer, OutputBuffer};
 use crate::hash::AddressHash;
-use crate::iface::{RxMessage, TxMessage};
+use crate::iface::{IfaceSource, RxMessage, TxMessage};
 use crate::packet::Packet;
 use crate::serde::Serialize;
 
@@ -318,6 +318,7 @@ async fn run_serial_stream<IO>(
                                                 .send(RxMessage {
                                                     address: iface_address,
                                                     packet,
+                                                    source: IfaceSource::None,
                                                 })
                                                 .await;
                                         }

--- a/crates/libs/rns-transport/src/iface/tcp_client.rs
+++ b/crates/libs/rns-transport/src/iface/tcp_client.rs
@@ -7,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::buffer::{InputBuffer, OutputBuffer};
 use crate::error::RnsError;
-use crate::iface::RxMessage;
+use crate::iface::{IfaceSource, RxMessage};
 use crate::packet::Packet;
 use crate::serde::Serialize;
 
@@ -162,6 +162,7 @@ impl TcpClient {
                                                             .send(RxMessage {
                                                                 address: iface_address,
                                                                 packet,
+                                                                source: IfaceSource::None,
                                                             })
                                                             .await;
                                                     } else {

--- a/crates/libs/rns-transport/src/iface/udp.rs
+++ b/crates/libs/rns-transport/src/iface/udp.rs
@@ -1,5 +1,7 @@
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
+use socket2::{Domain, Protocol, Socket, Type};
 use tokio::net::UdpSocket;
 use tokio_util::sync::CancellationToken;
 
@@ -10,6 +12,49 @@ use crate::packet::Packet;
 use crate::serde::Serialize;
 
 use super::{Interface, InterfaceContext};
+
+fn bind_udp(bind_addr: &str) -> std::io::Result<UdpSocket> {
+    let parsed: SocketAddr = bind_addr
+        .parse()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("bad bind address {}: {}", bind_addr, e)))?;
+
+    let domain = if parsed.is_ipv6() { Domain::IPV6 } else { Domain::IPV4 };
+    let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
+
+    // Allow multiple nodes (or restart of the same node) to bind the same port.
+    socket.set_reuse_address(true)?;
+    #[cfg(unix)]
+    socket.set_reuse_port(true)?;
+
+    // If binding to a multicast group directly, bind to the unspecified address on
+    // the same port instead; then join the group. This works cross-platform.
+    let (bound_addr, multicast_group) = match parsed.ip() {
+        IpAddr::V6(ip) if ip.is_multicast() => {
+            let any: SocketAddr = (std::net::Ipv6Addr::UNSPECIFIED, parsed.port()).into();
+            (any, Some(IpAddr::V6(ip)))
+        }
+        IpAddr::V4(ip) if ip.is_multicast() => {
+            let any: SocketAddr = (std::net::Ipv4Addr::UNSPECIFIED, parsed.port()).into();
+            (any, Some(IpAddr::V4(ip)))
+        }
+        _ => (parsed, None),
+    };
+
+    socket.bind(&bound_addr.into())?;
+
+    if let Some(group) = multicast_group {
+        match group {
+            IpAddr::V6(g) => socket.join_multicast_v6(&g, 0)?,
+            IpAddr::V4(g) => {
+                socket.join_multicast_v4(&g, &std::net::Ipv4Addr::UNSPECIFIED)?
+            }
+        }
+    }
+
+    socket.set_nonblocking(true)?;
+    let std_socket: std::net::UdpSocket = socket.into();
+    UdpSocket::from_std(std_socket)
+}
 
 // UDP trace logging stays on by default for packet-level network bring-up visibility.
 const PACKET_TRACE: bool = true;
@@ -37,8 +82,7 @@ impl UdpInterface {
                 break;
             }
 
-            let socket =
-                UdpSocket::bind(bind_addr.clone()).await.map_err(|_| RnsError::ConnectionError);
+            let socket = bind_udp(&bind_addr).map_err(|_| RnsError::ConnectionError);
 
             if socket.is_err() {
                 log::info!("udp_interface: couldn't bind to <{}>", bind_addr);

--- a/crates/libs/rns-transport/src/iface/udp.rs
+++ b/crates/libs/rns-transport/src/iface/udp.rs
@@ -1,22 +1,28 @@
+use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::net::UdpSocket;
+use tokio::sync::Mutex as TokioMutex;
 use tokio_util::sync::CancellationToken;
 
 use crate::buffer::{InputBuffer, OutputBuffer};
 use crate::error::RnsError;
-use crate::iface::RxMessage;
+use crate::hash::AddressHash;
+use crate::iface::{IfaceRole, IfaceSource, InterfaceManager, RxMessage, TxMessageType};
 use crate::packet::Packet;
 use crate::serde::Serialize;
 
 use super::{Interface, InterfaceContext};
 
 fn bind_udp(bind_addr: &str) -> std::io::Result<UdpSocket> {
-    let parsed: SocketAddr = bind_addr
-        .parse()
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("bad bind address {}: {}", bind_addr, e)))?;
+    let parsed: SocketAddr = bind_addr.parse().map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("bad bind address {}: {}", bind_addr, e),
+        )
+    })?;
 
     let domain = if parsed.is_ipv6() { Domain::IPV6 } else { Domain::IPV4 };
     let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
@@ -45,9 +51,7 @@ fn bind_udp(bind_addr: &str) -> std::io::Result<UdpSocket> {
     if let Some(group) = multicast_group {
         match group {
             IpAddr::V6(g) => socket.join_multicast_v6(&g, 0)?,
-            IpAddr::V4(g) => {
-                socket.join_multicast_v4(&g, &std::net::Ipv4Addr::UNSPECIFIED)?
-            }
+            IpAddr::V4(g) => socket.join_multicast_v4(&g, &std::net::Ipv4Addr::UNSPECIFIED)?,
         }
     }
 
@@ -59,19 +63,133 @@ fn bind_udp(bind_addr: &str) -> std::io::Result<UdpSocket> {
 // UDP trace logging stays on by default for packet-level network bring-up visibility.
 const PACKET_TRACE: bool = true;
 
+/// Returns true if `addr` parses as a SocketAddr whose IP is multicast
+/// (IPv4 `224.0.0.0/4` or IPv6 `ff00::/8`).
+fn is_multicast_addr(addr: &str) -> bool {
+    addr.parse::<SocketAddr>().ok().map(|sa| sa.ip().is_multicast()).unwrap_or(false)
+}
+
+/// Bidirectional map between a peer's reply `SocketAddr` and the
+/// virtual `AddressHash` the transport layer uses to route
+/// point-to-point traffic to that peer. Shared (via `Arc<Mutex<_>>`)
+/// between the multicast `UdpInterface`'s tx and rx tasks and the
+/// transport layer, which registers peers from received announces.
+///
+/// The same physical socket on the host carries both multicast
+/// broadcasts and per-peer unicast sends; this map is what lets the
+/// transport treat "reply to peer X" as a separate logical iface
+/// without spawning additional sockets.
+#[derive(Debug, Default)]
+pub struct PeerRouting {
+    by_addr: HashMap<SocketAddr, AddressHash>,
+    by_hash: HashMap<AddressHash, SocketAddr>,
+}
+
+impl PeerRouting {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a (peer addr ↔ virtual iface hash) mapping, overwriting
+    /// any prior entries for either key. Both directions stay
+    /// consistent.
+    pub fn insert(&mut self, addr: SocketAddr, hash: AddressHash) {
+        if let Some(prev_hash) = self.by_addr.insert(addr, hash) {
+            if prev_hash != hash {
+                self.by_hash.remove(&prev_hash);
+            }
+        }
+        if let Some(prev_addr) = self.by_hash.insert(hash, addr) {
+            if prev_addr != addr {
+                self.by_addr.remove(&prev_addr);
+            }
+        }
+    }
+
+    pub fn addr_for_hash(&self, hash: &AddressHash) -> Option<SocketAddr> {
+        self.by_hash.get(hash).copied()
+    }
+
+    pub fn hash_for_addr(&self, addr: &SocketAddr) -> Option<AddressHash> {
+        self.by_addr.get(addr).copied()
+    }
+
+    /// Remove by virtual iface hash. Used by the transport's GC pass
+    /// when a peer hasn't announced for `UNICAST_IFACE_IDLE_TIMEOUT`.
+    pub fn remove_by_hash(&mut self, hash: &AddressHash) -> Option<SocketAddr> {
+        let addr = self.by_hash.remove(hash)?;
+        self.by_addr.remove(&addr);
+        Some(addr)
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_hash.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_hash.is_empty()
+    }
+}
+
 pub struct UdpInterface {
     bind_addr: String,
     forward_addr: Option<String>,
+    is_multicast: bool,
+    /// Peer-routing map for multicast ifaces. When present, the tx task
+    /// resolves `TxMessageType::Direct` targets through this map (to
+    /// send unicast to a specific peer from the same socket that
+    /// carries multicast broadcasts), and the rx task attributes
+    /// received packets to a virtual iface hash based on the sender's
+    /// `SocketAddr`. For unicast ifaces this is `None`.
+    peer_routing: Option<Arc<TokioMutex<PeerRouting>>>,
 }
 
 impl UdpInterface {
+    /// Plain unicast UDP iface. Send/receive through a single
+    /// `(bind, forward)` pair. No per-peer routing.
     pub fn new<T: Into<String>>(bind_addr: T, forward_addr: Option<T>) -> Self {
-        Self { bind_addr: bind_addr.into(), forward_addr: forward_addr.map(Into::into) }
+        let bind_addr = bind_addr.into();
+        let forward_addr = forward_addr.map(Into::into);
+        let is_multicast = is_multicast_addr(&bind_addr)
+            || forward_addr.as_deref().map(is_multicast_addr).unwrap_or(false);
+        Self { bind_addr, forward_addr, is_multicast, peer_routing: None }
+    }
+
+    /// Multicast UDP iface with a shared peer-routing map. Announces
+    /// (and other `TxMessageType::Broadcast` traffic) still go to the
+    /// multicast group via `forward_addr`. Point-to-point sends target
+    /// a virtual iface hash registered in `peer_routing`; the tx task
+    /// resolves the hash to the peer's `SocketAddr` and sends unicast
+    /// from this same socket — so the peer sees replies as coming from
+    /// the well-known multicast port, matching its own entry for this
+    /// host and avoiding ephemeral-port proliferation.
+    pub fn new_multicast<T: Into<String>>(
+        bind_addr: T,
+        forward_addr: Option<T>,
+        peer_routing: Arc<TokioMutex<PeerRouting>>,
+    ) -> Self {
+        let mut iface = Self::new(bind_addr, forward_addr);
+        iface.peer_routing = Some(peer_routing);
+        iface
+    }
+
+    /// True if this iface is configured as multicast (by bind or
+    /// forward address, or by being constructed with a peer-routing
+    /// map). Used by `InterfaceManager` role tagging at spawn time.
+    pub fn is_multicast(&self) -> bool {
+        self.is_multicast || self.peer_routing.is_some()
     }
 
     pub async fn spawn(context: InterfaceContext<Self>) {
-        let bind_addr = { context.inner.lock().unwrap().bind_addr.clone() };
-        let forward_addr = { context.inner.lock().unwrap().forward_addr.clone() };
+        let (bind_addr, forward_addr, is_multicast, peer_routing) = {
+            let inner = context.inner.lock().unwrap();
+            (
+                inner.bind_addr.clone(),
+                inner.forward_addr.clone(),
+                inner.is_multicast,
+                inner.peer_routing.clone(),
+            )
+        };
         let iface_address = context.channel.address;
 
         let (rx_channel, tx_channel) = context.channel.split();
@@ -97,7 +215,12 @@ impl UdpInterface {
             let read_socket = Arc::new(socket);
             let write_socket = read_socket.clone();
 
-            log::info!("udp_interface bound to <{}>", bind_addr);
+            log::info!(
+                "udp_interface bound to <{}> (multicast={}, has_peer_routing={})",
+                bind_addr,
+                is_multicast,
+                peer_routing.is_some(),
+            );
 
             const BUFFER_SIZE: usize = core::mem::size_of::<Packet>() * 3;
 
@@ -107,6 +230,7 @@ impl UdpInterface {
                 let stop = stop.clone();
                 let socket = read_socket;
                 let rx_channel = rx_channel.clone();
+                let peer_routing = peer_routing.clone();
 
                 tokio::spawn(async move {
                     loop {
@@ -126,12 +250,32 @@ impl UdpInterface {
                                         stop.cancel();
                                         break;
                                     }
-                                    Ok((n, _in_addr)) => {
+                                    Ok((n, in_addr)) => {
                                         if let Ok(packet) = Packet::deserialize(&mut InputBuffer::new(&rx_buffer[..n])) {
+                                            // Re-attribute to a virtual per-peer iface if
+                                            // this source is in the routing map. This is
+                                            // what makes link.iface_matches succeed for a
+                                            // unicast proof that arrives on the same
+                                            // physical socket as multicast announces.
+                                            let attributed_iface = match peer_routing.as_ref() {
+                                                Some(routing) => routing
+                                                    .lock()
+                                                    .await
+                                                    .hash_for_addr(&in_addr)
+                                                    .unwrap_or(iface_address),
+                                                None => iface_address,
+                                            };
                                             if PACKET_TRACE {
-                                                log::trace!("udp_interface: rx << ({}) {}", iface_address, packet);
+                                                log::trace!(
+                                                    "udp_interface: rx << (iface {} / attributed {}) from {} {}",
+                                                    iface_address, attributed_iface, in_addr, packet
+                                                );
                                             }
-                                            let _ = rx_channel.send(RxMessage { address: iface_address, packet }).await;
+                                            let _ = rx_channel.send(RxMessage {
+                                                address: attributed_iface,
+                                                packet,
+                                                source: IfaceSource::Udp(in_addr),
+                                            }).await;
                                         } else {
                                             log::warn!("udp_interface: couldn't decode packet");
                                         }
@@ -153,6 +297,7 @@ impl UdpInterface {
                     let cancel = cancel.clone();
                     let tx_channel = tx_channel.clone();
                     let socket = write_socket;
+                    let peer_routing = peer_routing.clone();
 
                     tokio::spawn(async move {
                         loop {
@@ -172,13 +317,58 @@ impl UdpInterface {
                                         break;
                                 }
                                 Some(message) = tx_channel.recv() => {
-                                    let packet = message.packet;
-                                    if PACKET_TRACE {
-                                        log::trace!("udp_interface: tx >> ({}) {}", iface_address, packet);
-                                    }
-                                    let mut output = OutputBuffer::new(&mut tx_buffer);
-                                    if packet.serialize(&mut output).is_ok() {
-                                        let _ = socket.send_to(output.as_slice(), &forward_addr).await;
+                                    // Route the tx through the peer map:
+                                    //   Broadcast → multicast forward_addr (unchanged).
+                                    //   Direct(iface_hash):
+                                    //     - if hash resolves in peer_routing → unicast to that peer
+                                    //     - else if hash == this iface's own address → drop
+                                    //       (the tx-guard: Direct tx to a multicast iface is
+                                    //       nonsensical — every packet would flood the group)
+                                    //     - else → drop (unknown virtual iface)
+                                    let target = match message.tx_type {
+                                        TxMessageType::Broadcast(_) => Some(forward_addr.clone()),
+                                        TxMessageType::Direct(addr) => {
+                                            if let Some(ref routing) = peer_routing {
+                                                if let Some(peer) = routing.lock().await.addr_for_hash(&addr) {
+                                                    Some(peer.to_string())
+                                                } else if addr == iface_address {
+                                                    if PACKET_TRACE {
+                                                        log::trace!(
+                                                            "udp_interface: dropping Direct tx targeting multicast iface {} (type={:?})",
+                                                            iface_address,
+                                                            message.packet.header.packet_type,
+                                                        );
+                                                    }
+                                                    None
+                                                } else {
+                                                    if PACKET_TRACE {
+                                                        log::trace!(
+                                                            "udp_interface: dropping Direct tx for unknown virtual iface {}",
+                                                            addr,
+                                                        );
+                                                    }
+                                                    None
+                                                }
+                                            } else {
+                                                // Unicast iface with no peer routing — forward_addr is
+                                                // the fixed target, same as broadcast.
+                                                Some(forward_addr.clone())
+                                            }
+                                        }
+                                    };
+
+                                    if let Some(dest) = target {
+                                        let packet = message.packet;
+                                        if PACKET_TRACE {
+                                            log::trace!(
+                                                "udp_interface: tx >> ({}) to {} {}",
+                                                iface_address, dest, packet
+                                            );
+                                        }
+                                        let mut output = OutputBuffer::new(&mut tx_buffer);
+                                        if packet.serialize(&mut output).is_ok() {
+                                            let _ = socket.send_to(output.as_slice(), &dest).await;
+                                        }
                                     }
                                 }
                             };
@@ -201,10 +391,154 @@ impl Interface for UdpInterface {
     }
 }
 
+/// Spawn a multicast UDP interface with per-peer routing enabled.
+/// Returns the iface's `AddressHash` plus the shared `PeerRouting` map
+/// — pass the latter to the transport so it can `register` peers
+/// (typically from received announces), which then makes `Direct` tx
+/// targeting the virtual iface hash land as unicast on that peer.
+pub fn spawn_multicast_udp(
+    mgr: &mut InterfaceManager,
+    bind_addr: String,
+    forward_addr: Option<String>,
+) -> (AddressHash, Arc<TokioMutex<PeerRouting>>) {
+    let peer_routing = Arc::new(TokioMutex::new(PeerRouting::new()));
+    let iface = UdpInterface::new_multicast(bind_addr, forward_addr, peer_routing.clone());
+    let hash = mgr.spawn_as(iface, UdpInterface::spawn, IfaceRole::Multicast);
+    (hash, peer_routing)
+}
+
 pub fn encode_frame(data: &[u8]) -> Result<Vec<u8>, RnsError> {
     Ok(data.to_vec())
 }
 
 pub fn decode_frame(frame: &[u8]) -> Result<Vec<u8>, RnsError> {
     Ok(frame.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_detects_multicast_bind_v4() {
+        let iface =
+            UdpInterface::new("224.0.0.224:4242".to_string(), Some("224.0.0.224:4242".to_string()));
+        assert!(iface.is_multicast());
+    }
+
+    #[test]
+    fn new_detects_multicast_forward_even_if_bind_is_unicast() {
+        let iface =
+            UdpInterface::new("0.0.0.0:0".to_string(), Some("224.0.0.224:4242".to_string()));
+        assert!(iface.is_multicast());
+    }
+
+    #[test]
+    fn new_reports_unicast_for_plain_udp() {
+        let iface =
+            UdpInterface::new("127.0.0.1:5001".to_string(), Some("127.0.0.1:5002".to_string()));
+        assert!(!iface.is_multicast());
+    }
+
+    #[test]
+    fn new_reports_unicast_when_no_forward_addr() {
+        let iface = UdpInterface::new("0.0.0.0:0".to_string(), None::<String>);
+        assert!(!iface.is_multicast());
+    }
+
+    #[test]
+    fn new_multicast_reports_multicast_even_with_unicast_bind() {
+        let routing = Arc::new(TokioMutex::new(PeerRouting::new()));
+        let iface = UdpInterface::new_multicast(
+            "127.0.0.1:5001".to_string(),
+            Some("127.0.0.1:5002".to_string()),
+            routing,
+        );
+        assert!(iface.is_multicast(), "new_multicast must always report multicast=true");
+    }
+
+    #[test]
+    fn is_multicast_addr_detects_v4_link_local() {
+        assert!(is_multicast_addr("224.0.0.224:4242"));
+    }
+
+    #[test]
+    fn is_multicast_addr_detects_v6_link_local() {
+        assert!(is_multicast_addr("[ff02::1]:4242"));
+    }
+
+    #[test]
+    fn is_multicast_addr_rejects_unicast_v4() {
+        assert!(!is_multicast_addr("192.168.1.112:4242"));
+    }
+
+    #[test]
+    fn is_multicast_addr_rejects_wildcard() {
+        assert!(!is_multicast_addr("0.0.0.0:0"));
+    }
+
+    #[test]
+    fn is_multicast_addr_rejects_garbage() {
+        assert!(!is_multicast_addr("not a socket addr"));
+    }
+
+    fn fake_hash(byte: u8) -> AddressHash {
+        AddressHash::new_from_hash(&crate::hash::Hash::new_from_slice(&[byte; 32]))
+    }
+
+    fn fake_peer(port: u16) -> SocketAddr {
+        use std::net::{IpAddr, Ipv4Addr};
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 112)), port)
+    }
+
+    #[test]
+    fn peer_routing_insert_is_bidirectional() {
+        let mut r = PeerRouting::new();
+        let hash = fake_hash(1);
+        let peer = fake_peer(4242);
+        r.insert(peer, hash);
+        assert_eq!(r.hash_for_addr(&peer), Some(hash));
+        assert_eq!(r.addr_for_hash(&hash), Some(peer));
+        assert_eq!(r.len(), 1);
+    }
+
+    #[test]
+    fn peer_routing_insert_replacing_hash_clears_old_reverse_entry() {
+        let mut r = PeerRouting::new();
+        let peer = fake_peer(4242);
+        let h1 = fake_hash(1);
+        let h2 = fake_hash(2);
+        r.insert(peer, h1);
+        r.insert(peer, h2);
+        assert_eq!(r.hash_for_addr(&peer), Some(h2));
+        assert_eq!(r.addr_for_hash(&h2), Some(peer));
+        assert_eq!(r.addr_for_hash(&h1), None, "old hash should no longer map");
+        assert_eq!(r.len(), 1);
+    }
+
+    #[test]
+    fn peer_routing_insert_replacing_addr_clears_old_forward_entry() {
+        let mut r = PeerRouting::new();
+        let hash = fake_hash(1);
+        let p1 = fake_peer(4242);
+        let p2 = fake_peer(5252);
+        r.insert(p1, hash);
+        r.insert(p2, hash);
+        assert_eq!(r.addr_for_hash(&hash), Some(p2));
+        assert_eq!(r.hash_for_addr(&p2), Some(hash));
+        assert_eq!(r.hash_for_addr(&p1), None, "old addr should no longer map");
+        assert_eq!(r.len(), 1);
+    }
+
+    #[test]
+    fn peer_routing_remove_by_hash_clears_both_directions() {
+        let mut r = PeerRouting::new();
+        let hash = fake_hash(1);
+        let peer = fake_peer(4242);
+        r.insert(peer, hash);
+        assert_eq!(r.remove_by_hash(&hash), Some(peer));
+        assert!(r.is_empty());
+        assert_eq!(r.hash_for_addr(&peer), None);
+        assert_eq!(r.addr_for_hash(&hash), None);
+    }
 }

--- a/crates/libs/rns-transport/src/transport/announce.rs
+++ b/crates/libs/rns-transport/src/transport/announce.rs
@@ -5,6 +5,7 @@ async fn process_announce<'a>(
     packet: &Packet,
     mut handler: MutexGuard<'a, TransportHandler>,
     iface: AddressHash,
+    source: IfaceSource,
     announce: crate::destination::AnnounceInfo<'_>,
 ) -> MutexGuard<'a, TransportHandler> {
     let destination_known = handler.has_destination(&packet.destination);
@@ -41,6 +42,12 @@ async fn process_announce<'a>(
     let dest_hash = announce.destination.desc.address_hash;
     let destination = Arc::new(Mutex::new(announce.destination));
 
+    // Auto-unicast: if this announce arrived over a multicast iface from a
+    // known UDP peer, route future point-to-point traffic for this
+    // destination over a per-peer unicast UDP iface instead of back onto
+    // the multicast group. Otherwise keep the original iface.
+    let route_iface = handler.unicast_iface_for_source(iface, source).await.unwrap_or(iface);
+
     if !destination_known {
         if !handler.single_out_destinations.contains_key(&packet.destination) {
             log::trace!("tp({}): new announce for {}", handler.config.name, packet.destination);
@@ -48,9 +55,9 @@ async fn process_announce<'a>(
             handler.single_out_destinations.insert(packet.destination, destination.clone());
         }
 
-        handler.announce_table.add(packet, dest_hash, iface);
+        handler.announce_table.add(packet, dest_hash, route_iface);
 
-        handler.path_table.handle_announce(packet, packet.transport, iface);
+        handler.path_table.handle_announce(packet, packet.transport, route_iface);
     }
 
     let name_hash = {
@@ -60,7 +67,7 @@ async fn process_announce<'a>(
         name_hash.copy_from_slice(source);
         name_hash
     };
-    let interface = iface.as_slice().to_vec();
+    let interface = route_iface.as_slice().to_vec();
 
     let _ = handler.announce_tx.send(AnnounceEvent {
         destination,
@@ -78,13 +85,15 @@ pub(super) async fn handle_announce<'a>(
     packet: &Packet,
     mut handler: MutexGuard<'a, TransportHandler>,
     iface: AddressHash,
+    source: IfaceSource,
 ) {
     let announce = match DestinationAnnounce::validate(packet) {
         Ok(result) => result,
         Err(err) => {
             log::trace!(
                 "[transport] announce validate failed dst={} err={:?}",
-                packet.destination, err
+                packet.destination,
+                err
             );
             return;
         }
@@ -106,7 +115,7 @@ pub(super) async fn handle_announce<'a>(
         }
     }
 
-    let _ = process_announce(packet, handler, iface, announce).await;
+    let _ = process_announce(packet, handler, iface, source, announce).await;
 }
 
 pub(super) async fn retransmit_announces<'a>(mut handler: MutexGuard<'a, TransportHandler>) {
@@ -137,6 +146,11 @@ pub(super) async fn release_held_announces<'a>(handler: MutexGuard<'a, Transport
             }
         };
 
-        handler = process_announce(&packet, handler, iface, announce).await;
+        // Held announces predate auto-unicast redirection because we
+        // don't persist the `IfaceSource` across the hold queue.
+        // Replay on the stored iface; if that iface was multicast, the
+        // route won't get the unicast redirect until the next fresh
+        // announce from this peer arrives.
+        handler = process_announce(&packet, handler, iface, IfaceSource::None, announce).await;
     }
 }

--- a/crates/libs/rns-transport/src/transport/announce.rs
+++ b/crates/libs/rns-transport/src/transport/announce.rs
@@ -82,7 +82,7 @@ pub(super) async fn handle_announce<'a>(
     let announce = match DestinationAnnounce::validate(packet) {
         Ok(result) => result,
         Err(err) => {
-            eprintln!(
+            log::trace!(
                 "[transport] announce validate failed dst={} err={:?}",
                 packet.destination, err
             );

--- a/crates/libs/rns-transport/src/transport/core.rs
+++ b/crates/libs/rns-transport/src/transport/core.rs
@@ -73,6 +73,8 @@ impl Transport {
             resource_response_packets: Vec::new(),
             resource_events_tx: resource_events_tx.clone(),
             fixed_dest_path_requests: path_request_dest,
+            unicast_udp_ifaces: HashMap::new(),
+            multicast_peer_routings: HashMap::new(),
             cancel: cancel.clone(),
             receipt_handler: None,
         }));
@@ -165,6 +167,33 @@ impl Transport {
 
     pub fn iface_manager(&self) -> Arc<Mutex<InterfaceManager>> {
         self.iface_manager.clone()
+    }
+
+    /// Spawn a multicast UDP interface with per-peer routing.
+    ///
+    /// Announces and path requests broadcast to the multicast group
+    /// exactly as before. Point-to-point `Direct` tx for a peer
+    /// discovered via this iface is delivered through the same host
+    /// socket, unicast — the tx task resolves the virtual iface hash
+    /// to a `SocketAddr` via the `PeerRouting` map this method
+    /// registers with the transport handler.
+    ///
+    /// Callers (backend_lxmf.rs) should use this rather than spawning
+    /// a `UdpInterface` with `is_multicast=true` directly; going
+    /// through this helper ensures the transport handler knows about
+    /// the routing map so `unicast_iface_for_source` can register
+    /// peers into it.
+    pub async fn add_multicast_udp_interface(
+        &self,
+        bind_addr: String,
+        forward_addr: Option<String>,
+    ) -> AddressHash {
+        let (iface_hash, peer_routing) = {
+            let mut mgr = self.iface_manager.lock().await;
+            crate::iface::udp::spawn_multicast_udp(&mut mgr, bind_addr, forward_addr)
+        };
+        self.handler.lock().await.register_multicast_peer_routing(iface_hash, peer_routing);
+        iface_hash
     }
 
     pub fn channel(&self, link_id: AddressHash) -> TransportChannel {

--- a/crates/libs/rns-transport/src/transport/core.rs
+++ b/crates/libs/rns-transport/src/transport/core.rs
@@ -98,7 +98,7 @@ impl Transport {
                                         )
                                     },
                                 ) {
-                                    eprintln!(
+                                    log::trace!(
                                         "[tp-diag] received_data_forward link_id=/{}// peer=/{}// ctx={:02x} len={}",
                                         event.id,
                                         event.address_hash,
@@ -204,7 +204,7 @@ impl Transport {
         app_data: Option<&[u8]>,
     ) {
         let mut destination = destination.lock().await;
-        eprintln!(
+        log::trace!(
             "[tp] announce_tx dst={} app_data_len={}",
             destination.desc.address_hash,
             app_data.map(|value| value.len()).unwrap_or(0)

--- a/crates/libs/rns-transport/src/transport/handler.rs
+++ b/crates/libs/rns-transport/src/transport/handler.rs
@@ -62,13 +62,13 @@ impl TransportHandler {
 
     pub(super) async fn send_packet_with_trace(&mut self, mut packet: Packet) -> SendPacketTrace {
         if packet.header.packet_type == PacketType::Proof {
-            eprintln!(
+            log::trace!(
                 "[tp] send_proof dst={} ctx={:02x}",
                 packet.destination, packet.context as u8
             );
             if packet.context == PacketContext::LinkRequestProof {
                 if let Ok(raw) = packet.to_bytes() {
-                    eprintln!("[tp] lrproof_raw len={} hex={}", raw.len(), bytes_to_hex(&raw));
+                    log::trace!("[tp] lrproof_raw len={} hex={}", raw.len(), bytes_to_hex(&raw));
                 }
             }
         }
@@ -129,7 +129,7 @@ impl TransportHandler {
 
         if transport_diag_enabled() {
             if let Some(entry) = self.path_table.get(&packet.destination) {
-                eprintln!(
+                log::trace!(
                     "[tp-diag] route_lookup dst={} hops={} via_next_hop={} via_iface={}",
                     packet.destination, entry.hops, entry.received_from, entry.iface
                 );
@@ -141,7 +141,7 @@ impl TransportHandler {
                     entry.iface
                 );
             } else {
-                eprintln!("[tp-diag] route_lookup dst={} missing", packet.destination);
+                log::trace!("[tp-diag] route_lookup dst={} missing", packet.destination);
                 log::info!("[tp-diag] route_lookup dst={} missing", packet.destination);
             }
         }
@@ -156,7 +156,7 @@ impl TransportHandler {
                 SendPacketOutcome::DroppedNoRoute
             };
             if transport_diag_enabled() {
-                eprintln!(
+                log::trace!(
                     "[tp-diag] direct_send iface={} outcome={:?} matched={} sent={} failed={}",
                     iface,
                     outcome,
@@ -183,7 +183,7 @@ impl TransportHandler {
                 SendPacketOutcome::DroppedNoRoute
             };
             if transport_diag_enabled() {
-                eprintln!(
+                log::trace!(
                     "[tp-diag] broadcast_send outcome={:?} matched={} sent={} failed={}",
                     outcome, dispatch.matched_ifaces, dispatch.sent_ifaces, dispatch.failed_ifaces
                 );

--- a/crates/libs/rns-transport/src/transport/handler.rs
+++ b/crates/libs/rns-transport/src/transport/handler.rs
@@ -64,7 +64,8 @@ impl TransportHandler {
         if packet.header.packet_type == PacketType::Proof {
             log::trace!(
                 "[tp] send_proof dst={} ctx={:02x}",
-                packet.destination, packet.context as u8
+                packet.destination,
+                packet.context as u8
             );
             if packet.context == PacketContext::LinkRequestProof {
                 if let Ok(raw) = packet.to_bytes() {
@@ -131,7 +132,10 @@ impl TransportHandler {
             if let Some(entry) = self.path_table.get(&packet.destination) {
                 log::trace!(
                     "[tp-diag] route_lookup dst={} hops={} via_next_hop={} via_iface={}",
-                    packet.destination, entry.hops, entry.received_from, entry.iface
+                    packet.destination,
+                    entry.hops,
+                    entry.received_from,
+                    entry.iface
                 );
                 log::info!(
                     "[tp-diag] route_lookup dst={} hops={} via_next_hop={} via_iface={}",
@@ -185,7 +189,10 @@ impl TransportHandler {
             if transport_diag_enabled() {
                 log::trace!(
                     "[tp-diag] broadcast_send outcome={:?} matched={} sent={} failed={}",
-                    outcome, dispatch.matched_ifaces, dispatch.sent_ifaces, dispatch.failed_ifaces
+                    outcome,
+                    dispatch.matched_ifaces,
+                    dispatch.sent_ifaces,
+                    dispatch.failed_ifaces
                 );
                 log::info!(
                     "[tp-diag] broadcast_send outcome={:?} matched={} sent={} failed={}",
@@ -267,5 +274,114 @@ impl TransportHandler {
         let packet = self.path_requests.generate(address, tag);
 
         self.send(TxMessage { tx_type: TxMessageType::Broadcast(on_iface), packet }).await;
+    }
+
+    /// Register (or refresh) the *virtual* unicast iface that the
+    /// transport uses to route point-to-point traffic for the peer
+    /// that delivered this packet. Only acts when:
+    ///   - the packet arrived on a multicast iface, and
+    ///   - that multicast iface has a registered `PeerRouting` map
+    ///     (i.e. it was registered via
+    ///     `Transport::add_multicast_udp_interface`), and
+    ///   - the source is a UDP socket address.
+    ///
+    /// Returns the virtual iface hash to stick in the path_table so
+    /// subsequent `Direct` tx for this peer's destinations is routed
+    /// through the host multicast socket as a unicast send — and,
+    /// symmetrically, so inbound replies from this peer (which arrive
+    /// on the host multicast socket) get re-attributed to this same
+    /// virtual iface by the host's rx task. That symmetry is what
+    /// makes `Link::iface_matches` succeed on the proof/keepalive.
+    pub(super) async fn unicast_iface_for_source(
+        &mut self,
+        rx_iface: AddressHash,
+        source: IfaceSource,
+    ) -> Option<AddressHash> {
+        let peer = match source {
+            IfaceSource::Udp(addr) => addr,
+            IfaceSource::None => return None,
+        };
+
+        let role = { self.iface_manager.lock().await.role(&rx_iface) };
+        if role != Some(IfaceRole::Multicast) {
+            return None;
+        }
+
+        let peer_routing = self.multicast_peer_routings.get(&rx_iface).cloned()?;
+
+        let now = Instant::now();
+        if let Some(entry) = self.unicast_udp_ifaces.get_mut(&peer) {
+            entry.1 = now;
+            return Some(entry.0);
+        }
+
+        let virtual_hash = {
+            let mut mgr = self.iface_manager.lock().await;
+            mgr.register_virtual_iface(rx_iface, IfaceRole::VirtualUnicast)?
+        };
+        peer_routing.lock().await.insert(peer, virtual_hash);
+        log::debug!(
+            "tp({}): registered virtual UDP iface {} for peer {} on host {}",
+            self.config.name,
+            virtual_hash,
+            peer,
+            rx_iface,
+        );
+        self.unicast_udp_ifaces.insert(peer, (virtual_hash, now));
+        Some(virtual_hash)
+    }
+
+    /// Register a `PeerRouting` map for a multicast iface at
+    /// construction time. Called by
+    /// `Transport::add_multicast_udp_interface`.
+    pub(super) fn register_multicast_peer_routing(
+        &mut self,
+        iface: AddressHash,
+        routing: Arc<Mutex<crate::iface::udp::PeerRouting>>,
+    ) {
+        self.multicast_peer_routings.insert(iface, routing);
+    }
+
+    /// Drop virtual unicast ifaces that haven't seen a fresh announce
+    /// from their peer in `UNICAST_IFACE_IDLE_TIMEOUT`. Also clears
+    /// the corresponding entry from the host multicast iface's
+    /// `PeerRouting`, so future packets from that peer are reattributed
+    /// to the multicast iface (re-triggering a fresh virtual iface
+    /// registration if the peer reappears). Called from
+    /// `handle_cleanup`.
+    pub(super) async fn gc_unicast_ifaces(&mut self) {
+        let now = Instant::now();
+        let stale: Vec<std::net::SocketAddr> = self
+            .unicast_udp_ifaces
+            .iter()
+            .filter(|(_, (_, last_seen))| {
+                now.duration_since(*last_seen) > UNICAST_IFACE_IDLE_TIMEOUT
+            })
+            .map(|(peer, _)| *peer)
+            .collect();
+
+        if stale.is_empty() {
+            return;
+        }
+
+        for peer in stale {
+            if let Some((iface_hash, _)) = self.unicast_udp_ifaces.remove(&peer) {
+                let mut removed_from_routing = false;
+                for routing in self.multicast_peer_routings.values() {
+                    if routing.lock().await.remove_by_hash(&iface_hash).is_some() {
+                        removed_from_routing = true;
+                        break;
+                    }
+                }
+                let _ = removed_from_routing;
+                self.iface_manager.lock().await.stop_interface(iface_hash);
+                log::debug!(
+                    "tp({}): GC'd idle virtual UDP iface {} for peer {}",
+                    self.config.name,
+                    iface_hash,
+                    peer,
+                );
+            }
+        }
     }
 }

--- a/crates/libs/rns-transport/src/transport/jobs.rs
+++ b/crates/libs/rns-transport/src/transport/jobs.rs
@@ -164,7 +164,8 @@ pub(super) async fn handle_check_links<'a>(mut handler: MutexGuard<'a, Transport
     }
 }
 
-pub(super) async fn handle_cleanup<'a>(handler: MutexGuard<'a, TransportHandler>) {
+pub(super) async fn handle_cleanup<'a>(mut handler: MutexGuard<'a, TransportHandler>) {
+    handler.gc_unicast_ifaces().await;
     handler.iface_manager.lock().await.cleanup();
 }
 
@@ -228,7 +229,8 @@ pub(super) async fn manage_transport(
                             PacketType::Announce => handle_announce(
                                 &packet,
                                 handler,
-                                message.address
+                                message.address,
+                                message.source,
                             ).await,
                             PacketType::LinkRequest => handle_link_request(
                                 &packet,

--- a/crates/libs/rns-transport/src/transport/mod.rs
+++ b/crates/libs/rns-transport/src/transport/mod.rs
@@ -37,6 +37,8 @@ use crate::error::RnsError;
 use crate::hash::{AddressHash, Hash, HASH_SIZE};
 use crate::identity::{Identity, PrivateIdentity};
 
+use crate::iface::IfaceRole;
+use crate::iface::IfaceSource;
 use crate::iface::InterfaceManager;
 use crate::iface::InterfaceRxReceiver;
 use crate::iface::RxMessage;
@@ -119,6 +121,11 @@ const INTERVAL_ANNOUNCES_RETRANSMIT: Duration = Duration::from_secs(1);
 const INTERVAL_KEEP_PACKET_CACHED: Duration = Duration::from_secs(180);
 const INTERVAL_PACKET_CACHE_CLEANUP: Duration = Duration::from_secs(90);
 const LOCAL_PATH_RESPONSE_COOLDOWN: Duration = Duration::from_millis(750);
+
+/// How long an auto-spawned per-peer unicast UDP iface may sit idle
+/// before `handle_cleanup` tears it down. Sized so typical peers'
+/// announce cadences (default 300s) refresh it several times over.
+const UNICAST_IFACE_IDLE_TIMEOUT: Duration = Duration::from_secs(1800);
 
 // Other constants
 const KEEP_ALIVE_REQUEST: u8 = 0xFF;
@@ -214,6 +221,25 @@ pub(crate) struct TransportHandler {
     resource_events_tx: broadcast::Sender<ResourceEvent>,
 
     fixed_dest_path_requests: AddressHash,
+
+    /// Per-peer *virtual* unicast UDP ifaces pinned to a specific
+    /// `SocketAddr` when an announce arrives over a multicast iface.
+    /// Keyed by the peer's socket address; value is
+    /// `(virtual_iface_hash, last_seen)`. Refreshed on every announce
+    /// from that peer and GC'd by `handle_cleanup` after
+    /// `UNICAST_IFACE_IDLE_TIMEOUT`.
+    ///
+    /// The virtual iface shares its tx channel with the host multicast
+    /// iface; actual wire routing (unicast vs multicast) is resolved
+    /// inside the host `UdpInterface` by looking the hash up in its
+    /// `PeerRouting` map (see `multicast_peer_routings`).
+    unicast_udp_ifaces: HashMap<std::net::SocketAddr, (AddressHash, Instant)>,
+
+    /// One per registered multicast `UdpInterface`: the shared
+    /// `PeerRouting` that iface's tx/rx tasks consult. Populated by
+    /// `Transport::add_multicast_udp_interface`; consulted by
+    /// `unicast_iface_for_source` to register discovered peers.
+    multicast_peer_routings: HashMap<AddressHash, Arc<Mutex<crate::iface::udp::PeerRouting>>>,
 
     cancel: CancellationToken,
     receipt_handler: Option<Arc<dyn ReceiptHandler>>,

--- a/crates/libs/rns-transport/src/transport/path.rs
+++ b/crates/libs/rns-transport/src/transport/path.rs
@@ -183,7 +183,9 @@ pub(super) async fn handle_link_request<'a>(
 ) {
     log::trace!(
         "[tp] link_request dst={} ctx={:02x} hops={}",
-        packet.destination, packet.context as u8, packet.header.hops
+        packet.destination,
+        packet.context as u8,
+        packet.header.hops
     );
     if let Some(destination) = handler.single_in_destinations.get(&packet.destination).cloned() {
         log::trace!("tp({}): handle link request for {}", handler.config.name, packet.destination);

--- a/crates/libs/rns-transport/src/transport/path.rs
+++ b/crates/libs/rns-transport/src/transport/path.rs
@@ -135,7 +135,7 @@ pub(super) async fn handle_link_request_as_destination<'a>(
 
                 if let Ok(mut link) = link {
                     link.set_ingress_iface(iface);
-                    eprintln!(
+                    log::trace!(
                         "[tp] link_proof_tx dst={} link_id={}",
                         packet.destination,
                         link.id()
@@ -181,7 +181,7 @@ pub(super) async fn handle_link_request<'a>(
     iface: AddressHash,
     handler: MutexGuard<'a, TransportHandler>,
 ) {
-    eprintln!(
+    log::trace!(
         "[tp] link_request dst={} ctx={:02x} hops={}",
         packet.destination, packet.context as u8, packet.header.hops
     );

--- a/crates/libs/rns-transport/src/transport/tests.rs
+++ b/crates/libs/rns-transport/src/transport/tests.rs
@@ -97,7 +97,13 @@ async fn drop_duplicates() {
 
     assert!(handler.lock().await.filter_duplicate_packets(&announce).await);
 
-    handle_announce(&announce, handler.lock().await, next_hop_iface).await;
+    handle_announce(
+        &announce,
+        handler.lock().await,
+        next_hop_iface,
+        crate::iface::IfaceSource::None,
+    )
+    .await;
 
     let data_packet: Packet = Packet {
         data: PacketDataBuffer::new_from_slice(b"foo"),
@@ -141,7 +147,7 @@ async fn announce_retransmit_key_uses_destination_hash() {
     );
 
     let iface = AddressHash::new_from_rand(OsRng);
-    handle_announce(&announce, handler.lock().await, iface).await;
+    handle_announce(&announce, handler.lock().await, iface, crate::iface::IfaceSource::None).await;
     tokio::time::sleep(Duration::from_millis(550)).await;
 
     let mut guard = handler.lock().await;
@@ -186,7 +192,8 @@ async fn unknown_announces_are_held_per_interface_and_released_by_lowest_hops() 
     );
     let mut first_announce = first_destination.announce(OsRng, None).expect("announce");
     first_announce.header.hops = 4;
-    handle_announce(&first_announce, handler.lock().await, iface).await;
+    handle_announce(&first_announce, handler.lock().await, iface, crate::iface::IfaceSource::None)
+        .await;
     let first_event = timeout(Duration::from_millis(200), announce_rx.recv())
         .await
         .expect("first announce should emit")
@@ -200,7 +207,13 @@ async fn unknown_announces_are_held_per_interface_and_released_by_lowest_hops() 
     );
     let mut higher_hop_announce = higher_hop_destination.announce(OsRng, None).expect("announce");
     higher_hop_announce.header.hops = 3;
-    handle_announce(&higher_hop_announce, handler.lock().await, iface).await;
+    handle_announce(
+        &higher_hop_announce,
+        handler.lock().await,
+        iface,
+        crate::iface::IfaceSource::None,
+    )
+    .await;
     tokio::time::sleep(Duration::from_millis(1)).await;
 
     let mut lower_hop_destination = SingleInputDestination::new(
@@ -209,7 +222,13 @@ async fn unknown_announces_are_held_per_interface_and_released_by_lowest_hops() 
     );
     let mut lower_hop_announce = lower_hop_destination.announce(OsRng, None).expect("announce");
     lower_hop_announce.header.hops = 1;
-    handle_announce(&lower_hop_announce, handler.lock().await, iface).await;
+    handle_announce(
+        &lower_hop_announce,
+        handler.lock().await,
+        iface,
+        crate::iface::IfaceSource::None,
+    )
+    .await;
 
     let mut immediate_hops = Vec::new();
     while let Ok(event) = announce_rx.try_recv() {
@@ -289,14 +308,14 @@ async fn learned_announces_are_not_held_after_route_is_known() {
     );
     let announce = destination.announce(OsRng, None).expect("announce");
 
-    handle_announce(&announce, handler.lock().await, iface).await;
+    handle_announce(&announce, handler.lock().await, iface, crate::iface::IfaceSource::None).await;
     timeout(Duration::from_millis(200), announce_rx.recv())
         .await
         .expect("first announce should emit")
         .expect("broadcast receive");
 
     tokio::time::sleep(Duration::from_millis(5)).await;
-    handle_announce(&announce, handler.lock().await, iface).await;
+    handle_announce(&announce, handler.lock().await, iface, crate::iface::IfaceSource::None).await;
 
     let repeated = timeout(Duration::from_millis(200), announce_rx.recv())
         .await
@@ -332,7 +351,7 @@ async fn path_response_announces_are_not_held_by_rate_limits() {
     let mut announce = destination.announce(OsRng, None).expect("announce");
     announce.context = PacketContext::PathResponse;
 
-    handle_announce(&announce, handler.lock().await, iface).await;
+    handle_announce(&announce, handler.lock().await, iface, crate::iface::IfaceSource::None).await;
 
     let received = timeout(Duration::from_millis(200), announce_rx.recv())
         .await
@@ -440,7 +459,13 @@ async fn handle_inbound_for_test_rejects_forged_destination_proof() {
     let mut remote_destination =
         SingleInputDestination::new(remote_identity, DestinationName::new("lxmf", "delivery"));
     let announce = remote_destination.announce(OsRng, None).expect("valid announce packet");
-    handle_announce(&announce, handler.lock().await, AddressHash::new_from_rand(OsRng)).await;
+    handle_announce(
+        &announce,
+        handler.lock().await,
+        AddressHash::new_from_rand(OsRng),
+        crate::iface::IfaceSource::None,
+    )
+    .await;
 
     let count = Arc::new(AtomicUsize::new(0));
     transport.set_receipt_handler(Box::new(CountingReceiptHandler { count: count.clone() })).await;
@@ -473,7 +498,13 @@ async fn handle_inbound_for_test_accepts_valid_destination_proof() {
     let mut remote_destination =
         SingleInputDestination::new(remote_identity, DestinationName::new("lxmf", "delivery"));
     let announce = remote_destination.announce(OsRng, None).expect("valid announce packet");
-    handle_announce(&announce, handler.lock().await, AddressHash::new_from_rand(OsRng)).await;
+    handle_announce(
+        &announce,
+        handler.lock().await,
+        AddressHash::new_from_rand(OsRng),
+        crate::iface::IfaceSource::None,
+    )
+    .await;
 
     let count = Arc::new(AtomicUsize::new(0));
     transport.set_receipt_handler(Box::new(CountingReceiptHandler { count: count.clone() })).await;
@@ -508,7 +539,13 @@ async fn routed_link_request_proof_requires_matching_iface_and_signature() {
     let mut remote_destination =
         SingleInputDestination::new(remote_identity, DestinationName::new("lxmf", "delivery"));
     let announce = remote_destination.announce(OsRng, None).expect("valid announce packet");
-    handle_announce(&announce, handler.lock().await, AddressHash::new_from_rand(OsRng)).await;
+    handle_announce(
+        &announce,
+        handler.lock().await,
+        AddressHash::new_from_rand(OsRng),
+        crate::iface::IfaceSource::None,
+    )
+    .await;
 
     let received_from = AddressHash::new_from_slice(&[1u8; 16]);
     let next_hop = AddressHash::new_from_slice(&[2u8; 16]);
@@ -927,4 +964,315 @@ async fn send_resource_returns_error_when_advertisement_dispatch_drops() {
 
     let guard = handler.lock().await;
     assert!(guard.resource_manager.has_no_outbound_state());
+}
+
+// ---------------------------------------------------------------------
+// Per-peer virtual unicast iface registration
+// (see TransportHandler::unicast_iface_for_source)
+// ---------------------------------------------------------------------
+//
+// On receiving an announce from a UDP peer over a multicast iface, the
+// transport registers a *virtual* iface pinned to that peer's
+// SocketAddr in the iface's PeerRouting map. The virtual iface shares
+// its tx channel with the host multicast iface; the host's tx task
+// resolves the virtual hash to a unicast send on the same socket.
+// This is what stops the 22 Mb/s LAN flood without creating separate
+// per-peer sockets (which would bind to ephemeral ports and confuse
+// ingress attribution).
+
+fn peer_addr(port: u16) -> std::net::SocketAddr {
+    use std::net::{IpAddr, Ipv4Addr};
+    std::net::SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 112)), port)
+}
+
+/// Register a fake multicast iface (role-tagged only — no real socket)
+/// plus a shared `PeerRouting` map, and hand the routing map to the
+/// handler so `unicast_iface_for_source` can use it. Returns the
+/// iface's `AddressHash`.
+///
+/// Mirrors what `Transport::add_multicast_udp_interface` would do,
+/// but without spawning the real UdpInterface task (which needs real
+/// sockets). Tests can still exercise the handler's registration /
+/// cache / GC logic in isolation this way.
+async fn register_fake_multicast_iface(transport: &Transport) -> AddressHash {
+    let routing = Arc::new(Mutex::new(crate::iface::udp::PeerRouting::new()));
+    let iface_hash = {
+        let mgr = transport.iface_manager();
+        let mut mgr = mgr.lock().await;
+        let channel = mgr.new_channel_with_role(16, crate::iface::IfaceRole::Multicast);
+        *channel.address()
+    };
+    transport.get_handler().lock().await.register_multicast_peer_routing(iface_hash, routing);
+    iface_hash
+}
+
+async fn new_unicast_iface_in(transport: &Transport) -> AddressHash {
+    let mgr = transport.iface_manager();
+    let mut mgr = mgr.lock().await;
+    let channel = mgr.new_channel(16);
+    *channel.address()
+}
+
+#[tokio::test]
+async fn unicast_iface_for_source_returns_none_for_non_multicast_iface() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &identity, true));
+    let unicast_iface = new_unicast_iface_in(&transport).await;
+    let handler = transport.get_handler();
+
+    let result = handler
+        .lock()
+        .await
+        .unicast_iface_for_source(unicast_iface, crate::iface::IfaceSource::Udp(peer_addr(4242)))
+        .await;
+
+    assert_eq!(result, None, "non-multicast iface must not trigger auto-unicast");
+}
+
+#[tokio::test]
+async fn unicast_iface_for_source_returns_none_when_source_is_not_udp() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &identity, true));
+    let mc_iface = register_fake_multicast_iface(&transport).await;
+    let handler = transport.get_handler();
+
+    let result = handler
+        .lock()
+        .await
+        .unicast_iface_for_source(mc_iface, crate::iface::IfaceSource::None)
+        .await;
+
+    assert_eq!(result, None, "no source addr means no auto-unicast");
+}
+
+#[tokio::test]
+async fn unicast_iface_for_source_returns_none_when_no_peer_routing_registered() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &identity, true));
+    // Register a Multicast-tagged iface *without* a PeerRouting map.
+    let mc_iface = {
+        let mgr = transport.iface_manager();
+        let mut mgr = mgr.lock().await;
+        let channel = mgr.new_channel_with_role(16, crate::iface::IfaceRole::Multicast);
+        *channel.address()
+    };
+    let handler = transport.get_handler();
+
+    let result = handler
+        .lock()
+        .await
+        .unicast_iface_for_source(mc_iface, crate::iface::IfaceSource::Udp(peer_addr(4242)))
+        .await;
+
+    assert_eq!(
+        result, None,
+        "missing PeerRouting means we can't register — bail rather than silently misroute"
+    );
+}
+
+#[tokio::test]
+async fn unicast_iface_for_source_registers_virtual_iface_and_peer_routing() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &identity, true));
+    let mc_iface = register_fake_multicast_iface(&transport).await;
+    let handler = transport.get_handler();
+
+    let iface_count_before = { transport.iface_manager().lock().await.iface_count() };
+
+    let peer = peer_addr(4242);
+    let virtual_hash = handler
+        .lock()
+        .await
+        .unicast_iface_for_source(mc_iface, crate::iface::IfaceSource::Udp(peer))
+        .await
+        .expect("should register a virtual iface");
+
+    assert_ne!(
+        virtual_hash, mc_iface,
+        "virtual iface hash is distinct from the host multicast iface"
+    );
+
+    // A single LocalInterface entry was added (the virtual one).
+    let iface_count_after = { transport.iface_manager().lock().await.iface_count() };
+    assert_eq!(iface_count_after, iface_count_before + 1);
+
+    // Role is VirtualUnicast so InterfaceManager::send skips it on Broadcast tx.
+    let role = { transport.iface_manager().lock().await.role(&virtual_hash) };
+    assert_eq!(role, Some(crate::iface::IfaceRole::VirtualUnicast));
+
+    // Handler tracks it.
+    let guard = handler.lock().await;
+    assert_eq!(guard.unicast_udp_ifaces.len(), 1);
+    assert_eq!(guard.unicast_udp_ifaces.get(&peer).map(|(h, _)| *h), Some(virtual_hash),);
+
+    // And the PeerRouting map has the forward + reverse entries.
+    let routing = guard.multicast_peer_routings.get(&mc_iface).expect("routing");
+    let routing = routing.lock().await;
+    assert_eq!(routing.hash_for_addr(&peer), Some(virtual_hash));
+    assert_eq!(routing.addr_for_hash(&virtual_hash), Some(peer));
+}
+
+#[tokio::test]
+async fn unicast_iface_for_source_reuses_existing_virtual_iface_for_same_peer() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &identity, true));
+    let mc_iface = register_fake_multicast_iface(&transport).await;
+    let handler = transport.get_handler();
+
+    let peer = peer_addr(4242);
+    let first = handler
+        .lock()
+        .await
+        .unicast_iface_for_source(mc_iface, crate::iface::IfaceSource::Udp(peer))
+        .await
+        .expect("first");
+    let second = handler
+        .lock()
+        .await
+        .unicast_iface_for_source(mc_iface, crate::iface::IfaceSource::Udp(peer))
+        .await
+        .expect("second");
+
+    assert_eq!(first, second, "same peer reuses the same virtual iface hash");
+
+    let guard = handler.lock().await;
+    assert_eq!(guard.unicast_udp_ifaces.len(), 1);
+}
+
+#[tokio::test]
+async fn unicast_iface_for_source_registers_distinct_virtual_ifaces_for_distinct_peers() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &identity, true));
+    let mc_iface = register_fake_multicast_iface(&transport).await;
+    let handler = transport.get_handler();
+
+    let peer_a = peer_addr(4242);
+    let peer_b = peer_addr(5252);
+
+    let iface_a = handler
+        .lock()
+        .await
+        .unicast_iface_for_source(mc_iface, crate::iface::IfaceSource::Udp(peer_a))
+        .await
+        .expect("peer a");
+    let iface_b = handler
+        .lock()
+        .await
+        .unicast_iface_for_source(mc_iface, crate::iface::IfaceSource::Udp(peer_b))
+        .await
+        .expect("peer b");
+
+    assert_ne!(iface_a, iface_b);
+
+    let guard = handler.lock().await;
+    assert_eq!(guard.unicast_udp_ifaces.len(), 2);
+    let routing = guard.multicast_peer_routings.get(&mc_iface).expect("routing").lock().await;
+    assert_eq!(routing.hash_for_addr(&peer_a), Some(iface_a));
+    assert_eq!(routing.hash_for_addr(&peer_b), Some(iface_b));
+}
+
+#[tokio::test]
+async fn unicast_iface_for_source_refreshes_last_seen_on_repeat_call() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &identity, true));
+    let mc_iface = register_fake_multicast_iface(&transport).await;
+    let handler = transport.get_handler();
+
+    let peer = peer_addr(4242);
+    handler
+        .lock()
+        .await
+        .unicast_iface_for_source(mc_iface, crate::iface::IfaceSource::Udp(peer))
+        .await
+        .expect("register");
+
+    {
+        let mut guard = handler.lock().await;
+        let entry = guard.unicast_udp_ifaces.get_mut(&peer).expect("cached");
+        entry.1 = tokio::time::Instant::now() - Duration::from_secs(600);
+    }
+
+    handler
+        .lock()
+        .await
+        .unicast_iface_for_source(mc_iface, crate::iface::IfaceSource::Udp(peer))
+        .await
+        .expect("refresh");
+
+    let guard = handler.lock().await;
+    let (_, last_seen) = guard.unicast_udp_ifaces.get(&peer).expect("cached");
+    let age = tokio::time::Instant::now().saturating_duration_since(*last_seen);
+    assert!(age < Duration::from_secs(1), "last_seen must be refreshed; got age {:?}", age,);
+}
+
+#[tokio::test]
+async fn gc_unicast_ifaces_removes_stale_entries_from_routing_and_manager() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &identity, true));
+    let mc_iface = register_fake_multicast_iface(&transport).await;
+    let handler = transport.get_handler();
+
+    let stale_peer = peer_addr(4242);
+    let fresh_peer = peer_addr(5252);
+
+    let stale_iface = handler
+        .lock()
+        .await
+        .unicast_iface_for_source(mc_iface, crate::iface::IfaceSource::Udp(stale_peer))
+        .await
+        .expect("stale");
+    let fresh_iface = handler
+        .lock()
+        .await
+        .unicast_iface_for_source(mc_iface, crate::iface::IfaceSource::Udp(fresh_peer))
+        .await
+        .expect("fresh");
+
+    {
+        let mut guard = handler.lock().await;
+        let entry = guard.unicast_udp_ifaces.get_mut(&stale_peer).expect("cached");
+        entry.1 = tokio::time::Instant::now() - Duration::from_secs(3600);
+    }
+
+    handler.lock().await.gc_unicast_ifaces().await;
+
+    let guard = handler.lock().await;
+    assert!(!guard.unicast_udp_ifaces.contains_key(&stale_peer));
+    assert!(guard.unicast_udp_ifaces.contains_key(&fresh_peer));
+
+    // PeerRouting map no longer contains the stale peer.
+    let routing = guard.multicast_peer_routings.get(&mc_iface).expect("routing").lock().await;
+    assert_eq!(routing.hash_for_addr(&stale_peer), None);
+    assert_eq!(routing.hash_for_addr(&fresh_peer), Some(fresh_iface));
+    assert_eq!(routing.addr_for_hash(&stale_iface), None);
+    drop(routing);
+
+    // InterfaceManager stopped the stale virtual iface (role lookup now None).
+    let mgr = transport.iface_manager();
+    let mgr = mgr.lock().await;
+    assert_eq!(mgr.role(&stale_iface), None);
+    assert_eq!(mgr.role(&fresh_iface), Some(crate::iface::IfaceRole::VirtualUnicast));
+}
+
+#[tokio::test]
+async fn gc_unicast_ifaces_is_noop_when_no_entries_are_stale() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &identity, true));
+    let mc_iface = register_fake_multicast_iface(&transport).await;
+    let handler = transport.get_handler();
+
+    let peer = peer_addr(4242);
+    let iface = handler
+        .lock()
+        .await
+        .unicast_iface_for_source(mc_iface, crate::iface::IfaceSource::Udp(peer))
+        .await
+        .expect("register");
+
+    handler.lock().await.gc_unicast_ifaces().await;
+
+    let guard = handler.lock().await;
+    assert!(guard.unicast_udp_ifaces.contains_key(&peer));
+    let routing = guard.multicast_peer_routings.get(&mc_iface).expect("routing").lock().await;
+    assert_eq!(routing.hash_for_addr(&peer), Some(iface));
 }

--- a/crates/libs/rns-transport/src/transport/wire.rs
+++ b/crates/libs/rns-transport/src/transport/wire.rs
@@ -144,7 +144,7 @@ pub(super) async fn handle_proof(
         }
         return;
     }
-    eprintln!("[tp] proof dst={} ctx={:02x}", packet.destination, packet.context as u8);
+    log::trace!("[tp] proof dst={} ctx={:02x}", packet.destination, packet.context as u8);
     let receipt_hash = {
         let handler = handler.lock().await;
         validated_receipt_hash(&packet, &handler).await
@@ -306,7 +306,7 @@ pub(super) async fn handle_data<'a>(
             }
         }
 
-        eprintln!(
+        log::trace!(
             "[tp] link_data dst={} ctx={:02x} len={}",
             packet.destination,
             packet.context as u8,

--- a/crates/libs/rns-transport/tests/multicast_tx_guard.rs
+++ b/crates/libs/rns-transport/tests/multicast_tx_guard.rs
@@ -1,0 +1,205 @@
+//! Wire-level integration tests for the multicast UDP iface.
+//!
+//! Two properties we want to guarantee end-to-end, against real UDP
+//! sockets (no mocks):
+//!
+//!   1. tx-guard — `TxMessageType::Direct` targeting the multicast
+//!      iface's own `AddressHash` never reaches the wire. Otherwise a
+//!      Link keepalive / Data packet routed "directly at the multicast
+//!      iface" would flood the whole group, which is the bug that
+//!      originally brought us here.
+//!
+//!   2. per-peer unicast routing — `TxMessageType::Direct` targeting a
+//!      *virtual* iface hash registered in the host multicast iface's
+//!      `PeerRouting` map goes out as a plain UDP unicast from the
+//!      same physical socket that carries multicast broadcasts. The
+//!      source port is the multicast port (4242-alike), which is
+//!      exactly what we want so peers attribute unicast replies to the
+//!      same virtual iface they attributed the original announce to.
+//!
+//! The tests run against IPv4 `224.0.0.100`, link-local scope, which
+//! works on stock Linux/macOS loopback without any routing setup.
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use rns_transport::iface::udp::spawn_multicast_udp;
+use rns_transport::iface::{IfaceRole, InterfaceManager, TxMessage, TxMessageType};
+use rns_transport::packet::Packet;
+use socket2::{Domain, Protocol, Socket, Type};
+use tokio::net::UdpSocket;
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+
+const MCAST_GROUP: &str = "224.0.0.100";
+
+fn bind_listener(port: u16, join_mcast: bool) -> UdpSocket {
+    let socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))
+        .expect("create listener socket");
+    socket.set_reuse_address(true).expect("SO_REUSEADDR");
+    #[cfg(unix)]
+    socket.set_reuse_port(true).expect("SO_REUSEPORT");
+    let bind_any: SocketAddr = (Ipv4Addr::UNSPECIFIED, port).into();
+    socket.bind(&bind_any.into()).expect("bind listener");
+    if join_mcast {
+        let group: Ipv4Addr = MCAST_GROUP.parse().expect("MCAST_GROUP parses");
+        socket.join_multicast_v4(&group, &Ipv4Addr::UNSPECIFIED).expect("join mcast group");
+    }
+    socket.set_nonblocking(true).expect("nonblocking");
+    let std_sock: std::net::UdpSocket = socket.into();
+    UdpSocket::from_std(std_sock).expect("into tokio")
+}
+
+/// Pick an unused UDP port by briefly binding + closing.
+fn pick_free_port() -> u16 {
+    let probe = std::net::UdpSocket::bind("0.0.0.0:0").expect("probe port");
+    let port = probe.local_addr().expect("probe local_addr").port();
+    drop(probe);
+    port
+}
+
+#[tokio::test]
+async fn broadcast_tx_reaches_multicast_listeners() {
+    let port = pick_free_port();
+    let group_addr = format!("{}:{}", MCAST_GROUP, port);
+    let listener = bind_listener(port, true);
+
+    let mut mgr = InterfaceManager::new(64);
+    let (_iface_hash, _routing) =
+        spawn_multicast_udp(&mut mgr, group_addr.clone(), Some(group_addr.clone()));
+    let mgr = Arc::new(Mutex::new(mgr));
+
+    // Give the tx task a moment to bind and join the group.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    mgr.lock()
+        .await
+        .send(TxMessage { tx_type: TxMessageType::Broadcast(None), packet: Packet::default() })
+        .await;
+
+    let mut rx_buf = [0u8; 2048];
+    let result = timeout(Duration::from_millis(500), listener.recv_from(&mut rx_buf)).await;
+    assert!(result.is_ok(), "multicast listener expected to see the Broadcast tx within 500ms");
+}
+
+#[tokio::test]
+async fn direct_tx_targeting_multicast_iface_is_dropped() {
+    let port = pick_free_port();
+    let group_addr = format!("{}:{}", MCAST_GROUP, port);
+    let listener = bind_listener(port, true);
+
+    let mut mgr = InterfaceManager::new(64);
+    let (iface_hash, _routing) =
+        spawn_multicast_udp(&mut mgr, group_addr.clone(), Some(group_addr.clone()));
+    let mgr = Arc::new(Mutex::new(mgr));
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // Drain any stray packets that may have been queued while the
+    // socket was still binding / joining the group.
+    let mut rx_buf = [0u8; 2048];
+    let _ = timeout(Duration::from_millis(150), listener.recv_from(&mut rx_buf)).await;
+
+    // Direct tx targeting the multicast iface's own AddressHash is
+    // nonsensical (would send the packet to the multicast group the
+    // iface is joined to), so the tx-guard drops it.
+    mgr.lock()
+        .await
+        .send(TxMessage { tx_type: TxMessageType::Direct(iface_hash), packet: Packet::default() })
+        .await;
+
+    let result = timeout(Duration::from_millis(400), listener.recv_from(&mut rx_buf)).await;
+    assert!(
+        result.is_err(),
+        "multicast listener must NOT see the Direct tx targeting the multicast iface itself; \
+         saw {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn direct_tx_to_registered_virtual_iface_is_sent_unicast() {
+    // Two sockets, two ports:
+    //   - multicast iface in the manager, using `mcast_port`
+    //   - unicast listener at `peer_port`, NOT joined to the group
+    //
+    // We register the unicast listener's SocketAddr in the iface's
+    // PeerRouting under a virtual iface hash, then send a Direct tx
+    // to that virtual hash. The listener should receive it as a
+    // plain unicast UDP packet.
+    let mcast_port = pick_free_port();
+    let peer_port = pick_free_port();
+    assert_ne!(mcast_port, peer_port);
+
+    let group_addr = format!("{}:{}", MCAST_GROUP, mcast_port);
+    let peer_listener = bind_listener(peer_port, false);
+    let peer_addr: SocketAddr = format!("127.0.0.1:{}", peer_port).parse().unwrap();
+
+    let mut mgr = InterfaceManager::new(64);
+    let (host_hash, routing) =
+        spawn_multicast_udp(&mut mgr, group_addr.clone(), Some(group_addr.clone()));
+
+    // Register a virtual iface pinned to the peer.
+    let virtual_hash = mgr
+        .register_virtual_iface(host_hash, IfaceRole::VirtualUnicast)
+        .expect("register virtual iface");
+    routing.lock().await.insert(peer_addr, virtual_hash);
+
+    let mgr = Arc::new(Mutex::new(mgr));
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    mgr.lock()
+        .await
+        .send(TxMessage { tx_type: TxMessageType::Direct(virtual_hash), packet: Packet::default() })
+        .await;
+
+    let mut rx_buf = [0u8; 2048];
+    let (n, from) = timeout(Duration::from_millis(500), peer_listener.recv_from(&mut rx_buf))
+        .await
+        .expect("peer listener expected to see the unicast tx")
+        .expect("recv_from succeeded");
+    assert!(n > 0, "unicast tx should carry a non-empty serialized packet");
+    // Source port should be the multicast port — that's the whole
+    // point of routing unicast sends through the multicast socket.
+    assert_eq!(
+        from.port(),
+        mcast_port,
+        "unicast source port should equal the multicast port so peers \
+         attribute the reply to the same iface they attributed the announce to"
+    );
+}
+
+#[tokio::test]
+async fn direct_tx_to_unknown_virtual_iface_is_dropped() {
+    use rns_transport::hash::{AddressHash, Hash};
+
+    let port = pick_free_port();
+    let group_addr = format!("{}:{}", MCAST_GROUP, port);
+    let listener = bind_listener(port, true);
+
+    let mut mgr = InterfaceManager::new(64);
+    let (_host_hash, _routing) =
+        spawn_multicast_udp(&mut mgr, group_addr.clone(), Some(group_addr.clone()));
+    let mgr = Arc::new(Mutex::new(mgr));
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // An AddressHash the iface has never heard of.
+    let bogus: AddressHash = AddressHash::new_from_hash(&Hash::new_from_slice(&[0xAAu8; 32]));
+
+    // InterfaceManager::send only enqueues to ifaces whose AddressHash
+    // matches — an unregistered hash hits no ifaces and no tx task
+    // runs. (The separate unit tests in iface/udp.rs cover the case
+    // where the hash *does* reach the tx task but isn't in
+    // PeerRouting; ensuring matching + routing both drop is
+    // belt-and-suspenders.)
+    mgr.lock()
+        .await
+        .send(TxMessage { tx_type: TxMessageType::Direct(bogus), packet: Packet::default() })
+        .await;
+
+    let mut rx_buf = [0u8; 2048];
+    let result = timeout(Duration::from_millis(300), listener.recv_from(&mut rx_buf)).await;
+    assert!(result.is_err(), "nothing should be sent for an unknown iface hash");
+}


### PR DESCRIPTION
# Enable UDP multicast transport with per-peer auto-unicast routing

Branch: `udp-multicast` → `main`

## Summary

Contributor guide: `CONTRIBUTING.md`

Enables UDP multicast as a first-class `rns-transport` interface: the bind
joins the multicast group, announces flow over multicast, and per-peer
link traffic is auto-routed point-to-point through the same socket —
without spawning per-peer OS sockets and without leaking unicast onto the
group. Fixes a ~22 Mb/s identical-packet flood observed on real LANs as
soon as multicast discovery activated.

### Context & Caveats

This work was done in service of a proof-of-concept to add reticulum as a transport for Holochain with [Volla Messages](https://github.com/HelloVolla/volla-messages/tree/reticulum) as the use-case, where we wanted to be able to test on a local network with zero-config discovery.

N.B. This code was written by LLMs and was not carefully audited by a human.  It has been tested to work for the above use case, run instructions are [here](https://github.com/HelloVolla/volla-messages/blob/reticulum/docs/reticulum/two-node-test.md)

## Type
- [ ] breaking
- [x] refactor
- [x] reliability
- [ ] chore/governance

## Motivation

`rns-transport` already accepted a multicast group address as a UDP bind, but
two things prevented it from being usable on a real LAN:

1. **The socket couldn't actually join the group.** `UdpSocket::bind` with
   the standard tokio API doesn't set `SO_REUSEADDR` / `SO_REUSEPORT` before
   binding, so multiple nodes couldn't co-bind the same multicast port, and
   no `IP_ADD_MEMBERSHIP` / `IPV6_JOIN_GROUP` was issued. Multicast traffic
   simply did not arrive.

2. **Once it did arrive, it broke the network.** Every link keepalive and
   data packet for a multicast-discovered peer was sent as
   `TxMessageType::Direct(<multicast-iface-hash>)`, which the multicast
   `UdpInterface` happily re-broadcast to the whole group. Combined with
   `IP_MULTICAST_LOOP`, a single node responding to keepalives flooded the
   group at ~22 Mb/s of identical 20-byte packets. Effectively unusable on
   any LAN with more than a couple of peers.

The goal of this branch is to make multicast UDP a first-class
`rns-transport` interface: it joins the group, announces flow over
multicast, and per-peer link traffic flows point-to-point — without
spawning a fan-out of ephemeral sockets and without leaking unicast onto
the multicast group.

## Technical work

Three commits, each independently reviewable. Listed in dependency order:

### 1. `Enable UDP multicast in rns-transport interface`

Switches the UDP bind to `socket2` so `SO_REUSEADDR` (and `SO_REUSEPORT`
on unix) can be set before binding, then joins the IPv4 or IPv6 multicast
group when the configured bind address is a multicast address. Multiple
nodes can now co-bind the same multicast port on the same host and receive
multicast traffic.

### 2. `Route transport diag prints through log::trace`

Converts 13 `eprintln!` sites across
`transport/{wire,handler,path,announce,core}.rs` to `log::trace!` so they
honor `RUST_LOG` filtering instead of dumping unconditionally to stderr.
Pure cleanup — no behavior change. Included in this branch because
debugging the multicast flood was much harder with stderr noise on by
default.

### 3. `Route multicast-discovered peers through a single host multicast socket`

This is the whole point of the branch. Two complementary layers solve the
flood problem without spawning per-peer OS sockets:

- **Wire-level tx-guard.** A `UdpInterface` records whether its bind or
  forward address is multicast. Its tx task drops any
  `TxMessageType::Direct` on a multicast iface, with a trace log.
  `Broadcast` (announces, path requests) still flows. Defensive
  invariant — even if the routing layer above misbehaves, point-to-point
  traffic cannot leak onto the multicast group.

- **Virtual per-peer ifaces backed by one shared socket.** A single
  `UdpInterface` speaks both multicast broadcasts and per-peer unicasts
  from the same socket. Per-peer routing is internal to the iface:

  - **`PeerRouting`** (new, in `iface/udp.rs`) — bidirectional map
    between a peer's reply `SocketAddr` and the virtual `AddressHash`
    we route traffic for that peer under. Shared (`Arc<Mutex<_>>`)
    between the `UdpInterface`'s tx/rx tasks and the transport handler.

  - **`UdpInterface::new_multicast(bind, forward, peer_routing)`:**
    - tx_task: `Broadcast` → multicast group; `Direct(virtual_hash)` →
      look up peer in `peer_routing`, `send_to(peer_addr)` unicast from
      the multicast socket (source port = multicast port, matching the
      peer's own table entry for this host); `Direct(multicast_iface_hash)`
      → dropped by the tx-guard; unknown virtual hash → dropped.
    - rx_task: on each `recv_from`, looks up the source `SocketAddr` in
      `peer_routing`. Hit → emit `RxMessage { address: virtual_hash }`
      so link ingress attribution matches the iface used to send the
      original request. Miss → fall back to the multicast iface hash
      (matches the first-ever packet from a new peer — its inbound
      announce).

  - **`IfaceRole::{Multicast, Unicast, VirtualUnicast}`** tags each
    `LocalInterface`. `InterfaceManager::send` skips `VirtualUnicast`
    on `Broadcast` so a single announce is not enqueued N+1 times
    (once per sibling virtual iface).

  - **`InterfaceManager::register_virtual_iface(host, role)`** creates
    a `LocalInterface` that shares `tx_send` with `host` and has its
    own `CancellationToken` so the transport can GC stale peers
    without tearing down the host.

  - **`Transport::add_multicast_udp_interface(bind, forward)`** spawns
    the multicast iface AND registers the `PeerRouting` with the
    transport handler. Callers should prefer this over poking
    `iface_manager` directly so the handler learns about the routing
    map.

  - **`TransportHandler::unicast_iface_for_source`** on a
    multicast-iface announce from a UDP peer calls
    `register_virtual_iface` and inserts `(peer_addr, virtual_hash)`
    into the iface's `PeerRouting`. No real socket spawn. Per-peer
    entries are keyed by `SocketAddr`, refreshed on every announce, and
    GC'd after 30 minutes of idleness — GC also clears the
    `PeerRouting` entry.

- **`RxMessage` gains a `source: IfaceSource` field** so the rx path
  can attribute packets to a peer address. Non-UDP backends
  (`tcp_client`, `serial`, `reticulumd` BLE) emit `IfaceSource::None`.
  `handle_announce` signature takes `IfaceSource`; `jobs.rs` threads
  `message.source` through. `release_held_announces` replays with
  `IfaceSource::None` (replays are not tied to a specific peer).

## Testing

New unit tests (all in `src/transport/tests.rs` and `src/iface/udp.rs`):

- `PeerRouting` bidirectional semantics.
- `IfaceRole::VirtualUnicast` skipped on `Broadcast`.
- `register_virtual_iface` shares `tx_send`, has independent cancel.
- `UdpInterface::is_multicast` detection (v4 + v6).
- `is_multicast_addr` and the extracted `tx_guard_should_drop` helper.
- `InterfaceManager` role / `spawn_as` / cleanup paths.
- `unicast_iface_for_source`: non-multicast iface, non-UDP source,
  fresh registration, dedup per peer, distinct peers, last-seen
  refresh, GC stale + no-op.

New integration test (`tests/multicast_tx_guard.rs`): real IPv4 multicast
round-trip exercising both the tx-guard (`Broadcast` arrives, `Direct` to
multicast iface dropped) and per-peer unicast routing — a
`Direct(virtual_hash)` after registration arrives at a plain unicast
listener, with source port = multicast port (the whole point of routing
through one socket).

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `make test`  _(workspace `cargo test` — 170 transport-crate tests
      incl. 4 new multicast integration tests, plus full workspace suite)_
- [ ] `make test-all` (optional compatibility pass)  _(not run locally)_
- [ ] `make test-full-targets` (optional full-target parity check)  _(not run locally)_
- [x] `cargo doc --workspace --no-deps`
- [ ] `cargo deny check`  _(fails on pre-existing transitive advisories:
      `rustls-webpki` (RUSTSEC-2026-0098/0099/0104), `serde_cbor`
      (RUSTSEC-2021-0127), and yanked `js-sys` / `wasm-bindgen`. None are
      introduced by this branch; the only new direct dep is `socket2`.)_
- [ ] `cargo audit`  _(same 5 vulnerabilities in transitive deps as above)_

## Compatibility
- [ ] Updated compatibility matrix / contract docs (if needed)  _(no
      external contract or wire-protocol change — changes are to the
      in-process Rust API of `rns-transport` only; see Caveats for the
      `RxMessage` / `handle_announce` signature deltas that external
      in-tree callers will see)_

## Caveats / things reviewers should know

- **`RxMessage` shape change.** `RxMessage` gains a `source: IfaceSource`
  field. All in-tree iface backends are updated (`tcp_client`, `serial`,
  `reticulumd` BLE all emit `IfaceSource::None`). External consumers
  that construct `RxMessage` directly will need to add the field. This
  is the only public Rust-API signature change.

- **`handle_announce` signature.** Now takes `IfaceSource`. `jobs.rs`
  passes `message.source` through; `release_held_announces` replays
  with `IfaceSource::None` (rationale in inline comment — replays are
  not tied to a specific peer).

- **Per-peer GC window is hardcoded to 30 minutes.** Reasonable for
  LAN keepalive cadence but not configurable. Easy to lift to a config
  knob if reviewers want it surfaced.

- **No new sockets per peer.** Despite the per-peer iface abstraction,
  there is exactly one UDP socket per multicast group per host. Per-peer
  ifaces are virtual (share the host's `tx_send`). This is intentional:
  a peer socket bound to an ephemeral port cannot receive traffic that
  the remote directs to the multicast port, so attribution must happen
  on the multicast socket itself.

- **IPv6 multicast support is wired but not integration-tested.** The
  bind path joins the v6 group correctly and unit tests cover v6 address
  detection, but the round-trip integration test uses IPv4 only. A v6
  network test would be a useful follow-up.
