### PR TITLE
[codex] fix announce burst collapse

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -13,7 +13,7 @@ impl RpcDaemon {
 
     pub(super) fn next_announce_seq(&self) -> u64 {
         let mut guard = self.announce_next_seq.lock().expect("announce_next_seq mutex poisoned");
-        *guard = guard.saturating_add(1);
+        *guard = guard.wrapping_add(1);
         *guard
     }
 

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -11,6 +11,12 @@ impl RpcDaemon {
         guard.values().filter(|record| record.peer_type.as_deref() != Some("unpeered")).count()
     }
 
+    pub(super) fn next_announce_seq(&self) -> u64 {
+        let mut guard = self.announce_next_seq.lock().expect("announce_next_seq mutex poisoned");
+        *guard = guard.saturating_add(1);
+        *guard
+    }
+
     pub fn with_store(store: MessagesStore, identity_hash: String) -> Self {
         Self::with_store_and_bridges_and_sinks(store, identity_hash, None, None, Vec::new())
     }
@@ -64,6 +70,7 @@ impl RpcDaemon {
             event_queue: Mutex::new(VecDeque::new()),
             sdk_event_log: Mutex::new(VecDeque::new()),
             sdk_next_event_seq: Mutex::new(0),
+            announce_next_seq: Mutex::new(0),
             sdk_dropped_event_count: Mutex::new(0),
             sdk_active_contract_version: Mutex::new(2),
             sdk_profile: Mutex::new("desktop-full".to_string()),
@@ -614,7 +621,7 @@ impl RpcDaemon {
         };
 
         let announce_record = AnnounceRecord {
-            id: format!("announce-{}-{}-{}", timestamp, record.peer, record.seen_count),
+            id: format!("announce-{}-{}-{}", timestamp, record.peer, self.next_announce_seq()),
             peer: record.peer.clone(),
             timestamp,
             name: record.name.clone(),

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -648,6 +648,81 @@ fn stale_announce_does_not_regress_propagation_peer_state() {
 }
 
 #[test]
+fn discovered_announce_bursts_do_not_collapse_in_announce_log() {
+    let daemon = RpcDaemon::test_instance();
+    let timestamp = 1_700_000_250;
+
+    for idx in 0..4 {
+        daemon
+            .accept_announce_with_metadata(
+                "peer-discovered".to_string(),
+                timestamp,
+                Some(format!("Peer Discovered {idx}")),
+                Some("announce".to_string()),
+                None,
+                Some(vec!["propagation".to_string()]),
+                None,
+                None,
+                None,
+                Some(3),
+                Some(Some(1)),
+                Some(Some(4)),
+                None,
+                Some(1),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("accept discovered announce");
+    }
+
+    let announces = daemon
+        .handle_rpc(RpcRequest { id: 50, method: "list_announces".to_string(), params: None })
+        .expect("list announces")
+        .result
+        .expect("list announces result");
+    let rows = announces["announces"].as_array().expect("announce rows");
+    let matching = rows
+        .iter()
+        .filter(|row| row["peer"].as_str() == Some("peer-discovered"))
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 4, "same-second discovered announces must remain distinct");
+    let unique_ids = matching
+        .iter()
+        .filter_map(|row| row["id"].as_str())
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(unique_ids.len(), 4, "announce log IDs must be unique for burst traffic");
+
+    let legacy_event_ids = std::iter::from_fn(|| daemon.take_event())
+        .filter(|event| event.event_type == "announce_received")
+        .filter_map(|event| event.payload["id"].as_str().map(str::to_string))
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(
+        legacy_event_ids.len(),
+        4,
+        "daemon event queue must expose unique announce IDs for burst traffic"
+    );
+
+    let events = daemon
+        .handle_rpc(rpc_request(51, "sdk_poll_events_v2", json!({ "cursor": null, "max": 20 })))
+        .expect("poll sdk events")
+        .result
+        .expect("sdk events result");
+    let event_rows = events["events"].as_array().expect("event rows");
+    let announce_event_ids = event_rows
+        .iter()
+        .filter(|row| row["event_type"].as_str() == Some("announce_received"))
+        .filter_map(|row| row["payload"]["id"].as_str())
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(
+        announce_event_ids.len(),
+        4,
+        "SDK announce events must expose unique IDs for burst traffic"
+    );
+}
+
+#[test]
 fn peering_cost_policy_blocks_and_breaks_autopeers() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/crates/libs/rns-rpc/src/rpc/types.rs
+++ b/crates/libs/rns-rpc/src/rpc/types.rs
@@ -357,6 +357,7 @@ pub struct RpcDaemon {
     event_queue: Mutex<VecDeque<RpcEvent>>,
     sdk_event_log: Mutex<VecDeque<SequencedRpcEvent>>,
     sdk_next_event_seq: Mutex<u64>,
+    announce_next_seq: Mutex<u64>,
     sdk_dropped_event_count: Mutex<u64>,
     sdk_active_contract_version: Mutex<u16>,
     sdk_profile: Mutex<String>,


### PR DESCRIPTION
## Summary

Fixes daemon-side announce log collapse when several discovered announces from the same peer arrive inside the same second.

The daemon previously generated announce IDs from the announce timestamp, peer, and `seen_count`. For discovered/transient announces, the peer record is not persisted and `seen_count` remains `1`. Because announce timestamps are second-resolution, burst traffic from the same peer could reuse the same announce ID. The store uses replace semantics for announce IDs, so those bursts could collapse into one visible row. That made Rust appear to receive only a few announces compared with Python, and it also affected SDK consumers because SDK events are emitted from the same daemon announce path.

## Changes

- Add a daemon-local monotonic announce sequence counter.
- Use that counter when generating `AnnounceRecord.id`.
- Add regression coverage for same-second discovered announce bursts across:
  - daemon `list_announces`
  - daemon legacy event queue
  - SDK `sdk_poll_events_v2`

## Validation

- `cargo test -p reticulum-rs-rpc discovered_announce_bursts_do_not_collapse_in_announce_log -- --nocapture`
- `cargo test -p reticulum-rs-rpc announce_received -- --nocapture`
- `cargo test -p reticulum-rs-rpc`
- `cargo test -p reticulum-rs-transport announce -- --nocapture`
- `cargo test -p lxmf-sdk`
- `cargo test -p lxmf-cli`
- Live Rust/Python Reticulum interop with local `Reticulum`: 15 passed using `/opt/homebrew/bin/python3.12`.
- Live Rust/Python LXMF relay interop with local `LXMF`: 2 passed, both Python-to-Rust and Rust-to-Python relay paths.
