### PR TITLE
add transport path facade

### DIFF
--- a/crates/libs/rns-transport/src/transport/links.rs
+++ b/crates/libs/rns-transport/src/transport/links.rs
@@ -508,6 +508,10 @@ impl Transport {
         self.handler.lock().await.knows_destination(address)
     }
 
+    pub async fn has_path(&self, address: &AddressHash) -> bool {
+        self.handler.lock().await.path_table.get(address).is_some()
+    }
+
     pub async fn destination_identity(&self, address: &AddressHash) -> Option<Identity> {
         let destination =
             { self.handler.lock().await.single_out_destinations.get(address).cloned() }?;

--- a/crates/libs/rns-transport/src/transport/tests.rs
+++ b/crates/libs/rns-transport/src/transport/tests.rs
@@ -211,10 +211,7 @@ async fn reticulum_path_table_persistence_restores_route_and_identity_from_cache
     let restored_identity = restored.destination_identity(&destination).await.expect("identity");
     assert_eq!(restored_identity.public_key_bytes(), expected_identity.public_key_bytes());
     assert_eq!(restored_identity.verifying_key_bytes(), expected_identity.verifying_key_bytes());
-    assert!(
-        restored.get_handler().lock().await.path_table.get(&destination).is_some(),
-        "path table entry should be restored"
-    );
+    assert!(restored.has_path(&destination).await, "path table entry should be restored");
 }
 
 #[tokio::test]
@@ -262,7 +259,7 @@ async fn reticulum_tunnel_table_persistence_restores_tunnel_paths_after_reappear
 
     assert_eq!(restored.restore_reticulum_path_table(temp.path()).await.expect("restore"), 0);
     assert!(
-        restored.get_handler().lock().await.path_table.get(&destination).is_none(),
+        !restored.has_path(&destination).await,
         "tunnel table load should not restore active path before tunnel reappears"
     );
 
@@ -280,7 +277,7 @@ async fn reticulum_tunnel_table_persistence_restores_tunnel_paths_after_reappear
     }
 
     assert!(
-        restored.get_handler().lock().await.path_table.get(&destination).is_some(),
+        restored.has_path(&destination).await,
         "tunnel reappearance should restore the persisted tunnel path"
     );
     assert!(restored.destination_identity(&destination).await.is_some());


### PR DESCRIPTION
## Summary
- add `Transport::has_path()` as a small public route-presence facade
- update path/tunnel persistence tests to use the facade instead of reaching into `get_handler().path_table`

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p reticulum-rs-transport`
- `cargo clippy -p reticulum-rs-transport --tests --no-deps -- -D warnings`