### PR TITLE
extract peer control commands

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[path = "inbound_control_peer.rs"]
+mod peer_commands;
 #[path = "inbound_control_propagation.rs"]
 mod propagation_commands;
 #[path = "inbound_control_response.rs"]
@@ -131,43 +133,14 @@ fn handle_control_request(
     if path_hash == control_path_hash("/pn/get/stats") {
         return ControlResponse::Value(status::compose_python_status(daemon, control));
     }
-
-    let Some(peer_hex) = data.and_then(|value| match value {
-        rmpv::Value::Binary(bytes) if bytes.len() == 16 => Some(hex::encode(bytes)),
-        _ => None,
-    }) else {
-        return ControlResponse::Code(ERROR_INVALID_DATA);
-    };
-    let peer_exists = daemon
-        .handle_rpc(RpcRequest { id: 0, method: "list_peers".to_string(), params: None })
-        .ok()
-        .and_then(|response| response.result)
-        .and_then(|value| value.get("peers").cloned())
-        .and_then(|value| value.as_array().cloned())
-        .map(|rows| {
-            rows.iter()
-                .any(|row| row.get("peer").and_then(Value::as_str) == Some(peer_hex.as_str()))
-        })
-        .unwrap_or(false);
-    if !peer_exists {
-        return ControlResponse::Code(ERROR_NOT_FOUND);
-    }
-
-    if path_hash == control_path_hash("/pn/peer/sync") {
-        let _ = daemon.handle_rpc(RpcRequest {
-            id: 0,
-            method: "peer_sync".to_string(),
-            params: Some(json!({ "peer": peer_hex })),
-        });
-        return ControlResponse::Bool(true);
-    }
-    if path_hash == control_path_hash("/pn/peer/unpeer") {
-        let _ = daemon.handle_rpc(RpcRequest {
-            id: 0,
-            method: "peer_unpeer".to_string(),
-            params: Some(json!({ "peer": peer_hex })),
-        });
-        return ControlResponse::Bool(true);
+    if let Some(response) = peer_commands::handle_peer_command(
+        daemon,
+        path_hash,
+        data,
+        ERROR_INVALID_DATA,
+        ERROR_NOT_FOUND,
+    ) {
+        return response;
     }
 
     ControlResponse::Code(ERROR_INVALID_DATA)

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_peer.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_peer.rs
@@ -1,0 +1,117 @@
+use super::*;
+
+pub(super) fn handle_peer_command(
+    daemon: &RpcDaemon,
+    path_hash: [u8; 16],
+    data: Option<rmpv::Value>,
+    error_invalid_data: u8,
+    error_not_found: u8,
+) -> Option<ControlResponse> {
+    let method = if path_hash == control_path_hash("/pn/peer/sync") {
+        "peer_sync"
+    } else if path_hash == control_path_hash("/pn/peer/unpeer") {
+        "peer_unpeer"
+    } else {
+        return None;
+    };
+    let Some(peer_hex) = peer_hex_from_data(data) else {
+        return Some(ControlResponse::Code(error_invalid_data));
+    };
+    if !peer_exists(daemon, peer_hex.as_str()) {
+        return Some(ControlResponse::Code(error_not_found));
+    }
+    let _ = daemon.handle_rpc(RpcRequest {
+        id: 0,
+        method: method.to_string(),
+        params: Some(json!({ "peer": peer_hex })),
+    });
+    Some(ControlResponse::Bool(true))
+}
+
+fn peer_hex_from_data(data: Option<rmpv::Value>) -> Option<String> {
+    match data {
+        Some(rmpv::Value::Binary(bytes)) if bytes.len() == 16 => Some(hex::encode(bytes)),
+        _ => None,
+    }
+}
+
+fn peer_exists(daemon: &RpcDaemon, peer_hex: &str) -> bool {
+    daemon
+        .handle_rpc(RpcRequest { id: 0, method: "list_peers".to_string(), params: None })
+        .ok()
+        .and_then(|response| response.result)
+        .and_then(|value| value.get("peers").cloned())
+        .and_then(|value| value.as_array().cloned())
+        .map(|rows| {
+            rows.iter().any(|row| row.get("peer").and_then(Value::as_str) == Some(peer_hex))
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ERROR_INVALID_DATA: u8 = 0xF4;
+    const ERROR_NOT_FOUND: u8 = 0xFD;
+
+    #[test]
+    fn peer_command_returns_none_for_unhandled_path() {
+        let daemon = RpcDaemon::test_instance();
+
+        let response = handle_peer_command(
+            &daemon,
+            control_path_hash("/pn/get/stats"),
+            Some(rmpv::Value::Binary(vec![0; 16])),
+            ERROR_INVALID_DATA,
+            ERROR_NOT_FOUND,
+        );
+
+        assert!(response.is_none());
+    }
+
+    #[test]
+    fn peer_command_returns_not_found_for_unknown_peer() {
+        let daemon = RpcDaemon::test_instance();
+
+        let response = handle_peer_command(
+            &daemon,
+            control_path_hash("/pn/peer/sync"),
+            Some(rmpv::Value::Binary(vec![0xA5; 16])),
+            ERROR_INVALID_DATA,
+            ERROR_NOT_FOUND,
+        );
+
+        assert!(matches!(response, Some(ControlResponse::Code(ERROR_NOT_FOUND))));
+    }
+
+    #[test]
+    fn peer_unpeer_command_delegates_to_daemon_rpc() {
+        let daemon = RpcDaemon::test_instance();
+        let peer_bytes = [0xB6; 16];
+        let peer_hex = hex::encode(peer_bytes);
+        daemon
+            .handle_rpc(RpcRequest {
+                id: 1,
+                method: "peer_sync".to_string(),
+                params: Some(json!({ "peer": peer_hex })),
+            })
+            .expect("seed peer");
+
+        let response = handle_peer_command(
+            &daemon,
+            control_path_hash("/pn/peer/unpeer"),
+            Some(rmpv::Value::Binary(peer_bytes.to_vec())),
+            ERROR_INVALID_DATA,
+            ERROR_NOT_FOUND,
+        );
+
+        assert!(matches!(response, Some(ControlResponse::Bool(true))));
+        let peers = daemon
+            .handle_rpc(RpcRequest { id: 2, method: "list_peers".to_string(), params: None })
+            .expect("list peers")
+            .result
+            .expect("peers result");
+        assert_eq!(peers["peers"].as_array().map(Vec::len), Some(0));
+    }
+}


### PR DESCRIPTION
## Summary

- Move `/pn/peer/sync` and `/pn/peer/unpeer` handling out of the central inbound control dispatcher.
- Add `inbound_control_peer.rs` as the peer command handler module beside the existing propagation/status/response control modules.
- Add focused peer-command tests for unhandled paths, unknown peers, and unpeer delegation.

## Why

`inbound_control.rs` is still acting as both the authenticated request dispatcher and a domain command handler. This keeps the dispatcher responsible for identity/access/path parsing, while peer-specific command validation and daemon RPC delegation live in a focused module.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p reticulumd`
- `cargo clippy -p reticulumd --tests --no-deps -- -D warnings`