### PR TITLE
Fix queued byte count in mini runtime MessageQueued event

### DIFF
--- a/crates/libs/lxmf-embedded-mini/src/runtime.rs
+++ b/crates/libs/lxmf-embedded-mini/src/runtime.rs
@@ -109,12 +109,13 @@ impl<
         bytes.resize_default(message.encoded_len()?).map_err(|_| MiniError::CapacityExceeded)?;
         let written = message.encode(&mut bytes)?;
         bytes.truncate(written);
+        let queued_bytes = bytes.len();
         self.outbound
             .push_back(OutboundFrame { sequence, bytes })
             .map_err(|_| MiniError::Backpressure)?;
         self.next_sequence = self.next_sequence.saturating_add(1);
         self.stats.queued = self.stats.queued.saturating_add(1);
-        self.push_event(MiniEvent::MessageQueued { sequence, bytes: content.len() })?;
+        self.push_event(MiniEvent::MessageQueued { sequence, bytes: queued_bytes })?;
         Ok(sequence)
     }
 


### PR DESCRIPTION
### Motivation
- Ensure `MessageQueued` telemetry reports the actual encoded frame size queued for send instead of the raw `content.len()`, so queued-byte metrics match what is later reported by `FrameSent`.

### Description
- Capture the encoded frame length in a local `queued_bytes` before moving the `bytes` buffer into the outbound queue in `queue_message` in `runtime.rs`.
- Emit `MiniEvent::MessageQueued { sequence, bytes: queued_bytes }` instead of using `content.len()` so the event reflects the true queued frame size.

### Testing
- Ran `cargo test -p lxmf-embedded-mini` and all unit tests passed (`7 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5a099ce083258a7c6cb463ef740f)