### PR TITLE
[codex] add parallel ZeroMQ SDK transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +621,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,7 +648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -793,7 +815,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -1426,6 +1448,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "zeroize",
+ "zeromq",
 ]
 
 [[package]]
@@ -1436,7 +1459,7 @@ dependencies = [
  "criterion",
  "ed25519-dalek",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
  "reticulum-rs-core",
  "rmp-serde",
  "rmpv",
@@ -1808,6 +1831,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,12 +1864,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1919,7 +1980,7 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "rand_core",
+ "rand_core 0.6.4",
  "rmp-serde",
  "serde",
  "serde_bytes",
@@ -1937,11 +1998,12 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "rand_core",
+ "rand_core 0.6.4",
  "rmp-serde",
  "rmpv",
  "rusqlite",
  "serde",
+ "serde_bytes",
  "serde_cbor",
  "serde_json",
  "sha2",
@@ -1966,7 +2028,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "log",
- "rand_core",
+ "rand_core 0.6.4",
  "reticulum-rs-core",
  "rmp",
  "rmp-serde",
@@ -1996,7 +2058,7 @@ dependencies = [
  "hex",
  "hkdf",
  "lxmf-wire",
- "rand_core",
+ "rand_core 0.6.4",
  "reticulum-rs-core",
  "reticulum-rs-rpc",
  "reticulum-rs-transport",
@@ -2014,6 +2076,7 @@ dependencies = [
  "uuid",
  "x25519-dalek",
  "x509-parser",
+ "zeromq",
 ]
 
 [[package]]
@@ -2091,7 +2154,7 @@ version = "0.1.0"
 dependencies = [
  "hex",
  "lxmf-wire",
- "rand_core",
+ "rand_core 0.6.4",
  "reticulum-rs-core",
  "rmp-serde",
  "rmpv",
@@ -2220,12 +2283,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "saa"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5acb362a0e75c2a963532fa7fabf13dff81626dc494df16488d30befcbea0"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scc"
+version = "3.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcd12b6caff5213cc3c03123cde8c3db5e413008a63b0c0ba35e6275825ea92"
+dependencies = [
+ "saa",
+ "sdd",
 ]
 
 [[package]]
@@ -2239,6 +2318,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "4.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f0e40a01b94e35d1dacbcfbe5bfd3d31e37d9590b2e6d86a82b0e87bd4f551"
+dependencies = [
+ "saa",
+]
 
 [[package]]
 name = "semver"
@@ -2391,7 +2479,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2682,6 +2770,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -2843,6 +2932,7 @@ version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -3289,7 +3379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
 ]
@@ -3327,7 +3417,7 @@ dependencies = [
  "hex",
  "jsonschema",
  "lxmf-wire",
- "rand_core",
+ "rand_core 0.6.4",
  "reticulum-rs-core",
  "reticulum-rs-transport",
  "serde",
@@ -3375,6 +3465,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zeromq"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb2c254fd8f366755335c9e43b865f8484fe3bd717d65ffe7c3f28852863030"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "crossbeam-queue",
+ "futures",
+ "log",
+ "num-traits",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "regex",
+ "scc",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ tokio = { version = "1.44.2", features = ["full"] }
 tokio-rustls = "0.26.2"
 tokio-serial = "5.4.4"
 tokio-stream = "0.1"
+zeromq = { version = "0.6.0", default-features = false, features = ["tokio-runtime", "tcp-transport"] }
 rustls = "0.23.23"
 rustls-pemfile = "2.2.0"
 x509-parser = "0.16.0"

--- a/crates/apps/reticulumd/Cargo.toml
+++ b/crates/apps/reticulumd/Cargo.toml
@@ -33,6 +33,11 @@ tokio-rustls = { workspace = true }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
 x509-parser = { workspace = true }
+zeromq = { workspace = true, optional = true }
+
+[features]
+default = []
+zmq-pipeline-rpc = ["dep:zeromq"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/apps/reticulumd/src/bin/reticulumd/main.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/main.rs
@@ -60,12 +60,61 @@ struct Args {
     rpc_token_clock_skew_ms: u64,
     #[arg(long, default_value = DEFAULT_RPC_UNIX_PATH)]
     rpc_unix: Option<PathBuf>,
+    #[cfg(feature = "zmq-pipeline-rpc")]
+    #[arg(long)]
+    zmq_rpc_command: Option<String>,
 }
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
     let args = Args::parse();
+    #[cfg(feature = "zmq-pipeline-rpc")]
+    let zmq_rpc_command = args.zmq_rpc_command.clone();
     let context = bootstrap::bootstrap(args).await;
-    rpc_loop::run_rpc_loop(context.rpc_addr, context.daemon, context.rpc_tls, context.rpc_unix)
-        .await;
+    #[cfg(feature = "zmq-pipeline-rpc")]
+    {
+        run_daemon_loops(context, zmq_rpc_command).await;
+    }
+    #[cfg(not(feature = "zmq-pipeline-rpc"))]
+    {
+        rpc_loop::run_rpc_loop(context.rpc_addr, context.daemon, context.rpc_tls, context.rpc_unix)
+            .await;
+    }
+}
+
+#[cfg(feature = "zmq-pipeline-rpc")]
+async fn run_daemon_loops(context: bootstrap::BootstrapContext, zmq_rpc_command: Option<String>) {
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    tokio::spawn(async move {
+        match tokio::signal::ctrl_c().await {
+            Ok(()) => {
+                println!("[daemon] shutdown signal received");
+                let _ = shutdown_tx.send(true);
+            }
+            Err(err) => {
+                eprintln!("[daemon] failed to install shutdown signal handler: {}", err);
+            }
+        }
+    });
+
+    if let Some(command_endpoint) = zmq_rpc_command {
+        let daemon = context.daemon.clone();
+        let shutdown = shutdown_rx.clone();
+        tokio::spawn(async move {
+            let config =
+                zmq_rpc_loop::ZmqRpcLoopConfig { command_endpoint, require_auth_for_remote: true };
+            if let Err(err) = zmq_rpc_loop::run_zmq_rpc_loop_until(config, daemon, shutdown).await {
+                eprintln!("[daemon] zmq rpc loop stopped: {}", err);
+            }
+        });
+    }
+
+    rpc_loop::run_rpc_loop_until(
+        context.rpc_addr,
+        context.daemon,
+        context.rpc_tls,
+        context.rpc_unix,
+        shutdown_rx,
+    )
+    .await;
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/main.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/main.rs
@@ -13,6 +13,8 @@ mod outbound_resources;
 mod receipt_events;
 mod receipt_worker;
 mod rpc_loop;
+#[cfg(feature = "zmq-pipeline-rpc")]
+mod zmq_rpc_loop;
 #[cfg(test)]
 mod tests;
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/main.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/main.rs
@@ -13,10 +13,10 @@ mod outbound_resources;
 mod receipt_events;
 mod receipt_worker;
 mod rpc_loop;
-#[cfg(feature = "zmq-pipeline-rpc")]
-mod zmq_rpc_loop;
 #[cfg(test)]
 mod tests;
+#[cfg(feature = "zmq-pipeline-rpc")]
+mod zmq_rpc_loop;
 
 use clap::Parser;
 use std::path::PathBuf;

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop.rs
@@ -29,6 +29,7 @@ const RPC_MAX_HEADER_BYTES: usize = 16 * 1024;
 const RPC_MAX_BODY_BYTES: usize = 1024 * 1024;
 type ShutdownReceiver = watch::Receiver<bool>;
 
+#[cfg_attr(feature = "zmq-pipeline-rpc", allow(dead_code))]
 pub(super) async fn run_rpc_loop(
     addr: Option<SocketAddr>,
     daemon: Arc<RpcDaemon>,

--- a/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
@@ -1199,7 +1199,7 @@ interfaces = [
   {{ type = "lora", enabled = true, name = "lora-main", region = "US915", state_path = "{}" }}
 ]
 "#,
-            state_path.display()
+            state_path.to_string_lossy().replace('\\', "\\\\")
         ),
     )
     .expect("write config");
@@ -1289,7 +1289,7 @@ interfaces = [
   {{ type = "lora", enabled = true, name = "lora-main", region = "US915", state_path = "{}" }}
 ]
 "#,
-            state_path.display()
+            state_path.to_string_lossy().replace('\\', "\\\\")
         ),
     )
     .expect("write config");
@@ -1343,5 +1343,7 @@ fn test_args(
         rpc_token_jti_ttl_ms: 60_000,
         rpc_token_clock_skew_ms: 5_000,
         rpc_unix: None,
+        #[cfg(feature = "zmq-pipeline-rpc")]
+        zmq_rpc_command: None,
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
@@ -2,6 +2,7 @@
 
 use rns_rpc::rpc::zmq::{self, ZmqRpcEnvelope, ZmqRpcEnvelopeKind};
 use rns_rpc::{RpcDaemon, RpcError, RpcResponse};
+use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
 use tokio::sync::watch;
@@ -10,7 +11,6 @@ use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ZmqRpcLoopConfig {
     pub command_endpoint: String,
-    pub response_endpoint: String,
     pub require_auth_for_remote: bool,
 }
 
@@ -22,8 +22,8 @@ pub(super) async fn run_zmq_rpc_loop_until(
     validate_zmq_loop_config(&config)?;
     let mut commands = PullSocket::new();
     commands.bind(config.command_endpoint.as_str()).await.map_err(zmq_io_error)?;
-    let mut responses = PushSocket::new();
-    responses.bind(config.response_endpoint.as_str()).await.map_err(zmq_io_error)?;
+    let mut responses: HashMap<String, PushSocket> = HashMap::new();
+    println!("reticulumd listening on zmq {}", config.command_endpoint);
 
     loop {
         tokio::select! {
@@ -36,8 +36,7 @@ pub(super) async fn run_zmq_rpc_loop_until(
                 let response =
                     handle_zmq_command_message(daemon.as_ref(), message.map_err(zmq_io_error)?);
                 if let Some(response) = response {
-                    let encoded = zmq::encode_envelope(&response)?;
-                    responses.send(ZmqMessage::from(encoded)).await.map_err(zmq_io_error)?;
+                    send_zmq_response(&mut responses, response).await?;
                 }
             }
         }
@@ -45,29 +44,54 @@ pub(super) async fn run_zmq_rpc_loop_until(
     Ok(())
 }
 
-fn handle_zmq_command_message(daemon: &RpcDaemon, message: ZmqMessage) -> Option<ZmqRpcEnvelope> {
+struct ZmqOutboundResponse {
+    endpoint: String,
+    envelope: ZmqRpcEnvelope,
+}
+
+async fn send_zmq_response(
+    responses: &mut HashMap<String, PushSocket>,
+    response: ZmqOutboundResponse,
+) -> io::Result<()> {
+    if !responses.contains_key(&response.endpoint) {
+        let mut socket = PushSocket::new();
+        socket.connect(response.endpoint.as_str()).await.map_err(zmq_io_error)?;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        responses.insert(response.endpoint.clone(), socket);
+    }
+    let socket = responses
+        .get_mut(&response.endpoint)
+        .ok_or_else(|| io::Error::other("missing zmq response socket"))?;
+    let encoded = zmq::encode_envelope(&response.envelope)?;
+    socket.send(ZmqMessage::from(encoded)).await.map_err(zmq_io_error)
+}
+
+fn handle_zmq_command_message(
+    daemon: &RpcDaemon,
+    message: ZmqMessage,
+) -> Option<ZmqOutboundResponse> {
     let bytes = match Vec::<u8>::try_from(message) {
         Ok(bytes) => bytes,
-        Err(err) => return Some(error_envelope("", 0, "SDK_TRANSPORT_ZMQ_INVALID_MESSAGE", err)),
+        Err(_) => return None,
     };
     let envelope = match zmq::decode_envelope(&bytes) {
         Ok(envelope) => envelope,
-        Err(err) => {
-            return Some(error_envelope(
-                "",
-                0,
-                "SDK_TRANSPORT_ZMQ_INVALID_ENVELOPE",
-                err.to_string(),
-            ))
-        }
+        Err(_) => return None,
     };
+    let response_endpoint = envelope.response_endpoint.clone()?;
+    if validate_zmq_response_endpoint(response_endpoint.as_str()).is_err() {
+        return None;
+    }
     if envelope.kind != ZmqRpcEnvelopeKind::Request {
-        return Some(error_envelope(
-            envelope.session_id,
-            envelope.request_id,
-            "SDK_TRANSPORT_ZMQ_INVALID_KIND",
-            "zmq command ingress accepts request envelopes only",
-        ));
+        return Some(ZmqOutboundResponse {
+            endpoint: response_endpoint,
+            envelope: error_envelope(
+                envelope.session_id,
+                envelope.request_id,
+                "SDK_TRANSPORT_ZMQ_INVALID_KIND",
+                "zmq command ingress accepts request envelopes only",
+            ),
+        });
     }
     let response_payload =
         daemon.handle_framed_request(envelope.payload.as_slice()).unwrap_or_else(|err| {
@@ -78,7 +102,14 @@ fn handle_zmq_command_message(daemon: &RpcDaemon, message: ZmqMessage) -> Option
             };
             rns_rpc::rpc::codec::encode_frame(&response).unwrap_or_default()
         });
-    Some(ZmqRpcEnvelope::response(envelope.session_id, envelope.request_id, response_payload))
+    Some(ZmqOutboundResponse {
+        endpoint: response_endpoint,
+        envelope: ZmqRpcEnvelope::response(
+            envelope.session_id,
+            envelope.request_id,
+            response_payload,
+        ),
+    })
 }
 
 fn error_envelope(
@@ -100,16 +131,23 @@ fn error_envelope(
 }
 
 fn validate_zmq_loop_config(config: &ZmqRpcLoopConfig) -> io::Result<()> {
-    if config.require_auth_for_remote
-        && (!is_local_zmq_endpoint(&config.command_endpoint)
-            || !is_local_zmq_endpoint(&config.response_endpoint))
-    {
+    if config.require_auth_for_remote && !is_local_zmq_endpoint(&config.command_endpoint) {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
             "remote zmq endpoints require explicit authentication",
         ));
     }
     Ok(())
+}
+
+fn validate_zmq_response_endpoint(endpoint: &str) -> io::Result<()> {
+    if is_local_zmq_endpoint(endpoint) {
+        return Ok(());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::PermissionDenied,
+        "remote zmq response endpoints require explicit authentication",
+    ))
 }
 
 fn is_local_zmq_endpoint(endpoint: &str) -> bool {
@@ -131,11 +169,30 @@ mod tests {
     fn config_rejects_remote_without_auth_gate() {
         let config = ZmqRpcLoopConfig {
             command_endpoint: "tcp://0.0.0.0:9100".to_string(),
-            response_endpoint: "tcp://127.0.0.1:9101".to_string(),
             require_auth_for_remote: true,
         };
 
         let err = validate_zmq_loop_config(&config).expect_err("remote bind rejected");
+
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn config_rejects_remote_command_endpoint() {
+        let config = ZmqRpcLoopConfig {
+            command_endpoint: "tcp://192.0.2.10:9100".to_string(),
+            require_auth_for_remote: true,
+        };
+
+        let err = validate_zmq_loop_config(&config).expect_err("remote command endpoint rejected");
+
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn response_endpoint_rejects_remote_endpoint() {
+        let err = validate_zmq_response_endpoint("tcp://192.0.2.10:9101")
+            .expect_err("remote response endpoint rejected");
 
         assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
     }

--- a/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
@@ -37,7 +37,8 @@ pub(super) async fn run_zmq_rpc_loop_until(
                 }
             }
             message = commands.recv() => {
-                let response = handle_zmq_command_message(daemon.as_ref(), message.map_err(zmq_io_error)?);
+                let response =
+                    handle_zmq_command_message(daemon.as_ref(), message.map_err(zmq_io_error)?);
                 if let Some(response) = response {
                     let encoded = zmq::encode_envelope(&response)?;
                     responses.send(ZmqMessage::from(encoded)).await.map_err(zmq_io_error)?;

--- a/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use rns_rpc::rpc::zmq::{self, ZmqRpcEnvelope, ZmqRpcEnvelopeKind};
 use rns_rpc::{RpcDaemon, RpcError, RpcResponse};
 use std::io;
@@ -19,15 +21,9 @@ pub(super) async fn run_zmq_rpc_loop_until(
 ) -> io::Result<()> {
     validate_zmq_loop_config(&config)?;
     let mut commands = PullSocket::new();
-    commands
-        .bind(config.command_endpoint.as_str())
-        .await
-        .map_err(zmq_io_error)?;
+    commands.bind(config.command_endpoint.as_str()).await.map_err(zmq_io_error)?;
     let mut responses = PushSocket::new();
-    responses
-        .bind(config.response_endpoint.as_str())
-        .await
-        .map_err(zmq_io_error)?;
+    responses.bind(config.response_endpoint.as_str()).await.map_err(zmq_io_error)?;
 
     loop {
         tokio::select! {
@@ -73,9 +69,8 @@ fn handle_zmq_command_message(daemon: &RpcDaemon, message: ZmqMessage) -> Option
             "zmq command ingress accepts request envelopes only",
         ));
     }
-    let response_payload = daemon
-        .handle_framed_request(envelope.payload.as_slice())
-        .unwrap_or_else(|err| {
+    let response_payload =
+        daemon.handle_framed_request(envelope.payload.as_slice()).unwrap_or_else(|err| {
             let response = RpcResponse {
                 id: envelope.request_id,
                 result: None,
@@ -83,11 +78,7 @@ fn handle_zmq_command_message(daemon: &RpcDaemon, message: ZmqMessage) -> Option
             };
             rns_rpc::rpc::codec::encode_frame(&response).unwrap_or_default()
         });
-    Some(ZmqRpcEnvelope::response(
-        envelope.session_id,
-        envelope.request_id,
-        response_payload,
-    ))
+    Some(ZmqRpcEnvelope::response(envelope.session_id, envelope.request_id, response_payload))
 }
 
 fn error_envelope(
@@ -129,7 +120,7 @@ fn is_local_zmq_endpoint(endpoint: &str) -> bool {
 }
 
 fn zmq_io_error(err: impl std::fmt::Display) -> io::Error {
-    io::Error::new(io::ErrorKind::Other, err.to_string())
+    io::Error::other(err.to_string())
 }
 
 #[cfg(test)]

--- a/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
@@ -1,0 +1,150 @@
+use rns_rpc::rpc::zmq::{self, ZmqRpcEnvelope, ZmqRpcEnvelopeKind};
+use rns_rpc::{RpcDaemon, RpcError, RpcResponse};
+use std::io;
+use std::sync::Arc;
+use tokio::sync::watch;
+use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ZmqRpcLoopConfig {
+    pub command_endpoint: String,
+    pub response_endpoint: String,
+    pub require_auth_for_remote: bool,
+}
+
+pub(super) async fn run_zmq_rpc_loop_until(
+    config: ZmqRpcLoopConfig,
+    daemon: Arc<RpcDaemon>,
+    mut shutdown: watch::Receiver<bool>,
+) -> io::Result<()> {
+    validate_zmq_loop_config(&config)?;
+    let mut commands = PullSocket::new();
+    commands
+        .bind(config.command_endpoint.as_str())
+        .await
+        .map_err(zmq_io_error)?;
+    let mut responses = PushSocket::new();
+    responses
+        .bind(config.response_endpoint.as_str())
+        .await
+        .map_err(zmq_io_error)?;
+
+    loop {
+        tokio::select! {
+            changed = shutdown.changed() => {
+                if changed.is_err() || *shutdown.borrow() {
+                    break;
+                }
+            }
+            message = commands.recv() => {
+                let response = handle_zmq_command_message(daemon.as_ref(), message.map_err(zmq_io_error)?);
+                if let Some(response) = response {
+                    let encoded = zmq::encode_envelope(&response)?;
+                    responses.send(ZmqMessage::from(encoded)).await.map_err(zmq_io_error)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn handle_zmq_command_message(daemon: &RpcDaemon, message: ZmqMessage) -> Option<ZmqRpcEnvelope> {
+    let bytes = match Vec::<u8>::try_from(message) {
+        Ok(bytes) => bytes,
+        Err(err) => return Some(error_envelope("", 0, "SDK_TRANSPORT_ZMQ_INVALID_MESSAGE", err)),
+    };
+    let envelope = match zmq::decode_envelope(&bytes) {
+        Ok(envelope) => envelope,
+        Err(err) => {
+            return Some(error_envelope(
+                "",
+                0,
+                "SDK_TRANSPORT_ZMQ_INVALID_ENVELOPE",
+                err.to_string(),
+            ))
+        }
+    };
+    if envelope.kind != ZmqRpcEnvelopeKind::Request {
+        return Some(error_envelope(
+            envelope.session_id,
+            envelope.request_id,
+            "SDK_TRANSPORT_ZMQ_INVALID_KIND",
+            "zmq command ingress accepts request envelopes only",
+        ));
+    }
+    let response_payload = daemon
+        .handle_framed_request(envelope.payload.as_slice())
+        .unwrap_or_else(|err| {
+            let response = RpcResponse {
+                id: envelope.request_id,
+                result: None,
+                error: Some(RpcError::new("SDK_INTERNAL", err.to_string())),
+            };
+            rns_rpc::rpc::codec::encode_frame(&response).unwrap_or_default()
+        });
+    Some(ZmqRpcEnvelope::response(
+        envelope.session_id,
+        envelope.request_id,
+        response_payload,
+    ))
+}
+
+fn error_envelope(
+    session_id: impl Into<String>,
+    request_id: u64,
+    code: &'static str,
+    message: impl Into<String>,
+) -> ZmqRpcEnvelope {
+    let response = RpcResponse {
+        id: request_id,
+        result: None,
+        error: Some(RpcError::new(code, message.into())),
+    };
+    ZmqRpcEnvelope::response(
+        session_id.into(),
+        request_id,
+        rns_rpc::rpc::codec::encode_frame(&response).unwrap_or_default(),
+    )
+}
+
+fn validate_zmq_loop_config(config: &ZmqRpcLoopConfig) -> io::Result<()> {
+    if config.require_auth_for_remote
+        && (!is_local_zmq_endpoint(&config.command_endpoint)
+            || !is_local_zmq_endpoint(&config.response_endpoint))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "remote zmq endpoints require explicit authentication",
+        ));
+    }
+    Ok(())
+}
+
+fn is_local_zmq_endpoint(endpoint: &str) -> bool {
+    endpoint.starts_with("inproc://")
+        || endpoint.starts_with("tcp://127.")
+        || endpoint.starts_with("tcp://localhost:")
+        || endpoint.starts_with("tcp://[::1]:")
+}
+
+fn zmq_io_error(err: impl std::fmt::Display) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_rejects_remote_without_auth_gate() {
+        let config = ZmqRpcLoopConfig {
+            command_endpoint: "tcp://0.0.0.0:9100".to_string(),
+            response_endpoint: "tcp://127.0.0.1:9101".to_string(),
+            require_auth_for_remote: true,
+        };
+
+        let err = validate_zmq_loop_config(&config).expect_err("remote bind rejected");
+
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+}

--- a/crates/libs/lxmf-sdk/Cargo.toml
+++ b/crates/libs/lxmf-sdk/Cargo.toml
@@ -21,6 +21,7 @@ thiserror.workspace = true
 tokio = { workspace = true, optional = true }
 tokio-rustls = { workspace = true, optional = true }
 tokio-stream = { workspace = true, optional = true }
+zeromq = { workspace = true, optional = true }
 hmac.workspace = true
 sha2.workspace = true
 hex.workspace = true
@@ -31,6 +32,7 @@ default = ["std", "sdk-async", "rpc-backend"]
 std = []
 sdk-async = ["dep:tokio", "dep:tokio-stream"]
 rpc-backend = ["std", "dep:rns-rpc", "dep:rustls", "dep:rustls-pemfile", "dep:tokio-rustls"]
+zmq-pipeline-backend = ["std", "sdk-async", "dep:rns-rpc", "dep:zeromq"]
 embedded-alloc = []
 loom-tests = []
 
@@ -44,6 +46,10 @@ ignore = { development = ["loom"] }
 [[bench]]
 name = "sdk_client_paths"
 harness = false
+
+[[example]]
+name = "zmq_pipeline_send"
+required-features = ["zmq-pipeline-backend"]
 
 [lints]
 workspace = true

--- a/crates/libs/lxmf-sdk/examples/zmq_pipeline_send.rs
+++ b/crates/libs/lxmf-sdk/examples/zmq_pipeline_send.rs
@@ -1,5 +1,7 @@
+#![allow(clippy::result_large_err)]
+
 use lxmf_sdk::{
-    Client, LxmfSdk, SendRequest, SdkConfig, StartRequest, ZmqEndpointRole,
+    Client, LxmfSdk, SdkConfig, SendRequest, StartRequest, ZmqEndpointRole,
     ZmqPipelineBackendClient, ZmqPipelineBackendConfig, ZmqPipelineTokenAuth,
 };
 use serde_json::json;

--- a/crates/libs/lxmf-sdk/examples/zmq_pipeline_send.rs
+++ b/crates/libs/lxmf-sdk/examples/zmq_pipeline_send.rs
@@ -1,0 +1,77 @@
+use lxmf_sdk::{
+    Client, LxmfSdk, SendRequest, SdkConfig, StartRequest, ZmqEndpointRole,
+    ZmqPipelineBackendClient, ZmqPipelineBackendConfig, ZmqPipelineTokenAuth,
+};
+use serde_json::json;
+use std::time::Duration;
+
+fn main() -> Result<(), lxmf_sdk::SdkError> {
+    let command_endpoint =
+        std::env::var("LXMF_ZMQ_COMMAND").unwrap_or_else(|_| "tcp://127.0.0.1:9100".to_owned());
+    let response_endpoint =
+        std::env::var("LXMF_ZMQ_RESPONSE").unwrap_or_else(|_| "tcp://127.0.0.1:9101".to_owned());
+    let source = std::env::var("LXMF_SOURCE").unwrap_or_else(|_| "example.zmq".to_owned());
+    let destination =
+        std::env::var("LXMF_DESTINATION").unwrap_or_else(|_| "example.peer".to_owned());
+
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.command_role = endpoint_role_from_env("LXMF_ZMQ_COMMAND_ROLE", config.command_role);
+    config.response_role = endpoint_role_from_env("LXMF_ZMQ_RESPONSE_ROLE", config.response_role);
+    config.request_timeout = Duration::from_millis(
+        std::env::var("LXMF_ZMQ_TIMEOUT_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(5_000),
+    );
+    config.token_auth = token_auth_from_env();
+
+    let backend = ZmqPipelineBackendClient::new(config)?;
+    let client = Client::new(backend);
+    let handle = client.start(StartRequest::new(SdkConfig::desktop_local_default()))?;
+    println!("started runtime_id={}", handle.runtime_id);
+
+    let message_id = client.send(
+        SendRequest::new(
+            source,
+            destination,
+            json!({
+                "title": "ZeroMQ SDK Example",
+                "content": "hello from lxmf-sdk over ZeroMQ"
+            }),
+        )
+        .with_ttl_ms(30_000)
+        .with_correlation_id("example-zmq-pipeline-send"),
+    )?;
+    println!("queued message_id={message_id}");
+
+    let snapshot = client.snapshot()?;
+    println!(
+        "snapshot runtime_id={} state={:?} queued={} in_flight={}",
+        snapshot.runtime_id, snapshot.state, snapshot.queued_messages, snapshot.in_flight_messages
+    );
+
+    Ok(())
+}
+
+fn endpoint_role_from_env(name: &str, default_role: ZmqEndpointRole) -> ZmqEndpointRole {
+    match std::env::var(name).ok().as_deref() {
+        Some("bind") | Some("BIND") => ZmqEndpointRole::Bind,
+        Some("connect") | Some("CONNECT") => ZmqEndpointRole::Connect,
+        _ => default_role,
+    }
+}
+
+fn token_auth_from_env() -> Option<ZmqPipelineTokenAuth> {
+    let shared_secret = std::env::var("LXMF_ZMQ_TOKEN_SECRET").ok()?;
+    Some(ZmqPipelineTokenAuth {
+        issuer: std::env::var("LXMF_ZMQ_TOKEN_ISSUER")
+            .unwrap_or_else(|_| "lxmf-sdk-example".to_owned()),
+        audience: std::env::var("LXMF_ZMQ_TOKEN_AUDIENCE")
+            .unwrap_or_else(|_| "reticulumd-zmq".to_owned()),
+        shared_secret,
+        ttl_secs: std::env::var("LXMF_ZMQ_TOKEN_TTL_SECS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(60),
+    })
+}

--- a/crates/libs/lxmf-sdk/src/backend.rs
+++ b/crates/libs/lxmf-sdk/src/backend.rs
@@ -376,6 +376,9 @@ pub mod mobile_ble;
 #[cfg(all(feature = "rpc-backend", feature = "std"))]
 pub mod rpc;
 
+#[cfg(all(feature = "zmq-pipeline-backend", feature = "std"))]
+pub mod zmq_pipeline;
+
 #[cfg(test)]
 mod tests {
     include!("backend_tests.rs");

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -33,12 +33,27 @@ pub struct ZmqPipelineBackendClient {
     config: ZmqPipelineBackendConfig,
     session_id: String,
     next_request_id: AtomicU64,
+    runtime: Runtime,
+    transport: tokio::sync::Mutex<Option<ZmqPipelineTransport>>,
+}
+
+struct ZmqPipelineTransport {
+    command: PushSocket,
+    responses: PullSocket,
 }
 
 impl ZmqPipelineBackendClient {
     pub fn new(config: ZmqPipelineBackendConfig) -> Result<Self, SdkError> {
         config.validate()?;
-        Ok(Self { config, session_id: new_session_id(), next_request_id: AtomicU64::new(1) })
+        let runtime =
+            Runtime::new().map_err(|err| sdk_error(ErrorCategory::Internal, err.to_string()))?;
+        Ok(Self {
+            config,
+            session_id: new_session_id(),
+            next_request_id: AtomicU64::new(1),
+            runtime,
+            transport: tokio::sync::Mutex::new(None),
+        })
     }
 
     pub fn session_id(&self) -> &str {
@@ -69,9 +84,7 @@ impl ZmqPipelineBackendClient {
             ));
         }
 
-        let runtime =
-            Runtime::new().map_err(|err| sdk_error(ErrorCategory::Internal, err.to_string()))?;
-        let response = runtime.block_on(self.send_and_recv(encoded, request_id))?;
+        let response = self.runtime.block_on(self.send_and_recv(encoded, request_id))?;
         let rpc_response = parse_rpc_frame(&response.payload)
             .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
         if let Some(error) = rpc_response.error {
@@ -85,13 +98,16 @@ impl ZmqPipelineBackendClient {
         encoded: Vec<u8>,
         request_id: u64,
     ) -> Result<ZmqRpcEnvelope, SdkError> {
-        let mut command = PushSocket::new();
-        apply_role(&mut command, self.config.command_role, &self.config.command_endpoint).await?;
-        let mut responses = PullSocket::new();
-        apply_role(&mut responses, self.config.response_role, &self.config.response_endpoint)
-            .await?;
+        let mut transport = self.transport.lock().await;
+        if transport.is_none() {
+            *transport = Some(ZmqPipelineTransport::connect(&self.config).await?);
+        }
+        let transport = transport
+            .as_mut()
+            .ok_or_else(|| sdk_error(ErrorCategory::Internal, "missing zmq transport"))?;
 
-        command
+        transport
+            .command
             .send(ZmqMessage::from(encoded))
             .await
             .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
@@ -107,7 +123,7 @@ impl ZmqPipelineBackendClient {
                         "zmq rpc request timed out waiting for correlated response",
                     ));
                 }
-                message = responses.recv() => {
+                message = transport.responses.recv() => {
                     let bytes = Vec::<u8>::try_from(message.map_err(|err| {
                         sdk_error(ErrorCategory::Transport, err.to_string())
                     })?)
@@ -145,6 +161,17 @@ impl ZmqPipelineBackendClient {
             scheme: "bearer".to_string(),
             value: format!("{};sig={}", payload, sig),
         })
+    }
+}
+
+impl ZmqPipelineTransport {
+    async fn connect(config: &ZmqPipelineBackendConfig) -> Result<Self, SdkError> {
+        let mut command = PushSocket::new();
+        apply_role(&mut command, config.command_role, &config.command_endpoint).await?;
+        let mut responses = PullSocket::new();
+        apply_role(&mut responses, config.response_role, &config.response_endpoint).await?;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        Ok(Self { command, responses })
     }
 }
 

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -1,0 +1,647 @@
+use crate::backend::SdkBackend;
+use crate::capability::{EffectiveLimits, NegotiationRequest, NegotiationResponse};
+use crate::error::{code, ErrorCategory, SdkError};
+use crate::event::{EventBatch, EventCursor, SdkEvent, Severity};
+use crate::types::{
+    Ack, CancelResult, ConfigPatch, DeliverySnapshot, MessageId, RuntimeSnapshot, SendRequest,
+    ShutdownMode, RuntimeState,
+};
+use hmac::{Hmac, Mac};
+use rns_rpc::e2e_harness::{build_rpc_frame, parse_rpc_frame};
+use rns_rpc::rpc::zmq::{self, ZmqRpcAuthMetadata, ZmqRpcEnvelope, ZmqRpcEnvelopeKind};
+use rns_rpc::RpcError;
+use serde_json::{json, Value as JsonValue};
+use sha2::Sha256;
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::runtime::Runtime;
+use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZmqEndpointRole {
+    Bind,
+    Connect,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZmqPipelineTokenAuth {
+    pub issuer: String,
+    pub audience: String,
+    pub shared_secret: String,
+    pub ttl_secs: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZmqPipelineBackendConfig {
+    pub command_endpoint: String,
+    pub command_role: ZmqEndpointRole,
+    pub response_endpoint: String,
+    pub response_role: ZmqEndpointRole,
+    pub request_timeout: Duration,
+    pub max_envelope_bytes: usize,
+    pub token_auth: Option<ZmqPipelineTokenAuth>,
+}
+
+impl ZmqPipelineBackendConfig {
+    pub fn local_tcp(command_endpoint: impl Into<String>, response_endpoint: impl Into<String>) -> Self {
+        Self {
+            command_endpoint: command_endpoint.into(),
+            command_role: ZmqEndpointRole::Connect,
+            response_endpoint: response_endpoint.into(),
+            response_role: ZmqEndpointRole::Bind,
+            request_timeout: Duration::from_secs(5),
+            max_envelope_bytes: zmq::ZMQ_RPC_MAX_ENVELOPE_BYTES,
+            token_auth: None,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), SdkError> {
+        validate_endpoint_security(&self.command_endpoint, self.token_auth.is_some())?;
+        validate_endpoint_security(&self.response_endpoint, self.token_auth.is_some())?;
+        if self.max_envelope_bytes > zmq::ZMQ_RPC_MAX_ENVELOPE_BYTES {
+            return Err(SdkError::new(
+                code::VALIDATION_INVALID_ARGUMENT,
+                ErrorCategory::Validation,
+                "zmq max_envelope_bytes exceeds protocol limit",
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub struct ZmqPipelineBackendClient {
+    config: ZmqPipelineBackendConfig,
+    session_id: String,
+    next_request_id: AtomicU64,
+}
+
+impl ZmqPipelineBackendClient {
+    pub fn new(config: ZmqPipelineBackendConfig) -> Result<Self, SdkError> {
+        config.validate()?;
+        Ok(Self {
+            config,
+            session_id: new_session_id(),
+            next_request_id: AtomicU64::new(1),
+        })
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    fn next_request_id(&self) -> u64 {
+        self.next_request_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn call_rpc(&self, method: &str, params: Option<JsonValue>) -> Result<JsonValue, SdkError> {
+        let request_id = self.next_request_id();
+        let payload = build_rpc_frame(request_id, method, params)
+            .map_err(|err| sdk_error(ErrorCategory::Internal, err.to_string()))?;
+        let envelope = ZmqRpcEnvelope::request(
+            self.session_id.clone(),
+            request_id,
+            self.config.response_endpoint.clone(),
+            payload,
+            self.auth_metadata(),
+        );
+        let encoded = zmq::encode_envelope(&envelope)
+            .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+        if encoded.len() > self.config.max_envelope_bytes {
+            return Err(sdk_error(ErrorCategory::Transport, "zmq rpc envelope exceeded configured limit"));
+        }
+
+        let runtime = Runtime::new().map_err(|err| sdk_error(ErrorCategory::Internal, err.to_string()))?;
+        let response = runtime.block_on(self.send_and_recv(encoded, request_id))?;
+        let rpc_response = parse_rpc_frame(&response.payload)
+            .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+        if let Some(error) = rpc_response.error {
+            return Err(map_rpc_error(error));
+        }
+        Ok(rpc_response.result.unwrap_or(JsonValue::Null))
+    }
+
+    async fn send_and_recv(
+        &self,
+        encoded: Vec<u8>,
+        request_id: u64,
+    ) -> Result<ZmqRpcEnvelope, SdkError> {
+        let mut command = PushSocket::new();
+        apply_role(&mut command, self.config.command_role, &self.config.command_endpoint).await?;
+        let mut responses = PullSocket::new();
+        apply_role(&mut responses, self.config.response_role, &self.config.response_endpoint).await?;
+
+        command
+            .send(ZmqMessage::from(encoded))
+            .await
+            .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+
+        let deadline = tokio::time::sleep(self.config.request_timeout);
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                _ = &mut deadline => {
+                    return Err(SdkError::new(
+                        "SDK_TRANSPORT_ZMQ_TIMEOUT",
+                        ErrorCategory::Timeout,
+                        "zmq rpc request timed out waiting for correlated response",
+                    ));
+                }
+                message = responses.recv() => {
+                    let bytes = Vec::<u8>::try_from(message.map_err(|err| {
+                        sdk_error(ErrorCategory::Transport, err.to_string())
+                    })?)
+                    .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+                    let envelope = zmq::decode_envelope(&bytes)
+                        .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+                    if envelope.kind == ZmqRpcEnvelopeKind::Response
+                        && envelope.session_id == self.session_id
+                        && envelope.request_id == request_id
+                    {
+                        return Ok(envelope);
+                    }
+                }
+            }
+        }
+    }
+
+    fn auth_metadata(&self) -> Option<ZmqRpcAuthMetadata> {
+        let auth = self.config.token_auth.as_ref()?;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0);
+        let payload = format!(
+            "iss={};aud={};iat={};exp={};jti={}-{}",
+            auth.issuer,
+            auth.audience,
+            now,
+            now.saturating_add(auth.ttl_secs.max(1)),
+            self.session_id,
+            self.next_request_id.load(Ordering::Relaxed)
+        );
+        let sig = token_signature(auth.shared_secret.as_str(), payload.as_str());
+        Some(ZmqRpcAuthMetadata {
+            scheme: "bearer".to_string(),
+            value: format!("{};sig={}", payload, sig),
+        })
+    }
+
+    fn parse_required_string(value: &JsonValue, key: &'static str) -> Result<String, SdkError> {
+        value.get(key).and_then(JsonValue::as_str).map(str::to_owned).ok_or_else(|| {
+            SdkError::new(
+                code::INTERNAL,
+                ErrorCategory::Internal,
+                format!("rpc response missing string field '{key}'"),
+            )
+        })
+    }
+
+    fn parse_required_u64(value: &JsonValue, key: &'static str) -> Result<u64, SdkError> {
+        value.get(key).and_then(JsonValue::as_u64).ok_or_else(|| {
+            SdkError::new(
+                code::INTERNAL,
+                ErrorCategory::Internal,
+                format!("rpc response missing integer field '{key}'"),
+            )
+        })
+    }
+
+    fn parse_required_u16(value: &JsonValue, key: &'static str) -> Result<u16, SdkError> {
+        let raw = Self::parse_required_u64(value, key)?;
+        u16::try_from(raw).map_err(|_| {
+            SdkError::new(
+                code::INTERNAL,
+                ErrorCategory::Internal,
+                format!("rpc response field '{key}' is out of range"),
+            )
+        })
+    }
+
+    fn parse_effective_limits(value: &JsonValue) -> Result<EffectiveLimits, SdkError> {
+        Ok(EffectiveLimits {
+            max_poll_events: usize::try_from(Self::parse_required_u64(value, "max_poll_events")?)
+                .map_err(|_| sdk_error(ErrorCategory::Internal, "max_poll_events overflow"))?,
+            max_event_bytes: usize::try_from(Self::parse_required_u64(value, "max_event_bytes")?)
+                .map_err(|_| sdk_error(ErrorCategory::Internal, "max_event_bytes overflow"))?,
+            max_batch_bytes: usize::try_from(Self::parse_required_u64(value, "max_batch_bytes")?)
+                .map_err(|_| sdk_error(ErrorCategory::Internal, "max_batch_bytes overflow"))?,
+            max_extension_keys: usize::try_from(Self::parse_required_u64(
+                value,
+                "max_extension_keys",
+            )?)
+            .map_err(|_| sdk_error(ErrorCategory::Internal, "max_extension_keys overflow"))?,
+            idempotency_ttl_ms: Self::parse_required_u64(value, "idempotency_ttl_ms")?,
+        })
+    }
+
+    fn parse_cancel_result(value: &str) -> Result<CancelResult, SdkError> {
+        match value {
+            "Accepted" => Ok(CancelResult::Accepted),
+            "AlreadyTerminal" => Ok(CancelResult::AlreadyTerminal),
+            "NotFound" => Ok(CancelResult::NotFound),
+            "TooLateToCancel" => Ok(CancelResult::TooLateToCancel),
+            _ => Err(SdkError::new(
+                code::INTERNAL,
+                ErrorCategory::Internal,
+                "rpc returned unknown cancel result variant",
+            )),
+        }
+    }
+
+    fn parse_delivery_state(receipt_status: Option<&str>) -> DeliveryState {
+        let Some(raw) = receipt_status else {
+            return DeliveryState::Queued;
+        };
+        let normalized = raw.trim();
+        if normalized.get(..4).is_some_and(|prefix| prefix.eq_ignore_ascii_case("sent")) {
+            return DeliveryState::Sent;
+        }
+        if normalized.get(..6).is_some_and(|prefix| prefix.eq_ignore_ascii_case("failed")) {
+            return DeliveryState::Failed;
+        }
+        match normalized {
+            value if value.eq_ignore_ascii_case("queued") => DeliveryState::Queued,
+            value if value.eq_ignore_ascii_case("dispatching") => DeliveryState::Dispatching,
+            value if value.eq_ignore_ascii_case("in_flight") => DeliveryState::InFlight,
+            value if value.eq_ignore_ascii_case("inflight") => DeliveryState::InFlight,
+            value if value.eq_ignore_ascii_case("cancelled") => DeliveryState::Cancelled,
+            value if value.eq_ignore_ascii_case("delivered") => DeliveryState::Delivered,
+            value if value.eq_ignore_ascii_case("expired") => DeliveryState::Expired,
+            value if value.eq_ignore_ascii_case("rejected") => DeliveryState::Rejected,
+            _ => DeliveryState::Unknown,
+        }
+    }
+
+    fn parse_severity(value: &str) -> Severity {
+        match value {
+            raw if raw.eq_ignore_ascii_case("debug") => Severity::Debug,
+            raw if raw.eq_ignore_ascii_case("info") => Severity::Info,
+            raw if raw.eq_ignore_ascii_case("warn") || raw.eq_ignore_ascii_case("warning") => {
+                Severity::Warn
+            }
+            raw if raw.eq_ignore_ascii_case("error") => Severity::Error,
+            raw if raw.eq_ignore_ascii_case("critical") || raw.eq_ignore_ascii_case("fatal") => {
+                Severity::Critical
+            }
+            _ => Severity::Unknown,
+        }
+    }
+
+    fn parse_runtime_state(value: &str) -> RuntimeState {
+        match value {
+            raw if raw.eq_ignore_ascii_case("new") => RuntimeState::New,
+            raw if raw.eq_ignore_ascii_case("starting") => RuntimeState::Starting,
+            raw if raw.eq_ignore_ascii_case("running") => RuntimeState::Running,
+            raw if raw.eq_ignore_ascii_case("draining") => RuntimeState::Draining,
+            raw if raw.eq_ignore_ascii_case("stopped") => RuntimeState::Stopped,
+            raw if raw.eq_ignore_ascii_case("failed") => RuntimeState::Failed,
+            _ => RuntimeState::Unknown,
+        }
+    }
+}
+
+impl SdkBackend for ZmqPipelineBackendClient {
+    fn negotiate(&self, req: NegotiationRequest) -> Result<NegotiationResponse, SdkError> {
+        let result = self.call_rpc(
+            "sdk_negotiate_v2",
+            Some(json!({
+                "supported_contract_versions": req.supported_contract_versions,
+                "requested_capabilities": req.requested_capabilities,
+                "config": {
+                    "profile": req.profile,
+                    "bind_mode": req.bind_mode,
+                    "auth_mode": req.auth_mode,
+                    "overflow_policy": req.overflow_policy,
+                    "block_timeout_ms": req.block_timeout_ms,
+                    "rpc_backend": req.rpc_backend,
+                }
+            })),
+        )?;
+        let effective_capabilities = result
+            .get("effective_capabilities")
+            .and_then(JsonValue::as_array)
+            .map(|values| {
+                values.iter().filter_map(JsonValue::as_str).map(str::to_owned).collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let effective_limits =
+            Self::parse_effective_limits(result.get("effective_limits").ok_or_else(|| {
+                SdkError::new(
+                    code::INTERNAL,
+                    ErrorCategory::Internal,
+                    "rpc response missing effective_limits",
+                )
+            })?)?;
+        Ok(NegotiationResponse {
+            runtime_id: Self::parse_required_string(&result, "runtime_id")?,
+            active_contract_version: Self::parse_required_u16(&result, "active_contract_version")?,
+            effective_capabilities,
+            effective_limits,
+            contract_release: Self::parse_required_string(&result, "contract_release")?,
+            schema_namespace: Self::parse_required_string(&result, "schema_namespace")?,
+        })
+    }
+
+    fn send(&self, req: SendRequest) -> Result<MessageId, SdkError> {
+        let SendRequest {
+            source,
+            destination,
+            payload,
+            idempotency_key,
+            ttl_ms,
+            correlation_id,
+            extensions,
+        } = req;
+        let content = payload
+            .get("content")
+            .and_then(JsonValue::as_str)
+            .map(str::to_owned)
+            .unwrap_or_else(|| payload.to_string());
+        let title =
+            payload.get("title").and_then(JsonValue::as_str).map(str::to_owned).unwrap_or_default();
+        let mut fields = match payload {
+            JsonValue::Object(map) => JsonValue::Object(map),
+            other => json!({ "payload": other }),
+        };
+        if let JsonValue::Object(map) = &mut fields {
+            let mut sdk_meta = serde_json::Map::new();
+            if let Some(value) = idempotency_key {
+                sdk_meta.insert("idempotency_key".to_string(), JsonValue::String(value));
+            }
+            if let Some(value) = ttl_ms {
+                sdk_meta.insert("ttl_ms".to_string(), JsonValue::from(value));
+            }
+            if let Some(value) = correlation_id {
+                sdk_meta.insert("correlation_id".to_string(), JsonValue::String(value));
+            }
+            if !extensions.is_empty() {
+                sdk_meta.insert(
+                    "extensions".to_string(),
+                    JsonValue::Object(extensions.into_iter().collect()),
+                );
+            }
+            if !sdk_meta.is_empty() {
+                map.insert("_sdk".to_string(), JsonValue::Object(sdk_meta));
+            }
+        }
+        let value = self.call_rpc(
+            "sdk_send_v2",
+            Some(json!({
+                "id": format!("sdk-zmq-{}", self.next_request_id()),
+                "source": source,
+                "destination": destination,
+                "title": title,
+                "content": content,
+                "fields": fields,
+            })),
+        )?;
+        Ok(MessageId(Self::parse_required_string(&value, "message_id")?))
+    }
+
+    fn cancel(&self, id: MessageId) -> Result<CancelResult, SdkError> {
+        let result = self.call_rpc("sdk_cancel_message_v2", Some(json!({ "message_id": id.0 })))?;
+        Self::parse_cancel_result(Self::parse_required_string(&result, "result")?.as_str())
+    }
+
+    fn status(&self, id: MessageId) -> Result<Option<DeliverySnapshot>, SdkError> {
+        let result = self.call_rpc("sdk_status_v2", Some(json!({ "message_id": id.0 })))?;
+        let Some(record) = result.get("message") else {
+            return Ok(None);
+        };
+        if record.is_null() {
+            return Ok(None);
+        }
+        let state = Self::parse_delivery_state(record.get("receipt_status").and_then(JsonValue::as_str));
+        let terminal = matches!(
+            state,
+            DeliveryState::Delivered
+                | DeliveryState::Failed
+                | DeliveryState::Cancelled
+                | DeliveryState::Expired
+                | DeliveryState::Rejected
+        );
+        let timestamp = record.get("timestamp").and_then(JsonValue::as_i64).unwrap_or(0_i64);
+        Ok(Some(DeliverySnapshot {
+            message_id: id,
+            state,
+            terminal,
+            last_updated_ms: u64::try_from(timestamp.max(0)).unwrap_or(0).saturating_mul(1000),
+            attempts: 0,
+            reason_code: None,
+        }))
+    }
+
+    fn configure(&self, expected_revision: u64, patch: ConfigPatch) -> Result<Ack, SdkError> {
+        let result = self.call_rpc(
+            "sdk_configure_v2",
+            Some(json!({ "expected_revision": expected_revision, "patch": patch })),
+        )?;
+        Ok(Ack {
+            accepted: result.get("accepted").and_then(JsonValue::as_bool).unwrap_or(false),
+            revision: result.get("revision").and_then(JsonValue::as_u64),
+        })
+    }
+
+    fn poll_events(&self, cursor: Option<EventCursor>, max: usize) -> Result<EventBatch, SdkError> {
+        let result = self.call_rpc(
+            "sdk_poll_events_v2",
+            Some(json!({ "cursor": cursor.map(|cursor| cursor.0), "max": max })),
+        )?;
+        let events = result
+            .get("events")
+            .and_then(JsonValue::as_array)
+            .map(|rows| {
+                rows.iter()
+                    .map(|row| {
+                        Ok(SdkEvent {
+                            event_id: Self::parse_required_string(row, "event_id")?,
+                            runtime_id: Self::parse_required_string(row, "runtime_id")?,
+                            stream_id: Self::parse_required_string(row, "stream_id")?,
+                            seq_no: Self::parse_required_u64(row, "seq_no")?,
+                            contract_version: Self::parse_required_u16(row, "contract_version")?,
+                            ts_ms: Self::parse_required_u64(row, "ts_ms")?,
+                            event_type: Self::parse_required_string(row, "event_type")?,
+                            severity: row
+                                .get("severity")
+                                .and_then(JsonValue::as_str)
+                                .map(Self::parse_severity)
+                                .unwrap_or(Severity::Info),
+                            source_component: row
+                                .get("source_component")
+                                .and_then(JsonValue::as_str)
+                                .unwrap_or("rns-rpc")
+                                .to_owned(),
+                            operation_id: row.get("operation_id").and_then(JsonValue::as_str).map(str::to_owned),
+                            message_id: row.get("message_id").and_then(JsonValue::as_str).map(str::to_owned),
+                            peer_id: row.get("peer_id").and_then(JsonValue::as_str).map(str::to_owned),
+                            correlation_id: row.get("correlation_id").and_then(JsonValue::as_str).map(str::to_owned),
+                            trace_id: row.get("trace_id").and_then(JsonValue::as_str).map(str::to_owned),
+                            payload: row.get("payload").cloned().unwrap_or(JsonValue::Object(serde_json::Map::new())),
+                            extensions: BTreeMap::new(),
+                        })
+                    })
+                    .collect::<Result<Vec<_>, SdkError>>()
+            })
+            .transpose()?
+            .unwrap_or_default();
+        Ok(EventBatch {
+            events,
+            next_cursor: EventCursor(Self::parse_required_string(&result, "next_cursor")?),
+            dropped_count: result.get("dropped_count").and_then(JsonValue::as_u64).unwrap_or(0),
+            snapshot_high_watermark_seq_no: result
+                .get("snapshot_high_watermark_seq_no")
+                .and_then(JsonValue::as_u64),
+            extensions: BTreeMap::new(),
+        })
+    }
+
+    fn snapshot(&self) -> Result<RuntimeSnapshot, SdkError> {
+        let result = self.call_rpc("sdk_snapshot_v2", Some(json!({ "include_counts": true })))?;
+        Ok(RuntimeSnapshot {
+            runtime_id: Self::parse_required_string(&result, "runtime_id")?,
+            state: result
+                .get("state")
+                .and_then(JsonValue::as_str)
+                .map(Self::parse_runtime_state)
+                .unwrap_or(RuntimeState::Running),
+            active_contract_version: Self::parse_required_u16(&result, "active_contract_version")?,
+            event_stream_position: Self::parse_required_u64(&result, "event_stream_position")?,
+            config_revision: Self::parse_required_u64(&result, "config_revision")?,
+            queued_messages: result.get("queued_messages").and_then(JsonValue::as_u64).unwrap_or(0),
+            in_flight_messages: result.get("in_flight_messages").and_then(JsonValue::as_u64).unwrap_or(0),
+        })
+    }
+
+    fn shutdown(&self, mode: ShutdownMode) -> Result<Ack, SdkError> {
+        let mode = match mode {
+            ShutdownMode::Graceful => "graceful",
+            ShutdownMode::Immediate => "immediate",
+        };
+        let result = self.call_rpc("sdk_shutdown_v2", Some(json!({ "mode": mode })))?;
+        Ok(Ack {
+            accepted: result.get("accepted").and_then(JsonValue::as_bool).unwrap_or(false),
+            revision: None,
+        })
+    }
+}
+
+async fn apply_role<S>(socket: &mut S, role: ZmqEndpointRole, endpoint: &str) -> Result<(), SdkError>
+where
+    S: Socket,
+{
+    match role {
+        ZmqEndpointRole::Bind => {
+            socket.bind(endpoint).await.map(|_| ()).map_err(|err| {
+                sdk_error(ErrorCategory::Transport, format!("zmq bind {} failed: {}", endpoint, err))
+            })
+        }
+        ZmqEndpointRole::Connect => socket.connect(endpoint).await.map_err(|err| {
+            sdk_error(ErrorCategory::Transport, format!("zmq connect {} failed: {}", endpoint, err))
+        }),
+    }
+}
+
+fn validate_endpoint_security(endpoint: &str, has_auth: bool) -> Result<(), SdkError> {
+    if is_local_endpoint(endpoint) || has_auth {
+        return Ok(());
+    }
+    Err(SdkError::new(
+        code::SECURITY_AUTH_REQUIRED,
+        ErrorCategory::Security,
+        "remote zmq endpoints require explicit token authentication",
+    ))
+}
+
+fn is_local_endpoint(endpoint: &str) -> bool {
+    if endpoint.starts_with("inproc://") {
+        return true;
+    }
+    let Some(authority) = endpoint.strip_prefix("tcp://") else {
+        return false;
+    };
+    let host = authority
+        .rsplit_once(':')
+        .map(|(host, _)| host)
+        .unwrap_or(authority)
+        .trim_matches(['[', ']']);
+    host.eq_ignore_ascii_case("localhost")
+        || host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
+}
+
+fn sdk_error(category: ErrorCategory, message: impl Into<String>) -> SdkError {
+    SdkError::new(code::INTERNAL, category, message)
+}
+
+fn token_signature(secret: &str, payload: &str) -> String {
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes())
+        .expect("token shared secret must be non-empty");
+    mac.update(payload.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
+}
+
+fn new_session_id() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    format!("zmq-sdk-{:032x}", now)
+}
+
+fn map_rpc_error(error: RpcError) -> SdkError {
+    let category = match error.category.as_deref() {
+        Some("Validation") => ErrorCategory::Validation,
+        Some("Capability") => ErrorCategory::Capability,
+        Some("Config") => ErrorCategory::Config,
+        Some("Policy") => ErrorCategory::Policy,
+        Some("Security") => ErrorCategory::Security,
+        Some("Transport") => ErrorCategory::Transport,
+        Some("Timeout") => ErrorCategory::Timeout,
+        Some("Runtime") => ErrorCategory::Runtime,
+        _ => ErrorCategory::Internal,
+    };
+    SdkError::new(
+        error.machine_code.as_deref().unwrap_or(error.code.as_str()),
+        category,
+        error.message,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_rejects_remote_endpoints_without_auth() {
+        let config = ZmqPipelineBackendConfig::local_tcp(
+            "tcp://192.0.2.10:9000",
+            "tcp://127.0.0.1:9001",
+        );
+
+        let err = config.validate().expect_err("remote without auth rejected");
+
+        assert_eq!(err.category, ErrorCategory::Security);
+        assert_eq!(err.machine_code, code::SECURITY_AUTH_REQUIRED);
+    }
+
+    #[test]
+    fn config_accepts_loopback_without_auth() {
+        let config = ZmqPipelineBackendConfig::local_tcp(
+            "tcp://127.0.0.1:9000",
+            "tcp://localhost:9001",
+        );
+
+        config.validate().expect("loopback accepted");
+    }
+
+    #[test]
+    fn response_filter_requires_session_and_request_match() {
+        let session = "session-a".to_string();
+        let envelope = ZmqRpcEnvelope::response(session.clone(), 4, Vec::new());
+
+        assert_eq!(envelope.kind, ZmqRpcEnvelopeKind::Response);
+        assert_eq!(envelope.session_id, session);
+        assert_eq!(envelope.request_id, 4);
+    }
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -1,10 +1,10 @@
 use crate::backend::SdkBackend;
-use crate::capability::{EffectiveLimits, NegotiationRequest, NegotiationResponse};
+use crate::capability::{NegotiationRequest, NegotiationResponse};
 use crate::error::{code, ErrorCategory, SdkError};
 use crate::event::{EventBatch, EventCursor, SdkEvent, Severity};
 use crate::types::{
-    Ack, CancelResult, ConfigPatch, DeliverySnapshot, MessageId, RuntimeSnapshot, SendRequest,
-    ShutdownMode, RuntimeState,
+    Ack, CancelResult, ConfigPatch, DeliverySnapshot, DeliveryState, MessageId, RuntimeSnapshot,
+    RuntimeState, SendRequest, ShutdownMode,
 };
 use hmac::{Hmac, Mac};
 use rns_rpc::e2e_harness::{build_rpc_frame, parse_rpc_frame};
@@ -13,66 +13,21 @@ use rns_rpc::RpcError;
 use serde_json::{json, Value as JsonValue};
 use sha2::Sha256;
 use std::collections::BTreeMap;
-use std::net::IpAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
 use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ZmqEndpointRole {
-    Bind,
-    Connect,
-}
+#[path = "zmq_pipeline/config.rs"]
+mod config;
+#[path = "zmq_pipeline/parsing.rs"]
+mod parsing;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ZmqPipelineTokenAuth {
-    pub issuer: String,
-    pub audience: String,
-    pub shared_secret: String,
-    pub ttl_secs: u64,
-}
+#[cfg(test)]
+#[path = "zmq_pipeline/tests.rs"]
+mod tests;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ZmqPipelineBackendConfig {
-    pub command_endpoint: String,
-    pub command_role: ZmqEndpointRole,
-    pub response_endpoint: String,
-    pub response_role: ZmqEndpointRole,
-    pub request_timeout: Duration,
-    pub max_envelope_bytes: usize,
-    pub token_auth: Option<ZmqPipelineTokenAuth>,
-}
-
-impl ZmqPipelineBackendConfig {
-    pub fn local_tcp(
-        command_endpoint: impl Into<String>,
-        response_endpoint: impl Into<String>,
-    ) -> Self {
-        Self {
-            command_endpoint: command_endpoint.into(),
-            command_role: ZmqEndpointRole::Connect,
-            response_endpoint: response_endpoint.into(),
-            response_role: ZmqEndpointRole::Bind,
-            request_timeout: Duration::from_secs(5),
-            max_envelope_bytes: zmq::ZMQ_RPC_MAX_ENVELOPE_BYTES,
-            token_auth: None,
-        }
-    }
-
-    pub fn validate(&self) -> Result<(), SdkError> {
-        validate_endpoint_security(&self.command_endpoint, self.token_auth.is_some())?;
-        validate_endpoint_security(&self.response_endpoint, self.token_auth.is_some())?;
-        if self.max_envelope_bytes > zmq::ZMQ_RPC_MAX_ENVELOPE_BYTES {
-            return Err(SdkError::new(
-                code::VALIDATION_INVALID_ARGUMENT,
-                ErrorCategory::Validation,
-                "zmq max_envelope_bytes exceeds protocol limit",
-            ));
-        }
-        Ok(())
-    }
-}
+pub use config::{ZmqEndpointRole, ZmqPipelineBackendConfig, ZmqPipelineTokenAuth};
 
 pub struct ZmqPipelineBackendClient {
     config: ZmqPipelineBackendConfig,
@@ -83,11 +38,7 @@ pub struct ZmqPipelineBackendClient {
 impl ZmqPipelineBackendClient {
     pub fn new(config: ZmqPipelineBackendConfig) -> Result<Self, SdkError> {
         config.validate()?;
-        Ok(Self {
-            config,
-            session_id: new_session_id(),
-            next_request_id: AtomicU64::new(1),
-        })
+        Ok(Self { config, session_id: new_session_id(), next_request_id: AtomicU64::new(1) })
     }
 
     pub fn session_id(&self) -> &str {
@@ -194,119 +145,6 @@ impl ZmqPipelineBackendClient {
             scheme: "bearer".to_string(),
             value: format!("{};sig={}", payload, sig),
         })
-    }
-
-    fn parse_required_string(value: &JsonValue, key: &'static str) -> Result<String, SdkError> {
-        value.get(key).and_then(JsonValue::as_str).map(str::to_owned).ok_or_else(|| {
-            SdkError::new(
-                code::INTERNAL,
-                ErrorCategory::Internal,
-                format!("rpc response missing string field '{key}'"),
-            )
-        })
-    }
-
-    fn parse_required_u64(value: &JsonValue, key: &'static str) -> Result<u64, SdkError> {
-        value.get(key).and_then(JsonValue::as_u64).ok_or_else(|| {
-            SdkError::new(
-                code::INTERNAL,
-                ErrorCategory::Internal,
-                format!("rpc response missing integer field '{key}'"),
-            )
-        })
-    }
-
-    fn parse_required_u16(value: &JsonValue, key: &'static str) -> Result<u16, SdkError> {
-        let raw = Self::parse_required_u64(value, key)?;
-        u16::try_from(raw).map_err(|_| {
-            SdkError::new(
-                code::INTERNAL,
-                ErrorCategory::Internal,
-                format!("rpc response field '{key}' is out of range"),
-            )
-        })
-    }
-
-    fn parse_effective_limits(value: &JsonValue) -> Result<EffectiveLimits, SdkError> {
-        Ok(EffectiveLimits {
-            max_poll_events: usize::try_from(Self::parse_required_u64(value, "max_poll_events")?)
-                .map_err(|_| sdk_error(ErrorCategory::Internal, "max_poll_events overflow"))?,
-            max_event_bytes: usize::try_from(Self::parse_required_u64(value, "max_event_bytes")?)
-                .map_err(|_| sdk_error(ErrorCategory::Internal, "max_event_bytes overflow"))?,
-            max_batch_bytes: usize::try_from(Self::parse_required_u64(value, "max_batch_bytes")?)
-                .map_err(|_| sdk_error(ErrorCategory::Internal, "max_batch_bytes overflow"))?,
-            max_extension_keys: usize::try_from(Self::parse_required_u64(
-                value,
-                "max_extension_keys",
-            )?)
-            .map_err(|_| sdk_error(ErrorCategory::Internal, "max_extension_keys overflow"))?,
-            idempotency_ttl_ms: Self::parse_required_u64(value, "idempotency_ttl_ms")?,
-        })
-    }
-
-    fn parse_cancel_result(value: &str) -> Result<CancelResult, SdkError> {
-        match value {
-            "Accepted" => Ok(CancelResult::Accepted),
-            "AlreadyTerminal" => Ok(CancelResult::AlreadyTerminal),
-            "NotFound" => Ok(CancelResult::NotFound),
-            "TooLateToCancel" => Ok(CancelResult::TooLateToCancel),
-            _ => Err(SdkError::new(
-                code::INTERNAL,
-                ErrorCategory::Internal,
-                "rpc returned unknown cancel result variant",
-            )),
-        }
-    }
-
-    fn parse_delivery_state(receipt_status: Option<&str>) -> DeliveryState {
-        let Some(raw) = receipt_status else {
-            return DeliveryState::Queued;
-        };
-        let normalized = raw.trim();
-        if normalized.get(..4).is_some_and(|prefix| prefix.eq_ignore_ascii_case("sent")) {
-            return DeliveryState::Sent;
-        }
-        if normalized.get(..6).is_some_and(|prefix| prefix.eq_ignore_ascii_case("failed")) {
-            return DeliveryState::Failed;
-        }
-        match normalized {
-            value if value.eq_ignore_ascii_case("queued") => DeliveryState::Queued,
-            value if value.eq_ignore_ascii_case("dispatching") => DeliveryState::Dispatching,
-            value if value.eq_ignore_ascii_case("in_flight") => DeliveryState::InFlight,
-            value if value.eq_ignore_ascii_case("inflight") => DeliveryState::InFlight,
-            value if value.eq_ignore_ascii_case("cancelled") => DeliveryState::Cancelled,
-            value if value.eq_ignore_ascii_case("delivered") => DeliveryState::Delivered,
-            value if value.eq_ignore_ascii_case("expired") => DeliveryState::Expired,
-            value if value.eq_ignore_ascii_case("rejected") => DeliveryState::Rejected,
-            _ => DeliveryState::Unknown,
-        }
-    }
-
-    fn parse_severity(value: &str) -> Severity {
-        match value {
-            raw if raw.eq_ignore_ascii_case("debug") => Severity::Debug,
-            raw if raw.eq_ignore_ascii_case("info") => Severity::Info,
-            raw if raw.eq_ignore_ascii_case("warn") || raw.eq_ignore_ascii_case("warning") => {
-                Severity::Warn
-            }
-            raw if raw.eq_ignore_ascii_case("error") => Severity::Error,
-            raw if raw.eq_ignore_ascii_case("critical") || raw.eq_ignore_ascii_case("fatal") => {
-                Severity::Critical
-            }
-            _ => Severity::Unknown,
-        }
-    }
-
-    fn parse_runtime_state(value: &str) -> RuntimeState {
-        match value {
-            raw if raw.eq_ignore_ascii_case("new") => RuntimeState::New,
-            raw if raw.eq_ignore_ascii_case("starting") => RuntimeState::Starting,
-            raw if raw.eq_ignore_ascii_case("running") => RuntimeState::Running,
-            raw if raw.eq_ignore_ascii_case("draining") => RuntimeState::Draining,
-            raw if raw.eq_ignore_ascii_case("stopped") => RuntimeState::Stopped,
-            raw if raw.eq_ignore_ascii_case("failed") => RuntimeState::Failed,
-            _ => RuntimeState::Unknown,
-        }
     }
 }
 
@@ -575,33 +413,6 @@ where
     }
 }
 
-fn validate_endpoint_security(endpoint: &str, has_auth: bool) -> Result<(), SdkError> {
-    if is_local_endpoint(endpoint) || has_auth {
-        return Ok(());
-    }
-    Err(SdkError::new(
-        code::SECURITY_AUTH_REQUIRED,
-        ErrorCategory::Security,
-        "remote zmq endpoints require explicit token authentication",
-    ))
-}
-
-fn is_local_endpoint(endpoint: &str) -> bool {
-    if endpoint.starts_with("inproc://") {
-        return true;
-    }
-    let Some(authority) = endpoint.strip_prefix("tcp://") else {
-        return false;
-    };
-    let host = authority
-        .rsplit_once(':')
-        .map(|(host, _)| host)
-        .unwrap_or(authority)
-        .trim_matches(['[', ']']);
-    host.eq_ignore_ascii_case("localhost")
-        || host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
-}
-
 fn sdk_error(category: ErrorCategory, message: impl Into<String>) -> SdkError {
     SdkError::new(code::INTERNAL, category, message)
 }
@@ -638,38 +449,4 @@ fn map_rpc_error(error: RpcError) -> SdkError {
         category,
         error.message,
     )
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn config_rejects_remote_endpoints_without_auth() {
-        let config =
-            ZmqPipelineBackendConfig::local_tcp("tcp://192.0.2.10:9000", "tcp://127.0.0.1:9001");
-
-        let err = config.validate().expect_err("remote without auth rejected");
-
-        assert_eq!(err.category, ErrorCategory::Security);
-        assert_eq!(err.machine_code, code::SECURITY_AUTH_REQUIRED);
-    }
-
-    #[test]
-    fn config_accepts_loopback_without_auth() {
-        let config =
-            ZmqPipelineBackendConfig::local_tcp("tcp://127.0.0.1:9000", "tcp://localhost:9001");
-
-        config.validate().expect("loopback accepted");
-    }
-
-    #[test]
-    fn response_filter_requires_session_and_request_match() {
-        let session = "session-a".to_string();
-        let envelope = ZmqRpcEnvelope::response(session.clone(), 4, Vec::new());
-
-        assert_eq!(envelope.kind, ZmqRpcEnvelopeKind::Response);
-        assert_eq!(envelope.session_id, session);
-        assert_eq!(envelope.request_id, 4);
-    }
 }

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -45,7 +45,10 @@ pub struct ZmqPipelineBackendConfig {
 }
 
 impl ZmqPipelineBackendConfig {
-    pub fn local_tcp(command_endpoint: impl Into<String>, response_endpoint: impl Into<String>) -> Self {
+    pub fn local_tcp(
+        command_endpoint: impl Into<String>,
+        response_endpoint: impl Into<String>,
+    ) -> Self {
         Self {
             command_endpoint: command_endpoint.into(),
             command_role: ZmqEndpointRole::Connect,
@@ -109,10 +112,14 @@ impl ZmqPipelineBackendClient {
         let encoded = zmq::encode_envelope(&envelope)
             .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
         if encoded.len() > self.config.max_envelope_bytes {
-            return Err(sdk_error(ErrorCategory::Transport, "zmq rpc envelope exceeded configured limit"));
+            return Err(sdk_error(
+                ErrorCategory::Transport,
+                "zmq rpc envelope exceeded configured limit",
+            ));
         }
 
-        let runtime = Runtime::new().map_err(|err| sdk_error(ErrorCategory::Internal, err.to_string()))?;
+        let runtime =
+            Runtime::new().map_err(|err| sdk_error(ErrorCategory::Internal, err.to_string()))?;
         let response = runtime.block_on(self.send_and_recv(encoded, request_id))?;
         let rpc_response = parse_rpc_frame(&response.payload)
             .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
@@ -130,7 +137,8 @@ impl ZmqPipelineBackendClient {
         let mut command = PushSocket::new();
         apply_role(&mut command, self.config.command_role, &self.config.command_endpoint).await?;
         let mut responses = PullSocket::new();
-        apply_role(&mut responses, self.config.response_role, &self.config.response_endpoint).await?;
+        apply_role(&mut responses, self.config.response_role, &self.config.response_endpoint)
+            .await?;
 
         command
             .send(ZmqMessage::from(encoded))
@@ -413,7 +421,8 @@ impl SdkBackend for ZmqPipelineBackendClient {
         if record.is_null() {
             return Ok(None);
         }
-        let state = Self::parse_delivery_state(record.get("receipt_status").and_then(JsonValue::as_str));
+        let state =
+            Self::parse_delivery_state(record.get("receipt_status").and_then(JsonValue::as_str));
         let terminal = matches!(
             state,
             DeliveryState::Delivered
@@ -473,12 +482,30 @@ impl SdkBackend for ZmqPipelineBackendClient {
                                 .and_then(JsonValue::as_str)
                                 .unwrap_or("rns-rpc")
                                 .to_owned(),
-                            operation_id: row.get("operation_id").and_then(JsonValue::as_str).map(str::to_owned),
-                            message_id: row.get("message_id").and_then(JsonValue::as_str).map(str::to_owned),
-                            peer_id: row.get("peer_id").and_then(JsonValue::as_str).map(str::to_owned),
-                            correlation_id: row.get("correlation_id").and_then(JsonValue::as_str).map(str::to_owned),
-                            trace_id: row.get("trace_id").and_then(JsonValue::as_str).map(str::to_owned),
-                            payload: row.get("payload").cloned().unwrap_or(JsonValue::Object(serde_json::Map::new())),
+                            operation_id: row
+                                .get("operation_id")
+                                .and_then(JsonValue::as_str)
+                                .map(str::to_owned),
+                            message_id: row
+                                .get("message_id")
+                                .and_then(JsonValue::as_str)
+                                .map(str::to_owned),
+                            peer_id: row
+                                .get("peer_id")
+                                .and_then(JsonValue::as_str)
+                                .map(str::to_owned),
+                            correlation_id: row
+                                .get("correlation_id")
+                                .and_then(JsonValue::as_str)
+                                .map(str::to_owned),
+                            trace_id: row
+                                .get("trace_id")
+                                .and_then(JsonValue::as_str)
+                                .map(str::to_owned),
+                            payload: row
+                                .get("payload")
+                                .cloned()
+                                .unwrap_or(JsonValue::Object(serde_json::Map::new())),
                             extensions: BTreeMap::new(),
                         })
                     })
@@ -510,7 +537,10 @@ impl SdkBackend for ZmqPipelineBackendClient {
             event_stream_position: Self::parse_required_u64(&result, "event_stream_position")?,
             config_revision: Self::parse_required_u64(&result, "config_revision")?,
             queued_messages: result.get("queued_messages").and_then(JsonValue::as_u64).unwrap_or(0),
-            in_flight_messages: result.get("in_flight_messages").and_then(JsonValue::as_u64).unwrap_or(0),
+            in_flight_messages: result
+                .get("in_flight_messages")
+                .and_then(JsonValue::as_u64)
+                .unwrap_or(0),
         })
     }
 
@@ -527,16 +557,18 @@ impl SdkBackend for ZmqPipelineBackendClient {
     }
 }
 
-async fn apply_role<S>(socket: &mut S, role: ZmqEndpointRole, endpoint: &str) -> Result<(), SdkError>
+async fn apply_role<S>(
+    socket: &mut S,
+    role: ZmqEndpointRole,
+    endpoint: &str,
+) -> Result<(), SdkError>
 where
     S: Socket,
 {
     match role {
-        ZmqEndpointRole::Bind => {
-            socket.bind(endpoint).await.map(|_| ()).map_err(|err| {
-                sdk_error(ErrorCategory::Transport, format!("zmq bind {} failed: {}", endpoint, err))
-            })
-        }
+        ZmqEndpointRole::Bind => socket.bind(endpoint).await.map(|_| ()).map_err(|err| {
+            sdk_error(ErrorCategory::Transport, format!("zmq bind {} failed: {}", endpoint, err))
+        }),
         ZmqEndpointRole::Connect => socket.connect(endpoint).await.map_err(|err| {
             sdk_error(ErrorCategory::Transport, format!("zmq connect {} failed: {}", endpoint, err))
         }),
@@ -614,10 +646,8 @@ mod tests {
 
     #[test]
     fn config_rejects_remote_endpoints_without_auth() {
-        let config = ZmqPipelineBackendConfig::local_tcp(
-            "tcp://192.0.2.10:9000",
-            "tcp://127.0.0.1:9001",
-        );
+        let config =
+            ZmqPipelineBackendConfig::local_tcp("tcp://192.0.2.10:9000", "tcp://127.0.0.1:9001");
 
         let err = config.validate().expect_err("remote without auth rejected");
 
@@ -627,10 +657,8 @@ mod tests {
 
     #[test]
     fn config_accepts_loopback_without_auth() {
-        let config = ZmqPipelineBackendConfig::local_tcp(
-            "tcp://127.0.0.1:9000",
-            "tcp://localhost:9001",
-        );
+        let config =
+            ZmqPipelineBackendConfig::local_tcp("tcp://127.0.0.1:9000", "tcp://localhost:9001");
 
         config.validate().expect("loopback accepted");
     }

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/config.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/config.rs
@@ -34,9 +34,9 @@ impl ZmqPipelineBackendConfig {
         response_endpoint: impl Into<String>,
     ) -> Self {
         Self {
-            command_endpoint: command_endpoint.into(),
+            command_endpoint: normalize_loopback_endpoint(command_endpoint.into()),
             command_role: ZmqEndpointRole::Connect,
-            response_endpoint: response_endpoint.into(),
+            response_endpoint: normalize_loopback_endpoint(response_endpoint.into()),
             response_role: ZmqEndpointRole::Bind,
             request_timeout: Duration::from_secs(5),
             max_envelope_bytes: zmq::ZMQ_RPC_MAX_ENVELOPE_BYTES,
@@ -56,6 +56,13 @@ impl ZmqPipelineBackendConfig {
         }
         Ok(())
     }
+}
+
+fn normalize_loopback_endpoint(endpoint: String) -> String {
+    endpoint
+        .strip_prefix("tcp://127.0.0.1:")
+        .map(|port| format!("tcp://localhost:{port}"))
+        .unwrap_or(endpoint)
 }
 
 fn validate_endpoint_security(endpoint: &str, has_auth: bool) -> Result<(), SdkError> {

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/config.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/config.rs
@@ -1,0 +1,86 @@
+use crate::error::{code, ErrorCategory, SdkError};
+use rns_rpc::rpc::zmq;
+use std::net::IpAddr;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZmqEndpointRole {
+    Bind,
+    Connect,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZmqPipelineTokenAuth {
+    pub issuer: String,
+    pub audience: String,
+    pub shared_secret: String,
+    pub ttl_secs: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZmqPipelineBackendConfig {
+    pub command_endpoint: String,
+    pub command_role: ZmqEndpointRole,
+    pub response_endpoint: String,
+    pub response_role: ZmqEndpointRole,
+    pub request_timeout: Duration,
+    pub max_envelope_bytes: usize,
+    pub token_auth: Option<ZmqPipelineTokenAuth>,
+}
+
+impl ZmqPipelineBackendConfig {
+    pub fn local_tcp(
+        command_endpoint: impl Into<String>,
+        response_endpoint: impl Into<String>,
+    ) -> Self {
+        Self {
+            command_endpoint: command_endpoint.into(),
+            command_role: ZmqEndpointRole::Connect,
+            response_endpoint: response_endpoint.into(),
+            response_role: ZmqEndpointRole::Bind,
+            request_timeout: Duration::from_secs(5),
+            max_envelope_bytes: zmq::ZMQ_RPC_MAX_ENVELOPE_BYTES,
+            token_auth: None,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), SdkError> {
+        validate_endpoint_security(&self.command_endpoint, self.token_auth.is_some())?;
+        validate_endpoint_security(&self.response_endpoint, self.token_auth.is_some())?;
+        if self.max_envelope_bytes > zmq::ZMQ_RPC_MAX_ENVELOPE_BYTES {
+            return Err(SdkError::new(
+                code::VALIDATION_INVALID_ARGUMENT,
+                ErrorCategory::Validation,
+                "zmq max_envelope_bytes exceeds protocol limit",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn validate_endpoint_security(endpoint: &str, has_auth: bool) -> Result<(), SdkError> {
+    if is_local_endpoint(endpoint) || has_auth {
+        return Ok(());
+    }
+    Err(SdkError::new(
+        code::SECURITY_AUTH_REQUIRED,
+        ErrorCategory::Security,
+        "remote zmq endpoints require explicit token authentication",
+    ))
+}
+
+fn is_local_endpoint(endpoint: &str) -> bool {
+    if endpoint.starts_with("inproc://") {
+        return true;
+    }
+    let Some(authority) = endpoint.strip_prefix("tcp://") else {
+        return false;
+    };
+    let host = authority
+        .rsplit_once(':')
+        .map(|(host, _)| host)
+        .unwrap_or(authority)
+        .trim_matches(['[', ']']);
+    host.eq_ignore_ascii_case("localhost")
+        || host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/parsing.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/parsing.rs
@@ -1,0 +1,136 @@
+use super::{sdk_error, ZmqPipelineBackendClient};
+use crate::capability::EffectiveLimits;
+use crate::error::{code, ErrorCategory, SdkError};
+use crate::event::Severity;
+use crate::types::{CancelResult, DeliveryState, RuntimeState};
+use serde_json::Value as JsonValue;
+
+impl ZmqPipelineBackendClient {
+    pub(super) fn parse_required_string(
+        value: &JsonValue,
+        key: &'static str,
+    ) -> Result<String, SdkError> {
+        value.get(key).and_then(JsonValue::as_str).map(str::to_owned).ok_or_else(|| {
+            SdkError::new(
+                code::INTERNAL,
+                ErrorCategory::Internal,
+                format!("rpc response missing string field '{key}'"),
+            )
+        })
+    }
+
+    pub(super) fn parse_required_u64(
+        value: &JsonValue,
+        key: &'static str,
+    ) -> Result<u64, SdkError> {
+        value.get(key).and_then(JsonValue::as_u64).ok_or_else(|| {
+            SdkError::new(
+                code::INTERNAL,
+                ErrorCategory::Internal,
+                format!("rpc response missing integer field '{key}'"),
+            )
+        })
+    }
+
+    pub(super) fn parse_required_u16(
+        value: &JsonValue,
+        key: &'static str,
+    ) -> Result<u16, SdkError> {
+        let raw = Self::parse_required_u64(value, key)?;
+        u16::try_from(raw).map_err(|_| {
+            SdkError::new(
+                code::INTERNAL,
+                ErrorCategory::Internal,
+                format!("rpc response field '{key}' is out of range"),
+            )
+        })
+    }
+
+    pub(super) fn parse_effective_limits(value: &JsonValue) -> Result<EffectiveLimits, SdkError> {
+        Ok(EffectiveLimits {
+            max_poll_events: usize::try_from(Self::parse_required_u64(value, "max_poll_events")?)
+                .map_err(|_| {
+                sdk_error(ErrorCategory::Internal, "max_poll_events overflow")
+            })?,
+            max_event_bytes: usize::try_from(Self::parse_required_u64(value, "max_event_bytes")?)
+                .map_err(|_| {
+                sdk_error(ErrorCategory::Internal, "max_event_bytes overflow")
+            })?,
+            max_batch_bytes: usize::try_from(Self::parse_required_u64(value, "max_batch_bytes")?)
+                .map_err(|_| {
+                sdk_error(ErrorCategory::Internal, "max_batch_bytes overflow")
+            })?,
+            max_extension_keys: usize::try_from(Self::parse_required_u64(
+                value,
+                "max_extension_keys",
+            )?)
+            .map_err(|_| sdk_error(ErrorCategory::Internal, "max_extension_keys overflow"))?,
+            idempotency_ttl_ms: Self::parse_required_u64(value, "idempotency_ttl_ms")?,
+        })
+    }
+
+    pub(super) fn parse_cancel_result(value: &str) -> Result<CancelResult, SdkError> {
+        match value {
+            "Accepted" => Ok(CancelResult::Accepted),
+            "AlreadyTerminal" => Ok(CancelResult::AlreadyTerminal),
+            "NotFound" => Ok(CancelResult::NotFound),
+            "TooLateToCancel" => Ok(CancelResult::TooLateToCancel),
+            _ => Err(SdkError::new(
+                code::INTERNAL,
+                ErrorCategory::Internal,
+                "rpc returned unknown cancel result variant",
+            )),
+        }
+    }
+
+    pub(super) fn parse_delivery_state(receipt_status: Option<&str>) -> DeliveryState {
+        let Some(raw) = receipt_status else {
+            return DeliveryState::Queued;
+        };
+        let normalized = raw.trim();
+        if normalized.get(..4).is_some_and(|prefix| prefix.eq_ignore_ascii_case("sent")) {
+            return DeliveryState::Sent;
+        }
+        if normalized.get(..6).is_some_and(|prefix| prefix.eq_ignore_ascii_case("failed")) {
+            return DeliveryState::Failed;
+        }
+        match normalized {
+            value if value.eq_ignore_ascii_case("queued") => DeliveryState::Queued,
+            value if value.eq_ignore_ascii_case("dispatching") => DeliveryState::Dispatching,
+            value if value.eq_ignore_ascii_case("in_flight") => DeliveryState::InFlight,
+            value if value.eq_ignore_ascii_case("inflight") => DeliveryState::InFlight,
+            value if value.eq_ignore_ascii_case("cancelled") => DeliveryState::Cancelled,
+            value if value.eq_ignore_ascii_case("delivered") => DeliveryState::Delivered,
+            value if value.eq_ignore_ascii_case("expired") => DeliveryState::Expired,
+            value if value.eq_ignore_ascii_case("rejected") => DeliveryState::Rejected,
+            _ => DeliveryState::Unknown,
+        }
+    }
+
+    pub(super) fn parse_severity(value: &str) -> Severity {
+        match value {
+            raw if raw.eq_ignore_ascii_case("debug") => Severity::Debug,
+            raw if raw.eq_ignore_ascii_case("info") => Severity::Info,
+            raw if raw.eq_ignore_ascii_case("warn") || raw.eq_ignore_ascii_case("warning") => {
+                Severity::Warn
+            }
+            raw if raw.eq_ignore_ascii_case("error") => Severity::Error,
+            raw if raw.eq_ignore_ascii_case("critical") || raw.eq_ignore_ascii_case("fatal") => {
+                Severity::Critical
+            }
+            _ => Severity::Unknown,
+        }
+    }
+
+    pub(super) fn parse_runtime_state(value: &str) -> RuntimeState {
+        match value {
+            raw if raw.eq_ignore_ascii_case("new") => RuntimeState::New,
+            raw if raw.eq_ignore_ascii_case("starting") => RuntimeState::Starting,
+            raw if raw.eq_ignore_ascii_case("running") => RuntimeState::Running,
+            raw if raw.eq_ignore_ascii_case("draining") => RuntimeState::Draining,
+            raw if raw.eq_ignore_ascii_case("stopped") => RuntimeState::Stopped,
+            raw if raw.eq_ignore_ascii_case("failed") => RuntimeState::Failed,
+            _ => RuntimeState::Unknown,
+        }
+    }
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+#[test]
+fn config_rejects_remote_endpoints_without_auth() {
+    let config =
+        ZmqPipelineBackendConfig::local_tcp("tcp://192.0.2.10:9000", "tcp://127.0.0.1:9001");
+
+    let err = config.validate().expect_err("remote without auth rejected");
+
+    assert_eq!(err.category, ErrorCategory::Security);
+    assert_eq!(err.machine_code, code::SECURITY_AUTH_REQUIRED);
+}
+
+#[test]
+fn config_accepts_loopback_without_auth() {
+    let config =
+        ZmqPipelineBackendConfig::local_tcp("tcp://127.0.0.1:9000", "tcp://localhost:9001");
+
+    config.validate().expect("loopback accepted");
+}
+
+#[test]
+fn response_filter_requires_session_and_request_match() {
+    let session = "session-a".to_string();
+    let envelope = ZmqRpcEnvelope::response(session.clone(), 4, Vec::new());
+
+    assert_eq!(envelope.kind, ZmqRpcEnvelopeKind::Response);
+    assert_eq!(envelope.session_id, session);
+    assert_eq!(envelope.request_id, 4);
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
@@ -20,6 +20,15 @@ fn config_accepts_loopback_without_auth() {
 }
 
 #[test]
+fn config_normalizes_ipv4_loopback_for_windows_tcp_bind() {
+    let config =
+        ZmqPipelineBackendConfig::local_tcp("tcp://127.0.0.1:9000", "tcp://127.0.0.1:9001");
+
+    assert_eq!(config.command_endpoint, "tcp://localhost:9000");
+    assert_eq!(config.response_endpoint, "tcp://localhost:9001");
+}
+
+#[test]
 fn response_filter_requires_session_and_request_match() {
     let session = "session-a".to_string();
     let envelope = ZmqRpcEnvelope::response(session.clone(), 4, Vec::new());

--- a/crates/libs/lxmf-sdk/src/lib.rs
+++ b/crates/libs/lxmf-sdk/src/lib.rs
@@ -32,6 +32,10 @@ pub use backend::mobile_ble::{
 };
 #[cfg(all(feature = "rpc-backend", feature = "std"))]
 pub use backend::rpc::RpcBackendClient;
+#[cfg(all(feature = "zmq-pipeline-backend", feature = "std"))]
+pub use backend::zmq_pipeline::{
+    ZmqEndpointRole, ZmqPipelineBackendClient, ZmqPipelineBackendConfig, ZmqPipelineTokenAuth,
+};
 pub use backend::{
     KeyProviderClass, SdkBackend, SdkBackendAsyncEvents, SdkBackendKeyManagement, SdkKeyPurpose,
     SdkStoredKey,

--- a/crates/libs/lxmf-sdk/tests/transport_stress.rs
+++ b/crates/libs/lxmf-sdk/tests/transport_stress.rs
@@ -1,0 +1,236 @@
+#![cfg(all(feature = "rpc-backend", feature = "zmq-pipeline-backend"))]
+
+use lxmf_sdk::{
+    EventCursor, LxmfSdk, RpcBackendClient, SdkBackend, SdkConfig, SdkError, StartRequest,
+    ZmqEndpointRole, ZmqPipelineBackendClient, ZmqPipelineBackendConfig, ZmqPipelineTokenAuth,
+};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+struct StressStats {
+    label: &'static str,
+    iterations: usize,
+    elapsed: Duration,
+}
+
+impl StressStats {
+    fn ops_per_second(&self) -> f64 {
+        self.iterations as f64 / self.elapsed.as_secs_f64().max(f64::EPSILON)
+    }
+
+    fn avg_latency_us(&self) -> f64 {
+        self.elapsed.as_micros() as f64 / self.iterations.max(1) as f64
+    }
+}
+
+#[test]
+#[ignore = "requires live HTTP and ZeroMQ daemon endpoints"]
+fn compare_http_and_zmq_sdk_snapshot_stress() -> Result<(), SdkError> {
+    let iterations = stress_iterations();
+    let http = RpcBackendClient::new(http_endpoint());
+    let zmq = ZmqPipelineBackendClient::new(zmq_config())?;
+
+    warm_up_backend("http", &http)?;
+    warm_up_backend("zmq", &zmq)?;
+
+    let http_stats = stress_snapshot("http", &http, iterations)?;
+    let zmq_stats = stress_snapshot("zmq", &zmq, iterations)?;
+
+    print_comparison(&http_stats, &zmq_stats);
+    Ok(())
+}
+
+#[test]
+#[ignore = "requires live HTTP and ZeroMQ daemon endpoints"]
+fn compare_http_and_zmq_sdk_poll_events_stress() -> Result<(), SdkError> {
+    let iterations = stress_iterations();
+    let http = RpcBackendClient::new(http_endpoint());
+    let zmq = ZmqPipelineBackendClient::new(zmq_config())?;
+
+    warm_up_backend("http", &http)?;
+    warm_up_backend("zmq", &zmq)?;
+
+    let http_stats = stress_poll_events("http", &http, iterations)?;
+    let zmq_stats = stress_poll_events("zmq", &zmq, iterations)?;
+
+    print_comparison(&http_stats, &zmq_stats);
+    Ok(())
+}
+
+fn warm_up_backend<B>(label: &'static str, backend: &B) -> Result<(), SdkError>
+where
+    B: SdkBackend,
+{
+    let client = lxmf_sdk::Client::new(backend_ref(backend));
+    let _ = client.start(StartRequest::new(SdkConfig::desktop_local_default()))?;
+    let _ = backend.snapshot()?;
+    println!("{label} warmup complete");
+    Ok(())
+}
+
+fn stress_snapshot<B>(
+    label: &'static str,
+    backend: &B,
+    iterations: usize,
+) -> Result<StressStats, SdkError>
+where
+    B: SdkBackend,
+{
+    let started = Instant::now();
+    for _ in 0..iterations {
+        let _ = backend.snapshot()?;
+    }
+    Ok(StressStats { label, iterations, elapsed: started.elapsed() })
+}
+
+fn stress_poll_events<B>(
+    label: &'static str,
+    backend: &B,
+    iterations: usize,
+) -> Result<StressStats, SdkError>
+where
+    B: SdkBackend,
+{
+    let mut cursor: Option<EventCursor> = None;
+    let started = Instant::now();
+    for _ in 0..iterations {
+        let batch = backend.poll_events(cursor.clone(), 64)?;
+        cursor = Some(batch.next_cursor);
+    }
+    Ok(StressStats { label, iterations, elapsed: started.elapsed() })
+}
+
+fn print_comparison(http: &StressStats, zmq: &StressStats) {
+    println!(
+        "{}: iterations={} elapsed_ms={} ops_per_sec={:.2} avg_us={:.2}",
+        http.label,
+        http.iterations,
+        http.elapsed.as_millis(),
+        http.ops_per_second(),
+        http.avg_latency_us()
+    );
+    println!(
+        "{}: iterations={} elapsed_ms={} ops_per_sec={:.2} avg_us={:.2}",
+        zmq.label,
+        zmq.iterations,
+        zmq.elapsed.as_millis(),
+        zmq.ops_per_second(),
+        zmq.avg_latency_us()
+    );
+    println!(
+        "zmq/http throughput ratio={:.3}",
+        zmq.ops_per_second() / http.ops_per_second().max(f64::EPSILON)
+    );
+}
+
+fn http_endpoint() -> String {
+    std::env::var("LXMF_STRESS_HTTP_RPC")
+        .or_else(|_| std::env::var("LXMF_RPC"))
+        .unwrap_or_else(|_| "unix:/tmp/lxmf-rpc.sock".to_owned())
+}
+
+fn zmq_config() -> ZmqPipelineBackendConfig {
+    let command_endpoint =
+        std::env::var("LXMF_STRESS_ZMQ_COMMAND").unwrap_or_else(|_| "tcp://127.0.0.1:9100".to_owned());
+    let response_endpoint =
+        std::env::var("LXMF_STRESS_ZMQ_RESPONSE").unwrap_or_else(|_| "tcp://127.0.0.1:9101".to_owned());
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.command_role = endpoint_role_from_env("LXMF_STRESS_ZMQ_COMMAND_ROLE", config.command_role);
+    config.response_role =
+        endpoint_role_from_env("LXMF_STRESS_ZMQ_RESPONSE_ROLE", config.response_role);
+    config.request_timeout = Duration::from_millis(
+        std::env::var("LXMF_STRESS_TIMEOUT_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(5_000),
+    );
+    config.token_auth = token_auth_from_env();
+    config
+}
+
+fn endpoint_role_from_env(name: &str, default_role: ZmqEndpointRole) -> ZmqEndpointRole {
+    match std::env::var(name).ok().as_deref() {
+        Some("bind") | Some("BIND") => ZmqEndpointRole::Bind,
+        Some("connect") | Some("CONNECT") => ZmqEndpointRole::Connect,
+        _ => default_role,
+    }
+}
+
+fn token_auth_from_env() -> Option<ZmqPipelineTokenAuth> {
+    let shared_secret = std::env::var("LXMF_STRESS_ZMQ_TOKEN_SECRET").ok()?;
+    Some(ZmqPipelineTokenAuth {
+        issuer: std::env::var("LXMF_STRESS_ZMQ_TOKEN_ISSUER")
+            .unwrap_or_else(|_| "lxmf-sdk-stress".to_owned()),
+        audience: std::env::var("LXMF_STRESS_ZMQ_TOKEN_AUDIENCE")
+            .unwrap_or_else(|_| "reticulumd-zmq".to_owned()),
+        shared_secret,
+        ttl_secs: std::env::var("LXMF_STRESS_ZMQ_TOKEN_TTL_SECS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(60),
+    })
+}
+
+fn stress_iterations() -> usize {
+    std::env::var("LXMF_STRESS_ITERATIONS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(1_000)
+}
+
+fn backend_ref<'a, B: SdkBackend>(backend: &'a B) -> BackendRef<'a, B> {
+    BackendRef(backend)
+}
+
+struct BackendRef<'a, B>(&'a B);
+
+impl<B> SdkBackend for BackendRef<'_, B>
+where
+    B: SdkBackend,
+{
+    fn negotiate(
+        &self,
+        req: lxmf_sdk::NegotiationRequest,
+    ) -> Result<lxmf_sdk::NegotiationResponse, SdkError> {
+        self.0.negotiate(req)
+    }
+
+    fn send(&self, req: lxmf_sdk::SendRequest) -> Result<lxmf_sdk::MessageId, SdkError> {
+        self.0.send(req)
+    }
+
+    fn cancel(&self, id: lxmf_sdk::MessageId) -> Result<lxmf_sdk::CancelResult, SdkError> {
+        self.0.cancel(id)
+    }
+
+    fn status(
+        &self,
+        id: lxmf_sdk::MessageId,
+    ) -> Result<Option<lxmf_sdk::DeliverySnapshot>, SdkError> {
+        self.0.status(id)
+    }
+
+    fn configure(
+        &self,
+        expected_revision: u64,
+        patch: lxmf_sdk::ConfigPatch,
+    ) -> Result<lxmf_sdk::Ack, SdkError> {
+        self.0.configure(expected_revision, patch)
+    }
+
+    fn poll_events(
+        &self,
+        cursor: Option<EventCursor>,
+        max: usize,
+    ) -> Result<lxmf_sdk::EventBatch, SdkError> {
+        self.0.poll_events(cursor, max)
+    }
+
+    fn snapshot(&self) -> Result<lxmf_sdk::RuntimeSnapshot, SdkError> {
+        self.0.snapshot()
+    }
+
+    fn shutdown(&self, mode: lxmf_sdk::ShutdownMode) -> Result<lxmf_sdk::Ack, SdkError> {
+        self.0.shutdown(mode)
+    }
+}

--- a/crates/libs/lxmf-sdk/tests/transport_stress.rs
+++ b/crates/libs/lxmf-sdk/tests/transport_stress.rs
@@ -2,9 +2,11 @@
 #![allow(clippy::result_large_err)]
 
 use lxmf_sdk::{
-    EventCursor, LxmfSdk, RpcBackendClient, SdkBackend, SdkConfig, SdkError, StartRequest,
-    ZmqEndpointRole, ZmqPipelineBackendClient, ZmqPipelineBackendConfig, ZmqPipelineTokenAuth,
+    ConfigPatch, EventCursor, LxmfSdk, RpcBackendClient, SdkBackend, SdkConfig, SdkError,
+    StartRequest, ZmqEndpointRole, ZmqPipelineBackendClient, ZmqPipelineBackendConfig,
+    ZmqPipelineTokenAuth,
 };
+use serde_json::json;
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone)]
@@ -25,47 +27,65 @@ impl StressStats {
 }
 
 #[test]
-#[ignore = "requires live HTTP and ZeroMQ daemon endpoints"]
-fn compare_http_and_zmq_sdk_snapshot_stress() -> Result<(), SdkError> {
-    let iterations = stress_iterations();
-    let http = RpcBackendClient::new(http_endpoint());
-    let zmq = ZmqPipelineBackendClient::new(zmq_config())?;
+fn formats_terse_transport_stress_report_line() {
+    let http = StressStats { label: "http", iterations: 100, elapsed: Duration::from_millis(50) };
+    let zmq = StressStats { label: "zmq", iterations: 100, elapsed: Duration::from_millis(25) };
 
-    warm_up_backend("http", &http)?;
-    warm_up_backend("zmq", &zmq)?;
+    let line = format_comparison("snapshot", &http, &zmq);
 
-    let http_stats = stress_snapshot("http", &http, iterations)?;
-    let zmq_stats = stress_snapshot("zmq", &zmq, iterations)?;
-
-    print_comparison(&http_stats, &zmq_stats);
-    Ok(())
+    assert_eq!(
+        line,
+        "transport_stress op=snapshot iterations=100 http_ms=50 http_avg_us=500.00 http_ops=2000.00 zmq_ms=25 zmq_avg_us=250.00 zmq_ops=4000.00 zmq_http_ratio=2.000"
+    );
 }
 
 #[test]
 #[ignore = "requires live HTTP and ZeroMQ daemon endpoints"]
-fn compare_http_and_zmq_sdk_poll_events_stress() -> Result<(), SdkError> {
+fn compare_http_and_zmq_sdk_transport_stress() -> Result<(), SdkError> {
     let iterations = stress_iterations();
     let http = RpcBackendClient::new(http_endpoint());
     let zmq = ZmqPipelineBackendClient::new(zmq_config())?;
 
-    warm_up_backend("http", &http)?;
-    warm_up_backend("zmq", &zmq)?;
+    warm_up_backend(&http)?;
+    warm_up_backend(&zmq)?;
+    configure_stress_rate_limits(&http, iterations)?;
+
+    let http_stats = stress_snapshot("http", &http, iterations)?;
+    let zmq_stats = stress_snapshot("zmq", &zmq, iterations)?;
+
+    println!("{}", format_comparison("snapshot", &http_stats, &zmq_stats));
 
     let http_stats = stress_poll_events("http", &http, iterations)?;
     let zmq_stats = stress_poll_events("zmq", &zmq, iterations)?;
 
-    print_comparison(&http_stats, &zmq_stats);
+    println!("{}", format_comparison("poll_events", &http_stats, &zmq_stats));
     Ok(())
 }
 
-fn warm_up_backend<B>(label: &'static str, backend: &B) -> Result<(), SdkError>
+fn configure_stress_rate_limits<B>(backend: &B, iterations: usize) -> Result<(), SdkError>
+where
+    B: SdkBackend,
+{
+    let snapshot = backend.snapshot()?;
+    let limit = u64::try_from(iterations).unwrap_or(u64::MAX / 4).saturating_mul(4).max(1_000);
+    let patch = ConfigPatch::new().with_extension(
+        "rate_limits",
+        json!({
+            "per_ip_per_minute": limit,
+            "per_principal_per_minute": limit,
+        }),
+    );
+    let _ = backend.configure(snapshot.config_revision, patch)?;
+    Ok(())
+}
+
+fn warm_up_backend<B>(backend: &B) -> Result<(), SdkError>
 where
     B: SdkBackend,
 {
     let client = lxmf_sdk::Client::new(backend_ref(backend));
     let _ = client.start(StartRequest::new(SdkConfig::desktop_local_default()))?;
     let _ = backend.snapshot()?;
-    println!("{label} warmup complete");
     Ok(())
 }
 
@@ -101,33 +121,27 @@ where
     Ok(StressStats { label, iterations, elapsed: started.elapsed() })
 }
 
-fn print_comparison(http: &StressStats, zmq: &StressStats) {
-    println!(
-        "{}: iterations={} elapsed_ms={} ops_per_sec={:.2} avg_us={:.2}",
-        http.label,
+fn format_comparison(op: &str, http: &StressStats, zmq: &StressStats) -> String {
+    debug_assert_eq!(http.label, "http");
+    debug_assert_eq!(zmq.label, "zmq");
+    format!(
+        "transport_stress op={} iterations={} http_ms={} http_avg_us={:.2} http_ops={:.2} zmq_ms={} zmq_avg_us={:.2} zmq_ops={:.2} zmq_http_ratio={:.3}",
+        op,
         http.iterations,
         http.elapsed.as_millis(),
+        http.avg_latency_us(),
         http.ops_per_second(),
-        http.avg_latency_us()
-    );
-    println!(
-        "{}: iterations={} elapsed_ms={} ops_per_sec={:.2} avg_us={:.2}",
-        zmq.label,
-        zmq.iterations,
         zmq.elapsed.as_millis(),
+        zmq.avg_latency_us(),
         zmq.ops_per_second(),
-        zmq.avg_latency_us()
-    );
-    println!(
-        "zmq/http throughput ratio={:.3}",
         zmq.ops_per_second() / http.ops_per_second().max(f64::EPSILON)
-    );
+    )
 }
 
 fn http_endpoint() -> String {
     std::env::var("LXMF_STRESS_HTTP_RPC")
         .or_else(|_| std::env::var("LXMF_RPC"))
-        .unwrap_or_else(|_| "unix:/tmp/lxmf-rpc.sock".to_owned())
+        .unwrap_or_else(|_| "127.0.0.1:4242".to_owned())
 }
 
 fn zmq_config() -> ZmqPipelineBackendConfig {

--- a/crates/libs/lxmf-sdk/tests/transport_stress.rs
+++ b/crates/libs/lxmf-sdk/tests/transport_stress.rs
@@ -1,4 +1,5 @@
 #![cfg(all(feature = "rpc-backend", feature = "zmq-pipeline-backend"))]
+#![allow(clippy::result_large_err)]
 
 use lxmf_sdk::{
     EventCursor, LxmfSdk, RpcBackendClient, SdkBackend, SdkConfig, SdkError, StartRequest,

--- a/crates/libs/lxmf-sdk/tests/transport_stress.rs
+++ b/crates/libs/lxmf-sdk/tests/transport_stress.rs
@@ -130,12 +130,13 @@ fn http_endpoint() -> String {
 }
 
 fn zmq_config() -> ZmqPipelineBackendConfig {
-    let command_endpoint =
-        std::env::var("LXMF_STRESS_ZMQ_COMMAND").unwrap_or_else(|_| "tcp://127.0.0.1:9100".to_owned());
-    let response_endpoint =
-        std::env::var("LXMF_STRESS_ZMQ_RESPONSE").unwrap_or_else(|_| "tcp://127.0.0.1:9101".to_owned());
+    let command_endpoint = std::env::var("LXMF_STRESS_ZMQ_COMMAND")
+        .unwrap_or_else(|_| "tcp://127.0.0.1:9100".to_owned());
+    let response_endpoint = std::env::var("LXMF_STRESS_ZMQ_RESPONSE")
+        .unwrap_or_else(|_| "tcp://127.0.0.1:9101".to_owned());
     let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
-    config.command_role = endpoint_role_from_env("LXMF_STRESS_ZMQ_COMMAND_ROLE", config.command_role);
+    config.command_role =
+        endpoint_role_from_env("LXMF_STRESS_ZMQ_COMMAND_ROLE", config.command_role);
     config.response_role =
         endpoint_role_from_env("LXMF_STRESS_ZMQ_RESPONSE_ROLE", config.response_role);
     config.request_timeout = Duration::from_millis(

--- a/crates/libs/rns-rpc/Cargo.toml
+++ b/crates/libs/rns-rpc/Cargo.toml
@@ -25,6 +25,7 @@ hkdf.workspace = true
 base64.workspace = true
 serde_json.workspace = true
 serde_cbor.workspace = true
+serde_bytes.workspace = true
 rusqlite = { workspace = true }
 serde.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/crates/libs/rns-rpc/src/rpc/mod.rs
+++ b/crates/libs/rns-rpc/src/rpc/mod.rs
@@ -5,6 +5,7 @@ mod daemon;
 pub mod event_sink;
 pub mod http;
 pub mod replay;
+pub mod zmq;
 mod send_request;
 
 use rmpv::Value as MsgPackValue;

--- a/crates/libs/rns-rpc/src/rpc/mod.rs
+++ b/crates/libs/rns-rpc/src/rpc/mod.rs
@@ -5,8 +5,8 @@ mod daemon;
 pub mod event_sink;
 pub mod http;
 pub mod replay;
-pub mod zmq;
 mod send_request;
+pub mod zmq;
 
 use rmpv::Value as MsgPackValue;
 use serde::{Deserialize, Serialize};

--- a/crates/libs/rns-rpc/src/rpc/zmq.rs
+++ b/crates/libs/rns-rpc/src/rpc/zmq.rs
@@ -1,0 +1,140 @@
+use super::codec;
+use serde::{Deserialize, Serialize};
+use std::io;
+
+pub const ZMQ_RPC_PROTOCOL_VERSION: u16 = 1;
+pub const ZMQ_RPC_MAX_ENVELOPE_BYTES: usize = codec::MAX_FRAME_PAYLOAD_LEN + 64 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ZmqRpcEnvelopeKind {
+    Request,
+    Response,
+    Event,
+    Control,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ZmqRpcAuthMetadata {
+    pub scheme: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ZmqRpcEnvelope {
+    pub protocol_version: u16,
+    pub session_id: String,
+    pub request_id: u64,
+    pub kind: ZmqRpcEnvelopeKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth: Option<ZmqRpcAuthMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_endpoint: Option<String>,
+    #[serde(with = "serde_bytes")]
+    pub payload: Vec<u8>,
+}
+
+impl ZmqRpcEnvelope {
+    pub fn request(
+        session_id: impl Into<String>,
+        request_id: u64,
+        response_endpoint: impl Into<String>,
+        payload: Vec<u8>,
+        auth: Option<ZmqRpcAuthMetadata>,
+    ) -> Self {
+        Self {
+            protocol_version: ZMQ_RPC_PROTOCOL_VERSION,
+            session_id: session_id.into(),
+            request_id,
+            kind: ZmqRpcEnvelopeKind::Request,
+            auth,
+            response_endpoint: Some(response_endpoint.into()),
+            payload,
+        }
+    }
+
+    pub fn response(session_id: String, request_id: u64, payload: Vec<u8>) -> Self {
+        Self {
+            protocol_version: ZMQ_RPC_PROTOCOL_VERSION,
+            session_id,
+            request_id,
+            kind: ZmqRpcEnvelopeKind::Response,
+            auth: None,
+            response_endpoint: None,
+            payload,
+        }
+    }
+
+    pub fn validate(&self) -> io::Result<()> {
+        if self.protocol_version != ZMQ_RPC_PROTOCOL_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported zmq rpc protocol version {}", self.protocol_version),
+            ));
+        }
+        if self.session_id.trim().is_empty() {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "missing zmq rpc session_id"));
+        }
+        if self.payload.len() > codec::MAX_FRAME_PAYLOAD_LEN {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "zmq rpc payload too large"));
+        }
+        Ok(())
+    }
+}
+
+pub fn encode_envelope(envelope: &ZmqRpcEnvelope) -> io::Result<Vec<u8>> {
+    envelope.validate()?;
+    let encoded = codec::encode_frame(envelope)?;
+    if encoded.len() > ZMQ_RPC_MAX_ENVELOPE_BYTES {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "zmq rpc envelope too large"));
+    }
+    Ok(encoded)
+}
+
+pub fn decode_envelope(bytes: &[u8]) -> io::Result<ZmqRpcEnvelope> {
+    if bytes.len() > ZMQ_RPC_MAX_ENVELOPE_BYTES {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "zmq rpc envelope too large"));
+    }
+    let envelope: ZmqRpcEnvelope = codec::decode_frame(bytes)?;
+    envelope.validate()?;
+    Ok(envelope)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zmq_rpc_envelope_roundtrips_framed_rpc_payload() {
+        let payload = codec::encode_frame(&crate::rpc::RpcRequest {
+            id: 7,
+            method: "sdk_snapshot_v2".to_string(),
+            params: None,
+        })
+        .expect("rpc frame");
+        let envelope =
+            ZmqRpcEnvelope::request("session-a", 7, "tcp://127.0.0.1:9124", payload, None);
+
+        let encoded = encode_envelope(&envelope).expect("encode envelope");
+        let decoded = decode_envelope(&encoded).expect("decode envelope");
+
+        assert_eq!(decoded, envelope);
+    }
+
+    #[test]
+    fn zmq_rpc_envelope_rejects_wrong_protocol_version() {
+        let envelope = ZmqRpcEnvelope {
+            protocol_version: ZMQ_RPC_PROTOCOL_VERSION + 1,
+            session_id: "session-a".to_string(),
+            request_id: 1,
+            kind: ZmqRpcEnvelopeKind::Request,
+            auth: None,
+            response_endpoint: Some("tcp://127.0.0.1:9124".to_string()),
+            payload: Vec::new(),
+        };
+
+        let err = encode_envelope(&envelope).expect_err("bad version rejected");
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/crates/libs/rns-rpc/src/rpc/zmq.rs
+++ b/crates/libs/rns-rpc/src/rpc/zmq.rs
@@ -26,9 +26,9 @@ pub struct ZmqRpcEnvelope {
     pub session_id: String,
     pub request_id: u64,
     pub kind: ZmqRpcEnvelopeKind,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub auth: Option<ZmqRpcAuthMetadata>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub response_endpoint: Option<String>,
     #[serde(with = "serde_bytes")]
     pub payload: Vec<u8>,

--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -153,8 +153,8 @@
     },
     {
       "path": "docs/contracts/sdk-v2-backends.md",
-      "bytes": 7860,
-      "sha256": "e56e2e25a601acedaac8e537b63cbf7904db94df38a5406de84bf243a2e1fae5"
+      "bytes": 7887,
+      "sha256": "75428f04c8ab66f89f412791e475b30759af1b3b1bce090adb1da862353e63c3"
     },
     {
       "path": "docs/contracts/sdk-v2-commands.md",

--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -113,8 +113,8 @@
     },
     {
       "path": "docs/contracts/rpc-contract.md",
-      "bytes": 9234,
-      "sha256": "f0a6bd38b51b24b7ac5c737a9c95073b024fc4d08a890e6c69a0020387545e09"
+      "bytes": 10999,
+      "sha256": "ece1874351d187dd902592d12f8b57477a895f90612c737d0288ce37e7a16641"
     },
     {
       "path": "docs/contracts/schema-driven-clients.md",
@@ -153,8 +153,8 @@
     },
     {
       "path": "docs/contracts/sdk-v2-backends.md",
-      "bytes": 6854,
-      "sha256": "42913ab73666c2778ff2831b9965302e5e7e395c48f10c2546e2d501c73d4562"
+      "bytes": 7860,
+      "sha256": "e56e2e25a601acedaac8e537b63cbf7904db94df38a5406de84bf243a2e1fae5"
     },
     {
       "path": "docs/contracts/sdk-v2-commands.md",

--- a/docs/contracts/rpc-contract.md
+++ b/docs/contracts/rpc-contract.md
@@ -6,6 +6,9 @@ surface.
 
 Scope:
 - Transport: HTTP `POST /rpc` with framed MessagePack payloads over Unix sockets, TCP, or TLS/mTLS.
+- Experimental transport: feature-gated ZeroMQ pipeline RPC uses the same framed MessagePack RPC
+  payload bytes inside an application envelope. HTTP remains the default and authoritative transport
+  until the ZeroMQ release gates below pass.
 - Event stream: HTTP `GET /events` with framed MessagePack events.
 - Live event stream: HTTP `GET /events/stream` keeps the connection open and writes framed SDK
   event objects until the client disconnects. Frames use the same 4-byte big-endian length prefix
@@ -50,6 +53,45 @@ Response object:
 - `id: u64`
 - `result: object | array | scalar | null`
 - `error: { code: string, message: string } | null`
+
+## Experimental ZeroMQ pipeline transport
+
+Status: opt-in, feature-gated, not the default SDK transport.
+
+Crate/API pin:
+
+- Rust crate: `zeromq = 0.6.0`
+- Enabled crate features: `tokio-runtime`, `tcp-transport`
+- Initial socket pattern: paired `PUSH`/`PULL` sockets
+- IPC transport is deferred for the first cross-platform pass.
+
+Envelope:
+
+- `protocol_version: u16`, currently `1`
+- `session_id: string`
+- `request_id: u64`
+- `kind: request | response | event | control`
+- `auth: { scheme, value } | null`
+- `response_endpoint: string | null`
+- `payload: bytes`, containing the existing framed MessagePack RPC request or response
+
+Correlation is mandatory. SDK clients must accept a response only when both `session_id` and
+`request_id` match the pending call. ZeroMQ socket identity, round-robin delivery, and peer ordering
+are not sufficient for request/reply semantics.
+
+Security:
+
+- Loopback TCP endpoints may run in local-trusted mode.
+- Non-local TCP endpoints fail closed unless explicit application-layer auth metadata is configured.
+- The first auth mode is token/HMAC metadata equivalent to the HTTP bearer token semantics.
+- mTLS is not provided by ZeroMQ and must not be inferred from the socket layer.
+- IPC endpoints are deferred until the optional Unix-only transport feature is introduced.
+
+Events:
+
+- `sdk_poll_events_v2` cursor semantics remain authoritative.
+- Pushed event envelopes are a wakeup/optimization path only until they prove identical gap, cursor,
+  overflow, replay, and reset behavior.
 
 ## Stable method set
 

--- a/docs/contracts/sdk-v2-backends.md
+++ b/docs/contracts/sdk-v2-backends.md
@@ -206,7 +206,7 @@ Required behavior:
 Feature gates:
 
 - SDK: `lxmf-sdk/zmq-pipeline-backend`
-- Daemon loop scaffold: `reticulumd/zmq-pipeline-rpc`
+- Daemon loop: `reticulumd/zmq-pipeline-rpc` with `--zmq-rpc-command <endpoint>`
 
 Non-RPC backends may ignore RPC-specific config without violating contract.
 

--- a/docs/contracts/sdk-v2-backends.md
+++ b/docs/contracts/sdk-v2-backends.md
@@ -181,6 +181,33 @@ Conformance gate:
 - HTTP timeout settings
 - auth mode and token verifier settings
 
+## Experimental ZeroMQ Pipeline Backend
+
+`ZmqPipelineBackendClient` is a parallel SDK backend behind the `zmq-pipeline-backend` feature. It
+does not replace `RpcBackendClient`, and HTTP remains the default backend.
+
+Initial config surface:
+
+- command endpoint and role (`bind` or `connect`)
+- response endpoint and role (`bind` or `connect`)
+- request timeout
+- maximum envelope size
+- optional token auth metadata for non-local endpoints
+
+Required behavior:
+
+1. Use the existing framed MessagePack RPC request/response payloads unchanged.
+2. Wrap payloads in `ZmqRpcEnvelope` with protocol version, session ID, request ID, kind, auth
+   metadata, and response endpoint.
+3. Resolve responses only when both session and request identifiers match.
+4. Reject remote endpoints without explicit auth.
+5. Keep `poll_events` cursor behavior authoritative; pushed events are not a replacement contract.
+
+Feature gates:
+
+- SDK: `lxmf-sdk/zmq-pipeline-backend`
+- Daemon loop scaffold: `reticulumd/zmq-pipeline-rpc`
+
 Non-RPC backends may ignore RPC-specific config without violating contract.
 
 ## Security Controls at Backend Boundary

--- a/docs/runbooks/release-readiness.md
+++ b/docs/runbooks/release-readiness.md
@@ -89,6 +89,26 @@ cargo run -p xtask -- sdk-docs-check
 cargo run -p xtask -- sdk-migration-check
 ```
 
+ZeroMQ transport readiness checks before considering a default switch:
+
+```bash
+cargo check --workspace --all-targets
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
+cargo doc --workspace --no-deps
+bash tools/scripts/check-boundaries.sh
+cargo run -p rns-tools --bin rnx -- replay --trace docs/fixtures/sdk-v2/rpc/replay_known_send_cancel.v1.json
+```
+
+Additional required evidence:
+
+- local TCP SDK plus daemon integration covers start, send, cancel, status, configure, poll events,
+  snapshot, and shutdown
+- multi-client tests prove no cross-session response delivery
+- queue pressure, restart, reconnect, no-peer, oversized-frame, and sustained-event stress cases
+  map to documented SDK errors
+- remote ZeroMQ endpoints fail closed without token auth
+
 Extended/manual release checks:
 
 ```bash

--- a/docs/sdk/quickstart.md
+++ b/docs/sdk/quickstart.md
@@ -59,14 +59,31 @@ LXMF_ZMQ_RESPONSE=tcp://127.0.0.1:9101 \
 cargo run -p lxmf-sdk --example zmq_pipeline_send --features zmq-pipeline-backend
 ```
 
+Start `reticulumd` with HTTP and ZeroMQ enabled for a local stress comparison:
+
+```powershell
+cargo run -p reticulumd --features zmq-pipeline-rpc --bin reticulumd -- `
+  --rpc 127.0.0.1:4242 `
+  --zmq-rpc-command tcp://127.0.0.1:9100 `
+  --db target/stress-pr199/reticulumd.db `
+  --identity target/stress-pr199/reticulumd.identity
+```
+
 Run the ignored HTTP-vs-ZeroMQ stress comparison:
 
-```bash
-LXMF_STRESS_HTTP_RPC=unix:/tmp/lxmf-rpc.sock \
-LXMF_STRESS_ZMQ_COMMAND=tcp://127.0.0.1:9100 \
-LXMF_STRESS_ZMQ_RESPONSE=tcp://127.0.0.1:9101 \
-LXMF_STRESS_ITERATIONS=1000 \
-cargo test -p lxmf-sdk --features zmq-pipeline-backend --test transport_stress -- --ignored --nocapture
+```powershell
+$env:LXMF_STRESS_HTTP_RPC='127.0.0.1:4242'
+$env:LXMF_STRESS_ZMQ_COMMAND='tcp://127.0.0.1:9100'
+$env:LXMF_STRESS_ZMQ_RESPONSE='tcp://127.0.0.1:9101'
+$env:LXMF_STRESS_ITERATIONS='1000'
+cargo test -p lxmf-sdk --features zmq-pipeline-backend --test transport_stress -- --ignored --nocapture --test-threads=1
+```
+
+The stress output is a terse two-line timing report:
+
+```text
+transport_stress op=snapshot iterations=1000 http_ms=... http_avg_us=... http_ops=... zmq_ms=... zmq_avg_us=... zmq_ops=... zmq_http_ratio=...
+transport_stress op=poll_events iterations=1000 http_ms=... http_avg_us=... http_ops=... zmq_ms=... zmq_avg_us=... zmq_ops=... zmq_http_ratio=...
 ```
 
 For first-run token-authenticated TCP, put the shared secret in an environment variable

--- a/docs/sdk/quickstart.md
+++ b/docs/sdk/quickstart.md
@@ -16,6 +16,8 @@ cargo run -p reticulumd --bin reticulumd
 
 Then connect with `Client::rpc("unix:/tmp/lxmf-rpc.sock")`.
 
+HTTP/Unix RPC is still the default SDK path.
+
 For explicit TCP development, opt in with `--rpc`:
 
 ```bash
@@ -26,6 +28,46 @@ Remote TCP binds (`0.0.0.0`, non-loopback IPv4, or non-loopback IPv6) are refuse
 unless remote token auth is already configured in the persisted SDK runtime config or
 mTLS client authentication is configured at startup with `--rpc-tls-client-ca`.
 Use loopback TCP only for local development.
+
+## Experimental ZeroMQ Backend
+
+The ZeroMQ backend is parallel and opt-in:
+
+```toml
+lxmf-sdk = { path = "crates/libs/lxmf-sdk", features = ["zmq-pipeline-backend"] }
+```
+
+```rust
+use lxmf_sdk::{Client, ZmqPipelineBackendClient, ZmqPipelineBackendConfig};
+
+let backend = ZmqPipelineBackendClient::new(ZmqPipelineBackendConfig::local_tcp(
+    "tcp://127.0.0.1:9100",
+    "tcp://127.0.0.1:9101",
+))?;
+let client = Client::new(backend);
+```
+
+Use loopback endpoints for local testing. Remote ZeroMQ endpoints require explicit token auth; the
+backend rejects remote endpoints without it. `poll_events` remains the authoritative event recovery
+API even when ZeroMQ event wakeups are enabled.
+
+Run the example client:
+
+```bash
+LXMF_ZMQ_COMMAND=tcp://127.0.0.1:9100 \
+LXMF_ZMQ_RESPONSE=tcp://127.0.0.1:9101 \
+cargo run -p lxmf-sdk --example zmq_pipeline_send --features zmq-pipeline-backend
+```
+
+Run the ignored HTTP-vs-ZeroMQ stress comparison:
+
+```bash
+LXMF_STRESS_HTTP_RPC=unix:/tmp/lxmf-rpc.sock \
+LXMF_STRESS_ZMQ_COMMAND=tcp://127.0.0.1:9100 \
+LXMF_STRESS_ZMQ_RESPONSE=tcp://127.0.0.1:9101 \
+LXMF_STRESS_ITERATIONS=1000 \
+cargo test -p lxmf-sdk --features zmq-pipeline-backend --test transport_stress -- --ignored --nocapture
+```
 
 For first-run token-authenticated TCP, put the shared secret in an environment variable
 and point `reticulumd` at the variable name:


### PR DESCRIPTION
﻿## Summary

This PR adds a parallel, opt-in ZeroMQ pipeline transport beside the existing HTTP `RpcBackendClient` path. The current HTTP SDK backend remains unchanged and remains the default.

Changes include:

- shared `ZmqRpcEnvelope` encode/decode support in `reticulum-rs-rpc`
- feature-gated `ZmqPipelineBackendClient` in `lxmf-sdk`
- feature-gated `reticulumd --zmq-rpc-command <endpoint>` ZeroMQ daemon loop
- local-only ZeroMQ endpoint validation until daemon-side token auth exists
- ZeroMQ example client: `zmq_pipeline_send`
- ignored live-endpoint stress comparison test for HTTP vs ZeroMQ SDK calls
- contract, quickstart, and release-readiness documentation

## Runnable Stress Comparison

Stress comparison harness: `crates/libs/lxmf-sdk/tests/transport_stress.rs`

It runs one sequential ignored comparison against a single local `reticulumd` process and prints exactly one terse report line for each operation:

- `snapshot`
- `poll_events`

### Commands

Start the daemon with both HTTP RPC and ZeroMQ command RPC enabled:

```powershell
cargo run -p reticulumd --features zmq-pipeline-rpc --bin reticulumd -- `
  --rpc 127.0.0.1:4242 `
  --zmq-rpc-command tcp://127.0.0.1:9100 `
  --db target/stress-pr199/reticulumd.db `
  --identity target/stress-pr199/reticulumd.identity
```

Run the comparison:

```powershell
$env:LXMF_STRESS_HTTP_RPC='127.0.0.1:4242'
$env:LXMF_STRESS_ZMQ_COMMAND='tcp://127.0.0.1:9100'
$env:LXMF_STRESS_ZMQ_RESPONSE='tcp://127.0.0.1:9101'
$env:LXMF_STRESS_ITERATIONS='1000'
cargo test -p lxmf-sdk --features zmq-pipeline-backend --test transport_stress -- --ignored --nocapture --test-threads=1
```

The harness also honors `LXMF_RPC` as the fallback HTTP RPC endpoint variable.

## Stress Test / Performance Result

### 2026-05-23 Windows run

Environment:

- OS/shell: Windows PowerShell
- Rust tooling: `cargo 1.93.1 (083ac5135 2025-12-15)`
- PR head tested locally: `ad6cbd6762f08d9a1cdaf7249583ead2f8dba190`
- Local branch tested: `codex/pr199-zmq-pipeline-sdk`
- HTTP SDK: `RpcBackendClient` over `127.0.0.1:4242`
- ZeroMQ SDK: `ZmqPipelineBackendClient` over command `tcp://127.0.0.1:9100` and response `tcp://127.0.0.1:9101`
- Iterations per operation: `1000`

### SDK Timing Comparison

| Operation | HTTP SDK total | ZeroMQ SDK total | Time reduction | HTTP avg/call | ZeroMQ avg/call | ZeroMQ speedup | HTTP ops/s | ZeroMQ ops/s |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `snapshot` | 13,392 ms | 440 ms | 12,952 ms lower (96.7%) | 13,392.97 us | 440.20 us | 30.42x | 74.67 | 2,271.68 |
| `poll_events` | 15,594 ms | 391 ms | 15,203 ms lower (97.5%) | 15,594.23 us | 391.10 us | 39.87x | 64.13 | 2,556.91 |

The ZeroMQ SDK completed the same 1,000-call workloads in under half a second per operation on this local run, while the HTTP SDK took roughly 13-16 seconds. The reported speedup is the measured `http_avg_us / zmq_avg_us` ratio from the harness output.

Interpretation:

- HTTP warmup succeeded.
- ZeroMQ warmup succeeded.
- The ignored comparison test exited 0.
- The harness produced the expected two `transport_stress op=...` timing lines.
- No throughput claim is hard-coded; these timings are from the live local run above.

## Validation

- `cargo test -p reticulumd --features zmq-pipeline-rpc` passed
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend --test transport_stress` passed
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend --test transport_stress -- --ignored --nocapture --test-threads=1` passed against a live local daemon
- `cargo fmt --all --check` passed
