### PR TITLE
extract bootstrap destination setup

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport.rs
@@ -5,15 +5,16 @@ use super::{
 };
 #[path = "bootstrap_interface_startup.rs"]
 mod interface_startup;
+#[path = "bootstrap_transport_destinations.rs"]
+mod transport_destinations;
 use crate::bridge::PeerCrypto;
 use crate::interfaces::common::interface_label;
 use crate::Args;
-use reticulum_daemon::announce_names::encode_delivery_display_name_app_data;
 use reticulum_daemon::config::DaemonConfig;
 use reticulum_daemon::receipt_bridge::ReceiptBridge;
 use rns_core::identity::PrivateIdentity;
 use rns_rpc::InterfaceRecord;
-use rns_transport::destination::{DestinationName, SingleInputDestination};
+use rns_transport::destination::SingleInputDestination;
 use rns_transport::hash::AddressHash;
 use rns_transport::iface::tcp_server::TcpServer;
 use rns_transport::transport::{Transport, TransportConfig};
@@ -177,75 +178,20 @@ pub(super) async fn start_transport_and_interfaces(
             }
         }
 
-        let destination = transport_instance
-            .add_destination(transport_identity.clone(), DestinationName::new("lxmf", "delivery"))
-            .await;
-        {
-            let dest = destination.lock().await;
-            delivery_source_hash.copy_from_slice(dest.desc.address_hash.as_slice());
-            delivery_destination_hash_hex = Some(hex::encode(dest.desc.address_hash.as_slice()));
-            println!(
-                "{}",
-                pretty_daemon_line(&format!(
-                    "delivery destination hash={}",
-                    hex::encode(dest.desc.address_hash.as_slice())
-                ))
-            );
-        }
-        announce_destination = Some(destination);
-        transport_instance
-            .set_destination_announce_app_data(
-                announce_destination.as_ref().expect("delivery destination"),
-                local_display_name.and_then(encode_delivery_display_name_app_data),
-            )
-            .await;
-
-        if propagation_control_enabled {
-            let propagation = transport_instance
-                .add_destination(
-                    transport_identity.clone(),
-                    DestinationName::new("lxmf", "propagation"),
-                )
-                .await;
-            {
-                let dest = propagation.lock().await;
-                propagation_destination_hash_hex =
-                    Some(hex::encode(dest.desc.address_hash.as_slice()));
-                println!(
-                    "{}",
-                    pretty_daemon_line(&format!(
-                        "propagation destination hash={}",
-                        hex::encode(dest.desc.address_hash.as_slice())
-                    ))
-                );
-            }
-            propagation_destination = Some(propagation);
-            transport_instance
-                .set_destination_announce_app_data(
-                    propagation_destination.as_ref().expect("propagation destination"),
-                    encode_propagation_node_app_data(local_display_name),
-                )
-                .await;
-
-            let control = transport_instance
-                .add_destination(
-                    transport_identity.clone(),
-                    DestinationName::new("lxmf", "propagation.control"),
-                )
-                .await;
-            {
-                let dest = control.lock().await;
-                control_destination_hash_hex = Some(hex::encode(dest.desc.address_hash.as_slice()));
-                println!(
-                    "{}",
-                    pretty_daemon_line(&format!(
-                        "control destination hash={}",
-                        hex::encode(dest.desc.address_hash.as_slice())
-                    ))
-                );
-            }
-            control_destination = Some(control);
-        }
+        let destinations = transport_destinations::register_transport_destinations(
+            &mut transport_instance,
+            transport_identity.clone(),
+            local_display_name,
+            propagation_control_enabled,
+        )
+        .await;
+        announce_destination = Some(destinations.delivery);
+        propagation_destination = destinations.propagation;
+        control_destination = destinations.control;
+        delivery_destination_hash_hex = Some(destinations.delivery_destination_hash_hex);
+        propagation_destination_hash_hex = destinations.propagation_destination_hash_hex;
+        control_destination_hash_hex = destinations.control_destination_hash_hex;
+        delivery_source_hash = destinations.delivery_source_hash;
 
         transport = Some(Arc::new(transport_instance));
     } else if let Some(config) = daemon_config {

--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport_destinations.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport_destinations.rs
@@ -1,0 +1,89 @@
+use super::{encode_propagation_node_app_data, pretty_daemon_line};
+use reticulum_daemon::announce_names::encode_delivery_display_name_app_data;
+use rns_transport::destination::{DestinationName, SingleInputDestination};
+use rns_transport::identity::PrivateIdentity;
+use rns_transport::transport::Transport;
+use std::sync::Arc;
+
+pub(super) struct RegisteredTransportDestinations {
+    pub(super) delivery: Arc<tokio::sync::Mutex<SingleInputDestination>>,
+    pub(super) propagation: Option<Arc<tokio::sync::Mutex<SingleInputDestination>>>,
+    pub(super) control: Option<Arc<tokio::sync::Mutex<SingleInputDestination>>>,
+    pub(super) delivery_destination_hash_hex: String,
+    pub(super) propagation_destination_hash_hex: Option<String>,
+    pub(super) control_destination_hash_hex: Option<String>,
+    pub(super) delivery_source_hash: [u8; 16],
+}
+
+pub(super) async fn register_transport_destinations(
+    transport: &mut Transport,
+    transport_identity: PrivateIdentity,
+    local_display_name: Option<&str>,
+    propagation_control_enabled: bool,
+) -> RegisteredTransportDestinations {
+    let delivery = transport
+        .add_destination(transport_identity.clone(), DestinationName::new("lxmf", "delivery"))
+        .await;
+    let (delivery_source_hash, delivery_destination_hash_hex) =
+        destination_hash("delivery", &delivery).await;
+    transport
+        .set_destination_announce_app_data(
+            &delivery,
+            local_display_name.and_then(encode_delivery_display_name_app_data),
+        )
+        .await;
+
+    let mut propagation = None;
+    let mut control = None;
+    let mut propagation_destination_hash_hex = None;
+    let mut control_destination_hash_hex = None;
+    if propagation_control_enabled {
+        let propagation_destination = transport
+            .add_destination(
+                transport_identity.clone(),
+                DestinationName::new("lxmf", "propagation"),
+            )
+            .await;
+        let (_, hash_hex) = destination_hash("propagation", &propagation_destination).await;
+        propagation_destination_hash_hex = Some(hash_hex);
+        transport
+            .set_destination_announce_app_data(
+                &propagation_destination,
+                encode_propagation_node_app_data(local_display_name),
+            )
+            .await;
+        propagation = Some(propagation_destination);
+
+        let control_destination = transport
+            .add_destination(
+                transport_identity,
+                DestinationName::new("lxmf", "propagation.control"),
+            )
+            .await;
+        let (_, hash_hex) = destination_hash("control", &control_destination).await;
+        control_destination_hash_hex = Some(hash_hex);
+        control = Some(control_destination);
+    }
+
+    RegisteredTransportDestinations {
+        delivery,
+        propagation,
+        control,
+        delivery_destination_hash_hex,
+        propagation_destination_hash_hex,
+        control_destination_hash_hex,
+        delivery_source_hash,
+    }
+}
+
+async fn destination_hash(
+    label: &str,
+    destination: &Arc<tokio::sync::Mutex<SingleInputDestination>>,
+) -> ([u8; 16], String) {
+    let dest = destination.lock().await;
+    let mut hash = [0u8; 16];
+    hash.copy_from_slice(dest.desc.address_hash.as_slice());
+    let hash_hex = hex::encode(hash);
+    println!("{}", pretty_daemon_line(&format!("{label} destination hash={hash_hex}")));
+    (hash, hash_hex)
+}


### PR DESCRIPTION
## Summary

- Move delivery, propagation, and propagation-control destination registration out of `bootstrap_transport.rs`.
- Add `bootstrap_transport_destinations.rs` for destination creation, announce app-data setup, and destination hash reporting.
- Keep `bootstrap_transport.rs` focused on the broader transport startup orchestration.

## Why

The bootstrap refactor is separating startup ownership into clearer modules. Interface startup already lives in a dedicated module; this extracts the adjacent destination setup block so transport startup reads as orchestration rather than a mix of interface, persistence, and destination-registration details.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p reticulumd`
- `cargo clippy -p reticulumd --tests --no-deps -- -D warnings`