### PR TITLE
[codex] move send outcome tests

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
@@ -22,10 +22,9 @@ use reticulum_daemon::announce_names::{
 use reticulum_daemon::config::InterfaceConfig;
 use rns_core::identity::PrivateIdentity;
 use rns_rpc::{InterfaceRecord, MessagesStore, OutboundBridge, RpcDaemon, RpcRequest};
-use rns_transport::delivery::send_outcome_status;
 use rns_transport::destination::{link::LinkStatus, DestinationDesc, DestinationName};
 use rns_transport::destination_hash::parse_destination_hash_required;
-use rns_transport::transport::{SendPacketOutcome, Transport, TransportConfig};
+use rns_transport::transport::{Transport, TransportConfig};
 use serde_json::json;
 use std::collections::HashMap;
 use std::fs;
@@ -47,26 +46,6 @@ fn opportunistic_payload_keeps_payload_without_prefix() {
     let destination = [0xAA; 16];
     let payload = vec![0xBB; 24];
     assert_eq!(opportunistic_payload(&payload, &destination), payload.as_slice());
-}
-
-#[test]
-fn send_outcome_status_maps_success() {
-    assert_eq!(
-        send_outcome_status("opportunistic", SendPacketOutcome::SentDirect),
-        "sent: opportunistic"
-    );
-}
-
-#[test]
-fn send_outcome_status_maps_failures() {
-    assert_eq!(
-        send_outcome_status("opportunistic", SendPacketOutcome::DroppedMissingDestinationIdentity),
-        "failed: opportunistic missing destination identity"
-    );
-    assert_eq!(
-        send_outcome_status("opportunistic", SendPacketOutcome::DroppedNoRoute),
-        "failed: opportunistic no route"
-    );
 }
 
 #[test]

--- a/crates/libs/rns-transport/src/delivery.rs
+++ b/crates/libs/rns-transport/src/delivery.rs
@@ -137,3 +137,31 @@ pub async fn await_link_activation(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn send_outcome_status_maps_success() {
+        assert_eq!(
+            send_outcome_status("opportunistic", SendPacketOutcome::SentDirect),
+            "sent: opportunistic"
+        );
+    }
+
+    #[test]
+    fn send_outcome_status_maps_failures() {
+        assert_eq!(
+            send_outcome_status(
+                "opportunistic",
+                SendPacketOutcome::DroppedMissingDestinationIdentity,
+            ),
+            "failed: opportunistic missing destination identity"
+        );
+        assert_eq!(
+            send_outcome_status("opportunistic", SendPacketOutcome::DroppedNoRoute),
+            "failed: opportunistic no route"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This moves the send-outcome status mapper tests from the reticulumd bin tests into `rns_transport::delivery`, where `send_outcome_status` is implemented.

Changes:

- Add `delivery::tests::send_outcome_status_maps_success`.
- Add `delivery::tests::send_outcome_status_maps_failures`.
- Remove the duplicate app-level imports/tests from `reticulumd/src/bin/reticulumd/tests.rs`.

## Why

`send_outcome_status` is a transport facade helper, not reticulumd-specific behavior. Keeping its tests in the transport crate makes the library own its own contract and keeps reticulumd tests focused on daemon bridge behavior.

No runtime behavior changes.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p reticulum-rs-transport`
- `cargo clippy -p reticulum-rs-transport --no-deps -- -D warnings`
- `cargo test -p reticulumd`
- `cargo clippy -p reticulumd --tests --no-deps -- -D warnings`