### PR TITLE
[codex] Fix ZMQ token auth enforcement

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
@@ -19,7 +19,9 @@ pub(super) async fn run_zmq_rpc_loop_until(
     daemon: Arc<RpcDaemon>,
     mut shutdown: watch::Receiver<bool>,
 ) -> io::Result<()> {
-    validate_zmq_loop_config(&config)?;
+    validate_zmq_loop_config(&config, daemon.as_ref())?;
+    let command_endpoint_requires_auth =
+        config.require_auth_for_remote && !is_local_zmq_endpoint(&config.command_endpoint);
     let mut commands = PullSocket::new();
     commands.bind(config.command_endpoint.as_str()).await.map_err(zmq_io_error)?;
     let mut responses: HashMap<String, PushSocket> = HashMap::new();
@@ -34,7 +36,11 @@ pub(super) async fn run_zmq_rpc_loop_until(
             }
             message = commands.recv() => {
                 let response =
-                    handle_zmq_command_message(daemon.as_ref(), message.map_err(zmq_io_error)?);
+                    handle_zmq_command_message(
+                        daemon.as_ref(),
+                        message.map_err(zmq_io_error)?,
+                        command_endpoint_requires_auth,
+                    );
                 if let Some(response) = response {
                     send_zmq_response(&mut responses, response).await?;
                 }
@@ -69,6 +75,7 @@ async fn send_zmq_response(
 fn handle_zmq_command_message(
     daemon: &RpcDaemon,
     message: ZmqMessage,
+    command_endpoint_requires_auth: bool,
 ) -> Option<ZmqOutboundResponse> {
     let bytes = match Vec::<u8>::try_from(message) {
         Ok(bytes) => bytes,
@@ -79,7 +86,19 @@ fn handle_zmq_command_message(
         Err(_) => return None,
     };
     let response_endpoint = envelope.response_endpoint.clone()?;
-    if validate_zmq_response_endpoint(response_endpoint.as_str()).is_err() {
+    let response_endpoint_is_local = is_local_zmq_endpoint(response_endpoint.as_str());
+    if let Err(error) = authorize_zmq_envelope(
+        daemon,
+        &envelope,
+        command_endpoint_requires_auth,
+        response_endpoint_is_local,
+    ) {
+        if response_endpoint_is_local {
+            return Some(ZmqOutboundResponse {
+                endpoint: response_endpoint,
+                envelope: rpc_error_envelope(envelope.session_id, envelope.request_id, error),
+            });
+        }
         return None;
     }
     if envelope.kind != ZmqRpcEnvelopeKind::Request {
@@ -112,6 +131,46 @@ fn handle_zmq_command_message(
     })
 }
 
+#[allow(clippy::result_large_err)]
+fn authorize_zmq_envelope(
+    daemon: &RpcDaemon,
+    envelope: &ZmqRpcEnvelope,
+    command_endpoint_requires_auth: bool,
+    response_endpoint_is_local: bool,
+) -> Result<(), RpcError> {
+    if !command_endpoint_requires_auth
+        && response_endpoint_is_local
+        && !daemon.remote_rpc_auth_configured()
+    {
+        return Ok(());
+    }
+    let auth = envelope.auth.as_ref().ok_or_else(|| {
+        RpcError::new("SDK_SECURITY_AUTH_REQUIRED", "zmq rpc envelope auth metadata is required")
+    })?;
+    if !auth.scheme.eq_ignore_ascii_case("bearer") {
+        return Err(RpcError::new(
+            "SDK_SECURITY_TOKEN_INVALID",
+            "zmq rpc auth metadata must use bearer scheme",
+        ));
+    }
+    let value = auth
+        .value
+        .strip_prefix("Bearer ")
+        .or_else(|| auth.value.strip_prefix("bearer "))
+        .unwrap_or(auth.value.as_str());
+    let headers = vec![("authorization".to_string(), format!("Bearer {value}"))];
+    daemon.authorize_http_request(&headers, Some("0.0.0.0"))
+}
+
+fn rpc_error_envelope(session_id: String, request_id: u64, error: RpcError) -> ZmqRpcEnvelope {
+    let response = RpcResponse { id: request_id, result: None, error: Some(error) };
+    ZmqRpcEnvelope::response(
+        session_id,
+        request_id,
+        rns_rpc::rpc::codec::encode_frame(&response).unwrap_or_default(),
+    )
+}
+
 fn error_envelope(
     session_id: impl Into<String>,
     request_id: u64,
@@ -130,11 +189,14 @@ fn error_envelope(
     )
 }
 
-fn validate_zmq_loop_config(config: &ZmqRpcLoopConfig) -> io::Result<()> {
-    if config.require_auth_for_remote && !is_local_zmq_endpoint(&config.command_endpoint) {
+fn validate_zmq_loop_config(config: &ZmqRpcLoopConfig, daemon: &RpcDaemon) -> io::Result<()> {
+    if config.require_auth_for_remote
+        && !is_local_zmq_endpoint(&config.command_endpoint)
+        && !daemon.remote_rpc_token_auth_configured()
+    {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
-            "remote zmq endpoints require explicit authentication",
+            "remote zmq endpoints require explicit token authentication",
         ));
     }
     Ok(())
@@ -164,6 +226,7 @@ fn zmq_io_error(err: impl std::fmt::Display) -> io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rns_rpc::e2e_harness::{build_rpc_frame, parse_rpc_frame};
 
     #[test]
     fn config_rejects_remote_without_auth_gate() {
@@ -171,8 +234,9 @@ mod tests {
             command_endpoint: "tcp://0.0.0.0:9100".to_string(),
             require_auth_for_remote: true,
         };
+        let daemon = RpcDaemon::test_instance();
 
-        let err = validate_zmq_loop_config(&config).expect_err("remote bind rejected");
+        let err = validate_zmq_loop_config(&config, &daemon).expect_err("remote bind rejected");
 
         assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
     }
@@ -183,10 +247,23 @@ mod tests {
             command_endpoint: "tcp://192.0.2.10:9100".to_string(),
             require_auth_for_remote: true,
         };
+        let daemon = RpcDaemon::test_instance();
 
-        let err = validate_zmq_loop_config(&config).expect_err("remote command endpoint rejected");
+        let err = validate_zmq_loop_config(&config, &daemon)
+            .expect_err("remote command endpoint rejected");
 
         assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn config_accepts_remote_command_endpoint_with_token_auth() {
+        let config = ZmqRpcLoopConfig {
+            command_endpoint: "tcp://0.0.0.0:9100".to_string(),
+            require_auth_for_remote: true,
+        };
+        let daemon = token_auth_daemon();
+
+        validate_zmq_loop_config(&config, &daemon).expect("token auth allows remote zmq bind");
     }
 
     #[test]
@@ -195,5 +272,122 @@ mod tests {
             .expect_err("remote response endpoint rejected");
 
         assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn remote_response_endpoint_is_allowed_with_valid_token_auth() {
+        let daemon = token_auth_daemon();
+        let envelope = authenticated_envelope(
+            "session-a",
+            1,
+            "tcp://192.0.2.20:9101",
+            build_rpc_frame(1, "sdk_snapshot_v2", Some(serde_json::json!({}))).expect("rpc frame"),
+        );
+
+        let response = handle_zmq_command_message(
+            &daemon,
+            ZmqMessage::from(zmq::encode_envelope(&envelope).expect("zmq envelope")),
+            true,
+        )
+        .expect("authenticated remote response endpoint should be accepted");
+
+        assert_eq!(response.endpoint, "tcp://192.0.2.20:9101");
+        let rpc = parse_rpc_frame(&response.envelope.payload).expect("rpc response");
+        assert!(rpc.error.is_none(), "valid token auth should reach daemon RPC handler");
+    }
+
+    #[test]
+    fn missing_token_auth_returns_error_to_local_response_endpoint() {
+        let daemon = token_auth_daemon();
+        let payload =
+            build_rpc_frame(2, "sdk_snapshot_v2", Some(serde_json::json!({}))).expect("rpc frame");
+        let envelope =
+            ZmqRpcEnvelope::request("session-b", 2, "tcp://127.0.0.1:9101", payload, None);
+
+        let response = handle_zmq_command_message(
+            &daemon,
+            ZmqMessage::from(zmq::encode_envelope(&envelope).expect("zmq envelope")),
+            true,
+        )
+        .expect("local response endpoint should receive auth error");
+
+        let rpc = parse_rpc_frame(&response.envelope.payload).expect("rpc response");
+        let error = rpc.error.expect("auth error");
+        assert_eq!(error.code, "SDK_SECURITY_AUTH_REQUIRED");
+    }
+
+    #[test]
+    fn remote_command_bind_requires_auth_even_after_runtime_config_changes() {
+        let daemon = RpcDaemon::test_instance();
+        let payload =
+            build_rpc_frame(3, "sdk_snapshot_v2", Some(serde_json::json!({}))).expect("rpc frame");
+        let envelope =
+            ZmqRpcEnvelope::request("session-c", 3, "tcp://127.0.0.1:9101", payload, None);
+
+        let response = handle_zmq_command_message(
+            &daemon,
+            ZmqMessage::from(zmq::encode_envelope(&envelope).expect("zmq envelope")),
+            true,
+        )
+        .expect("remote command bind should return auth error to local response endpoint");
+
+        let rpc = parse_rpc_frame(&response.envelope.payload).expect("rpc response");
+        let error = rpc.error.expect("auth error");
+        assert_eq!(error.code, "SDK_SECURITY_AUTH_REQUIRED");
+    }
+
+    fn token_auth_daemon() -> RpcDaemon {
+        let daemon = RpcDaemon::test_instance();
+        daemon
+            .configure_remote_token_auth_for_startup(
+                "test-issuer",
+                "test-audience",
+                "test-secret",
+                30_000,
+                5_000,
+            )
+            .expect("token auth config");
+        daemon
+    }
+
+    fn authenticated_envelope(
+        session_id: &str,
+        request_id: u64,
+        response_endpoint: &str,
+        payload: Vec<u8>,
+    ) -> ZmqRpcEnvelope {
+        let iat = unix_seconds();
+        let exp = iat.saturating_add(60);
+        let jti = format!("{session_id}-{request_id}");
+        let signed_payload = format!(
+            "iss=test-issuer;aud=test-audience;jti={jti};sub=sdk-client;iat={iat};exp={exp}"
+        );
+        let sig = hmac_signature("test-secret", &signed_payload);
+        ZmqRpcEnvelope::request(
+            session_id,
+            request_id,
+            response_endpoint,
+            payload,
+            Some(rns_rpc::rpc::zmq::ZmqRpcAuthMetadata {
+                scheme: "bearer".to_string(),
+                value: format!("{signed_payload};sig={sig}"),
+            }),
+        )
+    }
+
+    fn unix_seconds() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0)
+    }
+
+    fn hmac_signature(secret: &str, payload: &str) -> String {
+        use hkdf::hmac::{Hmac, Mac};
+        use sha2::Sha256;
+
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("hmac secret");
+        mac.update(payload.as_bytes());
+        hex::encode(mac.finalize().into_bytes())
     }
 }

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -21,6 +21,8 @@ use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage}
 
 #[path = "zmq_pipeline/config.rs"]
 mod config;
+#[path = "zmq_pipeline/negotiation.rs"]
+mod negotiation;
 #[path = "zmq_pipeline/parsing.rs"]
 mod parsing;
 
@@ -74,7 +76,7 @@ impl ZmqPipelineBackendClient {
             request_id,
             self.config.response_endpoint.clone(),
             payload,
-            self.auth_metadata(),
+            self.auth_metadata_for_request(request_id),
         );
         let encoded = zmq::encode_envelope(&envelope)
             .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
@@ -142,20 +144,20 @@ impl ZmqPipelineBackendClient {
         }
     }
 
-    fn auth_metadata(&self) -> Option<ZmqRpcAuthMetadata> {
+    fn auth_metadata_for_request(&self, request_id: u64) -> Option<ZmqRpcAuthMetadata> {
         let auth = self.config.token_auth.as_ref()?;
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|duration| duration.as_secs())
             .unwrap_or(0);
         let payload = format!(
-            "iss={};aud={};iat={};exp={};jti={}-{}",
+            "iss={};aud={};jti={}-{};sub=sdk-client;iat={};exp={}",
             auth.issuer,
             auth.audience,
+            self.session_id,
+            request_id,
             now,
             now.saturating_add(auth.ttl_secs.max(1)),
-            self.session_id,
-            self.next_request_id.load(Ordering::Relaxed)
         );
         let sig = token_signature(auth.shared_secret.as_str(), payload.as_str());
         Some(ZmqRpcAuthMetadata {
@@ -178,6 +180,7 @@ impl ZmqPipelineTransport {
 
 impl SdkBackend for ZmqPipelineBackendClient {
     fn negotiate(&self, req: NegotiationRequest) -> Result<NegotiationResponse, SdkError> {
+        let (bind_mode, auth_mode, rpc_backend) = self.negotiation_security_config(&req);
         let result = self.call_rpc(
             "sdk_negotiate_v2",
             Some(json!({
@@ -185,11 +188,11 @@ impl SdkBackend for ZmqPipelineBackendClient {
                 "requested_capabilities": req.requested_capabilities,
                 "config": {
                     "profile": req.profile,
-                    "bind_mode": req.bind_mode,
-                    "auth_mode": req.auth_mode,
+                    "bind_mode": bind_mode,
+                    "auth_mode": auth_mode,
                     "overflow_policy": req.overflow_policy,
                     "block_timeout_ms": req.block_timeout_ms,
-                    "rpc_backend": req.rpc_backend,
+                    "rpc_backend": rpc_backend,
                 }
             })),
         )?;

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/negotiation.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/negotiation.rs
@@ -1,0 +1,69 @@
+use super::ZmqPipelineBackendClient;
+use crate::capability::NegotiationRequest;
+use crate::types::{AuthMode, BindMode};
+use serde_json::{json, Value as JsonValue};
+
+impl ZmqPipelineBackendClient {
+    pub(super) fn negotiation_security_config(
+        &self,
+        req: &NegotiationRequest,
+    ) -> (&'static str, &'static str, Option<JsonValue>) {
+        if let Some(auth) = self.config.token_auth.as_ref() {
+            return (
+                "remote",
+                "token",
+                Some(json!({
+                    "token_auth": {
+                        "issuer": auth.issuer,
+                        "audience": auth.audience,
+                        "jti_cache_ttl_ms": auth.ttl_secs.saturating_mul(1000).max(1),
+                        "clock_skew_ms": 5_000,
+                        "shared_secret": auth.shared_secret,
+                    }
+                })),
+            );
+        }
+        (
+            bind_mode_to_wire(req.bind_mode.clone()),
+            auth_mode_to_wire(req.auth_mode.clone()),
+            req.rpc_backend.as_ref().map(|config| {
+                json!({
+                    "listen_addr": config.listen_addr,
+                    "read_timeout_ms": config.read_timeout_ms,
+                    "write_timeout_ms": config.write_timeout_ms,
+                    "max_header_bytes": config.max_header_bytes,
+                    "max_body_bytes": config.max_body_bytes,
+                    "token_auth": config.token_auth.as_ref().map(|token| json!({
+                        "issuer": token.issuer,
+                        "audience": token.audience,
+                        "jti_cache_ttl_ms": token.jti_cache_ttl_ms,
+                        "clock_skew_ms": token.clock_skew_ms,
+                        "shared_secret": token.shared_secret,
+                    })),
+                    "mtls_auth": config.mtls_auth.as_ref().map(|mtls| json!({
+                        "ca_bundle_path": mtls.ca_bundle_path,
+                        "require_client_cert": mtls.require_client_cert,
+                        "allowed_san": mtls.allowed_san,
+                        "client_cert_path": mtls.client_cert_path,
+                        "client_key_path": mtls.client_key_path,
+                    })),
+                })
+            }),
+        )
+    }
+}
+
+fn bind_mode_to_wire(bind_mode: BindMode) -> &'static str {
+    match bind_mode {
+        BindMode::LocalOnly => "local_only",
+        BindMode::Remote => "remote",
+    }
+}
+
+fn auth_mode_to_wire(auth_mode: AuthMode) -> &'static str {
+    match auth_mode {
+        AuthMode::LocalTrusted => "local_trusted",
+        AuthMode::Token => "token",
+        AuthMode::Mtls => "mtls",
+    }
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
@@ -48,6 +48,99 @@ fn response_filter_requires_session_and_request_match() {
 }
 
 #[test]
+fn token_auth_metadata_matches_daemon_bearer_claim_shape() {
+    let mut config =
+        ZmqPipelineBackendConfig::local_tcp("tcp://127.0.0.1:9000", "tcp://127.0.0.1:9001");
+    config.token_auth = Some(ZmqPipelineTokenAuth {
+        issuer: "test-issuer".to_string(),
+        audience: "test-audience".to_string(),
+        shared_secret: "test-secret".to_string(),
+        ttl_secs: 60,
+    });
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let auth = client.auth_metadata_for_request(7).expect("auth metadata");
+    let claims = parse_claims(&auth.value);
+    let signed_payload = format!(
+        "iss={};aud={};jti={};sub={};iat={};exp={}",
+        claims.get("iss").expect("issuer"),
+        claims.get("aud").expect("audience"),
+        claims.get("jti").expect("jti"),
+        claims.get("sub").expect("subject"),
+        claims.get("iat").expect("iat"),
+        claims.get("exp").expect("exp")
+    );
+    let expected_sig = token_signature("test-secret", &signed_payload);
+    let expected_jti = format!("{}-7", client.session_id());
+
+    assert_eq!(auth.scheme, "bearer");
+    assert_eq!(claims.get("iss").map(String::as_str), Some("test-issuer"));
+    assert_eq!(claims.get("aud").map(String::as_str), Some("test-audience"));
+    assert_eq!(claims.get("jti").map(String::as_str), Some(expected_jti.as_str()));
+    assert_eq!(claims.get("sub").map(String::as_str), Some("sdk-client"));
+    assert_eq!(claims.get("sig").map(String::as_str), Some(expected_sig.as_str()));
+}
+
+#[test]
+fn negotiate_with_token_auth_preserves_remote_token_runtime_config() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "runtime_id": "runtime-zmq-token",
+            "active_contract_version": 2,
+            "effective_capabilities": [],
+            "effective_limits": {
+                "max_poll_events": 64,
+                "max_event_bytes": 32768,
+                "max_batch_bytes": 1048576,
+                "max_extension_keys": 32,
+                "idempotency_ttl_ms": 60000
+            },
+            "contract_release": "v2",
+            "schema_namespace": "sdk.v2"
+        }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    config.token_auth = Some(ZmqPipelineTokenAuth {
+        issuer: "test-issuer".to_string(),
+        audience: "test-audience".to_string(),
+        shared_secret: "test-secret".to_string(),
+        ttl_secs: 60,
+    });
+    let backend = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let response = backend
+        .negotiate(crate::capability::NegotiationRequest {
+            supported_contract_versions: vec![2],
+            requested_capabilities: Vec::new(),
+            profile: crate::types::Profile::DesktopLocalRuntime,
+            bind_mode: crate::types::BindMode::LocalOnly,
+            auth_mode: crate::types::AuthMode::LocalTrusted,
+            overflow_policy: crate::types::OverflowPolicy::Reject,
+            block_timeout_ms: None,
+            rpc_backend: None,
+        })
+        .expect("negotiate");
+
+    assert_eq!(response.runtime_id, "runtime-zmq-token");
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "sdk_negotiate_v2");
+    let config = &request.params.as_ref().expect("params")["config"];
+    assert_eq!(config["bind_mode"], json!("remote"));
+    assert_eq!(config["auth_mode"], json!("token"));
+    assert_eq!(config["rpc_backend"]["token_auth"]["issuer"], json!("test-issuer"));
+    assert_eq!(config["rpc_backend"]["token_auth"]["audience"], json!("test-audience"));
+    assert_eq!(config["rpc_backend"]["token_auth"]["shared_secret"], json!("test-secret"));
+    server.join().expect("server joined");
+}
+
+#[test]
 fn identity_announce_now_uses_zmq_sdk_method() {
     let command_endpoint = unused_loopback_endpoint();
     let response_endpoint = unused_loopback_endpoint();
@@ -117,6 +210,16 @@ fn identity_presence_list_uses_zmq_sdk_method_and_decodes_response() {
     assert_eq!(request.params.as_ref().expect("params")["cursor"], json!("presence:0"));
     assert_eq!(request.params.as_ref().expect("params")["limit"], json!(1));
     server.join().expect("server joined");
+}
+
+fn parse_claims(token: &str) -> BTreeMap<String, String> {
+    token
+        .split(';')
+        .map(|part| {
+            let (key, value) = part.split_once('=').expect("claim key/value");
+            (key.to_string(), value.to_string())
+        })
+        .collect()
 }
 
 fn unused_loopback_endpoint() -> String {

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_helpers.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_helpers.rs
@@ -442,6 +442,26 @@ impl RpcDaemon {
             && self.validate_sdk_runtime_config(&config).is_ok()
     }
 
+    pub fn remote_rpc_token_auth_configured(&self) -> bool {
+        let config = self.sdk_runtime_config.lock().expect("sdk_runtime_config mutex poisoned");
+        let bind_mode = config
+            .get("bind_mode")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("local_only")
+            .trim()
+            .to_ascii_lowercase();
+        let auth_mode = config
+            .get("auth_mode")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("local_trusted")
+            .trim()
+            .to_ascii_lowercase();
+
+        bind_mode == "remote"
+            && auth_mode == "token"
+            && self.validate_sdk_runtime_config(&config).is_ok()
+    }
+
     #[allow(clippy::result_large_err)]
     pub fn configure_remote_token_auth_for_startup(
         &self,


### PR DESCRIPTION
## Summary

- allow remote ZMQ command binds when daemon token auth is configured
- validate ZMQ envelope bearer auth for remote command and response endpoints
- return correlated RPC errors for local response endpoints instead of silent timeouts
- emit daemon-compatible SDK bearer metadata and preserve token-auth runtime config during negotiation

## Root cause

The SDK could configure remote ZMQ endpoints and emit auth metadata, but the daemon loop rejected non-local endpoints by policy and did not authorize `envelope.auth`. Bad auth or endpoint configuration therefore surfaced as SDK timeouts.

## Validation

- `cargo test -p reticulumd --features zmq-pipeline-rpc zmq`
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend zmq -- --test-threads=1`
- `cargo test -p reticulum-rs-rpc sdk_security_authorize_http_request_rejects_replayed_token_jti`
- `cargo clippy -p lxmf-sdk --features zmq-pipeline-backend --all-targets -- -D warnings`
- `cargo clippy -p reticulumd --features zmq-pipeline-rpc --all-targets -- -D warnings`
- live token-authenticated remote ZMQ SDK flow against `reticulumd --zmq-rpc-command tcp://0.0.0.0:<port>`