### PR TITLE
Fix CI cleanup after UDP multicast merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/apps/lxmf-cli/src/bin/lxmd/config.rs
+++ b/crates/apps/lxmf-cli/src/bin/lxmd/config.rs
@@ -479,11 +479,7 @@ pub(crate) fn parse_python_reticulum_interfaces(input: &str) -> Vec<crate::Singl
             "target_port" | "listen_port" | "port" => {
                 current.port = value.parse::<u16>().ok();
             }
-            "listen_ip" => {
-                if !value.is_empty() {
-                    current.host = Some(value.to_string());
-                }
-            }
+            "listen_ip" if !value.is_empty() => current.host = Some(value.to_string()),
             _ => {}
         }
     }

--- a/crates/apps/lxmf-cli/src/bin/lxmd/query.rs
+++ b/crates/apps/lxmf-cli/src/bin/lxmd/query.rs
@@ -174,7 +174,7 @@ fn print_remote_peer_summary(status: &serde_json::Value) {
     }
 
     let mut rows: Vec<_> = peers.iter().collect();
-    rows.sort_by(|(left, _), (right, _)| left.cmp(right));
+    rows.sort_by_key(|(peer, _)| *peer);
     for (peer, details) in rows {
         let name = details.get("name").and_then(|value| value.as_str()).unwrap_or("");
         let last_heard = details.get("last_heard").and_then(|value| value.as_i64()).unwrap_or(0);

--- a/crates/libs/lxmf-sdk/src/messaging.rs
+++ b/crates/libs/lxmf-sdk/src/messaging.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -157,7 +158,7 @@ impl MessagingStore {
 
     pub fn list_announces(&self) -> Vec<AnnounceRecord> {
         let mut records = self.announce_records.values().cloned().collect::<Vec<_>>();
-        records.sort_by(|left, right| right.received_at_ms.cmp(&left.received_at_ms));
+        records.sort_by_key(|record| Reverse(record.received_at_ms));
         records
     }
 
@@ -245,7 +246,7 @@ impl MessagingStore {
             }
         }
 
-        peers.sort_by(|left, right| right.last_seen_at_ms.cmp(&left.last_seen_at_ms));
+        peers.sort_by_key(|peer| Reverse(peer.last_seen_at_ms));
         peers
     }
 
@@ -356,7 +357,7 @@ impl MessagingStore {
         }
 
         let mut out = by_conversation.into_values().collect::<Vec<_>>();
-        out.sort_by(|left, right| right.last_message_at_ms.cmp(&left.last_message_at_ms));
+        out.sort_by_key(|conversation| Reverse(conversation.last_message_at_ms));
         out
     }
 

--- a/crates/libs/rns-embedded-runtime/src/lib.rs
+++ b/crates/libs/rns-embedded-runtime/src/lib.rs
@@ -310,10 +310,7 @@ impl EmbeddedNodeRuntime {
             return Ok(());
         }
 
-        loop {
-            let Some(frame) = self.outbound.front().cloned() else {
-                break;
-            };
+        while let Some(frame) = self.outbound.front().cloned() {
             match transport.send_frame(&frame) {
                 Ok(()) => {
                     self.outbound.pop_front();

--- a/xtask/src/client_codegen.rs
+++ b/xtask/src/client_codegen.rs
@@ -2088,41 +2088,13 @@ fn validate_json_value(name: &str, value: &Value, schema: &Value) -> Result<()> 
             return Ok(());
         }
         match value_type {
-            "object" => {
-                if !value.is_object() {
-                    bail!("{name} must be object");
-                }
-            }
-            "array" => {
-                if !value.is_array() {
-                    bail!("{name} must be array");
-                }
-            }
-            "string" => {
-                if !value.is_string() {
-                    bail!("{name} must be string");
-                }
-            }
-            "number" => {
-                if !value.is_number() {
-                    bail!("{name} must be number");
-                }
-            }
-            "integer" => {
-                if !(value.is_i64() || value.is_u64()) {
-                    bail!("{name} must be integer");
-                }
-            }
-            "boolean" => {
-                if !value.is_boolean() {
-                    bail!("{name} must be boolean");
-                }
-            }
-            "null" => {
-                if !value.is_null() {
-                    bail!("{name} must be null");
-                }
-            }
+            "object" if !value.is_object() => bail!("{name} must be object"),
+            "array" if !value.is_array() => bail!("{name} must be array"),
+            "string" if !value.is_string() => bail!("{name} must be string"),
+            "number" if !value.is_number() => bail!("{name} must be number"),
+            "integer" if !(value.is_i64() || value.is_u64()) => bail!("{name} must be integer"),
+            "boolean" if !value.is_boolean() => bail!("{name} must be boolean"),
+            "null" if !value.is_null() => bail!("{name} must be null"),
             _ => {}
         }
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4177,7 +4177,7 @@ fn capture_platform_descriptor() -> Result<String> {
         });
         let arch = std::env::var("PROCESSOR_ARCHITECTURE")
             .unwrap_or_else(|_| std::env::consts::ARCH.to_string());
-        return Ok(format!("{release}; arch={arch}"));
+        Ok(format!("{release}; arch={arch}"))
     }
 
     #[cfg(not(target_family = "windows"))]


### PR DESCRIPTION
## Summary
- rebases the PR #151 CI follow-up onto current main after UDP multicast merged
- updates rustls-webpki from 0.103.10 to 0.103.13 to clear the new RustSec advisories
- keeps the remaining changes limited to Clippy cleanup in lxmd, lxmf-sdk, rns-embedded-runtime, and xtask

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
- cargo check --workspace --all-targets
- cargo nextest run --workspace --lib --bins
- cargo deny check bans licenses sources
- cargo audit --ignore RUSTSEC-2024-0421 --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2026-0009 --ignore RUSTSEC-2025-0134
- cargo xtask ci --stage sdk-schema-check
- cargo xtask publish-crates --wave all --dry-run --allow-dirty
- cargo check -p reticulumd -p rns-tools
- bash tools/scripts/check-boundaries.sh

## Note
- cargo test --workspace --tests still fails locally on macOS in crates/libs/rns-transport/tests/multicast_tx_guard.rs::broadcast_tx_reaches_multicast_listeners; the same test also fails on untouched origin/main at d5efc08, so it is not introduced by this cleanup commit.