### PR TITLE
extract outbound resource tracking

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap.rs
@@ -1,7 +1,8 @@
 use super::announce_worker::spawn_announce_worker;
 use super::bridge::TransportBridge;
-use super::inbound_worker::{spawn_inbound_worker, OutboundResourceTracking};
+use super::inbound_worker::spawn_inbound_worker;
 use super::interface_hot_apply::LegacyTcpInterfaceMutationBridge;
+use super::outbound_resources::OutboundResourceMap;
 use super::receipt_worker::spawn_receipt_worker;
 use super::Args;
 #[path = "bootstrap_transport.rs"]
@@ -99,8 +100,7 @@ pub(super) async fn bootstrap(args: Args) -> BootstrapContext {
         })
         .unwrap_or_default();
     let receipt_map: Arc<Mutex<HashMap<String, String>>> = Arc::new(Mutex::new(HashMap::new()));
-    let outbound_resource_map: Arc<Mutex<HashMap<String, OutboundResourceTracking>>> =
-        Arc::new(Mutex::new(HashMap::new()));
+    let outbound_resource_map: OutboundResourceMap = Arc::new(Mutex::new(HashMap::new()));
     let (receipt_tx, receipt_rx) = unbounded_channel();
     let propagation_control_enabled = env_flag("LXMD_PROPAGATION_NODE");
     let configured_control_identities = parse_hex_list_env("LXMD_CONTROL_ALLOWED");

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge.rs
@@ -20,8 +20,9 @@ mod paper;
 mod propagation;
 #[path = "bridge_remote_control.rs"]
 mod remote_control;
-use super::inbound_worker::{
-    track_outbound_resource, OutboundResourceTracking, OUTBOUND_RESOURCE_SENT_STATUS,
+use super::outbound_resources::{
+    track_outbound_resource, OutboundResourceMap, OutboundResourceTracking,
+    OUTBOUND_RESOURCE_SENT_STATUS,
 };
 use reticulum_daemon::receipt_bridge::{track_receipt_mapping, ReceiptEvent};
 use rns_core::identity::PrivateIdentity;
@@ -70,7 +71,7 @@ pub(super) struct TransportBridge {
     peer_crypto: Arc<Mutex<HashMap<String, PeerCrypto>>>,
     outbound_propagation_identities: Arc<Mutex<HashMap<String, Identity>>>,
     receipt_map: Arc<Mutex<HashMap<String, String>>>,
-    outbound_resource_map: Arc<Mutex<HashMap<String, OutboundResourceTracking>>>,
+    outbound_resource_map: OutboundResourceMap,
     outbound_propagation_link: Arc<tokio::sync::Mutex<Option<CachedPropagationLink>>>,
     receipt_tx: tokio::sync::mpsc::UnboundedSender<ReceiptEvent>,
 }
@@ -93,7 +94,7 @@ impl TransportBridge {
         control_announce_destination: Option<Arc<tokio::sync::Mutex<SingleInputDestination>>>,
         peer_crypto: Arc<Mutex<HashMap<String, PeerCrypto>>>,
         receipt_map: Arc<Mutex<HashMap<String, String>>>,
-        outbound_resource_map: Arc<Mutex<HashMap<String, OutboundResourceTracking>>>,
+        outbound_resource_map: OutboundResourceMap,
         receipt_tx: tokio::sync::mpsc::UnboundedSender<ReceiptEvent>,
     ) -> Self {
         Self {

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task.rs
@@ -12,7 +12,7 @@ pub(super) struct DeliveryTask {
     pub(super) peer_crypto: Arc<Mutex<HashMap<String, PeerCrypto>>>,
     pub(super) outbound_propagation_identities: Arc<Mutex<HashMap<String, Identity>>>,
     pub(super) receipt_map: Arc<Mutex<HashMap<String, String>>>,
-    pub(super) outbound_resource_map: Arc<Mutex<HashMap<String, OutboundResourceTracking>>>,
+    pub(super) outbound_resource_map: OutboundResourceMap,
     pub(super) outbound_propagation_link: Arc<tokio::sync::Mutex<Option<CachedPropagationLink>>>,
     pub(super) receipt_tx: tokio::sync::mpsc::UnboundedSender<ReceiptEvent>,
     pub(super) message_id: String,

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control.rs
@@ -6,6 +6,8 @@ mod response;
 #[path = "inbound_control_status.rs"]
 mod status;
 use response::ControlResponse;
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 pub(super) fn spawn_control_worker(
     daemon: Arc<RpcDaemon>,

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker.rs
@@ -1,5 +1,6 @@
 use super::bootstrap::PropagationControlContext;
 use super::bridge_helpers::diagnostics_enabled;
+use super::outbound_resources::{take_outbound_resource_tracking, OutboundResourceMap};
 #[path = "inbound_control.rs"]
 mod control;
 #[path = "inbound_delivery_events.rs"]
@@ -22,25 +23,14 @@ use rns_transport::resource::ResourceEventKind;
 use rns_transport::transport::Transport;
 use routing::InboundLxmfDestination;
 use serde_json::{json, Value};
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-
-pub(super) const OUTBOUND_RESOURCE_SENT_STATUS: &str = "sent: link resource";
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct OutboundResourceTracking {
-    pub(super) message_id: String,
-    pub(super) peer: String,
-    pub(super) bytes: usize,
-    pub(super) sent_status: String,
-}
+use std::sync::Arc;
 
 pub(super) fn spawn_inbound_worker(
     daemon: Arc<RpcDaemon>,
     transport: Arc<Transport>,
     control: PropagationControlContext,
     receipt_tx: tokio::sync::mpsc::UnboundedSender<ReceiptEvent>,
-    outbound_resource_map: Arc<Mutex<HashMap<String, OutboundResourceTracking>>>,
+    outbound_resource_map: OutboundResourceMap,
 ) {
     if control.enabled {
         control::spawn_control_worker(daemon.clone(), transport.clone(), control.clone());
@@ -202,32 +192,6 @@ fn spawn_packet_inbound_worker(
             }
         }
     });
-}
-
-pub(super) fn track_outbound_resource(
-    outbound_resource_map: &Arc<Mutex<HashMap<String, OutboundResourceTracking>>>,
-    resource_hash_hex: String,
-    tracking: OutboundResourceTracking,
-) {
-    if let Ok(mut guard) = outbound_resource_map.lock() {
-        guard.insert(resource_hash_hex, tracking);
-    }
-}
-
-pub(super) fn take_outbound_resource_tracking(
-    outbound_resource_map: &Arc<Mutex<HashMap<String, OutboundResourceTracking>>>,
-    resource_hash_hex: &str,
-) -> Option<OutboundResourceTracking> {
-    outbound_resource_map.lock().ok().and_then(|mut guard| guard.remove(resource_hash_hex))
-}
-
-pub(super) fn prune_outbound_resource_mappings_for_message(
-    outbound_resource_map: &Arc<Mutex<HashMap<String, OutboundResourceTracking>>>,
-    message_id: &str,
-) {
-    if let Ok(mut guard) = outbound_resource_map.lock() {
-        guard.retain(|_, tracking| tracking.message_id != message_id);
-    }
 }
 
 #[cfg(test)]

--- a/crates/apps/reticulumd/src/bin/reticulumd/main.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/main.rs
@@ -8,6 +8,7 @@ mod bridge_helpers;
 mod inbound_worker;
 mod interface_hot_apply;
 mod interfaces;
+mod outbound_resources;
 mod receipt_events;
 mod receipt_worker;
 mod rpc_loop;

--- a/crates/apps/reticulumd/src/bin/reticulumd/outbound_resources.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/outbound_resources.rs
@@ -1,0 +1,89 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+pub(super) const OUTBOUND_RESOURCE_SENT_STATUS: &str = "sent: link resource";
+
+pub(super) type OutboundResourceMap = Arc<Mutex<HashMap<String, OutboundResourceTracking>>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct OutboundResourceTracking {
+    pub(super) message_id: String,
+    pub(super) peer: String,
+    pub(super) bytes: usize,
+    pub(super) sent_status: String,
+}
+
+pub(super) fn track_outbound_resource(
+    outbound_resource_map: &OutboundResourceMap,
+    resource_hash_hex: String,
+    tracking: OutboundResourceTracking,
+) {
+    if let Ok(mut guard) = outbound_resource_map.lock() {
+        guard.insert(resource_hash_hex, tracking);
+    }
+}
+
+pub(super) fn take_outbound_resource_tracking(
+    outbound_resource_map: &OutboundResourceMap,
+    resource_hash_hex: &str,
+) -> Option<OutboundResourceTracking> {
+    outbound_resource_map.lock().ok().and_then(|mut guard| guard.remove(resource_hash_hex))
+}
+
+pub(super) fn prune_outbound_resource_mappings_for_message(
+    outbound_resource_map: &OutboundResourceMap,
+    message_id: &str,
+) {
+    if let Ok(mut guard) = outbound_resource_map.lock() {
+        guard.retain(|_, tracking| tracking.message_id != message_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        prune_outbound_resource_mappings_for_message, take_outbound_resource_tracking,
+        track_outbound_resource, OutboundResourceTracking, OUTBOUND_RESOURCE_SENT_STATUS,
+    };
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn outbound_resource_tracking_round_trips_and_prunes() {
+        let map = Arc::new(Mutex::new(HashMap::new()));
+        track_outbound_resource(
+            &map,
+            "res-1".to_string(),
+            OutboundResourceTracking {
+                message_id: "msg-1".to_string(),
+                peer: "peer-a".to_string(),
+                bytes: 128,
+                sent_status: OUTBOUND_RESOURCE_SENT_STATUS.to_string(),
+            },
+        );
+        track_outbound_resource(
+            &map,
+            "res-2".to_string(),
+            OutboundResourceTracking {
+                message_id: "msg-2".to_string(),
+                peer: "peer-b".to_string(),
+                bytes: 256,
+                sent_status: OUTBOUND_RESOURCE_SENT_STATUS.to_string(),
+            },
+        );
+
+        let tracking = take_outbound_resource_tracking(&map, "res-1").expect("resource mapping");
+        assert_eq!(tracking.message_id, "msg-1");
+        assert_eq!(tracking.peer, "peer-a");
+        assert_eq!(tracking.bytes, 128);
+        assert_eq!(tracking.sent_status, OUTBOUND_RESOURCE_SENT_STATUS);
+
+        prune_outbound_resource_mappings_for_message(&map, "msg-2");
+        assert!(take_outbound_resource_tracking(&map, "res-2").is_none());
+    }
+
+    #[test]
+    fn outbound_resource_completion_stays_non_terminal() {
+        assert_eq!(OUTBOUND_RESOURCE_SENT_STATUS, "sent: link resource");
+    }
+}

--- a/crates/apps/reticulumd/src/bin/reticulumd/receipt_events.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/receipt_events.rs
@@ -1,6 +1,6 @@
 use super::bridge_helpers::log_delivery_trace;
-use super::inbound_worker::{
-    prune_outbound_resource_mappings_for_message, OutboundResourceTracking,
+use super::outbound_resources::{
+    prune_outbound_resource_mappings_for_message, OutboundResourceMap,
 };
 use reticulum_daemon::receipt_bridge::{handle_receipt_event, ReceiptEvent};
 use rns_rpc::RpcDaemon;
@@ -35,7 +35,7 @@ pub(super) fn handle_receipt_update(
     daemon: &RpcDaemon,
     event: ReceiptEvent,
     receipt_map: &Arc<Mutex<HashMap<String, String>>>,
-    outbound_resource_map: &Arc<Mutex<HashMap<String, OutboundResourceTracking>>>,
+    outbound_resource_map: &OutboundResourceMap,
 ) {
     let message_id = event.message_id.clone();
     let status = event.status.clone();

--- a/crates/apps/reticulumd/src/bin/reticulumd/receipt_worker.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/receipt_worker.rs
@@ -1,4 +1,4 @@
-use super::inbound_worker::OutboundResourceTracking;
+use super::outbound_resources::OutboundResourceMap;
 use super::receipt_events::handle_receipt_update;
 use reticulum_daemon::receipt_bridge::ReceiptEvent;
 use rns_rpc::RpcDaemon;
@@ -10,7 +10,7 @@ pub(super) fn spawn_receipt_worker(
     daemon: Arc<RpcDaemon>,
     mut receipt_rx: UnboundedReceiver<ReceiptEvent>,
     receipt_map: Arc<Mutex<HashMap<String, String>>>,
-    outbound_resource_map: Arc<Mutex<HashMap<String, OutboundResourceTracking>>>,
+    outbound_resource_map: OutboundResourceMap,
 ) {
     let daemon_receipts = daemon;
     tokio::spawn(async move {

--- a/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
@@ -6,10 +6,6 @@ use crate::bridge::{
     validate_delivery_request, PeerCrypto, RequestedDeliveryMethod, TransportBridge,
 };
 use crate::bridge_helpers::opportunistic_payload;
-use crate::inbound_worker::{
-    prune_outbound_resource_mappings_for_message, take_outbound_resource_tracking,
-    track_outbound_resource, OutboundResourceTracking, OUTBOUND_RESOURCE_SENT_STATUS,
-};
 use crate::interfaces::{lora, serial};
 use crate::{bootstrap, Args};
 use futures::FutureExt;
@@ -46,45 +42,6 @@ fn opportunistic_payload_keeps_payload_without_prefix() {
     let destination = [0xAA; 16];
     let payload = vec![0xBB; 24];
     assert_eq!(opportunistic_payload(&payload, &destination), payload.as_slice());
-}
-
-#[test]
-fn outbound_resource_tracking_round_trips_and_prunes() {
-    let map = Arc::new(Mutex::new(HashMap::new()));
-    track_outbound_resource(
-        &map,
-        "res-1".to_string(),
-        OutboundResourceTracking {
-            message_id: "msg-1".to_string(),
-            peer: "peer-a".to_string(),
-            bytes: 128,
-            sent_status: OUTBOUND_RESOURCE_SENT_STATUS.to_string(),
-        },
-    );
-    track_outbound_resource(
-        &map,
-        "res-2".to_string(),
-        OutboundResourceTracking {
-            message_id: "msg-2".to_string(),
-            peer: "peer-b".to_string(),
-            bytes: 256,
-            sent_status: OUTBOUND_RESOURCE_SENT_STATUS.to_string(),
-        },
-    );
-
-    let tracking = take_outbound_resource_tracking(&map, "res-1").expect("resource mapping");
-    assert_eq!(tracking.message_id, "msg-1");
-    assert_eq!(tracking.peer, "peer-a");
-    assert_eq!(tracking.bytes, 128);
-    assert_eq!(tracking.sent_status, OUTBOUND_RESOURCE_SENT_STATUS);
-
-    prune_outbound_resource_mappings_for_message(&map, "msg-2");
-    assert!(take_outbound_resource_tracking(&map, "res-2").is_none());
-}
-
-#[test]
-fn outbound_resource_completion_stays_non_terminal() {
-    assert_eq!(OUTBOUND_RESOURCE_SENT_STATUS, "sent: link resource");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- move outbound resource correlation bookkeeping out of `inbound_worker.rs` into `outbound_resources.rs`
- add an `OutboundResourceMap` type alias for the shared correlation map used by bridge, receipt, and bootstrap code
- keep the outbound resource tracking/prune tests with the owning module
- add explicit imports for inbound control/receipt modules that previously relied on broad parent imports

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p reticulumd`
- `cargo clippy -p reticulumd --tests --no-deps -- -D warnings`