### PR TITLE
Install BLE deps in nightly workflows

### DIFF
--- a/.github/workflows/nightly-mesh.yml
+++ b/.github/workflows/nightly-mesh.yml
@@ -14,6 +14,10 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
+      - name: Install Linux BLE build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libdbus-1-dev
       - uses: dtolnay/rust-toolchain@stable
       - name: Multi-node mesh simulation
         run: cargo run -p xtask -- mesh-sim

--- a/.github/workflows/nightly-soak-chaos.yml
+++ b/.github/workflows/nightly-soak-chaos.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Linux BLE build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libdbus-1-dev
       - uses: dtolnay/rust-toolchain@stable
       - name: Nightly soak + chaos campaign
         run: CYCLES=3 BURST_ROUNDS=8 TIMEOUT_SECS=25 PAUSE_SECS=1 CHAOS_INTERVAL=2 CHAOS_NODES=5 CHAOS_TIMEOUT_SECS=90 MAX_FAILURES=0 REPORT_PATH=target/soak/soak-report.json ./tools/scripts/soak-rnx.sh


### PR DESCRIPTION
## Summary
- install pkg-config and libdbus-1-dev before nightly mesh simulation
- install the same Linux BLE build dependencies before nightly soak chaos

## Why
The latest scheduled runs failed during libdbus-sys setup because dbus-1 was unavailable on ubuntu-latest. Regular CI already installs these deps.

## Validation
- ruby YAML parser loaded both updated workflow files
- PR CI passed: quality, tests, contracts, security
- Manual Nightly Mesh Simulation passed on this branch: https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/25173620990
- Manual Nightly Soak Chaos passed on this branch: https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/25173621009