### PR TITLE
[codex] Rename TCP interface hot apply bridge

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap.rs
@@ -1,7 +1,7 @@
 use super::announce_worker::spawn_announce_worker;
 use super::bridge::TransportBridge;
 use super::inbound_worker::spawn_inbound_worker;
-use super::interface_hot_apply::LegacyTcpInterfaceMutationBridge;
+use super::interface_hot_apply::TcpInterfaceMutationBridge;
 use super::outbound_resources::OutboundResourceMap;
 use super::receipt_worker::spawn_receipt_worker;
 use super::Args;
@@ -134,7 +134,7 @@ pub(super) async fn bootstrap(args: Args) -> BootstrapContext {
     configured_interfaces = startup.configured_interfaces;
     let startup_successes = startup.startup_successes;
     let startup_failures = startup.startup_failures;
-    let hot_apply_seeded_tcp = startup.hot_apply_seeded_tcp;
+    let seeded_tcp_interfaces = startup.seeded_tcp_interfaces;
     let selected_tcp_server = startup.selected_tcp_server;
 
     if !startup_failures.is_empty() {
@@ -211,9 +211,9 @@ pub(super) async fn bootstrap(args: Args) -> BootstrapContext {
         announce_bridge,
     ));
     if let Some(transport) = transport.as_ref() {
-        daemon.set_interface_mutation_bridge(Arc::new(LegacyTcpInterfaceMutationBridge::spawn(
+        daemon.set_interface_mutation_bridge(Arc::new(TcpInterfaceMutationBridge::spawn(
             transport.iface_manager(),
-            hot_apply_seeded_tcp,
+            seeded_tcp_interfaces,
         )));
     }
     if let Some(bridge) = bridge.as_ref() {

--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup.rs
@@ -2,7 +2,7 @@ use super::super::{
     mark_interface_runtime_fields, mark_interface_startup_status, strict_tcp_client_preflight,
 };
 use super::{InterfaceStartupFailure, TcpServerSelection};
-use crate::interface_hot_apply::legacy_tcp_interface_key;
+use crate::interface_hot_apply::tcp_interface_key;
 use crate::interfaces::{ble, common::interface_label, lora, serial, udp};
 use crate::Args;
 use reticulum_daemon::config::{DaemonConfig, InterfaceConfig};
@@ -16,7 +16,7 @@ use std::sync::Arc;
 pub(super) struct InterfaceStartupBatch {
     pub(super) startup_successes: usize,
     pub(super) startup_failures: Vec<InterfaceStartupFailure>,
-    pub(super) hot_apply_seeded_tcp: Vec<(String, InterfaceRecord, AddressHash)>,
+    pub(super) seeded_tcp_interfaces: Vec<(String, InterfaceRecord, AddressHash)>,
     pub(super) tunnel_synth_ifaces: Vec<AddressHash>,
 }
 
@@ -30,7 +30,7 @@ pub(super) async fn startup_configured_interfaces(
 ) -> InterfaceStartupBatch {
     let mut startup_successes = 0usize;
     let mut startup_failures = Vec::new();
-    let mut hot_apply_seeded_tcp = Vec::new();
+    let mut seeded_tcp_interfaces = Vec::new();
     let mut tunnel_synth_ifaces = Vec::new();
 
     for (index, iface) in config.interfaces.iter().enumerate() {
@@ -64,7 +64,7 @@ pub(super) async fn startup_configured_interfaces(
                     iface_manager,
                     &mut configured_interfaces[index],
                     &mut startup_failures,
-                    &mut hot_apply_seeded_tcp,
+                    &mut seeded_tcp_interfaces,
                 )
                 .await
                 {
@@ -136,7 +136,7 @@ pub(super) async fn startup_configured_interfaces(
     InterfaceStartupBatch {
         startup_successes,
         startup_failures,
-        hot_apply_seeded_tcp,
+        seeded_tcp_interfaces,
         tunnel_synth_ifaces,
     }
 }
@@ -200,7 +200,7 @@ async fn startup_tcp_client(
     iface_manager: &Arc<tokio::sync::Mutex<rns_transport::iface::InterfaceManager>>,
     record: &mut InterfaceRecord,
     startup_failures: &mut Vec<InterfaceStartupFailure>,
-    hot_apply_seeded_tcp: &mut Vec<(String, InterfaceRecord, AddressHash)>,
+    seeded_tcp_interfaces: &mut Vec<(String, InterfaceRecord, AddressHash)>,
 ) -> Option<AddressHash> {
     let (Some(host), Some(port)) = (iface.host.as_ref(), iface.port) else {
         record_startup_failure(
@@ -240,8 +240,8 @@ async fn startup_tcp_client(
     );
     let runtime_iface = client_iface.to_string();
     mark_interface_startup_status(record, "spawned", None, Some(runtime_iface.as_str()));
-    if let Some(key) = legacy_tcp_interface_key(record) {
-        hot_apply_seeded_tcp.push((key, record.clone(), client_iface));
+    if let Some(key) = tcp_interface_key(record) {
+        seeded_tcp_interfaces.push((key, record.clone(), client_iface));
     }
     Some(client_iface)
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport.rs
@@ -35,7 +35,7 @@ pub(super) struct TransportStartupArtifacts {
     pub(super) configured_interfaces: Vec<InterfaceRecord>,
     pub(super) startup_successes: usize,
     pub(super) startup_failures: Vec<InterfaceStartupFailure>,
-    pub(super) hot_apply_seeded_tcp: Vec<(String, InterfaceRecord, AddressHash)>,
+    pub(super) seeded_tcp_interfaces: Vec<(String, InterfaceRecord, AddressHash)>,
 }
 
 pub(super) struct TransportStartupInput<'a> {
@@ -92,7 +92,7 @@ pub(super) async fn start_transport_and_interfaces(
     let mut delivery_source_hash = [0u8; 16];
     let mut startup_successes = 0usize;
     let mut startup_failures = Vec::new();
-    let mut hot_apply_seeded_tcp = Vec::new();
+    let mut seeded_tcp_interfaces = Vec::new();
 
     if transport_required {
         if let Some(addr) = selected_tcp_server.bind_addr.as_ref() {
@@ -140,7 +140,7 @@ pub(super) async fn start_transport_and_interfaces(
             for iface in startup.tunnel_synth_ifaces {
                 transport_instance.synthesize_tunnel_on_interface(iface).await;
             }
-            hot_apply_seeded_tcp.extend(startup.hot_apply_seeded_tcp);
+            seeded_tcp_interfaces.extend(startup.seeded_tcp_interfaces);
         }
 
         match transport_instance.restore_reticulum_path_table(reticulum_storage_path).await {
@@ -237,6 +237,6 @@ pub(super) async fn start_transport_and_interfaces(
         configured_interfaces,
         startup_successes,
         startup_failures,
-        hot_apply_seeded_tcp,
+        seeded_tcp_interfaces,
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply.rs
@@ -12,22 +12,22 @@ use crate::bootstrap::{
 };
 
 #[derive(Clone)]
-pub(super) struct LegacyTcpInterfaceMutationBridge {
-    tx: UnboundedSender<LegacyTcpInterfaceCommand>,
+pub(super) struct TcpInterfaceMutationBridge {
+    tx: UnboundedSender<TcpInterfaceCommand>,
 }
 
-impl LegacyTcpInterfaceMutationBridge {
+impl TcpInterfaceMutationBridge {
     pub(super) fn spawn(
         iface_manager: Arc<tokio::sync::Mutex<InterfaceManager>>,
         seeded: Vec<(String, InterfaceRecord, AddressHash)>,
     ) -> Self {
         let (tx, rx) = unbounded_channel();
-        tokio::spawn(run_legacy_tcp_interface_worker(iface_manager, rx, seeded));
+        tokio::spawn(run_tcp_interface_mutation_worker(iface_manager, rx, seeded));
         Self { tx }
     }
 }
 
-impl InterfaceMutationBridge for LegacyTcpInterfaceMutationBridge {
+impl InterfaceMutationBridge for TcpInterfaceMutationBridge {
     fn apply_interfaces(
         &self,
         interfaces: Vec<InterfaceRecord>,
@@ -44,14 +44,14 @@ impl InterfaceMutationBridge for LegacyTcpInterfaceMutationBridge {
                 record
             })
             .collect::<Vec<_>>();
-        self.tx.send(LegacyTcpInterfaceCommand::Apply { interfaces }).map_err(|_| {
+        self.tx.send(TcpInterfaceCommand::Apply { interfaces }).map_err(|_| {
             io::Error::new(io::ErrorKind::BrokenPipe, "interface mutation worker is not running")
         })?;
         Ok(effective)
     }
 }
 
-enum LegacyTcpInterfaceCommand {
+enum TcpInterfaceCommand {
     Apply { interfaces: Vec<InterfaceRecord> },
 }
 
@@ -61,9 +61,9 @@ struct ManagedTcpInterface {
     address: AddressHash,
 }
 
-async fn run_legacy_tcp_interface_worker(
+async fn run_tcp_interface_mutation_worker(
     iface_manager: Arc<tokio::sync::Mutex<InterfaceManager>>,
-    mut rx: UnboundedReceiver<LegacyTcpInterfaceCommand>,
+    mut rx: UnboundedReceiver<TcpInterfaceCommand>,
     seeded: Vec<(String, InterfaceRecord, AddressHash)>,
 ) {
     let mut managed = seeded
@@ -73,14 +73,14 @@ async fn run_legacy_tcp_interface_worker(
 
     while let Some(command) = rx.recv().await {
         match command {
-            LegacyTcpInterfaceCommand::Apply { interfaces } => {
-                apply_legacy_tcp_interfaces(&iface_manager, &mut managed, interfaces).await;
+            TcpInterfaceCommand::Apply { interfaces } => {
+                apply_tcp_interface_records(&iface_manager, &mut managed, interfaces).await;
             }
         }
     }
 }
 
-async fn apply_legacy_tcp_interfaces(
+async fn apply_tcp_interface_records(
     iface_manager: &Arc<tokio::sync::Mutex<InterfaceManager>>,
     managed: &mut HashMap<String, ManagedTcpInterface>,
     interfaces: Vec<InterfaceRecord>,
@@ -88,7 +88,7 @@ async fn apply_legacy_tcp_interfaces(
     let desired = interfaces
         .into_iter()
         .filter_map(|record| {
-            let key = legacy_tcp_interface_key(&record)?;
+            let key = tcp_interface_key(&record)?;
             Some((key, record))
         })
         .collect::<HashMap<_, _>>();
@@ -97,7 +97,7 @@ async fn apply_legacy_tcp_interfaces(
     for key in current_keys {
         let should_remove = match (managed.get(&key), desired.get(&key)) {
             (Some(current), Some(next)) => {
-                !next.enabled || legacy_tcp_changed(&current.record, next)
+                !next.enabled || tcp_interface_record_changed(&current.record, next)
             }
             (Some(_), None) => true,
             (None, _) => false,
@@ -125,7 +125,7 @@ async fn apply_legacy_tcp_interfaces(
     }
 }
 
-pub(super) fn legacy_tcp_interface_key(record: &InterfaceRecord) -> Option<String> {
+pub(super) fn tcp_interface_key(record: &InterfaceRecord) -> Option<String> {
     if record.kind != "tcp_client" {
         return None;
     }
@@ -139,7 +139,7 @@ pub(super) fn legacy_tcp_interface_key(record: &InterfaceRecord) -> Option<Strin
     Some(format!("{host}:{port}"))
 }
 
-fn legacy_tcp_changed(current: &InterfaceRecord, next: &InterfaceRecord) -> bool {
+fn tcp_interface_record_changed(current: &InterfaceRecord, next: &InterfaceRecord) -> bool {
     current.enabled != next.enabled || current.host != next.host || current.port != next.port
 }
 
@@ -150,8 +150,7 @@ fn tcp_endpoint(record: &InterfaceRecord) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        InterfaceManager, InterfaceMutationBridge, InterfaceRecord,
-        LegacyTcpInterfaceMutationBridge,
+        InterfaceManager, InterfaceMutationBridge, InterfaceRecord, TcpInterfaceMutationBridge,
     };
     use std::sync::Arc;
     use tokio::net::TcpListener;
@@ -173,7 +172,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
         let addr = listener.local_addr().expect("listener addr");
         let iface_manager = Arc::new(tokio::sync::Mutex::new(InterfaceManager::new(8)));
-        let bridge = LegacyTcpInterfaceMutationBridge::spawn(iface_manager, Vec::new());
+        let bridge = TcpInterfaceMutationBridge::spawn(iface_manager, Vec::new());
 
         let applied = bridge
             .apply_interfaces(vec![tcp_record("loopback", "127.0.0.1", addr.port())])


### PR DESCRIPTION
## Summary

This is a narrow naming cleanup in the active reticulumd TCP interface mutation path. The hot-apply worker was still named as a `LegacyTcpInterfaceMutationBridge` with `legacy_tcp_*` helpers, even though it is the current runtime bridge used by daemon interface mutation.

The change renames the bridge, command, worker, TCP record key helper, and seeded interface handoff around the actual product concept: TCP interface mutation and configured TCP interface records. Behavior is unchanged; the daemon still marks enabled TCP clients as spawned/running for RPC and applies changes through the same worker.

## Why

The broader refactor direction is to keep reticulumd organized around explicit daemon boundaries and product/protocol concepts, not old implementation accidents. This removes misleading legacy naming without introducing a trait layer or broad structural rewrite.

## Changes

- Rename `LegacyTcpInterfaceMutationBridge` to `TcpInterfaceMutationBridge`.
- Rename `LegacyTcpInterfaceCommand` and worker/apply helpers to TCP interface mutation names.
- Rename `legacy_tcp_interface_key` to `tcp_interface_key`.
- Rename the bootstrap handoff from `hot_apply_seeded_tcp` to `seeded_tcp_interfaces`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p reticulumd`
- `cargo clippy -p reticulumd --tests --no-deps -- -D warnings`