### PR TITLE
Add external client interop release gate

### DIFF
--- a/docs/contracts/external-client-interop-acceptance-v1.md
+++ b/docs/contracts/external-client-interop-acceptance-v1.md
@@ -74,11 +74,29 @@ A passing run must retain:
 - external client delivery hash
 - exact message bodies used for both directions
 
+## Release Gate Command
+
+The release gate runs one concrete external-client proof through:
+
+```bash
+tools/scripts/external-client-interop-gate.sh <meshchatx|sideband|columba> [client-root]
+```
+
+The command delegates to the matching client-specific smoke harness, validates
+that the machine-readable report contains the required proof fields and artifact
+paths, and writes:
+
+- `target/interop/external-client-gate/<client>/report.json`
+- `target/interop/external-client-gate/<client>/gate-summary.json`
+
+Release notes may only claim external-client interoperability for a client whose
+gate summary has `status: "pass"` for the release candidate.
+
 ## Non-Goals
 
 This contract does not yet require:
 
 - CI gating
 
-That belongs to the later release-gated interop track once the local harnesses
-are stable on repeated runs.
+The release gate is intentionally local/manual until external client checkouts
+and credentials are available in automation.

--- a/docs/contracts/external-client-interop-acceptance-v1.md
+++ b/docs/contracts/external-client-interop-acceptance-v1.md
@@ -82,6 +82,16 @@ The release gate runs one concrete external-client proof through:
 tools/scripts/external-client-interop-gate.sh <meshchatx|sideband|columba> [client-root]
 ```
 
+The gate does not fetch external clients. The selected client must already be
+available as a local checkout, either through the optional `[client-root]`
+argument or the matching environment variable:
+
+- `MESHCHATX_ROOT`
+- `SIDEBAND_ROOT`
+- `COLUMBA_ROOT`
+
+The default local paths are `../MeshChatX`, `../Sideband`, and `../columba`.
+
 The command delegates to the matching client-specific smoke harness, validates
 that the machine-readable report contains the required proof fields and artifact
 paths, and writes:
@@ -99,4 +109,6 @@ This contract does not yet require:
 - CI gating
 
 The release gate is intentionally local/manual until external client checkouts
-and credentials are available in automation.
+and credentials are available in automation. A future CI version must provide
+those checkouts explicitly, for example through a pinned external interop
+workspace, private checkout token, or prebuilt client image.

--- a/docs/runbooks/release-readiness.md
+++ b/docs/runbooks/release-readiness.md
@@ -115,6 +115,16 @@ cargo run -p xtask -- reproducible-build-check
 cargo run -p xtask -- leader-readiness-check
 ```
 
+External-client interop release gate:
+
+```bash
+tools/scripts/external-client-interop-gate.sh meshchatx /path/to/MeshChatX
+```
+
+Use `sideband /path/to/Sideband` or `columba /path/to/columba` when that client
+is the release target. Do not claim interoperability for a client unless this
+gate emits `status: "pass"` in its summary artifact for the release candidate.
+
 Optional soak:
 
 ```bash
@@ -165,6 +175,11 @@ Leader-grade readiness certification artifact:
 - `target/release-readiness/leader-grade-readiness.md`
 - `target/release-readiness/certification-report.md`
 - `target/release-readiness/certification-report.json`
+
+External-client interop gate artifacts:
+
+- `target/interop/external-client-gate/<client>/report.json`
+- `target/interop/external-client-gate/<client>/gate-summary.json`
 
 Embedded footprint report artifact:
 

--- a/docs/runbooks/release-readiness.md
+++ b/docs/runbooks/release-readiness.md
@@ -119,11 +119,14 @@ External-client interop release gate:
 
 ```bash
 tools/scripts/external-client-interop-gate.sh meshchatx /path/to/MeshChatX
+tools/scripts/external-client-interop-gate.sh sideband /path/to/Sideband
+tools/scripts/external-client-interop-gate.sh columba /path/to/columba
 ```
 
-Use `sideband /path/to/Sideband` or `columba /path/to/columba` when that client
-is the release target. Do not claim interoperability for a client unless this
-gate emits `status: "pass"` in its summary artifact for the release candidate.
+The gate does not download external clients. Provide the source checkout as the
+second argument or set `MESHCHATX_ROOT`, `SIDEBAND_ROOT`, or `COLUMBA_ROOT`.
+Do not claim interoperability for a client unless this gate emits
+`status: "pass"` in its summary artifact for the release candidate.
 
 Optional soak:
 

--- a/tools/scripts/external-client-interop-gate.sh
+++ b/tools/scripts/external-client-interop-gate.sh
@@ -10,6 +10,7 @@ usage() {
 Usage: tools/scripts/external-client-interop-gate.sh <meshchatx|sideband|columba> [client-root]
 
 Runs one external-client interoperability proof and emits a stable gate summary.
+The selected external client must already exist as a local source checkout.
 
 Environment overrides:
   MESHCHATX_ROOT, SIDEBAND_ROOT, COLUMBA_ROOT
@@ -49,23 +50,35 @@ fi
 
 case "${CLIENT}" in
   meshchatx)
-    if [[ -n "${CLIENT_ROOT}" ]]; then
-      export MESHCHATX_ROOT="${CLIENT_ROOT}"
+    MESHCHATX_ROOT="${CLIENT_ROOT:-${MESHCHATX_ROOT:-${REPO_ROOT}/../MeshChatX}}"
+    if [[ ! -d "${MESHCHATX_ROOT}" ]]; then
+      echo "MeshChatX checkout not found at ${MESHCHATX_ROOT}" >&2
+      echo "Pass a checkout path as the second argument or set MESHCHATX_ROOT." >&2
+      exit 1
     fi
+    export MESHCHATX_ROOT
     LOG_DIR="${LOG_DIR}" REPORT_PATH="${REPORT_PATH}" \
       bash tools/scripts/meshchatx-reticulumd-smoke.sh
     ;;
   sideband)
-    if [[ -n "${CLIENT_ROOT}" ]]; then
-      export SIDEBAND_ROOT="${CLIENT_ROOT}"
+    SIDEBAND_ROOT="${CLIENT_ROOT:-${SIDEBAND_ROOT:-${REPO_ROOT}/../Sideband}}"
+    if [[ ! -d "${SIDEBAND_ROOT}" ]]; then
+      echo "Sideband checkout not found at ${SIDEBAND_ROOT}" >&2
+      echo "Pass a checkout path as the second argument or set SIDEBAND_ROOT." >&2
+      exit 1
     fi
+    export SIDEBAND_ROOT
     LOG_DIR="${LOG_DIR}" REPORT_PATH="${REPORT_PATH}" \
       bash tools/scripts/sideband-reticulumd-smoke.sh
     ;;
   columba)
-    if [[ -n "${CLIENT_ROOT}" ]]; then
-      export COLUMBA_ROOT="${CLIENT_ROOT}"
+    COLUMBA_ROOT="${CLIENT_ROOT:-${COLUMBA_ROOT:-${REPO_ROOT}/../columba}}"
+    if [[ ! -d "${COLUMBA_ROOT}" ]]; then
+      echo "Columba checkout not found at ${COLUMBA_ROOT}" >&2
+      echo "Pass a checkout path as the second argument or set COLUMBA_ROOT." >&2
+      exit 1
     fi
+    export COLUMBA_ROOT
     LOG_DIR="${LOG_DIR}" REPORT_PATH="${REPORT_PATH}" \
       bash tools/scripts/columba-reticulumd-smoke.sh
     ;;

--- a/tools/scripts/external-client-interop-gate.sh
+++ b/tools/scripts/external-client-interop-gate.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: tools/scripts/external-client-interop-gate.sh <meshchatx|sideband|columba> [client-root]
+
+Runs one external-client interoperability proof and emits a stable gate summary.
+
+Environment overrides:
+  MESHCHATX_ROOT, SIDEBAND_ROOT, COLUMBA_ROOT
+  LOG_DIR, REPORT_PATH, GATE_SUMMARY_PATH
+  RPC_ADDR, TRANSPORT_ADDR
+EOF
+}
+
+CLIENT="${1:-}"
+CLIENT_ROOT="${2:-}"
+
+if [[ -z "${CLIENT}" ]]; then
+  usage
+  exit 2
+fi
+
+case "${CLIENT}" in
+  meshchatx | sideband | columba) ;;
+  *)
+    usage
+    echo "unknown external client '${CLIENT}'" >&2
+    exit 2
+    ;;
+esac
+
+LOG_DIR="${LOG_DIR:-${REPO_ROOT}/target/interop/external-client-gate/${CLIENT}}"
+REPORT_PATH="${REPORT_PATH:-${LOG_DIR}/report.json}"
+GATE_SUMMARY_PATH="${GATE_SUMMARY_PATH:-${LOG_DIR}/gate-summary.json}"
+mkdir -p "${LOG_DIR}"
+
+case "${CLIENT}" in
+  meshchatx)
+    if [[ -n "${CLIENT_ROOT}" ]]; then
+      export MESHCHATX_ROOT="${CLIENT_ROOT}"
+    fi
+    LOG_DIR="${LOG_DIR}" REPORT_PATH="${REPORT_PATH}" \
+      bash tools/scripts/meshchatx-reticulumd-smoke.sh
+    ;;
+  sideband)
+    if [[ -n "${CLIENT_ROOT}" ]]; then
+      export SIDEBAND_ROOT="${CLIENT_ROOT}"
+    fi
+    LOG_DIR="${LOG_DIR}" REPORT_PATH="${REPORT_PATH}" \
+      bash tools/scripts/sideband-reticulumd-smoke.sh
+    ;;
+  columba)
+    if [[ -n "${CLIENT_ROOT}" ]]; then
+      export COLUMBA_ROOT="${CLIENT_ROOT}"
+    fi
+    LOG_DIR="${LOG_DIR}" REPORT_PATH="${REPORT_PATH}" \
+      bash tools/scripts/columba-reticulumd-smoke.sh
+    ;;
+esac
+
+python3 - <<'PY' "${CLIENT}" "${REPORT_PATH}" "${GATE_SUMMARY_PATH}"
+import json
+import os
+import sys
+
+client, report_path, summary_path = sys.argv[1:4]
+
+with open(report_path, "r", encoding="utf-8") as handle:
+    report = json.load(handle)
+
+def require_text(key):
+    value = report.get(key)
+    if not isinstance(value, str) or not value:
+        raise SystemExit(f"interop report missing non-empty '{key}'")
+    return value
+
+def require_artifact(path):
+    if not isinstance(path, str) or not path:
+        raise SystemExit("interop report contains an empty artifact path")
+    if not os.path.exists(path):
+        raise SystemExit(f"interop artifact does not exist: {path}")
+    return path
+
+if client == "meshchatx":
+    external_hash = require_text("meshchatx_hash")
+    artifacts = report.get("artifacts")
+    if not isinstance(artifacts, dict):
+        raise SystemExit("meshchatx report missing artifacts object")
+    reticulumd_log = require_artifact(artifacts.get("reticulumd_log"))
+    external_log = require_artifact(artifacts.get("meshchatx_log"))
+    proof = report.get("proof")
+    if not isinstance(proof, dict):
+        raise SystemExit("meshchatx report missing proof object")
+    for key in ("daemon_to_meshchatx", "meshchatx_to_daemon"):
+        if not isinstance(proof.get(key), str) or not proof[key]:
+            raise SystemExit(f"meshchatx report missing proof.{key}")
+else:
+    external_hash = require_text("external_client_hash")
+    reticulumd_log = require_artifact(report.get("reticulumd_log"))
+    external_log_key = f"{client}_log"
+    external_log = require_artifact(report.get(external_log_key))
+    for key in ("daemon_to_external_content", "external_to_daemon_content"):
+        if not isinstance(report.get(key), str) or not report[key]:
+            raise SystemExit(f"{client} report missing {key}")
+
+summary = {
+    "status": "pass",
+    "client": client,
+    "report_path": report_path,
+    "daemon_hash": require_text("daemon_hash"),
+    "external_client_hash": external_hash,
+    "artifacts": {
+        "reticulumd_log": reticulumd_log,
+        "external_client_log": external_log,
+    },
+}
+
+os.makedirs(os.path.dirname(summary_path), exist_ok=True)
+with open(summary_path, "w", encoding="utf-8") as handle:
+    json.dump(summary, handle, indent=2, sort_keys=True)
+PY
+
+echo "[external-client-interop-gate] pass"
+echo "[external-client-interop-gate] report=${REPORT_PATH}"
+echo "[external-client-interop-gate] summary=${GATE_SUMMARY_PATH}"

--- a/tools/scripts/external-client-interop-gate.sh
+++ b/tools/scripts/external-client-interop-gate.sh
@@ -40,6 +40,13 @@ REPORT_PATH="${REPORT_PATH:-${LOG_DIR}/report.json}"
 GATE_SUMMARY_PATH="${GATE_SUMMARY_PATH:-${LOG_DIR}/gate-summary.json}"
 mkdir -p "${LOG_DIR}"
 
+if [[ "${REPORT_PATH}" != */* ]]; then
+  REPORT_PATH="./${REPORT_PATH}"
+fi
+if [[ "${GATE_SUMMARY_PATH}" != */* ]]; then
+  GATE_SUMMARY_PATH="./${GATE_SUMMARY_PATH}"
+fi
+
 case "${CLIENT}" in
   meshchatx)
     if [[ -n "${CLIENT_ROOT}" ]]; then
@@ -121,7 +128,9 @@ summary = {
     },
 }
 
-os.makedirs(os.path.dirname(summary_path), exist_ok=True)
+summary_dir = os.path.dirname(summary_path)
+if summary_dir:
+    os.makedirs(summary_dir, exist_ok=True)
 with open(summary_path, "w", encoding="utf-8") as handle:
     json.dump(summary, handle, indent=2, sort_keys=True)
 PY


### PR DESCRIPTION
## Summary
- add a unified external-client interop release gate wrapper for MeshChatX, Sideband, and Columba
- validate the client-specific proof report and emit a stable gate summary artifact
- document the release gate command and artifact paths in the acceptance contract and release readiness runbook

## Issue
- Moves #43 forward by turning the existing client-specific smoke harnesses into one release-gate entrypoint.

## Validation
- bash -n tools/scripts/external-client-interop-gate.sh
- git diff --check
- verified no-argument usage exits with code 2

## Not run
- Full external-client proof, because it requires a real MeshChatX, Sideband, or Columba checkout on the runner.