### PR TITLE
Document external interop gate ownership

### DIFF
--- a/docs/contracts/external-client-interop-acceptance-v1.md
+++ b/docs/contracts/external-client-interop-acceptance-v1.md
@@ -124,7 +124,7 @@ or removing interoperability support:
 4. Harness flake or environment failure.
 
 The classification and the relevant report/log paths must be recorded in the
-release notes or follow-up issue. Client-specific harness fixes belong with the
+release notes or a follow-up issue. Client-specific harness fixes belong with the
 matching smoke script and runbook in this repository; external client behavior
 changes should be tracked against the upstream client checkout and pinned in the
 next passing gate summary.

--- a/docs/contracts/external-client-interop-acceptance-v1.md
+++ b/docs/contracts/external-client-interop-acceptance-v1.md
@@ -109,6 +109,26 @@ proof, logs, destination hashes, and the client-specific proof report path.
 Release notes may only claim external-client interoperability for a client whose
 gate summary has `status: "pass"` for the release candidate.
 
+## Ownership And Failure Handling
+
+The release owner is responsible for running the gate for each external client
+named in release notes and retaining the generated `gate-summary.json` with the
+release candidate evidence.
+
+If the gate fails, the release owner must classify the failure before claiming
+or removing interoperability support:
+
+1. Rust-side regression in this repository.
+2. External client setup or dependency drift.
+3. External client behavior change.
+4. Harness flake or environment failure.
+
+The classification and the relevant report/log paths must be recorded in the
+release notes or follow-up issue. Client-specific harness fixes belong with the
+matching smoke script and runbook in this repository; external client behavior
+changes should be tracked against the upstream client checkout and pinned in the
+next passing gate summary.
+
 ## Non-Goals
 
 This contract does not yet require:

--- a/docs/runbooks/release-readiness.md
+++ b/docs/runbooks/release-readiness.md
@@ -189,6 +189,11 @@ Git revision metadata when available, generated client config/state artifacts,
 logs, and destination hashes. Keep this artifact with the release candidate
 evidence before making any external-client interoperability claim.
 
+When the gate fails, classify it as a Rust-side regression, external client
+setup/dependency drift, external client behavior change, or harness/environment
+flake. Record that classification with the report/log paths in the release notes
+or a follow-up issue before shipping.
+
 Embedded footprint report artifact:
 
 - `target/embedded/footprint-report.txt`


### PR DESCRIPTION
## Summary
- document who owns running the external-client interop gate for release claims
- define failure classifications for gate failures
- require report/log paths to be recorded before shipping when the gate fails

## Issue
- Completes the ownership and failure-handling expectation from #43.

## Validation
- git diff --check