### PR TITLE
move propagation link cache state

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge.rs
@@ -50,12 +50,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 pub(crate) use delivery_method::{validate_delivery_request, RequestedDeliveryMethod};
 use delivery_task::{DeliveryTask, LinkModeStatuses};
 use identity_resolver::resolve_destination_identity_blocking;
-
-#[derive(Clone)]
-struct CachedPropagationLink {
-    node_hex: String,
-    link: Arc<tokio::sync::Mutex<Link>>,
-}
+use propagation::CachedPropagationLink;
 
 pub(super) struct TransportBridge {
     daemon: Arc<Mutex<Option<Arc<RpcDaemon>>>>,

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_propagation.rs
@@ -1,4 +1,3 @@
-use super::CachedPropagationLink;
 use lxmf::WireMessage;
 use rand_core::OsRng;
 use reticulum_daemon::lxmf_stamps::generate_propagation_stamp;
@@ -13,6 +12,12 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 pub(super) const PROPAGATION_INVALID_STAMP_SIGNAL: u8 = 0xF5;
 pub(super) const DEFAULT_PROPAGATION_STAMP_COST: u32 = 13;
+
+#[derive(Clone)]
+pub(super) struct CachedPropagationLink {
+    pub(super) node_hex: String,
+    pub(super) link: Arc<tokio::sync::Mutex<Link>>,
+}
 
 pub(super) fn build_propagation_payload(
     payload: &[u8],


### PR DESCRIPTION
## Summary

- Move `CachedPropagationLink` from the top-level bridge module into `bridge_propagation.rs`.
- Keep existing bridge fields and delivery task access intact through the bridge module import.
- Leave behavior unchanged; this is an ownership/naming cleanup for propagation bridge state.

## Why

The propagation link cache is only interpreted by propagation bridge code. Moving the state type next to the cache behavior keeps `bridge.rs` closer to a facade shell and gives propagation-specific state a clearer owner.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p reticulumd`
- `cargo clippy -p reticulumd --tests --no-deps -- -D warnings`