### PR TITLE
make resource status predicates explicit

### DIFF
--- a/crates/libs/rns-transport/src/resource.rs
+++ b/crates/libs/rns-transport/src/resource.rs
@@ -50,6 +50,16 @@ pub enum ResourceStatus {
     Failed,
 }
 
+impl ResourceStatus {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Complete | Self::Failed)
+    }
+
+    fn accepts_transfer_activity(self) -> bool {
+        matches!(self, Self::Advertised | Self::Transferring | Self::AwaitingProof)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResourceAdvertisement {
     pub transfer_size: u64,

--- a/crates/libs/rns-transport/src/resource/receiver.rs
+++ b/crates/libs/rns-transport/src/resource/receiver.rs
@@ -254,7 +254,7 @@ impl ResourceReceiver {
     }
 
     fn is_active(&self) -> bool {
-        !matches!(self.status, ResourceStatus::Complete | ResourceStatus::Failed)
+        !self.status.is_terminal()
     }
 
     fn mark_request(&mut self) {
@@ -263,7 +263,7 @@ impl ResourceReceiver {
     }
 
     fn retry_due(&self, now: Instant, retry_interval: Duration, max_retries: u8) -> bool {
-        if self.status == ResourceStatus::Complete || self.status == ResourceStatus::Failed {
+        if self.status.is_terminal() {
             return false;
         }
         if self.retry_count >= max_retries {

--- a/crates/libs/rns-transport/src/resource/sender.rs
+++ b/crates/libs/rns-transport/src/resource/sender.rs
@@ -245,10 +245,7 @@ impl ResourceSender {
             }
         }
 
-        if self.status == ResourceStatus::Advertised
-            || self.status == ResourceStatus::Transferring
-            || self.status == ResourceStatus::AwaitingProof
-        {
+        if self.status.accepts_transfer_activity() {
             let now = Instant::now();
             self.last_activity = now;
             self.retries_left = self.max_retries;

--- a/crates/libs/rns-transport/src/resource/tests.rs
+++ b/crates/libs/rns-transport/src/resource/tests.rs
@@ -25,6 +25,31 @@ mod tests {
     }
 
     #[test]
+    fn resource_status_predicates_make_transfer_fsm_edges_explicit() {
+        for status in [
+            ResourceStatus::None,
+            ResourceStatus::Advertised,
+            ResourceStatus::Transferring,
+            ResourceStatus::AwaitingProof,
+        ] {
+            assert!(!status.is_terminal());
+        }
+        for status in [ResourceStatus::Complete, ResourceStatus::Failed] {
+            assert!(status.is_terminal());
+        }
+        for status in [
+            ResourceStatus::Advertised,
+            ResourceStatus::Transferring,
+            ResourceStatus::AwaitingProof,
+        ] {
+            assert!(status.accepts_transfer_activity());
+        }
+        for status in [ResourceStatus::None, ResourceStatus::Complete, ResourceStatus::Failed] {
+            assert!(!status.accepts_transfer_activity());
+        }
+    }
+
+    #[test]
     fn resource_sender_marks_request_and_response_advertisements() {
         let signer = PrivateIdentity::new_from_rand(OsRng);
         let identity = *signer.as_identity();


### PR DESCRIPTION
## Summary

- Add explicit `ResourceStatus` predicates for terminal states and transfer-active states.
- Use those predicates in the resource sender and receiver instead of repeating raw status matches.
- Add a focused test that documents the resource-transfer FSM edges.

## Why

Resource transfer already behaves like a small state machine. This keeps the existing states and behavior, but makes the important transitions readable from the enum instead of scattering the state interpretation through sender and receiver code.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p reticulum-rs-transport`
- `cargo clippy -p reticulum-rs-transport --no-deps -- -D warnings`