### PR TITLE
[codex] Extract RPC access logging

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_access_log.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_access_log.rs
@@ -1,0 +1,215 @@
+use rns_rpc::rpc::codec;
+use rns_rpc::{http, RpcRequest};
+use serde_json::json;
+use std::io::IsTerminal;
+use std::net::SocketAddr;
+
+#[derive(Debug, Default, Clone)]
+pub(super) struct RpcRequestLogMeta {
+    http_method: String,
+    path: String,
+    rpc_method: Option<String>,
+    rpc_request_id: Option<u64>,
+    trace_ref: Option<String>,
+}
+
+pub(super) fn parse_request_log_meta(request: &[u8]) -> RpcRequestLogMeta {
+    let mut meta = RpcRequestLogMeta::default();
+    let Some(header_end) = http::find_header_end(request) else {
+        return meta;
+    };
+    let headers = &request[..header_end];
+    let Some((http_method, path)) = parse_http_request_line(headers) else {
+        return meta;
+    };
+    meta.http_method = http_method.to_string();
+    meta.path = path.to_string();
+
+    if http_method != "POST" || path != "/rpc" {
+        return meta;
+    }
+    let Some(content_length) = http::parse_content_length(headers) else {
+        return meta;
+    };
+    let body_start = header_end + 4;
+    if request.len() < body_start.saturating_add(content_length) {
+        return meta;
+    }
+    let body = &request[body_start..body_start + content_length];
+    let Ok(rpc_request) = codec::decode_frame::<RpcRequest>(body) else {
+        return meta;
+    };
+    meta.trace_ref = Some(format!("rpc:{}:{:016x}", rpc_request.method, rpc_request.id));
+    meta.rpc_method = Some(rpc_request.method);
+    meta.rpc_request_id = Some(rpc_request.id);
+    meta
+}
+
+pub(super) fn emit_rpc_access_log(
+    peer_addr: SocketAddr,
+    meta: &RpcRequestLogMeta,
+    response: &[u8],
+    elapsed_ms: u64,
+    error_text: Option<&str>,
+) {
+    let status_code = parse_status_code(response).unwrap_or(0);
+    if pretty_console_logs_enabled() {
+        eprintln!(
+            "{} {} {} {} {}{}{}",
+            pretty_tag("rpc", 34),
+            pretty_status(&status_code.to_string(), status_code_color(status_code)),
+            pretty_elapsed(elapsed_ms),
+            pretty_method(&format!("{} {}", meta.http_method, meta.path)),
+            pretty_secondary(&format!("peer={peer_addr}")),
+            meta.rpc_method
+                .as_ref()
+                .map(|method| format!(" {}", pretty_secondary(&format!("rpc={method}"))))
+                .unwrap_or_default(),
+            error_text.map(|error| format!(" {}", pretty_error(error))).unwrap_or_default()
+        );
+        return;
+    }
+    let payload = json!({
+        "event": "rpc_request",
+        "peer": peer_addr.to_string(),
+        "http_method": meta.http_method,
+        "path": meta.path,
+        "rpc_method": meta.rpc_method,
+        "rpc_request_id": meta.rpc_request_id,
+        "trace_ref": meta.trace_ref,
+        "status_code": status_code,
+        "elapsed_ms": elapsed_ms,
+        "ok": error_text.is_none(),
+        "error": error_text,
+    });
+    eprintln!("{}", payload);
+}
+
+fn parse_http_request_line(headers: &[u8]) -> Option<(&str, &str)> {
+    let text = std::str::from_utf8(headers).ok()?;
+    let line = text.lines().next()?;
+    let mut parts = line.split_whitespace();
+    let method = parts.next()?;
+    let path = parts.next()?;
+    Some((method, path))
+}
+
+fn parse_status_code(response: &[u8]) -> Option<u16> {
+    let text = std::str::from_utf8(response).ok()?;
+    let line = text.lines().next()?;
+    let mut parts = line.split_whitespace();
+    let _http_version = parts.next()?;
+    let code = parts.next()?;
+    code.parse::<u16>().ok()
+}
+
+fn pretty_console_logs_enabled() -> bool {
+    matches!(
+        std::env::var("LXMF_LOG_PRETTY").ok().as_deref(),
+        Some("1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON")
+    )
+}
+
+fn pretty_color_enabled() -> bool {
+    if matches!(
+        std::env::var("LXMF_LOG_COLOR").ok().as_deref(),
+        Some("1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON" | "always" | "ALWAYS")
+    ) {
+        return true;
+    }
+    if matches!(
+        std::env::var("LXMF_LOG_COLOR").ok().as_deref(),
+        Some("0" | "false" | "FALSE" | "no" | "NO" | "off" | "OFF" | "never" | "NEVER")
+    ) {
+        return false;
+    }
+    pretty_console_logs_enabled() && std::io::stderr().is_terminal()
+}
+
+fn ansi(text: &str, code: &str) -> String {
+    if pretty_color_enabled() {
+        format!("\x1b[{code}m{text}\x1b[0m")
+    } else {
+        text.to_string()
+    }
+}
+
+fn pretty_tag(label: &str, color: u8) -> String {
+    ansi(&format!("[{label:<4}]"), &color.to_string())
+}
+
+fn pretty_status(label: &str, color: u8) -> String {
+    ansi(&format!("{label:<4}"), &format!("1;{color}"))
+}
+
+fn pretty_elapsed(elapsed_ms: u64) -> String {
+    ansi(&format!("{elapsed_ms:>4}ms"), "2")
+}
+
+fn pretty_method(method: &str) -> String {
+    ansi(method, "1")
+}
+
+fn pretty_secondary(value: &str) -> String {
+    ansi(value, "2")
+}
+
+fn pretty_error(value: &str) -> String {
+    ansi(&format!("error={value}"), "31")
+}
+
+fn status_code_color(status_code: u16) -> u8 {
+    match status_code {
+        200..=299 => 32,
+        400..=499 => 33,
+        _ => 31,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_request_log_meta_extracts_rpc_fields() {
+        let rpc_body = codec::encode_frame(&RpcRequest {
+            id: 44,
+            method: "sdk_poll_events_v2".to_string(),
+            params: Some(json!({ "cursor": null, "max": 1 })),
+        })
+        .expect("encode rpc body");
+        let request = format!(
+            "POST /rpc HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n",
+            rpc_body.len()
+        );
+        let mut raw = request.into_bytes();
+        raw.extend_from_slice(&rpc_body);
+
+        let meta = parse_request_log_meta(&raw);
+        assert_eq!(meta.http_method, "POST");
+        assert_eq!(meta.path, "/rpc");
+        assert_eq!(meta.rpc_method.as_deref(), Some("sdk_poll_events_v2"));
+        assert_eq!(meta.rpc_request_id, Some(44));
+        assert!(meta
+            .trace_ref
+            .as_deref()
+            .is_some_and(|value| value.contains("sdk_poll_events_v2")));
+    }
+
+    #[test]
+    fn parse_request_log_meta_keeps_non_rpc_requests_lightweight() {
+        let raw = b"GET /healthz HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        let meta = parse_request_log_meta(raw);
+        assert_eq!(meta.http_method, "GET");
+        assert_eq!(meta.path, "/healthz");
+        assert!(meta.rpc_method.is_none());
+        assert!(meta.rpc_request_id.is_none());
+        assert!(meta.trace_ref.is_none());
+    }
+
+    #[test]
+    fn parse_status_code_extracts_numeric_status() {
+        let response = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+        assert_eq!(parse_status_code(response), Some(200));
+    }
+}

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop.rs
@@ -1,12 +1,12 @@
 use super::bootstrap::RpcTlsConfig;
-use rns_rpc::rpc::codec;
-use rns_rpc::{http, RpcDaemon, RpcRequest};
+#[path = "rpc_access_log.rs"]
+mod rpc_access_log;
+use rns_rpc::{http, RpcDaemon};
+use rpc_access_log::{emit_rpc_access_log, parse_request_log_meta};
 use rustls::server::WebPkiClientVerifier;
 use rustls::{RootCertStore, ServerConfig};
 use rustls_pemfile::private_key;
-use serde_json::json;
 use std::fs::File;
-use std::io::IsTerminal;
 use std::io::{self, BufReader};
 use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
@@ -22,15 +22,6 @@ use x509_parser::prelude::{FromDer, GeneralName, X509Certificate};
 const RPC_READ_TIMEOUT: Duration = Duration::from_secs(5);
 const RPC_MAX_HEADER_BYTES: usize = 16 * 1024;
 const RPC_MAX_BODY_BYTES: usize = 1024 * 1024;
-
-#[derive(Debug, Default, Clone)]
-struct RpcRequestLogMeta {
-    http_method: String,
-    path: String,
-    rpc_method: Option<String>,
-    rpc_request_id: Option<u64>,
-    trace_ref: Option<String>,
-}
 
 pub(super) async fn run_rpc_loop(
     addr: SocketAddr,
@@ -193,159 +184,6 @@ fn request_read_error_response(error: &io::Error) -> &'static [u8] {
     }
 }
 
-fn parse_request_log_meta(request: &[u8]) -> RpcRequestLogMeta {
-    let mut meta = RpcRequestLogMeta::default();
-    let Some(header_end) = http::find_header_end(request) else {
-        return meta;
-    };
-    let headers = &request[..header_end];
-    let Some((http_method, path)) = parse_http_request_line(headers) else {
-        return meta;
-    };
-    meta.http_method = http_method.to_string();
-    meta.path = path.to_string();
-
-    if http_method != "POST" || path != "/rpc" {
-        return meta;
-    }
-    let Some(content_length) = http::parse_content_length(headers) else {
-        return meta;
-    };
-    let body_start = header_end + 4;
-    if request.len() < body_start.saturating_add(content_length) {
-        return meta;
-    }
-    let body = &request[body_start..body_start + content_length];
-    let Ok(rpc_request) = codec::decode_frame::<RpcRequest>(body) else {
-        return meta;
-    };
-    meta.trace_ref = Some(format!("rpc:{}:{:016x}", rpc_request.method, rpc_request.id));
-    meta.rpc_method = Some(rpc_request.method);
-    meta.rpc_request_id = Some(rpc_request.id);
-    meta
-}
-
-fn parse_http_request_line(headers: &[u8]) -> Option<(&str, &str)> {
-    let text = std::str::from_utf8(headers).ok()?;
-    let line = text.lines().next()?;
-    let mut parts = line.split_whitespace();
-    let method = parts.next()?;
-    let path = parts.next()?;
-    Some((method, path))
-}
-
-fn parse_status_code(response: &[u8]) -> Option<u16> {
-    let text = std::str::from_utf8(response).ok()?;
-    let line = text.lines().next()?;
-    let mut parts = line.split_whitespace();
-    let _http_version = parts.next()?;
-    let code = parts.next()?;
-    code.parse::<u16>().ok()
-}
-
-fn emit_rpc_access_log(
-    peer_addr: SocketAddr,
-    meta: &RpcRequestLogMeta,
-    response: &[u8],
-    elapsed_ms: u64,
-    error_text: Option<&str>,
-) {
-    let status_code = parse_status_code(response).unwrap_or(0);
-    if pretty_console_logs_enabled() {
-        eprintln!(
-            "{} {} {} {} {}{}{}",
-            pretty_tag("rpc", 34),
-            pretty_status(&status_code.to_string(), status_code_color(status_code)),
-            pretty_elapsed(elapsed_ms),
-            pretty_method(&format!("{} {}", meta.http_method, meta.path)),
-            pretty_secondary(&format!("peer={peer_addr}")),
-            meta.rpc_method
-                .as_ref()
-                .map(|method| format!(" {}", pretty_secondary(&format!("rpc={method}"))))
-                .unwrap_or_default(),
-            error_text.map(|error| format!(" {}", pretty_error(error))).unwrap_or_default()
-        );
-        return;
-    }
-    let payload = json!({
-        "event": "rpc_request",
-        "peer": peer_addr.to_string(),
-        "http_method": meta.http_method,
-        "path": meta.path,
-        "rpc_method": meta.rpc_method,
-        "rpc_request_id": meta.rpc_request_id,
-        "trace_ref": meta.trace_ref,
-        "status_code": status_code,
-        "elapsed_ms": elapsed_ms,
-        "ok": error_text.is_none(),
-        "error": error_text,
-    });
-    eprintln!("{}", payload);
-}
-
-fn pretty_console_logs_enabled() -> bool {
-    matches!(
-        std::env::var("LXMF_LOG_PRETTY").ok().as_deref(),
-        Some("1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON")
-    )
-}
-
-fn pretty_color_enabled() -> bool {
-    if matches!(
-        std::env::var("LXMF_LOG_COLOR").ok().as_deref(),
-        Some("1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON" | "always" | "ALWAYS")
-    ) {
-        return true;
-    }
-    if matches!(
-        std::env::var("LXMF_LOG_COLOR").ok().as_deref(),
-        Some("0" | "false" | "FALSE" | "no" | "NO" | "off" | "OFF" | "never" | "NEVER")
-    ) {
-        return false;
-    }
-    pretty_console_logs_enabled() && std::io::stderr().is_terminal()
-}
-
-fn ansi(text: &str, code: &str) -> String {
-    if pretty_color_enabled() {
-        format!("\x1b[{code}m{text}\x1b[0m")
-    } else {
-        text.to_string()
-    }
-}
-
-fn pretty_tag(label: &str, color: u8) -> String {
-    ansi(&format!("[{label:<4}]"), &color.to_string())
-}
-
-fn pretty_status(label: &str, color: u8) -> String {
-    ansi(&format!("{label:<4}"), &format!("1;{color}"))
-}
-
-fn pretty_elapsed(elapsed_ms: u64) -> String {
-    ansi(&format!("{elapsed_ms:>4}ms"), "2")
-}
-
-fn pretty_method(method: &str) -> String {
-    ansi(method, "1")
-}
-
-fn pretty_secondary(value: &str) -> String {
-    ansi(value, "2")
-}
-
-fn pretty_error(value: &str) -> String {
-    ansi(&format!("error={value}"), "31")
-}
-
-fn status_code_color(status_code: u16) -> u8 {
-    match status_code {
-        200..=299 => 32,
-        400..=499 => 33,
-        _ => 31,
-    }
-}
-
 fn build_tls_server_config(config: &RpcTlsConfig) -> io::Result<std::sync::Arc<ServerConfig>> {
     let server_chain = load_cert_chain(config.cert_chain_path.as_path())?;
     let private_key = load_private_key(config.private_key_path.as_path())?;
@@ -502,49 +340,6 @@ fn parse_subject_alt_names(cert: &X509Certificate<'_>) -> Vec<String> {
 mod rpc_loop_tests {
     use super::*;
     use tokio::io::{duplex, AsyncWriteExt};
-
-    #[test]
-    fn parse_request_log_meta_extracts_rpc_fields() {
-        let rpc_body = codec::encode_frame(&RpcRequest {
-            id: 44,
-            method: "sdk_poll_events_v2".to_string(),
-            params: Some(json!({ "cursor": null, "max": 1 })),
-        })
-        .expect("encode rpc body");
-        let request = format!(
-            "POST /rpc HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n",
-            rpc_body.len()
-        );
-        let mut raw = request.into_bytes();
-        raw.extend_from_slice(&rpc_body);
-
-        let meta = parse_request_log_meta(&raw);
-        assert_eq!(meta.http_method, "POST");
-        assert_eq!(meta.path, "/rpc");
-        assert_eq!(meta.rpc_method.as_deref(), Some("sdk_poll_events_v2"));
-        assert_eq!(meta.rpc_request_id, Some(44));
-        assert!(meta
-            .trace_ref
-            .as_deref()
-            .is_some_and(|value| value.contains("sdk_poll_events_v2")));
-    }
-
-    #[test]
-    fn parse_request_log_meta_keeps_non_rpc_requests_lightweight() {
-        let raw = b"GET /healthz HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        let meta = parse_request_log_meta(raw);
-        assert_eq!(meta.http_method, "GET");
-        assert_eq!(meta.path, "/healthz");
-        assert!(meta.rpc_method.is_none());
-        assert!(meta.rpc_request_id.is_none());
-        assert!(meta.trace_ref.is_none());
-    }
-
-    #[test]
-    fn parse_status_code_extracts_numeric_status() {
-        let response = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
-        assert_eq!(parse_status_code(response), Some(200));
-    }
 
     #[test]
     fn read_http_request_collects_complete_post_body() {


### PR DESCRIPTION
## Summary

This extracts RPC access-log parsing and formatting out of `rpc_loop.rs` into `rpc_access_log.rs`.

The socket loop still owns accepting connections, reading requests, invoking the RPC daemon, writing responses, and shutting down the stream. The new module owns request-log metadata extraction, status parsing, JSON log emission, and pretty-log formatting.

## Why

This keeps the runtime loop closer to the worker/event-loop pattern: read an event, delegate business/observability concerns, write the response. It is a narrow module extraction with no RPC behavior change.

## Changes

- Add `crates/apps/reticulumd/src/bin/reticulumd/rpc_access_log.rs`.
- Move `RpcRequestLogMeta`, request-log parsing, status parsing, and pretty/JSON log emission into that module.
- Move the access-log parser tests alongside the moved code.
- Leave `rpc_loop.rs` focused on connection lifecycle and HTTP request reading.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p reticulumd`
- `cargo clippy -p reticulumd --tests --no-deps -- -D warnings`