### PR TITLE
[codex] Scale ZeroMQ SDK delivery pipeline

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge.rs
@@ -6,6 +6,8 @@ use super::bridge_helpers::{
 mod announce;
 #[path = "bridge_delivery_method.rs"]
 mod delivery_method;
+#[path = "bridge_delivery_scheduler.rs"]
+mod delivery_scheduler;
 #[path = "bridge_delivery_task.rs"]
 mod delivery_task;
 #[path = "bridge_delivery_task_cancel.rs"]
@@ -68,6 +70,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 pub(crate) use delivery_method::{validate_delivery_request, RequestedDeliveryMethod};
+use delivery_scheduler::{DeliveryScheduler, DeliverySchedulerConfig};
 use delivery_task::{DeliveryTask, LinkModeStatuses};
 use identity_resolver::resolve_destination_identity_blocking;
 #[cfg(test)]
@@ -91,6 +94,7 @@ pub(super) struct TransportBridge {
     outbound_resource_map: OutboundResourceMap,
     outbound_propagation_link: Arc<tokio::sync::Mutex<Option<CachedPropagationLink>>>,
     receipt_tx: tokio::sync::mpsc::Sender<ReceiptEvent>,
+    delivery_scheduler: DeliveryScheduler,
 }
 
 #[derive(Clone, Copy)]
@@ -132,6 +136,7 @@ impl TransportBridge {
             outbound_resource_map,
             outbound_propagation_link: Arc::new(tokio::sync::Mutex::new(None)),
             receipt_tx,
+            delivery_scheduler: DeliveryScheduler::spawn(DeliverySchedulerConfig::from_env()),
         }
     }
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_scheduler.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_scheduler.rs
@@ -1,0 +1,262 @@
+use super::delivery_task::DeliveryTask;
+use serde_json::{json, Value as JsonValue};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
+
+const DEFAULT_DELIVERY_QUEUE_CAPACITY: usize = 16_384;
+const DEFAULT_GLOBAL_CONCURRENCY: usize = 32;
+const DEFAULT_PER_PEER_IN_FLIGHT: usize = 1;
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct DeliverySchedulerConfig {
+    pub(super) queue_capacity: usize,
+    pub(super) global_concurrency: usize,
+    pub(super) per_peer_in_flight: usize,
+}
+
+impl Default for DeliverySchedulerConfig {
+    fn default() -> Self {
+        Self {
+            queue_capacity: DEFAULT_DELIVERY_QUEUE_CAPACITY,
+            global_concurrency: DEFAULT_GLOBAL_CONCURRENCY,
+            per_peer_in_flight: DEFAULT_PER_PEER_IN_FLIGHT,
+        }
+    }
+}
+
+impl DeliverySchedulerConfig {
+    pub(super) fn from_env() -> Self {
+        let defaults = Self::default();
+        Self {
+            queue_capacity: env_usize("LXMD_DELIVERY_QUEUE_CAPACITY")
+                .unwrap_or(defaults.queue_capacity)
+                .max(1),
+            global_concurrency: env_usize("LXMD_DELIVERY_GLOBAL_CONCURRENCY")
+                .unwrap_or(defaults.global_concurrency)
+                .max(1),
+            per_peer_in_flight: env_usize("LXMD_DELIVERY_PER_PEER_IN_FLIGHT")
+                .unwrap_or(defaults.per_peer_in_flight)
+                .max(1),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(super) struct DeliverySchedulerSnapshot {
+    pub(super) accepted_total: u64,
+    pub(super) rejected_queue_full_total: u64,
+    pub(super) queued_current: u64,
+    pub(super) in_flight_current: u64,
+    pub(super) completed_total: u64,
+    pub(super) queued_by_peer: BTreeMap<String, u64>,
+    pub(super) in_flight_by_peer: BTreeMap<String, u64>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct DeliverySchedulerMetrics {
+    accepted_total: AtomicU64,
+    rejected_queue_full_total: AtomicU64,
+    queued_current: AtomicU64,
+    in_flight_current: AtomicU64,
+    completed_total: AtomicU64,
+    peers: Mutex<HashMap<String, PeerDeliveryCounters>>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct PeerDeliveryCounters {
+    queued: u64,
+    in_flight: u64,
+}
+
+impl DeliverySchedulerMetrics {
+    pub(super) fn record_admitted_for_peer(&self, peer: &str) {
+        self.accepted_total.fetch_add(1, Ordering::Relaxed);
+        self.queued_current.fetch_add(1, Ordering::Relaxed);
+        self.update_peer(peer, |counters| counters.queued = counters.queued.saturating_add(1));
+    }
+
+    pub(super) fn record_queue_full(&self) {
+        self.rejected_queue_full_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_dequeued_for_peer(&self, peer: &str) {
+        self.queued_current.fetch_sub(1, Ordering::Relaxed);
+        self.update_peer(peer, |counters| counters.queued = counters.queued.saturating_sub(1));
+    }
+
+    fn record_started_for_peer(&self, peer: &str) {
+        self.in_flight_current.fetch_add(1, Ordering::Relaxed);
+        self.update_peer(peer, |counters| {
+            counters.in_flight = counters.in_flight.saturating_add(1);
+        });
+    }
+
+    fn record_completed_for_peer(&self, peer: &str) {
+        self.in_flight_current.fetch_sub(1, Ordering::Relaxed);
+        self.completed_total.fetch_add(1, Ordering::Relaxed);
+        self.update_peer(peer, |counters| {
+            counters.in_flight = counters.in_flight.saturating_sub(1);
+        });
+    }
+
+    pub(super) fn snapshot(&self) -> DeliverySchedulerSnapshot {
+        let peers = self.peers.lock().expect("delivery scheduler peer metrics mutex poisoned");
+        let mut queued_by_peer = BTreeMap::new();
+        let mut in_flight_by_peer = BTreeMap::new();
+        for (peer, counters) in peers.iter() {
+            if counters.queued > 0 {
+                queued_by_peer.insert(peer.clone(), counters.queued);
+            }
+            if counters.in_flight > 0 {
+                in_flight_by_peer.insert(peer.clone(), counters.in_flight);
+            }
+        }
+        DeliverySchedulerSnapshot {
+            accepted_total: self.accepted_total.load(Ordering::Relaxed),
+            rejected_queue_full_total: self.rejected_queue_full_total.load(Ordering::Relaxed),
+            queued_current: self.queued_current.load(Ordering::Relaxed),
+            in_flight_current: self.in_flight_current.load(Ordering::Relaxed),
+            completed_total: self.completed_total.load(Ordering::Relaxed),
+            queued_by_peer,
+            in_flight_by_peer,
+        }
+    }
+
+    fn update_peer(&self, peer: &str, update: impl FnOnce(&mut PeerDeliveryCounters)) {
+        let mut peers = self.peers.lock().expect("delivery scheduler peer metrics mutex poisoned");
+        let counters = peers.entry(peer.to_string()).or_default();
+        update(counters);
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct DeliveryScheduler {
+    config: DeliverySchedulerConfig,
+    tx: mpsc::Sender<ScheduledDelivery>,
+    backlog_limit: Arc<Semaphore>,
+    metrics: Arc<DeliverySchedulerMetrics>,
+}
+
+impl DeliveryScheduler {
+    pub(super) fn spawn(config: DeliverySchedulerConfig) -> Self {
+        let (tx, rx) = mpsc::channel(config.queue_capacity);
+        let backlog_limit = Arc::new(Semaphore::new(config.queue_capacity));
+        let metrics = Arc::new(DeliverySchedulerMetrics::default());
+        let runtime_metrics = Arc::clone(&metrics);
+        std::thread::Builder::new()
+            .name("rpc-outbound-delivery-runtime".to_string())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build outbound delivery runtime");
+                let local = tokio::task::LocalSet::new();
+                local.block_on(&runtime, run_scheduler(rx, config, runtime_metrics));
+            })
+            .expect("spawn rpc outbound delivery runtime");
+
+        Self { config, tx, backlog_limit, metrics }
+    }
+
+    pub(super) fn enqueue(&self, task: DeliveryTask) -> Result<(), std::io::Error> {
+        let peer = task.destination_hex.clone();
+        let capacity_permit = self.backlog_limit.clone().try_acquire_owned().map_err(|_| {
+            self.metrics.record_queue_full();
+            std::io::Error::new(std::io::ErrorKind::WouldBlock, "outbound delivery queue full")
+        })?;
+        match self.tx.try_send(ScheduledDelivery { task, _capacity_permit: capacity_permit }) {
+            Ok(()) => {
+                self.metrics.record_admitted_for_peer(&peer);
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.metrics.record_queue_full();
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::WouldBlock,
+                    "outbound delivery queue full",
+                ))
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "outbound delivery runtime stopped",
+            )),
+        }
+    }
+
+    pub(super) fn status_json(&self) -> JsonValue {
+        let snapshot = self.metrics.snapshot();
+        json!({
+            "queue_capacity": self.config.queue_capacity,
+            "global_concurrency": self.config.global_concurrency,
+            "per_peer_in_flight": self.config.per_peer_in_flight,
+            "accepted_total": snapshot.accepted_total,
+            "rejected_queue_full_total": snapshot.rejected_queue_full_total,
+            "queued_total": snapshot.queued_current,
+            "in_flight_total": snapshot.in_flight_current,
+            "completed_total": snapshot.completed_total,
+            "queued_by_peer": snapshot.queued_by_peer,
+            "in_flight_by_peer": snapshot.in_flight_by_peer,
+        })
+    }
+}
+
+struct ScheduledDelivery {
+    task: DeliveryTask,
+    _capacity_permit: OwnedSemaphorePermit,
+}
+
+async fn run_scheduler(
+    mut rx: mpsc::Receiver<ScheduledDelivery>,
+    config: DeliverySchedulerConfig,
+    metrics: Arc<DeliverySchedulerMetrics>,
+) {
+    let global_limit = Arc::new(Semaphore::new(config.global_concurrency));
+    let mut peer_limits: HashMap<String, Arc<Semaphore>> = HashMap::new();
+
+    while let Some(delivery) = rx.recv().await {
+        let peer = delivery.task.destination_hex.clone();
+        let peer_limit = peer_limits
+            .entry(peer.clone())
+            .or_insert_with(|| Arc::new(Semaphore::new(config.per_peer_in_flight)))
+            .clone();
+        let global_limit = Arc::clone(&global_limit);
+        let metrics = Arc::clone(&metrics);
+        tokio::task::spawn_local(async move {
+            let Ok(_global_permit) = global_limit.acquire_owned().await else {
+                return;
+            };
+            let Ok(_peer_permit) = peer_limit.acquire_owned().await else {
+                return;
+            };
+            metrics.record_dequeued_for_peer(&peer);
+            metrics.record_started_for_peer(&peer);
+            delivery.task.run().await;
+            metrics.record_completed_for_peer(&peer);
+        });
+    }
+}
+
+fn env_usize(name: &str) -> Option<usize> {
+    std::env::var(name).ok().and_then(|value| value.trim().parse::<usize>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scheduler_metrics_record_admission_and_queue_pressure() {
+        let metrics = DeliverySchedulerMetrics::default();
+
+        metrics.record_admitted_for_peer("peer-a");
+        metrics.record_admitted_for_peer("peer-a");
+        metrics.record_queue_full();
+
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.accepted_total, 2);
+        assert_eq!(snapshot.rejected_queue_full_total, 1);
+        assert_eq!(snapshot.queued_current, 2);
+    }
+}

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_link_send.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_link_send.rs
@@ -18,10 +18,9 @@ impl DeliveryTask {
                 &self.message_id,
                 &self.destination_hex,
                 trace_stage,
-                "opening link",
+                "opening or reusing link",
             );
         }
-        self.transport.reset_out_link(&destination_desc.address_hash).await;
         let result = send_via_link(
             self.transport.as_ref(),
             destination_desc,

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_outbound.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_outbound.rs
@@ -134,16 +134,10 @@ impl OutboundBridge for TransportBridge {
             try_propagation_on_fail: options.try_propagation_on_fail,
             propagation_node_hex,
         };
-        std::thread::Builder::new()
-            .name("rpc-outbound-delivery-task".to_string())
-            .spawn(move || {
-                let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .expect("build outbound delivery runtime");
-                runtime.block_on(task.run());
-            })
-            .map_err(|err| std::io::Error::other(format!("spawn outbound delivery task: {err}")))?;
-        Ok(())
+        self.delivery_scheduler.enqueue(task)
+    }
+
+    fn delivery_pipeline_status(&self) -> Option<serde_json::Value> {
+        Some(self.delivery_scheduler.status_json())
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/receipt_worker.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/receipt_worker.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc::Receiver;
 
+const RECEIPT_WORKER_DRAIN_LIMIT: usize = 256;
+
 pub(super) fn spawn_receipt_worker(
     daemon: Arc<RpcDaemon>,
     mut receipt_rx: Receiver<ReceiptEvent>,
@@ -16,6 +18,21 @@ pub(super) fn spawn_receipt_worker(
     tokio::spawn(async move {
         while let Some(event) = receipt_rx.recv().await {
             handle_receipt_update(&daemon_receipts, event, &receipt_map, &outbound_resource_map);
+            for _ in 0..RECEIPT_WORKER_DRAIN_LIMIT {
+                match receipt_rx.try_recv() {
+                    Ok(event) => {
+                        handle_receipt_update(
+                            &daemon_receipts,
+                            event,
+                            &receipt_map,
+                            &outbound_resource_map,
+                        );
+                    }
+                    Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+                    Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => return,
+                }
+            }
+            tokio::task::yield_now().await;
         }
     });
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
@@ -5,8 +5,11 @@ use rns_rpc::{RpcDaemon, RpcError, RpcResponse};
 use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch, Semaphore};
 use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
+
+const ZMQ_RPC_WORKER_CONCURRENCY: usize = 32;
+const ZMQ_RPC_RESPONSE_QUEUE_CAPACITY: usize = 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ZmqRpcLoopConfig {
@@ -24,7 +27,10 @@ pub(super) async fn run_zmq_rpc_loop_until(
         config.require_auth_for_remote && !is_local_zmq_endpoint(&config.command_endpoint);
     let mut commands = PullSocket::new();
     commands.bind(config.command_endpoint.as_str()).await.map_err(zmq_io_error)?;
-    let mut responses: HashMap<String, PushSocket> = HashMap::new();
+    let (response_tx, response_rx) =
+        mpsc::channel::<ZmqOutboundResponse>(ZMQ_RPC_RESPONSE_QUEUE_CAPACITY);
+    let response_writer = tokio::spawn(run_zmq_response_writer(response_rx));
+    let rpc_permits = Arc::new(Semaphore::new(ZMQ_RPC_WORKER_CONCURRENCY));
     println!("reticulumd listening on zmq {}", config.command_endpoint);
 
     loop {
@@ -43,20 +49,30 @@ pub(super) async fn run_zmq_rpc_loop_until(
                     }
                     Err(err) => return Err(zmq_io_error(err)),
                 };
-                let response =
-                    handle_zmq_command_message(
-                        daemon.as_ref(),
-                        message,
-                        command_endpoint_requires_auth,
-                    );
-                if let Some(response) = response {
-                    if let Err(err) = send_zmq_response(&mut responses, response).await {
-                        eprintln!("[daemon] zmq rpc response dropped client connection: {}", err);
+                let daemon = Arc::clone(&daemon);
+                let response_tx = response_tx.clone();
+                let rpc_permits = Arc::clone(&rpc_permits);
+                tokio::spawn(async move {
+                    let Ok(_permit) = rpc_permits.acquire_owned().await else {
+                        return;
+                    };
+                    let response =
+                        handle_zmq_command_message(
+                            daemon.as_ref(),
+                            message,
+                            command_endpoint_requires_auth,
+                        );
+                    if let Some(response) = response {
+                        if response_tx.send(response).await.is_err() {
+                            eprintln!("[daemon] zmq rpc response writer stopped");
+                        }
                     }
-                }
+                });
             }
         }
     }
+    drop(response_tx);
+    let _ = response_writer.await;
     Ok(())
 }
 
@@ -66,20 +82,22 @@ struct ZmqOutboundResponse {
 }
 
 async fn send_zmq_response(
-    responses: &mut HashMap<String, PushSocket>,
+    _responses: &mut HashMap<String, PushSocket>,
     response: ZmqOutboundResponse,
 ) -> io::Result<()> {
-    if !responses.contains_key(&response.endpoint) {
-        let mut socket = PushSocket::new();
-        socket.connect(response.endpoint.as_str()).await.map_err(zmq_io_error)?;
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        responses.insert(response.endpoint.clone(), socket);
-    }
-    let socket = responses
-        .get_mut(&response.endpoint)
-        .ok_or_else(|| io::Error::other("missing zmq response socket"))?;
+    let mut socket = PushSocket::new();
+    socket.connect(response.endpoint.as_str()).await.map_err(zmq_io_error)?;
     let encoded = zmq::encode_envelope(&response.envelope)?;
     socket.send(ZmqMessage::from(encoded)).await.map_err(zmq_io_error)
+}
+
+async fn run_zmq_response_writer(mut responses_rx: mpsc::Receiver<ZmqOutboundResponse>) {
+    let mut responses = HashMap::new();
+    while let Some(response) = responses_rx.recv().await {
+        if let Err(err) = send_zmq_response(&mut responses, response).await {
+            eprintln!("[daemon] zmq rpc response dropped client connection: {}", err);
+        }
+    }
 }
 
 fn handle_zmq_command_message(

--- a/crates/libs/lxmf-sdk/src/app/node_tests_backend_core.rs
+++ b/crates/libs/lxmf-sdk/src/app/node_tests_backend_core.rs
@@ -34,6 +34,8 @@ macro_rules! mock_backend_core_methods {
             },
             contract_release: "v2.5".to_owned(),
             schema_namespace: "v2".to_owned(),
+            sdk_version: crate::SDK_VERSION.to_owned(),
+            python_reference: crate::ParityReference::default(),
         })
     }
 

--- a/crates/libs/lxmf-sdk/src/app/operations.rs
+++ b/crates/libs/lxmf-sdk/src/app/operations.rs
@@ -344,6 +344,15 @@ fn built_in_entries() -> Vec<OperationEntry> {
         )
         .with_alias("sdk_send_v2"),
         OperationEntry::new(
+            "app.delivery.send_batch",
+            "delivery",
+            OperationKind::Command,
+            TransportVariant::Rpc,
+            "Queue a batch of outbound messages for delivery.",
+        )
+        .with_alias("sdk_send_batch_v2")
+        .with_required_capability("sdk.capability.batch_send"),
+        OperationEntry::new(
             "app.delivery.status",
             "delivery",
             OperationKind::Query,

--- a/crates/libs/lxmf-sdk/src/app/tests/node_support.rs
+++ b/crates/libs/lxmf-sdk/src/app/tests/node_support.rs
@@ -145,6 +145,8 @@ impl SdkBackend for MockBackend {
             },
             contract_release: "v2.5".to_owned(),
             schema_namespace: "v2".to_owned(),
+            sdk_version: crate::SDK_VERSION.to_owned(),
+            python_reference: crate::ParityReference::default(),
         })
     }
 

--- a/crates/libs/lxmf-sdk/src/backend/rpc.rs
+++ b/crates/libs/lxmf-sdk/src/backend/rpc.rs
@@ -4,7 +4,9 @@ use crate::backend::SdkBackend;
 use crate::backend::SdkEventStream;
 #[cfg(feature = "sdk-async")]
 use crate::backend::{SdkBackendAsyncEvents, SdkBackendAsyncOps};
-use crate::capability::{EffectiveLimits, NegotiationRequest, NegotiationResponse};
+use crate::capability::{
+    EffectiveLimits, NegotiationRequest, NegotiationResponse, ParityReference,
+};
 use crate::domain::{
     AttachmentDownloadChunk, AttachmentDownloadChunkRequest, AttachmentId, AttachmentListRequest,
     AttachmentListResult, AttachmentMeta, AttachmentStoreRequest, AttachmentUploadChunkAck,

--- a/crates/libs/lxmf-sdk/src/backend/rpc/core_impl.rs
+++ b/crates/libs/lxmf-sdk/src/backend/rpc/core_impl.rs
@@ -107,6 +107,9 @@ impl RpcBackendClient {
             })?)?;
         let contract_release = Self::parse_required_string(&result, "contract_release")?;
         let schema_namespace = Self::parse_required_string(&result, "schema_namespace")?;
+        let sdk_version =
+            Self::parse_optional_string_or_default(&result, "sdk_version", crate::SDK_VERSION)?;
+        let python_reference = Self::parse_parity_reference(&result)?;
         {
             let mut guard = self
                 .negotiated_capabilities
@@ -136,6 +139,8 @@ impl RpcBackendClient {
             effective_limits,
             contract_release,
             schema_namespace,
+            sdk_version,
+            python_reference,
         })
     }
 
@@ -209,6 +214,9 @@ impl RpcBackendClient {
             })?)?;
         let contract_release = Self::parse_required_string(&result, "contract_release")?;
         let schema_namespace = Self::parse_required_string(&result, "schema_namespace")?;
+        let sdk_version =
+            Self::parse_optional_string_or_default(&result, "sdk_version", crate::SDK_VERSION)?;
+        let python_reference = Self::parse_parity_reference(&result)?;
         {
             let mut guard = self
                 .negotiated_capabilities
@@ -238,6 +246,8 @@ impl RpcBackendClient {
             effective_limits,
             contract_release,
             schema_namespace,
+            sdk_version,
+            python_reference,
         })
     }
 

--- a/crates/libs/lxmf-sdk/src/backend/rpc/parsing.rs
+++ b/crates/libs/lxmf-sdk/src/backend/rpc/parsing.rs
@@ -14,6 +14,30 @@ impl RpcBackendClient {
         })
     }
 
+    pub(super) fn parse_optional_string_or_default(
+        value: &JsonValue,
+        key: &'static str,
+        default: &str,
+    ) -> Result<String, SdkError> {
+        match value.get(key) {
+            None | Some(JsonValue::Null) => Ok(default.to_owned()),
+            Some(raw) => raw.as_str().map(str::to_owned).ok_or_else(|| {
+                SdkError::new(
+                    code::INTERNAL,
+                    ErrorCategory::Internal,
+                    format!("rpc response field '{key}' must be a string"),
+                )
+            }),
+        }
+    }
+
+    pub(super) fn parse_parity_reference(value: &JsonValue) -> Result<ParityReference, SdkError> {
+        match value.get("python_reference") {
+            None | Some(JsonValue::Null) => Ok(ParityReference::default()),
+            Some(raw) => Self::decode_value(raw.clone(), "python reference metadata"),
+        }
+    }
+
     pub(super) fn parse_required_u16(
         value: &JsonValue,
         key: &'static str,

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -31,6 +31,7 @@ mod parsing;
 mod tests;
 
 pub use config::{ZmqEndpointRole, ZmqPipelineBackendConfig, ZmqPipelineTokenAuth};
+use negotiation::new_session_id;
 
 pub struct ZmqPipelineBackendClient {
     config: ZmqPipelineBackendConfig,
@@ -475,14 +476,6 @@ fn token_signature(secret: &str, payload: &str) -> String {
         .expect("token shared secret must be non-empty");
     mac.update(payload.as_bytes());
     hex::encode(mac.finalize().into_bytes())
-}
-
-fn new_session_id() -> String {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    format!("zmq-sdk-{:032x}", now)
 }
 
 fn map_rpc_error(error: RpcError) -> SdkError {

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -218,6 +218,12 @@ impl SdkBackend for ZmqPipelineBackendClient {
             effective_limits,
             contract_release: Self::parse_required_string(&result, "contract_release")?,
             schema_namespace: Self::parse_required_string(&result, "schema_namespace")?,
+            sdk_version: Self::parse_optional_string_or_default(
+                &result,
+                "sdk_version",
+                crate::SDK_VERSION,
+            )?,
+            python_reference: Self::parse_parity_reference(&result)?,
         })
     }
 

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/negotiation.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/negotiation.rs
@@ -2,6 +2,15 @@ use super::ZmqPipelineBackendClient;
 use crate::capability::NegotiationRequest;
 use crate::types::{AuthMode, BindMode};
 use serde_json::{json, Value as JsonValue};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub(super) fn new_session_id() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    format!("zmq-sdk-{:032x}", now)
+}
 
 impl ZmqPipelineBackendClient {
     pub(super) fn negotiation_security_config(

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/parsing.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/parsing.rs
@@ -1,5 +1,5 @@
 use super::{sdk_error, ZmqPipelineBackendClient};
-use crate::capability::EffectiveLimits;
+use crate::capability::{EffectiveLimits, ParityReference};
 use crate::error::{code, ErrorCategory, SdkError};
 use crate::event::Severity;
 use crate::types::{Ack, CancelResult, DeliveryState, RuntimeState};
@@ -31,6 +31,30 @@ impl ZmqPipelineBackendClient {
                 format!("rpc response missing integer field '{key}'"),
             )
         })
+    }
+
+    pub(super) fn parse_optional_string_or_default(
+        value: &JsonValue,
+        key: &'static str,
+        default: &str,
+    ) -> Result<String, SdkError> {
+        match value.get(key) {
+            None | Some(JsonValue::Null) => Ok(default.to_owned()),
+            Some(raw) => raw.as_str().map(str::to_owned).ok_or_else(|| {
+                SdkError::new(
+                    code::INTERNAL,
+                    ErrorCategory::Internal,
+                    format!("rpc response field '{key}' must be a string"),
+                )
+            }),
+        }
+    }
+
+    pub(super) fn parse_parity_reference(value: &JsonValue) -> Result<ParityReference, SdkError> {
+        match value.get("python_reference") {
+            None | Some(JsonValue::Null) => Ok(ParityReference::default()),
+            Some(raw) => Self::decode_value(raw.clone(), "python reference metadata"),
+        }
     }
 
     pub(super) fn parse_required_u16(

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
@@ -100,7 +100,13 @@ fn negotiate_with_token_auth_preserves_remote_token_runtime_config() {
                 "idempotency_ttl_ms": 60000
             },
             "contract_release": "v2",
-            "schema_namespace": "sdk.v2"
+            "schema_namespace": "sdk.v2",
+            "sdk_version": "9.8.7-test",
+            "python_reference": {
+                "reticulum_conformance_ref": "conformance-test-ref",
+                "python_reticulum_ref": "reticulum-test-ref",
+                "python_lxmf_ref": "lxmf-test-ref"
+            }
         }),
         Arc::clone(&captured),
     );
@@ -128,6 +134,8 @@ fn negotiate_with_token_auth_preserves_remote_token_runtime_config() {
         .expect("negotiate");
 
     assert_eq!(response.runtime_id, "runtime-zmq-token");
+    assert_eq!(response.sdk_version, "9.8.7-test");
+    assert_eq!(response.python_reference.python_lxmf_ref, "lxmf-test-ref");
     let captured = captured.lock().expect("captured request");
     let request = captured.as_ref().expect("zmq request");
     assert_eq!(request.method, "sdk_negotiate_v2");
@@ -137,6 +145,54 @@ fn negotiate_with_token_auth_preserves_remote_token_runtime_config() {
     assert_eq!(config["rpc_backend"]["token_auth"]["issuer"], json!("test-issuer"));
     assert_eq!(config["rpc_backend"]["token_auth"]["audience"], json!("test-audience"));
     assert_eq!(config["rpc_backend"]["token_auth"]["shared_secret"], json!("test-secret"));
+    server.join().expect("server joined");
+}
+
+#[test]
+fn negotiate_without_reported_parity_metadata_falls_back_to_local_constants() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "runtime_id": "runtime-zmq-legacy",
+            "active_contract_version": 2,
+            "effective_capabilities": [],
+            "effective_limits": {
+                "max_poll_events": 64,
+                "max_event_bytes": 32768,
+                "max_batch_bytes": 1048576,
+                "max_extension_keys": 32,
+                "idempotency_ttl_ms": 60000
+            },
+            "contract_release": "v2",
+            "schema_namespace": "sdk.v2"
+        }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let backend = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let response = backend
+        .negotiate(crate::capability::NegotiationRequest {
+            supported_contract_versions: vec![2],
+            requested_capabilities: Vec::new(),
+            profile: crate::types::Profile::DesktopLocalRuntime,
+            bind_mode: crate::types::BindMode::LocalOnly,
+            auth_mode: crate::types::AuthMode::LocalTrusted,
+            overflow_policy: crate::types::OverflowPolicy::Reject,
+            block_timeout_ms: None,
+            rpc_backend: None,
+        })
+        .expect("negotiate");
+
+    assert_eq!(response.sdk_version, crate::SDK_VERSION);
+    assert_eq!(
+        response.python_reference.python_reticulum_ref,
+        crate::PYTHON_RETICULUM_REFERENCE_REF
+    );
     server.join().expect("server joined");
 }
 

--- a/crates/libs/lxmf-sdk/src/backend_tests.rs
+++ b/crates/libs/lxmf-sdk/src/backend_tests.rs
@@ -25,6 +25,8 @@ impl SdkBackend for NoKeyBackend {
             },
             contract_release: "v2.5".to_owned(),
             schema_namespace: "v2".to_owned(),
+            sdk_version: crate::SDK_VERSION.to_owned(),
+            python_reference: crate::ParityReference::default(),
         })
     }
 

--- a/crates/libs/lxmf-sdk/src/capability.rs
+++ b/crates/libs/lxmf-sdk/src/capability.rs
@@ -35,6 +35,24 @@ pub struct EffectiveLimits {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[non_exhaustive]
+pub struct ParityReference {
+    pub reticulum_conformance_ref: String,
+    pub python_reticulum_ref: String,
+    pub python_lxmf_ref: String,
+}
+
+impl Default for ParityReference {
+    fn default() -> Self {
+        Self {
+            reticulum_conformance_ref: crate::RETICULUM_CONFORMANCE_REFERENCE_REF.to_owned(),
+            python_reticulum_ref: crate::PYTHON_RETICULUM_REFERENCE_REF.to_owned(),
+            python_lxmf_ref: crate::PYTHON_LXMF_REFERENCE_REF.to_owned(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct NegotiationRequest {
     pub supported_contract_versions: Vec<u16>,
     pub requested_capabilities: Vec<String>,
@@ -55,6 +73,10 @@ pub struct NegotiationResponse {
     pub effective_limits: EffectiveLimits,
     pub contract_release: String,
     pub schema_namespace: String,
+    #[serde(default = "crate::default_sdk_version")]
+    pub sdk_version: String,
+    #[serde(default)]
+    pub python_reference: ParityReference,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/libs/lxmf-sdk/src/client/tests.rs
+++ b/crates/libs/lxmf-sdk/src/client/tests.rs
@@ -246,6 +246,8 @@ fn successful_negotiation() -> Result<NegotiationResponse, SdkError> {
         },
         contract_release: "v2.5".to_owned(),
         schema_namespace: "v2".to_owned(),
+        sdk_version: crate::SDK_VERSION.to_owned(),
+        python_reference: crate::ParityReference::default(),
     })
 }
 

--- a/crates/libs/lxmf-sdk/src/lib.rs
+++ b/crates/libs/lxmf-sdk/src/lib.rs
@@ -46,7 +46,7 @@ pub use backend::{SdkBackendAsyncOps, SdkBoxFuture, SdkEventStream};
 pub use capability::{
     effective_capabilities_for_profile, negotiate_contract_version, negotiate_plugins,
     CapabilityDescriptor, CapabilityState, EffectiveLimits, NegotiationRequest,
-    NegotiationResponse, PluginDescriptor, PluginState,
+    NegotiationResponse, ParityReference, PluginDescriptor, PluginState,
 };
 // Stability class: internal
 pub use client::Client;
@@ -96,3 +96,11 @@ pub use types::{
 
 pub const CONTRACT_RELEASE: &str = "v2.5";
 pub const SCHEMA_NAMESPACE: &str = "v2";
+pub const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const RETICULUM_CONFORMANCE_REFERENCE_REF: &str = "0319444b20e0815f26c6b9ceeba8fa44de037c9b";
+pub const PYTHON_RETICULUM_REFERENCE_REF: &str = "15320e4d2cfabb143c1db20ca887e275fd521585";
+pub const PYTHON_LXMF_REFERENCE_REF: &str = "727830cefda83d9c6e3982b48675425f3f988f9c";
+
+pub(crate) fn default_sdk_version() -> String {
+    SDK_VERSION.to_owned()
+}

--- a/crates/libs/lxmf-sdk/src/profiles.rs
+++ b/crates/libs/lxmf-sdk/src/profiles.rs
@@ -7,6 +7,7 @@ const CAP_MANUAL_TICK: &str = "sdk.capability.manual_tick";
 const CAP_TOKEN_AUTH: &str = "sdk.capability.token_auth";
 const CAP_MTLS_AUTH: &str = "sdk.capability.mtls_auth";
 const CAP_RECEIPT_TERMINALITY: &str = "sdk.capability.receipt_terminality";
+const CAP_BATCH_SEND: &str = "sdk.capability.batch_send";
 const CAP_CONFIG_REVISION_CAS: &str = "sdk.capability.config_revision_cas";
 const CAP_IDEMPOTENCY_TTL: &str = "sdk.capability.idempotency_ttl";
 const CAP_TOPICS: &str = "sdk.capability.topics";
@@ -58,6 +59,7 @@ const DESKTOP_FULL_SUPPORTED: &[&str] = &[
     CAP_TOKEN_AUTH,
     CAP_MTLS_AUTH,
     CAP_RECEIPT_TERMINALITY,
+    CAP_BATCH_SEND,
     CAP_CONFIG_REVISION_CAS,
     CAP_IDEMPOTENCY_TTL,
     CAP_TOPICS,
@@ -89,6 +91,7 @@ const DESKTOP_LOCAL_RUNTIME_SUPPORTED: &[&str] = &[
     CAP_TOKEN_AUTH,
     CAP_MTLS_AUTH,
     CAP_RECEIPT_TERMINALITY,
+    CAP_BATCH_SEND,
     CAP_CONFIG_REVISION_CAS,
     CAP_IDEMPOTENCY_TTL,
     CAP_TOPICS,
@@ -118,6 +121,7 @@ const EMBEDDED_ALLOC_SUPPORTED: &[&str] = &[
     CAP_MANUAL_TICK,
     CAP_TOKEN_AUTH,
     CAP_RECEIPT_TERMINALITY,
+    CAP_BATCH_SEND,
     CAP_CONFIG_REVISION_CAS,
     CAP_IDEMPOTENCY_TTL,
     CAP_TOPICS,

--- a/crates/libs/rns-rpc/src/rpc/daemon.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon.rs
@@ -7,7 +7,7 @@ mod cursor_utils;
 mod sdk_helpers;
 
 use cursor_utils::*;
-use sdk_helpers::STORE_FORWARD_MAX_MESSAGES_LIMIT;
+use sdk_helpers::{python_reference_meta, SDK_VERSION, STORE_FORWARD_MAX_MESSAGES_LIMIT};
 mod dispatch;
 mod dispatch_legacy_clear;
 mod dispatch_legacy_messages;

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch.rs
@@ -58,6 +58,7 @@ impl RpcDaemon {
                         "delivery_policy": snapshot.delivery_policy,
                         "propagation": snapshot.propagation,
                         "stamp_policy": snapshot.stamp_policy,
+                        "delivery_pipeline": self.outbound_bridge.as_ref().and_then(|bridge| bridge.delivery_pipeline_status()),
                         "capabilities": Self::capabilities(),
                     })),
                     error: None,

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -418,6 +418,13 @@ impl RpcDaemon {
                     error: None,
                 })
             }
+            "sdk_send_batch_v2" => {
+                let params = request.params.ok_or_else(|| {
+                    std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing params")
+                })?;
+                let parsed = parse_outbound_send_batch_request(params)?;
+                self.store_outbound_batch(request.id, parsed)
+            }
             "send_message" | "send_message_v2" | "sdk_send_v2" => {
                 let params = request.params.ok_or_else(|| {
                     std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing params")

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_router.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_router.rs
@@ -18,6 +18,7 @@ impl RpcDaemon {
             | "send_message"
             | "send_message_v2"
             | "sdk_send_v2"
+            | "sdk_send_batch_v2"
             | "receive_message"
             | "record_receipt"
             | "sdk_cancel_message_v2"

--- a/crates/libs/rns-rpc/src/rpc/daemon/metrics.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/metrics.rs
@@ -25,7 +25,7 @@ impl RpcDaemon {
         metrics.rpc_requests_total = metrics.rpc_requests_total.saturating_add(1);
         Self::metrics_increment(&mut metrics.rpc_requests_by_method, method);
         match method {
-            "sdk_send_v2" | "send_message" | "send_message_v2" => {
+            "sdk_send_v2" | "sdk_send_batch_v2" | "send_message" | "send_message_v2" => {
                 metrics.sdk_send_total = metrics.sdk_send_total.saturating_add(1);
             }
             "sdk_poll_events_v2" => {
@@ -50,7 +50,7 @@ impl RpcDaemon {
             Self::metrics_increment(&mut metrics.rpc_errors_by_method, method);
         }
         match method {
-            "sdk_send_v2" | "send_message" | "send_message_v2" => {
+            "sdk_send_v2" | "sdk_send_batch_v2" | "send_message" | "send_message_v2" => {
                 metrics.sdk_send_latency_ms.observe(elapsed_ms);
                 if response.error.is_some() {
                     metrics.sdk_send_error_total = metrics.sdk_send_error_total.saturating_add(1);
@@ -107,7 +107,7 @@ impl RpcDaemon {
         metrics.rpc_errors_total = metrics.rpc_errors_total.saturating_add(1);
         Self::metrics_increment(&mut metrics.rpc_errors_by_method, method);
         match method {
-            "sdk_send_v2" | "send_message" | "send_message_v2" => {
+            "sdk_send_v2" | "sdk_send_batch_v2" | "send_message" | "send_message_v2" => {
                 metrics.sdk_send_error_total = metrics.sdk_send_error_total.saturating_add(1);
                 metrics.sdk_send_latency_ms.observe(elapsed_ms);
             }

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_auth_http.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_auth_http.rs
@@ -6,6 +6,8 @@ impl RpcDaemon {
         json!({
             "contract_version": format!("v{}", self.active_contract_version()),
             "profile": profile,
+            "sdk_version": SDK_VERSION,
+            "python_reference": python_reference_meta(),
             "rpc_endpoint": JsonValue::Null,
         })
     }

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_capabilities.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_capabilities.rs
@@ -120,6 +120,7 @@ impl RpcDaemon {
             "sdk.capability.token_auth".to_string(),
             "sdk.capability.mtls_auth".to_string(),
             "sdk.capability.receipt_terminality".to_string(),
+            "sdk.capability.batch_send".to_string(),
             "sdk.capability.config_revision_cas".to_string(),
             "sdk.capability.idempotency_ttl".to_string(),
             "sdk.capability.topics".to_string(),

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_helpers.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_helpers.rs
@@ -11,6 +11,20 @@ pub(super) struct SdkStoreForwardPolicy {
 
 use super::*;
 
+pub(super) const SDK_VERSION: &str = "0.2.1";
+pub(super) const RETICULUM_CONFORMANCE_REFERENCE_REF: &str =
+    "0319444b20e0815f26c6b9ceeba8fa44de037c9b";
+pub(super) const PYTHON_RETICULUM_REFERENCE_REF: &str = "15320e4d2cfabb143c1db20ca887e275fd521585";
+pub(super) const PYTHON_LXMF_REFERENCE_REF: &str = "727830cefda83d9c6e3982b48675425f3f988f9c";
+
+pub(super) fn python_reference_meta() -> JsonValue {
+    json!({
+        "reticulum_conformance_ref": RETICULUM_CONFORMANCE_REFERENCE_REF,
+        "python_reticulum_ref": PYTHON_RETICULUM_REFERENCE_REF,
+        "python_lxmf_ref": PYTHON_LXMF_REFERENCE_REF,
+    })
+}
+
 impl RpcDaemon {
     pub(super) fn sdk_config_error(code: &str, message: &str) -> RpcError {
         RpcError::new(code, message)

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_helpers.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_helpers.rs
@@ -740,6 +740,7 @@ impl RpcDaemon {
         matches!(
             method,
             "sdk_send_v2"
+                | "sdk_send_batch_v2"
                 | "send_message"
                 | "send_message_v2"
                 | "sdk_cancel_message_v2"
@@ -781,6 +782,27 @@ impl RpcDaemon {
                     details.insert(
                         "message_id".to_string(),
                         JsonValue::String(message_id.to_string()),
+                    );
+                }
+            }
+            "sdk_send_batch_v2" => {
+                if let Some(batch_id) = result.get("batch_id").and_then(JsonValue::as_str) {
+                    details.insert("batch_id".to_string(), JsonValue::String(batch_id.to_string()));
+                }
+                if let Some(accepted_count) =
+                    result.get("accepted_count").and_then(JsonValue::as_u64)
+                {
+                    details.insert(
+                        "accepted_count".to_string(),
+                        JsonValue::Number(serde_json::Number::from(accepted_count)),
+                    );
+                }
+                if let Some(rejected_count) =
+                    result.get("rejected_count").and_then(JsonValue::as_u64)
+                {
+                    details.insert(
+                        "rejected_count".to_string(),
+                        JsonValue::Number(serde_json::Number::from(rejected_count)),
                     );
                 }
             }

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_negotiate_poll.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_negotiate_poll.rs
@@ -390,6 +390,8 @@ impl RpcDaemon {
                 "effective_limits": limits,
                 "contract_release": "v2.5",
                 "schema_namespace": "v2",
+                "sdk_version": SDK_VERSION,
+                "python_reference": python_reference_meta(),
                 "meta": self.response_meta(),
             })),
             error: None,

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_outbound.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_outbound.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 const OUTBOUND_DELIVERY_QUEUE_CAPACITY: usize = 1024;
+const OUTBOUND_DELIVERY_WORKER_LANES: usize = 16;
 
 impl RpcDaemon {
     pub(super) fn spawn_outbound_delivery_worker(
@@ -12,33 +13,57 @@ impl RpcDaemon {
         let bridge = bridge?;
         let (tx, rx) =
             mpsc::sync_channel::<OutboundDeliveryCommand>(OUTBOUND_DELIVERY_QUEUE_CAPACITY);
-        std::thread::Builder::new()
-            .name("rpc-outbound-delivery-worker".to_string())
-            .spawn(move || {
-                while let Ok(command) = rx.recv() {
-                    if let Err(err) = bridge.deliver(&command.record, &command.options) {
-                        let status = format!("failed: {err}");
-                        let resolved_status = {
-                            let _status_guard = delivery_status_lock
-                                .lock()
-                                .expect("delivery_status_lock mutex poisoned");
-                            store
-                                .resolve_receipt_status(command.record.id.as_str(), status.as_str())
-                                .unwrap_or_else(|_| Some(status.clone()))
-                                .unwrap_or_else(|| status.clone())
-                        };
-                        if resolved_status == status {
-                            Self::append_delivery_trace_to(
-                                &delivery_traces,
-                                command.record.id.as_str(),
-                                status,
-                            );
-                        }
-                    }
-                }
-            })
-            .expect("spawn rpc outbound delivery worker");
+        let rx = Arc::new(Mutex::new(rx));
+        for lane in 0..OUTBOUND_DELIVERY_WORKER_LANES {
+            let bridge = Arc::clone(&bridge);
+            let store = Arc::clone(&store);
+            let delivery_traces = Arc::clone(&delivery_traces);
+            let delivery_status_lock = Arc::clone(&delivery_status_lock);
+            let rx = Arc::clone(&rx);
+            std::thread::Builder::new()
+                .name(format!("rpc-outbound-delivery-worker-{lane}"))
+                .spawn(move || loop {
+                    let command = {
+                        let guard = rx.lock().expect("outbound delivery receiver mutex poisoned");
+                        guard.recv()
+                    };
+                    let Ok(command) = command else {
+                        break;
+                    };
+                    Self::process_outbound_delivery_command(
+                        &bridge,
+                        &store,
+                        &delivery_traces,
+                        &delivery_status_lock,
+                        command,
+                    );
+                })
+                .expect("spawn rpc outbound delivery worker");
+        }
         Some(tx)
+    }
+
+    fn process_outbound_delivery_command(
+        bridge: &Arc<dyn OutboundBridge>,
+        store: &Arc<MessagesStore>,
+        delivery_traces: &Arc<Mutex<HashMap<String, Vec<DeliveryTraceEntry>>>>,
+        delivery_status_lock: &Arc<Mutex<()>>,
+        command: OutboundDeliveryCommand,
+    ) {
+        if let Err(err) = bridge.deliver(&command.record, &command.options) {
+            let status = format!("failed: {err}");
+            let resolved_status = {
+                let _status_guard =
+                    delivery_status_lock.lock().expect("delivery_status_lock mutex poisoned");
+                store
+                    .resolve_receipt_status(command.record.id.as_str(), status.as_str())
+                    .unwrap_or_else(|_| Some(status.clone()))
+                    .unwrap_or_else(|| status.clone())
+            };
+            if resolved_status == status {
+                Self::append_delivery_trace_to(delivery_traces, command.record.id.as_str(), status);
+            }
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -274,6 +299,75 @@ impl RpcDaemon {
         Ok(RpcResponse { id: request_id, result: Some(json!({ "message_id": id })), error: None })
     }
 
+    pub(super) fn store_outbound_batch(
+        &self,
+        request_id: u64,
+        parsed: NormalizedSendBatchRequest,
+    ) -> Result<RpcResponse, std::io::Error> {
+        let mut accepted_count = 0_u64;
+        let mut rejected_count = 0_u64;
+        let mut results = Vec::with_capacity(parsed.messages.len());
+        for item in parsed.messages {
+            let item_id = item.id.clone();
+            match self.store_outbound(
+                request_id,
+                item.id,
+                parsed.source.clone(),
+                item.destination,
+                item.title,
+                item.content,
+                item.fields,
+                item.method,
+                item.stamp_cost,
+                item.options,
+                item.include_ticket,
+            ) {
+                Ok(response) => {
+                    if let Some(error) = response.error {
+                        rejected_count = rejected_count.saturating_add(1);
+                        results.push(json!({
+                            "id": item_id,
+                            "accepted": false,
+                            "error": error,
+                        }));
+                    } else {
+                        accepted_count = accepted_count.saturating_add(1);
+                        let message_id = response
+                            .result
+                            .as_ref()
+                            .and_then(|result| result.get("message_id"))
+                            .and_then(JsonValue::as_str)
+                            .unwrap_or(item_id.as_str());
+                        results.push(json!({
+                            "id": item_id,
+                            "message_id": message_id,
+                            "accepted": true,
+                        }));
+                    }
+                }
+                Err(err) => {
+                    rejected_count = rejected_count.saturating_add(1);
+                    results.push(json!({
+                        "id": item_id,
+                        "accepted": false,
+                        "error": RpcError::new("SDK_INTERNAL", err.to_string()),
+                    }));
+                }
+            }
+        }
+
+        Ok(RpcResponse {
+            id: request_id,
+            result: Some(json!({
+                "batch_id": parsed.batch_id,
+                "accepted_count": accepted_count,
+                "rejected_count": rejected_count,
+                "results": results,
+            })),
+            error: None,
+        })
+    }
+
     fn schedule_bridge_delivery(
         &self,
         record: MessageRecord,
@@ -312,6 +406,7 @@ impl RpcDaemon {
             "send_message",
             "send_message_v2",
             "sdk_send_v2",
+            "sdk_send_batch_v2",
             "sdk_negotiate_v2",
             "sdk_status_v2",
             "sdk_configure_v2",

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_runtime.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_runtime.rs
@@ -112,6 +112,7 @@ impl RpcDaemon {
             id: request.id,
             result: Some(json!({
                 "message": message,
+                "delivery_pipeline": self.outbound_bridge.as_ref().and_then(|bridge| bridge.delivery_pipeline_status()),
                 "meta": self.response_meta(),
             })),
             error: None,
@@ -281,6 +282,7 @@ impl RpcDaemon {
                 "effective_capabilities": effective_capabilities,
                 "queued_messages": queued_messages,
                 "in_flight_messages": in_flight_messages,
+                "delivery_pipeline": self.outbound_bridge.as_ref().and_then(|bridge| bridge.delivery_pipeline_status()),
                 "counts_included": params.include_counts,
                 "meta": self.response_meta(),
             })),

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/events_basic.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/events_basic.rs
@@ -1,699 +1,723 @@
-    #[test]
-    fn sdk_poll_events_v2_validates_cursor_and_expires_stale_tokens() {
-        let daemon = RpcDaemon::test_instance();
-        daemon.emit_event(RpcEvent {
-            event_type: "inbound".to_string(),
-            payload: json!({ "message_id": "m-1" }),
-        });
-        let first = daemon
-            .handle_rpc(rpc_request(
-                3,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": null,
-                    "max": 4
-                }),
-            ))
-            .expect("poll");
-        let first_result = first.result.expect("result");
-        let cursor = first_result["next_cursor"].as_str().expect("cursor").to_string();
-        assert!(first_result["events"].as_array().is_some_and(|events| !events.is_empty()));
-
-        let invalid = daemon
-            .handle_rpc(rpc_request(
-                4,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": "bad-cursor",
-                    "max": 4
-                }),
-            ))
-            .expect("invalid poll should still return response");
-        assert_eq!(invalid.error.expect("error").code, "SDK_RUNTIME_INVALID_CURSOR");
-
-        for idx in 0..(SDK_EVENT_LOG_CAPACITY + 8) {
-            daemon.emit_event(RpcEvent {
-                event_type: "inbound".to_string(),
-                payload: json!({ "message_id": format!("overflow-{idx}") }),
-            });
-        }
-
-        let expired = daemon
-            .handle_rpc(rpc_request(
-                5,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": cursor,
-                    "max": 2
-                }),
-            ))
-            .expect("expired poll should return response");
-        assert_eq!(expired.error.expect("error").code, "SDK_RUNTIME_CURSOR_EXPIRED");
-    }
-
-    #[test]
-    fn sdk_poll_events_v2_requires_successful_reset_after_degraded_state() {
-        let daemon = RpcDaemon::test_instance();
-        daemon.emit_event(RpcEvent { event_type: "inbound".to_string(), payload: json!({}) });
-        let first = daemon
-            .handle_rpc(rpc_request(
-                30,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": null,
-                    "max": 1
-                }),
-            ))
-            .expect("initial poll");
-        let cursor =
-            first.result.expect("result")["next_cursor"].as_str().expect("cursor").to_string();
-
-        for idx in 0..(SDK_EVENT_LOG_CAPACITY + 4) {
-            daemon.emit_event(RpcEvent {
-                event_type: "inbound".to_string(),
-                payload: json!({ "idx": idx }),
-            });
-        }
-
-        let expired = daemon
-            .handle_rpc(rpc_request(
-                31,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": cursor,
-                    "max": 1
-                }),
-            ))
-            .expect("expired");
-        assert_eq!(expired.error.expect("error").code, "SDK_RUNTIME_CURSOR_EXPIRED");
-
-        let invalid_reset = daemon
-            .handle_rpc(rpc_request(
-                32,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": null,
-                    "max": 0
-                }),
-            ))
-            .expect("invalid reset");
-        assert_eq!(invalid_reset.error.expect("error").code, "SDK_VALIDATION_INVALID_ARGUMENT");
-
-        let still_degraded = daemon
-            .handle_rpc(rpc_request(
-                33,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": "v2:test-identity:sdk-events:999999",
-                    "max": 1
-                }),
-            ))
-            .expect("still degraded");
-        assert_eq!(still_degraded.error.expect("error").code, "SDK_RUNTIME_STREAM_DEGRADED");
-
-        let reset_ok = daemon
-            .handle_rpc(rpc_request(
-                34,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": null,
-                    "max": 1
-                }),
-            ))
-            .expect("reset");
-        assert!(reset_ok.error.is_none());
-    }
-
-    #[test]
-    fn sdk_send_v2_persists_outbound_message() {
-        let daemon = RpcDaemon::test_instance();
-        let response = daemon
-            .handle_rpc(rpc_request(
-                5,
-                "sdk_send_v2",
-                json!({
-                    "id": "sdk-send-1",
-                    "source": "src",
-                    "destination": "dst",
-                    "title": "",
-                    "content": "hello"
-                }),
-            ))
-            .expect("sdk_send_v2");
-        assert!(response.error.is_none());
-        assert_eq!(response.result.expect("result")["message_id"], json!("sdk-send-1"));
-    }
-
-    #[test]
-    fn sdk_send_v2_exposes_stage_metrics() {
-        let daemon = RpcDaemon::test_instance();
-        let baseline = daemon.metrics_snapshot();
-
-        let response = daemon
-            .handle_rpc(rpc_request(
-                6,
-                "sdk_send_v2",
-                json!({
-                    "id": "sdk-send-metrics-1",
-                    "source": "src",
-                    "destination": "dst",
-                    "title": "",
-                    "content": "hello"
-                }),
-            ))
-            .expect("sdk_send_v2");
-        assert!(response.error.is_none());
-
-        let snapshot = daemon.metrics_snapshot();
-        let before = &baseline["counters"];
-        let after = &snapshot["counters"];
-        assert_eq!(
-            after["sdk_send_store_write_ops_total"].as_u64(),
-            Some(before["sdk_send_store_write_ops_total"].as_u64().unwrap_or(0).saturating_add(1))
-        );
-        assert_eq!(
-            after["sdk_send_delivery_schedule_ops_total"].as_u64(),
-            Some(
-                before["sdk_send_delivery_schedule_ops_total"]
-                    .as_u64()
-                    .unwrap_or(0)
-                    .saturating_add(1)
-            )
-        );
-        assert_eq!(
-            after["sdk_send_event_publish_ops_total"].as_u64(),
-            Some(before["sdk_send_event_publish_ops_total"].as_u64().unwrap_or(0).saturating_add(1))
-        );
-        assert!(
-            after["sdk_send_store_write_ns_total"].as_u64().unwrap_or(0)
-                >= before["sdk_send_store_write_ns_total"].as_u64().unwrap_or(0)
-        );
-        assert!(
-            after["sdk_send_delivery_schedule_ns_total"].as_u64().unwrap_or(0)
-                >= before["sdk_send_delivery_schedule_ns_total"].as_u64().unwrap_or(0)
-        );
-        assert!(
-            after["sdk_send_event_publish_ns_total"].as_u64().unwrap_or(0)
-                >= before["sdk_send_event_publish_ns_total"].as_u64().unwrap_or(0)
-        );
-    }
-
-    #[test]
-    fn sdk_poll_events_v2_rejects_oversized_event_payload() {
-        let daemon = RpcDaemon::test_instance();
-        let configure = daemon
-            .handle_rpc(rpc_request(
-                40,
-                "sdk_configure_v2",
-                json!({
-                    "expected_revision": 0,
-                    "patch": { "event_stream": { "max_event_bytes": 16_384 } }
-                }),
-            ))
-            .expect("configure");
-        assert!(configure.error.is_none());
-        let first_poll = daemon
-            .handle_rpc(rpc_request(
-                41,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": null,
-                    "max": 8
-                }),
-            ))
-            .expect("poll");
-        let cursor =
-            first_poll.result.expect("result")["next_cursor"].as_str().map(ToOwned::to_owned);
-
-        daemon.emit_event(RpcEvent {
-            event_type: "inbound".to_string(),
-            payload: json!({
-                "message_id": "too-large",
-                "blob": "x".repeat(17_000),
+#[test]
+fn sdk_poll_events_v2_validates_cursor_and_expires_stale_tokens() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.emit_event(RpcEvent {
+        event_type: "inbound".to_string(),
+        payload: json!({ "message_id": "m-1" }),
+    });
+    let first = daemon
+        .handle_rpc(rpc_request(
+            3,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": null,
+                "max": 4
             }),
-        });
+        ))
+        .expect("poll");
+    let first_result = first.result.expect("result");
+    let cursor = first_result["next_cursor"].as_str().expect("cursor").to_string();
+    assert!(first_result["events"].as_array().is_some_and(|events| !events.is_empty()));
 
-        let response = daemon
-            .handle_rpc(rpc_request(
-                42,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": cursor,
-                    "max": 1
-                }),
-            ))
-            .expect("poll");
-        assert_eq!(response.error.expect("error").code, "SDK_VALIDATION_EVENT_TOO_LARGE");
+    let invalid = daemon
+        .handle_rpc(rpc_request(
+            4,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": "bad-cursor",
+                "max": 4
+            }),
+        ))
+        .expect("invalid poll should still return response");
+    assert_eq!(invalid.error.expect("error").code, "SDK_RUNTIME_INVALID_CURSOR");
+
+    for idx in 0..(SDK_EVENT_LOG_CAPACITY + 8) {
+        daemon.emit_event(RpcEvent {
+            event_type: "inbound".to_string(),
+            payload: json!({ "message_id": format!("overflow-{idx}") }),
+        });
     }
 
-    #[test]
-    fn sdk_poll_events_v2_rejects_oversized_batch() {
-        let daemon = RpcDaemon::test_instance();
-        let configure = daemon
-            .handle_rpc(rpc_request(
-                50,
-                "sdk_configure_v2",
-                json!({
-                    "expected_revision": 0,
-                    "patch": {
-                        "event_stream": {
-                            "max_event_bytes": 900,
-                            "max_batch_bytes": 1_024
-                        }
+    let expired = daemon
+        .handle_rpc(rpc_request(
+            5,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": cursor,
+                "max": 2
+            }),
+        ))
+        .expect("expired poll should return response");
+    assert_eq!(expired.error.expect("error").code, "SDK_RUNTIME_CURSOR_EXPIRED");
+}
+
+#[test]
+fn sdk_poll_events_v2_requires_successful_reset_after_degraded_state() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.emit_event(RpcEvent { event_type: "inbound".to_string(), payload: json!({}) });
+    let first = daemon
+        .handle_rpc(rpc_request(
+            30,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": null,
+                "max": 1
+            }),
+        ))
+        .expect("initial poll");
+    let cursor = first.result.expect("result")["next_cursor"].as_str().expect("cursor").to_string();
+
+    for idx in 0..(SDK_EVENT_LOG_CAPACITY + 4) {
+        daemon.emit_event(RpcEvent {
+            event_type: "inbound".to_string(),
+            payload: json!({ "idx": idx }),
+        });
+    }
+
+    let expired = daemon
+        .handle_rpc(rpc_request(
+            31,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": cursor,
+                "max": 1
+            }),
+        ))
+        .expect("expired");
+    assert_eq!(expired.error.expect("error").code, "SDK_RUNTIME_CURSOR_EXPIRED");
+
+    let invalid_reset = daemon
+        .handle_rpc(rpc_request(
+            32,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": null,
+                "max": 0
+            }),
+        ))
+        .expect("invalid reset");
+    assert_eq!(invalid_reset.error.expect("error").code, "SDK_VALIDATION_INVALID_ARGUMENT");
+
+    let still_degraded = daemon
+        .handle_rpc(rpc_request(
+            33,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": "v2:test-identity:sdk-events:999999",
+                "max": 1
+            }),
+        ))
+        .expect("still degraded");
+    assert_eq!(still_degraded.error.expect("error").code, "SDK_RUNTIME_STREAM_DEGRADED");
+
+    let reset_ok = daemon
+        .handle_rpc(rpc_request(
+            34,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": null,
+                "max": 1
+            }),
+        ))
+        .expect("reset");
+    assert!(reset_ok.error.is_none());
+}
+
+#[test]
+fn sdk_send_v2_persists_outbound_message() {
+    let daemon = RpcDaemon::test_instance();
+    let response = daemon
+        .handle_rpc(rpc_request(
+            5,
+            "sdk_send_v2",
+            json!({
+                "id": "sdk-send-1",
+                "source": "src",
+                "destination": "dst",
+                "title": "",
+                "content": "hello"
+            }),
+        ))
+        .expect("sdk_send_v2");
+    assert!(response.error.is_none());
+    assert_eq!(response.result.expect("result")["message_id"], json!("sdk-send-1"));
+}
+
+#[test]
+fn sdk_send_batch_v2_persists_ordered_outbound_messages() {
+    let daemon = RpcDaemon::test_instance();
+    let response = daemon
+        .handle_rpc(rpc_request(
+            55,
+            "sdk_send_batch_v2",
+            json!({
+                "batch_id": "batch-1",
+                "source": "src",
+                "messages": [
+                    {
+                        "id": "batch-msg-1",
+                        "destination": "dst-1",
+                        "title": "",
+                        "content": "hello one"
+                    },
+                    {
+                        "id": "batch-msg-2",
+                        "destination": "dst-2",
+                        "title": "RCH",
+                        "content": "hello two",
+                        "method": "propagated"
                     }
-                }),
-            ))
-            .expect("configure");
-        assert!(configure.error.is_none());
-        let first_poll = daemon
-            .handle_rpc(rpc_request(
-                51,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": null,
-                    "max": 8
-                }),
-            ))
-            .expect("poll");
-        let cursor =
-            first_poll.result.expect("result")["next_cursor"].as_str().map(ToOwned::to_owned);
-
-        daemon.emit_event(RpcEvent {
-            event_type: "inbound".to_string(),
-            payload: json!({
-                "message_id": "m-batch-1",
-                "blob": "x".repeat(768),
+                ]
             }),
-        });
-        daemon.emit_event(RpcEvent {
-            event_type: "inbound".to_string(),
-            payload: json!({
-                "message_id": "m-batch-2",
-                "blob": "y".repeat(768),
+        ))
+        .expect("sdk_send_batch_v2");
+    assert!(response.error.is_none());
+    let result = response.result.expect("result");
+    assert_eq!(result["batch_id"], json!("batch-1"));
+    assert_eq!(result["accepted_count"], json!(2));
+    assert_eq!(result["rejected_count"], json!(0));
+    assert_eq!(result["results"][0]["id"], json!("batch-msg-1"));
+    assert_eq!(result["results"][0]["message_id"], json!("batch-msg-1"));
+    assert_eq!(result["results"][0]["accepted"], json!(true));
+    assert_eq!(result["results"][1]["id"], json!("batch-msg-2"));
+    assert_eq!(result["results"][1]["message_id"], json!("batch-msg-2"));
+    assert_eq!(result["results"][1]["accepted"], json!(true));
+
+    let messages = daemon
+        .handle_rpc(RpcRequest { id: 56, method: "list_messages".into(), params: None })
+        .expect("list messages")
+        .result
+        .expect("result");
+    let rows = messages["messages"].as_array().expect("messages");
+    assert!(rows.iter().any(|row| row["id"] == json!("batch-msg-1")));
+    assert!(rows.iter().any(|row| row["id"] == json!("batch-msg-2")));
+}
+
+#[test]
+fn sdk_send_v2_exposes_stage_metrics() {
+    let daemon = RpcDaemon::test_instance();
+    let baseline = daemon.metrics_snapshot();
+
+    let response = daemon
+        .handle_rpc(rpc_request(
+            6,
+            "sdk_send_v2",
+            json!({
+                "id": "sdk-send-metrics-1",
+                "source": "src",
+                "destination": "dst",
+                "title": "",
+                "content": "hello"
             }),
-        });
+        ))
+        .expect("sdk_send_v2");
+    assert!(response.error.is_none());
 
-        let response = daemon
-            .handle_rpc(rpc_request(
-                52,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": cursor,
-                    "max": 2
-                }),
-            ))
-            .expect("poll");
-        assert_eq!(response.error.expect("error").code, "SDK_VALIDATION_BATCH_TOO_LARGE");
-    }
+    let snapshot = daemon.metrics_snapshot();
+    let before = &baseline["counters"];
+    let after = &snapshot["counters"];
+    assert_eq!(
+        after["sdk_send_store_write_ops_total"].as_u64(),
+        Some(before["sdk_send_store_write_ops_total"].as_u64().unwrap_or(0).saturating_add(1))
+    );
+    assert_eq!(
+        after["sdk_send_delivery_schedule_ops_total"].as_u64(),
+        Some(
+            before["sdk_send_delivery_schedule_ops_total"].as_u64().unwrap_or(0).saturating_add(1)
+        )
+    );
+    assert_eq!(
+        after["sdk_send_event_publish_ops_total"].as_u64(),
+        Some(before["sdk_send_event_publish_ops_total"].as_u64().unwrap_or(0).saturating_add(1))
+    );
+    assert!(
+        after["sdk_send_store_write_ns_total"].as_u64().unwrap_or(0)
+            >= before["sdk_send_store_write_ns_total"].as_u64().unwrap_or(0)
+    );
+    assert!(
+        after["sdk_send_delivery_schedule_ns_total"].as_u64().unwrap_or(0)
+            >= before["sdk_send_delivery_schedule_ns_total"].as_u64().unwrap_or(0)
+    );
+    assert!(
+        after["sdk_send_event_publish_ns_total"].as_u64().unwrap_or(0)
+            >= before["sdk_send_event_publish_ns_total"].as_u64().unwrap_or(0)
+    );
+}
 
-    #[test]
-    fn sdk_poll_events_v2_rejects_event_with_too_many_extension_keys() {
-        let daemon = RpcDaemon::test_instance();
-        let configure = daemon
-            .handle_rpc(rpc_request(
-                60,
-                "sdk_configure_v2",
-                json!({
-                    "expected_revision": 0,
-                    "patch": { "event_stream": { "max_extension_keys": 1 } }
-                }),
-            ))
-            .expect("configure");
-        assert!(configure.error.is_none());
-        let first_poll = daemon
-            .handle_rpc(rpc_request(
-                61,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": null,
-                    "max": 8
-                }),
-            ))
-            .expect("poll");
-        let cursor =
-            first_poll.result.expect("result")["next_cursor"].as_str().map(ToOwned::to_owned);
+#[test]
+fn sdk_poll_events_v2_rejects_oversized_event_payload() {
+    let daemon = RpcDaemon::test_instance();
+    let configure = daemon
+        .handle_rpc(rpc_request(
+            40,
+            "sdk_configure_v2",
+            json!({
+                "expected_revision": 0,
+                "patch": { "event_stream": { "max_event_bytes": 16_384 } }
+            }),
+        ))
+        .expect("configure");
+    assert!(configure.error.is_none());
+    let first_poll = daemon
+        .handle_rpc(rpc_request(
+            41,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": null,
+                "max": 8
+            }),
+        ))
+        .expect("poll");
+    let cursor = first_poll.result.expect("result")["next_cursor"].as_str().map(ToOwned::to_owned);
 
-        daemon.emit_event(RpcEvent {
-            event_type: "inbound".to_string(),
-            payload: json!({
-                "message_id": "m-ext",
-                "extensions": {
-                    "k1": true,
-                    "k2": false
+    daemon.emit_event(RpcEvent {
+        event_type: "inbound".to_string(),
+        payload: json!({
+            "message_id": "too-large",
+            "blob": "x".repeat(17_000),
+        }),
+    });
+
+    let response = daemon
+        .handle_rpc(rpc_request(
+            42,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": cursor,
+                "max": 1
+            }),
+        ))
+        .expect("poll");
+    assert_eq!(response.error.expect("error").code, "SDK_VALIDATION_EVENT_TOO_LARGE");
+}
+
+#[test]
+fn sdk_poll_events_v2_rejects_oversized_batch() {
+    let daemon = RpcDaemon::test_instance();
+    let configure = daemon
+        .handle_rpc(rpc_request(
+            50,
+            "sdk_configure_v2",
+            json!({
+                "expected_revision": 0,
+                "patch": {
+                    "event_stream": {
+                        "max_event_bytes": 900,
+                        "max_batch_bytes": 1_024
+                    }
                 }
             }),
-        });
+        ))
+        .expect("configure");
+    assert!(configure.error.is_none());
+    let first_poll = daemon
+        .handle_rpc(rpc_request(
+            51,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": null,
+                "max": 8
+            }),
+        ))
+        .expect("poll");
+    let cursor = first_poll.result.expect("result")["next_cursor"].as_str().map(ToOwned::to_owned);
 
-        let response = daemon
-            .handle_rpc(rpc_request(
-                62,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": cursor,
-                    "max": 1
-                }),
-            ))
-            .expect("poll");
-        assert_eq!(
-            response.error.expect("error").code,
-            "SDK_VALIDATION_MAX_EXTENSION_KEYS_EXCEEDED"
-        );
-    }
+    daemon.emit_event(RpcEvent {
+        event_type: "inbound".to_string(),
+        payload: json!({
+            "message_id": "m-batch-1",
+            "blob": "x".repeat(768),
+        }),
+    });
+    daemon.emit_event(RpcEvent {
+        event_type: "inbound".to_string(),
+        payload: json!({
+            "message_id": "m-batch-2",
+            "blob": "y".repeat(768),
+        }),
+    });
 
-    #[test]
-    fn sdk_domain_methods_respect_capability_gating_when_removed() {
-        let daemon = RpcDaemon::test_instance();
-        {
-            let mut capabilities = daemon
-                .sdk_effective_capabilities
-                .lock()
-                .expect("sdk_effective_capabilities mutex poisoned");
-            *capabilities = vec!["sdk.capability.cursor_replay".to_string()];
-        }
-        let response = daemon
-            .handle_rpc(rpc_request(
-                77,
-                "sdk_topic_create_v2",
-                json!({ "topic_path": "ops/alpha" }),
-            ))
-            .expect("rpc response");
-        let error = response.error.expect("expected capability error");
-        assert_eq!(error.code, "SDK_CAPABILITY_DISABLED");
-        assert!(error.message.contains("sdk_topic_create_v2"));
-    }
+    let response = daemon
+        .handle_rpc(rpc_request(
+            52,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": cursor,
+                "max": 2
+            }),
+        ))
+        .expect("poll");
+    assert_eq!(response.error.expect("error").code, "SDK_VALIDATION_BATCH_TOO_LARGE");
+}
 
-    #[test]
-    fn sdk_overflow_policy_reject_keeps_oldest_events_and_drops_newest() {
-        let daemon = RpcDaemon::test_instance();
-        let configure = daemon
-            .handle_rpc(rpc_request(
-                90,
-                "sdk_configure_v2",
-                json!({
-                    "expected_revision": 0,
-                    "patch": {
-                        "overflow_policy": "reject",
-                        "event_stream": { "max_poll_events": 2048 }
-                    }
-                }),
-            ))
-            .expect("configure");
-        assert!(configure.error.is_none());
+#[test]
+fn sdk_poll_events_v2_rejects_event_with_too_many_extension_keys() {
+    let daemon = RpcDaemon::test_instance();
+    let configure = daemon
+        .handle_rpc(rpc_request(
+            60,
+            "sdk_configure_v2",
+            json!({
+                "expected_revision": 0,
+                "patch": { "event_stream": { "max_extension_keys": 1 } }
+            }),
+        ))
+        .expect("configure");
+    assert!(configure.error.is_none());
+    let first_poll = daemon
+        .handle_rpc(rpc_request(
+            61,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": null,
+                "max": 8
+            }),
+        ))
+        .expect("poll");
+    let cursor = first_poll.result.expect("result")["next_cursor"].as_str().map(ToOwned::to_owned);
 
-        for idx in 0..(SDK_EVENT_LOG_CAPACITY + 1) {
-            daemon.emit_event(RpcEvent {
-                event_type: "inbound".to_string(),
-                payload: json!({ "idx": idx }),
-            });
-        }
+    daemon.emit_event(RpcEvent {
+        event_type: "inbound".to_string(),
+        payload: json!({
+            "message_id": "m-ext",
+            "extensions": {
+                "k1": true,
+                "k2": false
+            }
+        }),
+    });
 
-        let response = daemon
-            .handle_rpc(rpc_request(
-                91,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": null,
-                    "max": 2048
-                }),
-            ))
-            .expect("poll");
-        let result = response.result.expect("result");
-        let events = result["events"].as_array().expect("events array");
-        let payload_indices = events
-            .iter()
-            .filter_map(|row| {
-                row.get("payload")
-                    .and_then(|payload| payload.get("idx"))
-                    .and_then(JsonValue::as_u64)
-            })
-            .collect::<Vec<_>>();
+    let response = daemon
+        .handle_rpc(rpc_request(
+            62,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": cursor,
+                "max": 1
+            }),
+        ))
+        .expect("poll");
+    assert_eq!(response.error.expect("error").code, "SDK_VALIDATION_MAX_EXTENSION_KEYS_EXCEEDED");
+}
 
-        assert!(result["dropped_count"].as_u64().unwrap_or(0) > 0);
-        assert!(
-            payload_indices.contains(&0),
-            "reject policy should retain oldest entries instead of evicting head"
-        );
-        assert!(
-            !payload_indices.contains(&(SDK_EVENT_LOG_CAPACITY as u64)),
-            "reject policy should drop newest event when capacity is exhausted"
-        );
-    }
-
-    #[test]
-    fn sdk_overflow_policy_drop_oldest_evicts_head_entries() {
-        let daemon = RpcDaemon::test_instance();
-        let configure = daemon
-            .handle_rpc(rpc_request(
-                92,
-                "sdk_configure_v2",
-                json!({
-                    "expected_revision": 0,
-                    "patch": {
-                        "overflow_policy": "drop_oldest",
-                        "event_stream": { "max_poll_events": 2048 }
-                    }
-                }),
-            ))
-            .expect("configure");
-        assert!(configure.error.is_none());
-
-        for idx in 0..(SDK_EVENT_LOG_CAPACITY + 1) {
-            daemon.emit_event(RpcEvent {
-                event_type: "inbound".to_string(),
-                payload: json!({ "idx": idx }),
-            });
-        }
-
-        let response = daemon
-            .handle_rpc(rpc_request(
-                93,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": null,
-                    "max": 2048
-                }),
-            ))
-            .expect("poll");
-        let result = response.result.expect("result");
-        let events = result["events"].as_array().expect("events array");
-        let payload_indices = events
-            .iter()
-            .filter_map(|row| {
-                row.get("payload")
-                    .and_then(|payload| payload.get("idx"))
-                    .and_then(JsonValue::as_u64)
-            })
-            .collect::<Vec<_>>();
-
-        assert!(result["dropped_count"].as_u64().unwrap_or(0) > 0);
-        assert!(
-            !payload_indices.contains(&0),
-            "drop_oldest policy should evict oldest entry once capacity is exceeded"
-        );
-        assert!(
-            payload_indices.contains(&(SDK_EVENT_LOG_CAPACITY as u64)),
-            "drop_oldest policy should retain newest event"
-        );
-    }
-
-    #[test]
-    fn sdk_event_queues_remain_bounded_under_sustained_load() {
-        let daemon = RpcDaemon::test_instance();
-        let configure = daemon
-            .handle_rpc(rpc_request(
-                94,
-                "sdk_configure_v2",
-                json!({
-                    "expected_revision": 0,
-                    "patch": {
-                        "overflow_policy": "drop_oldest",
-                        "event_stream": { "max_poll_events": 4096 }
-                    }
-                }),
-            ))
-            .expect("configure");
-        assert!(configure.error.is_none());
-
-        for idx in 0..(SDK_EVENT_LOG_CAPACITY * 8) {
-            daemon.emit_event(RpcEvent {
-                event_type: "queue_pressure".to_string(),
-                payload: json!({ "idx": idx }),
-            });
-        }
-
-        let legacy_len = daemon.event_queue.lock().expect("event_queue mutex poisoned").len();
-        let sdk_len = daemon.sdk_event_log.lock().expect("sdk_event_log mutex poisoned").len();
-        let dropped = *daemon
-            .sdk_dropped_event_count
+#[test]
+fn sdk_domain_methods_respect_capability_gating_when_removed() {
+    let daemon = RpcDaemon::test_instance();
+    {
+        let mut capabilities = daemon
+            .sdk_effective_capabilities
             .lock()
-            .expect("sdk_dropped_event_count mutex poisoned");
+            .expect("sdk_effective_capabilities mutex poisoned");
+        *capabilities = vec!["sdk.capability.cursor_replay".to_string()];
+    }
+    let response = daemon
+        .handle_rpc(rpc_request(77, "sdk_topic_create_v2", json!({ "topic_path": "ops/alpha" })))
+        .expect("rpc response");
+    let error = response.error.expect("expected capability error");
+    assert_eq!(error.code, "SDK_CAPABILITY_DISABLED");
+    assert!(error.message.contains("sdk_topic_create_v2"));
+}
 
-        assert!(
-            legacy_len <= LEGACY_EVENT_QUEUE_CAPACITY,
-            "legacy queue must stay bounded under load"
-        );
-        assert_eq!(
-            sdk_len, SDK_EVENT_LOG_CAPACITY,
-            "sdk event log must remain capped under load"
-        );
-        assert!(dropped > 0, "drop_oldest policy should report dropped events under pressure");
+#[test]
+fn sdk_overflow_policy_reject_keeps_oldest_events_and_drops_newest() {
+    let daemon = RpcDaemon::test_instance();
+    let configure = daemon
+        .handle_rpc(rpc_request(
+            90,
+            "sdk_configure_v2",
+            json!({
+                "expected_revision": 0,
+                "patch": {
+                    "overflow_policy": "reject",
+                    "event_stream": { "max_poll_events": 2048 }
+                }
+            }),
+        ))
+        .expect("configure");
+    assert!(configure.error.is_none());
+
+    for idx in 0..(SDK_EVENT_LOG_CAPACITY + 1) {
+        daemon.emit_event(RpcEvent {
+            event_type: "inbound".to_string(),
+            payload: json!({ "idx": idx }),
+        });
     }
 
-    #[test]
-    fn sdk_property_cursor_monotonicity_randomized_poll_batches() {
-        let daemon = RpcDaemon::test_instance();
-        let total_events = 240_u64;
-        for idx in 0..total_events {
-            daemon.emit_event(RpcEvent {
-                event_type: "property_cursor".to_string(),
-                payload: json!({ "idx": idx }),
-            });
-        }
+    let response = daemon
+        .handle_rpc(rpc_request(
+            91,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": null,
+                "max": 2048
+            }),
+        ))
+        .expect("poll");
+    let result = response.result.expect("result");
+    let events = result["events"].as_array().expect("events array");
+    let payload_indices = events
+        .iter()
+        .filter_map(|row| {
+            row.get("payload").and_then(|payload| payload.get("idx")).and_then(JsonValue::as_u64)
+        })
+        .collect::<Vec<_>>();
 
-        let mut cursor: Option<String> = None;
-        let mut last_seq = 0_u64;
-        let mut seen = std::collections::BTreeSet::new();
-        let mut seed = 0x9E37_79B9_7F4A_7C15_u64;
+    assert!(result["dropped_count"].as_u64().unwrap_or(0) > 0);
+    assert!(
+        payload_indices.contains(&0),
+        "reject policy should retain oldest entries instead of evicting head"
+    );
+    assert!(
+        !payload_indices.contains(&(SDK_EVENT_LOG_CAPACITY as u64)),
+        "reject policy should drop newest event when capacity is exhausted"
+    );
+}
 
-        for iteration in 0..512_u64 {
-            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
-            let max = ((seed % 11) + 1) as usize;
-            let response = daemon
-                .handle_rpc(rpc_request(
-                    1_000 + iteration,
-                    "sdk_poll_events_v2",
-                    json!({
-                        "cursor": cursor.clone(),
-                        "max": max,
-                    }),
-                ))
-                .expect("poll");
-            assert!(response.error.is_none(), "poll should remain stable for randomized batches");
-            let result = response.result.expect("result");
-            let events = result["events"].as_array().expect("events array");
-            for event in events {
-                let seq = event["seq_no"].as_u64().expect("seq_no");
-                assert!(seq > last_seq, "event sequence must remain strictly increasing");
-                assert!(seen.insert(seq), "sequence IDs must not repeat");
-                last_seq = seq;
-            }
-            cursor = result["next_cursor"].as_str().map(ToOwned::to_owned);
-            if seen.len() >= total_events as usize {
-                break;
-            }
-        }
+#[test]
+fn sdk_overflow_policy_drop_oldest_evicts_head_entries() {
+    let daemon = RpcDaemon::test_instance();
+    let configure = daemon
+        .handle_rpc(rpc_request(
+            92,
+            "sdk_configure_v2",
+            json!({
+                "expected_revision": 0,
+                "patch": {
+                    "overflow_policy": "drop_oldest",
+                    "event_stream": { "max_poll_events": 2048 }
+                }
+            }),
+        ))
+        .expect("configure");
+    assert!(configure.error.is_none());
 
-        assert_eq!(
-            seen.len(),
-            total_events as usize,
-            "randomized cursor polling should read every emitted event exactly once"
-        );
+    for idx in 0..(SDK_EVENT_LOG_CAPACITY + 1) {
+        daemon.emit_event(RpcEvent {
+            event_type: "inbound".to_string(),
+            payload: json!({ "idx": idx }),
+        });
     }
 
-    #[test]
-    fn sdk_property_stream_gap_reports_consistent_drop_metadata() {
-        let daemon = RpcDaemon::test_instance();
-        let configure = daemon
-            .handle_rpc(rpc_request(
-                1_100,
-                "sdk_configure_v2",
-                json!({
-                    "expected_revision": 0,
-                    "patch": {
-                        "overflow_policy": "drop_oldest",
-                        "event_stream": { "max_poll_events": 4096 }
-                    }
-                }),
-            ))
-            .expect("configure");
-        assert!(configure.error.is_none());
+    let response = daemon
+        .handle_rpc(rpc_request(
+            93,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": null,
+                "max": 2048
+            }),
+        ))
+        .expect("poll");
+    let result = response.result.expect("result");
+    let events = result["events"].as_array().expect("events array");
+    let payload_indices = events
+        .iter()
+        .filter_map(|row| {
+            row.get("payload").and_then(|payload| payload.get("idx")).and_then(JsonValue::as_u64)
+        })
+        .collect::<Vec<_>>();
 
-        for idx in 0..(SDK_EVENT_LOG_CAPACITY + 64) {
-            daemon.emit_event(RpcEvent {
-                event_type: "property_gap".to_string(),
-                payload: json!({ "idx": idx }),
-            });
-        }
+    assert!(result["dropped_count"].as_u64().unwrap_or(0) > 0);
+    assert!(
+        !payload_indices.contains(&0),
+        "drop_oldest policy should evict oldest entry once capacity is exceeded"
+    );
+    assert!(
+        payload_indices.contains(&(SDK_EVENT_LOG_CAPACITY as u64)),
+        "drop_oldest policy should retain newest event"
+    );
+}
 
-        let first = daemon
+#[test]
+fn sdk_event_queues_remain_bounded_under_sustained_load() {
+    let daemon = RpcDaemon::test_instance();
+    let configure = daemon
+        .handle_rpc(rpc_request(
+            94,
+            "sdk_configure_v2",
+            json!({
+                "expected_revision": 0,
+                "patch": {
+                    "overflow_policy": "drop_oldest",
+                    "event_stream": { "max_poll_events": 4096 }
+                }
+            }),
+        ))
+        .expect("configure");
+    assert!(configure.error.is_none());
+
+    for idx in 0..(SDK_EVENT_LOG_CAPACITY * 8) {
+        daemon.emit_event(RpcEvent {
+            event_type: "queue_pressure".to_string(),
+            payload: json!({ "idx": idx }),
+        });
+    }
+
+    let legacy_len = daemon.event_queue.lock().expect("event_queue mutex poisoned").len();
+    let sdk_len = daemon.sdk_event_log.lock().expect("sdk_event_log mutex poisoned").len();
+    let dropped =
+        *daemon.sdk_dropped_event_count.lock().expect("sdk_dropped_event_count mutex poisoned");
+
+    assert!(legacy_len <= LEGACY_EVENT_QUEUE_CAPACITY, "legacy queue must stay bounded under load");
+    assert_eq!(sdk_len, SDK_EVENT_LOG_CAPACITY, "sdk event log must remain capped under load");
+    assert!(dropped > 0, "drop_oldest policy should report dropped events under pressure");
+}
+
+#[test]
+fn sdk_property_cursor_monotonicity_randomized_poll_batches() {
+    let daemon = RpcDaemon::test_instance();
+    let total_events = 240_u64;
+    for idx in 0..total_events {
+        daemon.emit_event(RpcEvent {
+            event_type: "property_cursor".to_string(),
+            payload: json!({ "idx": idx }),
+        });
+    }
+
+    let mut cursor: Option<String> = None;
+    let mut last_seq = 0_u64;
+    let mut seen = std::collections::BTreeSet::new();
+    let mut seed = 0x9E37_79B9_7F4A_7C15_u64;
+
+    for iteration in 0..512_u64 {
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let max = ((seed % 11) + 1) as usize;
+        let response = daemon
             .handle_rpc(rpc_request(
-                1_101,
+                1_000 + iteration,
                 "sdk_poll_events_v2",
                 json!({
-                    "cursor": null,
-                    "max": 32
+                    "cursor": cursor.clone(),
+                    "max": max,
                 }),
             ))
-            .expect("first poll");
-        assert!(first.error.is_none(), "first poll should succeed");
-        let first_result = first.result.expect("result");
-        let dropped_count = first_result["dropped_count"].as_u64().unwrap_or(0);
-        assert!(dropped_count > 0, "overflow run should report dropped_count");
-
-        let events = first_result["events"].as_array().expect("events array");
-        let gap_event = events
-            .iter()
-            .find(|event| event.get("event_type").and_then(JsonValue::as_str) == Some("StreamGap"))
-            .expect("first poll should include StreamGap marker");
-        let gap_payload = gap_event["payload"].as_object().expect("gap payload object");
-        let expected_seq_no =
-            gap_payload.get("expected_seq_no").and_then(JsonValue::as_u64).expect("expected");
-        let observed_seq_no =
-            gap_payload.get("observed_seq_no").and_then(JsonValue::as_u64).expect("observed");
-        let payload_dropped =
-            gap_payload.get("dropped_count").and_then(JsonValue::as_u64).expect("dropped");
-        assert_eq!(payload_dropped, dropped_count, "gap payload must match top-level dropped_count");
-        assert_eq!(
-            expected_seq_no.saturating_add(payload_dropped),
-            observed_seq_no,
-            "gap metadata invariant expected + dropped == observed must hold"
-        );
-
-        let mut last_seq = 0_u64;
+            .expect("poll");
+        assert!(response.error.is_none(), "poll should remain stable for randomized batches");
+        let result = response.result.expect("result");
+        let events = result["events"].as_array().expect("events array");
         for event in events {
-            let seq = event["seq_no"].as_u64().expect("seq");
-            assert!(seq > last_seq, "first poll sequence should be strictly increasing");
+            let seq = event["seq_no"].as_u64().expect("seq_no");
+            assert!(seq > last_seq, "event sequence must remain strictly increasing");
+            assert!(seen.insert(seq), "sequence IDs must not repeat");
             last_seq = seq;
         }
+        cursor = result["next_cursor"].as_str().map(ToOwned::to_owned);
+        if seen.len() >= total_events as usize {
+            break;
+        }
+    }
 
-        let follow_cursor = first_result["next_cursor"].as_str().expect("cursor").to_string();
-        let follow = daemon
-            .handle_rpc(rpc_request(
-                1_102,
-                "sdk_poll_events_v2",
-                json!({
-                    "cursor": follow_cursor,
-                    "max": 16
-                }),
-            ))
-            .expect("follow poll");
-        assert!(follow.error.is_none(), "follow-up poll should succeed");
-        let follow_result = follow.result.expect("result");
-        assert_eq!(
-            follow_result["dropped_count"].as_u64().unwrap_or(u64::MAX),
-            0,
-            "cursored polls must not re-report dropped_count"
-        );
-        assert!(
-            follow_result["events"].as_array().is_some_and(|rows| {
-                rows.iter().all(|event| {
-                    event.get("event_type").and_then(JsonValue::as_str) != Some("StreamGap")
-                })
+    assert_eq!(
+        seen.len(),
+        total_events as usize,
+        "randomized cursor polling should read every emitted event exactly once"
+    );
+}
+
+#[test]
+fn sdk_property_stream_gap_reports_consistent_drop_metadata() {
+    let daemon = RpcDaemon::test_instance();
+    let configure = daemon
+        .handle_rpc(rpc_request(
+            1_100,
+            "sdk_configure_v2",
+            json!({
+                "expected_revision": 0,
+                "patch": {
+                    "overflow_policy": "drop_oldest",
+                    "event_stream": { "max_poll_events": 4096 }
+                }
             }),
-            "cursored polls must not inject StreamGap events"
-        );
+        ))
+        .expect("configure");
+    assert!(configure.error.is_none());
+
+    for idx in 0..(SDK_EVENT_LOG_CAPACITY + 64) {
+        daemon.emit_event(RpcEvent {
+            event_type: "property_gap".to_string(),
+            payload: json!({ "idx": idx }),
+        });
     }
 
-    #[test]
-    fn native_stream_gap_frame_matches_poll_gap_metadata_shape() {
-        let daemon = RpcDaemon::test_instance();
-        let frame = daemon.sdk_stream_gap_frame(42, 47, 5);
+    let first = daemon
+        .handle_rpc(rpc_request(
+            1_101,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": null,
+                "max": 32
+            }),
+        ))
+        .expect("first poll");
+    assert!(first.error.is_none(), "first poll should succeed");
+    let first_result = first.result.expect("result");
+    let dropped_count = first_result["dropped_count"].as_u64().unwrap_or(0);
+    assert!(dropped_count > 0, "overflow run should report dropped_count");
 
-        assert_eq!(frame["event_type"].as_str(), Some("StreamGap"));
-        assert_eq!(frame["seq_no"].as_u64(), Some(46));
-        assert_eq!(frame["event_id"].as_str(), Some("gap-46"));
-        assert_eq!(frame["payload"]["expected_seq_no"].as_u64(), Some(42));
-        assert_eq!(frame["payload"]["observed_seq_no"].as_u64(), Some(47));
-        assert_eq!(frame["payload"]["dropped_count"].as_u64(), Some(5));
-        assert_eq!(frame["payload"]["recovery_required"].as_bool(), Some(true));
+    let events = first_result["events"].as_array().expect("events array");
+    let gap_event = events
+        .iter()
+        .find(|event| event.get("event_type").and_then(JsonValue::as_str) == Some("StreamGap"))
+        .expect("first poll should include StreamGap marker");
+    let gap_payload = gap_event["payload"].as_object().expect("gap payload object");
+    let expected_seq_no =
+        gap_payload.get("expected_seq_no").and_then(JsonValue::as_u64).expect("expected");
+    let observed_seq_no =
+        gap_payload.get("observed_seq_no").and_then(JsonValue::as_u64).expect("observed");
+    let payload_dropped =
+        gap_payload.get("dropped_count").and_then(JsonValue::as_u64).expect("dropped");
+    assert_eq!(payload_dropped, dropped_count, "gap payload must match top-level dropped_count");
+    assert_eq!(
+        expected_seq_no.saturating_add(payload_dropped),
+        observed_seq_no,
+        "gap metadata invariant expected + dropped == observed must hold"
+    );
+
+    let mut last_seq = 0_u64;
+    for event in events {
+        let seq = event["seq_no"].as_u64().expect("seq");
+        assert!(seq > last_seq, "first poll sequence should be strictly increasing");
+        last_seq = seq;
     }
+
+    let follow_cursor = first_result["next_cursor"].as_str().expect("cursor").to_string();
+    let follow = daemon
+        .handle_rpc(rpc_request(
+            1_102,
+            "sdk_poll_events_v2",
+            json!({
+                "cursor": follow_cursor,
+                "max": 16
+            }),
+        ))
+        .expect("follow poll");
+    assert!(follow.error.is_none(), "follow-up poll should succeed");
+    let follow_result = follow.result.expect("result");
+    assert_eq!(
+        follow_result["dropped_count"].as_u64().unwrap_or(u64::MAX),
+        0,
+        "cursored polls must not re-report dropped_count"
+    );
+    assert!(
+        follow_result["events"].as_array().is_some_and(|rows| {
+            rows.iter().all(|event| {
+                event.get("event_type").and_then(JsonValue::as_str) != Some("StreamGap")
+            })
+        }),
+        "cursored polls must not inject StreamGap events"
+    );
+}
+
+#[test]
+fn native_stream_gap_frame_matches_poll_gap_metadata_shape() {
+    let daemon = RpcDaemon::test_instance();
+    let frame = daemon.sdk_stream_gap_frame(42, 47, 5);
+
+    assert_eq!(frame["event_type"].as_str(), Some("StreamGap"));
+    assert_eq!(frame["seq_no"].as_u64(), Some(46));
+    assert_eq!(frame["event_id"].as_str(), Some("gap-46"));
+    assert_eq!(frame["payload"]["expected_seq_no"].as_u64(), Some(42));
+    assert_eq!(frame["payload"]["observed_seq_no"].as_u64(), Some(47));
+    assert_eq!(frame["payload"]["dropped_count"].as_u64(), Some(5));
+    assert_eq!(frame["payload"]["recovery_required"].as_bool(), Some(true));
+}

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/negotiate_security.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/negotiate_security.rs
@@ -21,7 +21,51 @@
         let result = response.result.expect("result");
         assert_eq!(result["active_contract_version"], json!(2));
         assert_eq!(result["contract_release"], json!("v2.5"));
+        assert_eq!(result["sdk_version"].as_str(), Some(expected_lxmf_sdk_version().as_str()));
+        assert_eq!(
+            result["python_reference"],
+            json!({
+                "reticulum_conformance_ref": expected_python_reference("RETICULUM_CONFORMANCE_REF"),
+                "python_reticulum_ref": expected_python_reference("PYTHON_RETICULUM_REF"),
+                "python_lxmf_ref": expected_python_reference("PYTHON_LXMF_REF"),
+            })
+        );
+        assert_eq!(
+            result["meta"]["python_reference"],
+            result["python_reference"],
+            "response metadata should repeat the parity checkpoint for clients that only inspect meta"
+        );
         assert_eq!(result["effective_limits"]["max_poll_events"], json!(64));
+    }
+
+    fn expected_lxmf_sdk_version() -> String {
+        let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("libs dir")
+            .join("lxmf-sdk")
+            .join("Cargo.toml");
+        let text = std::fs::read_to_string(&manifest).expect("read lxmf-sdk Cargo.toml");
+        text.lines()
+            .find_map(|line| line.trim().strip_prefix("version = "))
+            .map(|value| value.trim_matches('"').to_string())
+            .expect("lxmf-sdk package version")
+    }
+
+    fn expected_python_reference(name: &str) -> String {
+        let workflow = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(3)
+            .expect("repo root")
+            .join(".github")
+            .join("workflows")
+            .join("python-interop.yml");
+        let needle = format!("{name}: ");
+        let text = std::fs::read_to_string(&workflow).expect("read python interop workflow");
+        text.lines()
+            .find_map(|line| line.trim().strip_prefix(&needle))
+            .map(str::trim)
+            .map(str::to_string)
+            .expect("python reference env pin")
     }
 
     #[test]

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/runtime_state.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/runtime_state.rs
@@ -16,10 +16,54 @@ impl OutboundBridge for PendingOutboundBridge {
     }
 }
 
+struct PipelineStatusBridge;
+
+impl OutboundBridge for PipelineStatusBridge {
+    fn deliver(
+        &self,
+        _record: &MessageRecord,
+        _options: &OutboundDeliveryOptions,
+    ) -> Result<(), std::io::Error> {
+        Ok(())
+    }
+
+    fn delivery_pipeline_status(&self) -> Option<serde_json::Value> {
+        Some(json!({
+            "queued_total": 3,
+            "in_flight_total": 1,
+            "rejected_queue_full_total": 0,
+        }))
+    }
+}
+
 struct SlowOutboundBridge {
     started_tx: StdMutex<Option<std_mpsc::Sender<()>>>,
     release_rx: StdMutex<std_mpsc::Receiver<()>>,
     blocked_once: StdAtomicBool,
+}
+
+struct BlockingOutboundBridge {
+    started_tx: StdMutex<std_mpsc::Sender<String>>,
+    release_rx: StdMutex<std_mpsc::Receiver<()>>,
+}
+
+impl BlockingOutboundBridge {
+    fn new(started_tx: std_mpsc::Sender<String>, release_rx: std_mpsc::Receiver<()>) -> Self {
+        Self { started_tx: StdMutex::new(started_tx), release_rx: StdMutex::new(release_rx) }
+    }
+}
+
+impl OutboundBridge for BlockingOutboundBridge {
+    fn deliver(
+        &self,
+        record: &MessageRecord,
+        _options: &OutboundDeliveryOptions,
+    ) -> Result<(), std::io::Error> {
+        let _ = self.started_tx.lock().expect("started mutex").send(record.id.clone());
+        let _ =
+            self.release_rx.lock().expect("release mutex").recv_timeout(StdDuration::from_secs(2));
+        Ok(())
+    }
 }
 
 impl SlowOutboundBridge {
@@ -169,6 +213,30 @@ fn send_with_bridge_stays_in_sending_until_acknowledged() {
 }
 
 #[test]
+fn sdk_status_v2_includes_delivery_pipeline_status_when_bridge_reports_it() {
+    let store = MessagesStore::in_memory().expect("in-memory store");
+    let daemon = RpcDaemon::with_store_and_bridges(
+        store,
+        "pipeline-status-node".to_string(),
+        Some(Arc::new(PipelineStatusBridge)),
+        None,
+    );
+
+    let status = daemon
+        .handle_rpc(rpc_request(
+            12,
+            "sdk_status_v2",
+            json!({ "message_id": "pipeline-status-missing" }),
+        ))
+        .expect("status");
+    let result = status.result.expect("result");
+
+    assert_eq!(result["delivery_pipeline"]["queued_total"], json!(3));
+    assert_eq!(result["delivery_pipeline"]["in_flight_total"], json!(1));
+    assert_eq!(result["delivery_pipeline"]["rejected_queue_full_total"], json!(0));
+}
+
+#[test]
 fn bridge_backed_send_schedules_without_waiting_on_slow_delivery() {
     let store = MessagesStore::in_memory().expect("in-memory store");
     let (started_tx, started_rx) = std_mpsc::channel();
@@ -219,6 +287,46 @@ fn bridge_backed_send_schedules_without_waiting_on_slow_delivery() {
     );
 
     release_tx.send(()).expect("release slow bridge");
+}
+
+#[test]
+fn outbound_delivery_worker_uses_bounded_parallel_lanes() {
+    let store = MessagesStore::in_memory().expect("in-memory store");
+    let (started_tx, started_rx) = std_mpsc::channel();
+    let (release_tx, release_rx) = std_mpsc::channel();
+    let daemon = RpcDaemon::with_store_and_bridges(
+        store,
+        "parallel-bridge-node".to_string(),
+        Some(Arc::new(BlockingOutboundBridge::new(started_tx, release_rx))),
+        None,
+    );
+
+    for index in 0..2 {
+        let response = daemon
+            .handle_rpc(rpc_request(
+                20 + index,
+                "send_message_v2",
+                json!({
+                    "id": format!("parallel-bridge-{index}"),
+                    "source": "src",
+                    "destination": "dst",
+                    "title": "",
+                    "content": "hello"
+                }),
+            ))
+            .expect("send");
+        assert!(response.error.is_none());
+    }
+
+    let first =
+        started_rx.recv_timeout(StdDuration::from_secs(1)).expect("first delivery should start");
+    let second = started_rx
+        .recv_timeout(StdDuration::from_secs(1))
+        .expect("second delivery should start before first is released");
+    assert_ne!(first, second);
+
+    release_tx.send(()).expect("release first");
+    release_tx.send(()).expect("release second");
 }
 
 #[test]

--- a/crates/libs/rns-rpc/src/rpc/mod.rs
+++ b/crates/libs/rns-rpc/src/rpc/mod.rs
@@ -19,7 +19,9 @@ use std::sync::{mpsc, Arc, Mutex};
 use tokio::sync::broadcast;
 use tokio::time::Duration;
 
-use send_request::parse_outbound_send_request;
+use send_request::{
+    parse_outbound_send_batch_request, parse_outbound_send_request, NormalizedSendBatchRequest,
+};
 
 include!("types.rs");
 include!("params.rs");

--- a/crates/libs/rns-rpc/src/rpc/send_request.rs
+++ b/crates/libs/rns-rpc/src/rpc/send_request.rs
@@ -37,10 +37,57 @@ struct SendMessageV2Params {
     source_private_key: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct SendBatchV2Params {
+    batch_id: String,
+    source: String,
+    messages: Vec<SendBatchV2Item>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SendBatchV2Item {
+    id: String,
+    destination: String,
+    #[serde(default)]
+    title: String,
+    content: String,
+    fields: Option<JsonValue>,
+    #[serde(default)]
+    method: Option<String>,
+    #[serde(default)]
+    stamp_cost: Option<u32>,
+    #[serde(default)]
+    include_ticket: Option<bool>,
+    #[serde(default)]
+    try_propagation_on_fail: Option<bool>,
+    #[serde(default)]
+    source_private_key: Option<String>,
+}
+
 #[derive(Debug)]
 pub(super) struct NormalizedSendRequest {
     pub(super) id: String,
     pub(super) source: String,
+    pub(super) destination: String,
+    pub(super) title: String,
+    pub(super) content: String,
+    pub(super) fields: Option<JsonValue>,
+    pub(super) method: Option<String>,
+    pub(super) stamp_cost: Option<u32>,
+    pub(super) options: OutboundDeliveryOptions,
+    pub(super) include_ticket: Option<bool>,
+}
+
+#[derive(Debug)]
+pub(super) struct NormalizedSendBatchRequest {
+    pub(super) batch_id: String,
+    pub(super) source: String,
+    pub(super) messages: Vec<NormalizedSendBatchItem>,
+}
+
+#[derive(Debug)]
+pub(super) struct NormalizedSendBatchItem {
+    pub(super) id: String,
     pub(super) destination: String,
     pub(super) title: String,
     pub(super) content: String,
@@ -107,6 +154,44 @@ pub(super) fn parse_outbound_send_request(
             Err(Error::new(ErrorKind::InvalidInput, format!("unsupported send method '{method}'")))
         }
     }
+}
+
+pub(super) fn parse_outbound_send_batch_request(
+    params: JsonValue,
+) -> Result<NormalizedSendBatchRequest, Error> {
+    let parsed: SendBatchV2Params =
+        serde_json::from_value(params).map_err(|err| Error::new(ErrorKind::InvalidInput, err))?;
+    if parsed.messages.is_empty() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "sdk_send_batch_v2 requires at least one message",
+        ));
+    }
+    let mut messages = Vec::with_capacity(parsed.messages.len());
+    for item in parsed.messages {
+        validate_outbound_fields_strict(item.fields.as_ref())?;
+        let outbound_method = item.method.clone();
+        let include_ticket = item.include_ticket;
+        messages.push(NormalizedSendBatchItem {
+            id: item.id,
+            destination: item.destination,
+            title: item.title,
+            content: item.content,
+            fields: item.fields,
+            method: outbound_method.clone(),
+            stamp_cost: item.stamp_cost,
+            options: OutboundDeliveryOptions {
+                method: outbound_method,
+                stamp_cost: item.stamp_cost,
+                include_ticket: include_ticket.unwrap_or_default(),
+                try_propagation_on_fail: item.try_propagation_on_fail.unwrap_or_default(),
+                ticket: None,
+                source_private_key: item.source_private_key,
+            },
+            include_ticket,
+        });
+    }
+    Ok(NormalizedSendBatchRequest { batch_id: parsed.batch_id, source: parsed.source, messages })
 }
 
 fn validate_outbound_fields_strict(fields: Option<&JsonValue>) -> Result<(), Error> {

--- a/crates/libs/rns-rpc/src/rpc/types.rs
+++ b/crates/libs/rns-rpc/src/rpc/types.rs
@@ -477,6 +477,10 @@ pub trait OutboundBridge: Send + Sync {
     fn decode_paper_uri(&self, _uri: &str) -> Result<Option<PaperDecodeOutcome>, std::io::Error> {
         Ok(None)
     }
+
+    fn delivery_pipeline_status(&self) -> Option<JsonValue> {
+        None
+    }
 }
 
 pub trait AnnounceBridge: Send + Sync {

--- a/crates/libs/rns-transport/src/transport/announce.rs
+++ b/crates/libs/rns-transport/src/transport/announce.rs
@@ -78,9 +78,9 @@ async fn process_announce<'a>(
     let interface = route_iface.as_slice().to_vec();
 
     eprintln!(
-        "[announce-debug] accepted dst={} app_data={}",
+        "[announce-debug] accepted dst={} app_data_hex={}",
         packet.destination,
-        String::from_utf8_lossy(announce.app_data)
+        hex::encode(announce.app_data)
     );
 
     let _ = handler.announce_tx.send(AnnounceEvent {

--- a/crates/libs/test-support/src/sdk_schema/mod.rs
+++ b/crates/libs/test-support/src/sdk_schema/mod.rs
@@ -130,6 +130,7 @@ struct SchemaSet {
 struct RpcCoreSchemaSet {
     sdk_negotiate_v2: JSONSchema,
     sdk_send_v2: JSONSchema,
+    sdk_send_batch_v2: JSONSchema,
     sdk_status_v2: JSONSchema,
     sdk_configure_v2: JSONSchema,
     sdk_poll_events_v2: JSONSchema,
@@ -141,6 +142,7 @@ struct RpcCoreSchemaSet {
 struct OpenRpcCoreSchemaSet {
     sdk_negotiate_v2: JSONSchema,
     sdk_send_v2: JSONSchema,
+    sdk_send_batch_v2: JSONSchema,
     sdk_status_v2: JSONSchema,
     sdk_configure_v2: JSONSchema,
     sdk_poll_events_v2: JSONSchema,
@@ -198,6 +200,7 @@ fn load_rpc_core_schemas() -> RpcCoreSchemaSet {
 
     let sdk_negotiate_v2 = read_json(&schema_dir.join("sdk_negotiate_v2.schema.json"));
     let sdk_send_v2 = read_json(&schema_dir.join("sdk_send_v2.schema.json"));
+    let sdk_send_batch_v2 = read_json(&schema_dir.join("sdk_send_batch_v2.schema.json"));
     let sdk_status_v2 = read_json(&schema_dir.join("sdk_status_v2.schema.json"));
     let sdk_configure_v2 = read_json(&schema_dir.join("sdk_configure_v2.schema.json"));
     let sdk_poll_events_v2 = read_json(&schema_dir.join("sdk_poll_events_v2.schema.json"));
@@ -208,6 +211,7 @@ fn load_rpc_core_schemas() -> RpcCoreSchemaSet {
     RpcCoreSchemaSet {
         sdk_negotiate_v2: compile_schema(&sdk_negotiate_v2, "rpc/sdk_negotiate_v2"),
         sdk_send_v2: compile_schema(&sdk_send_v2, "rpc/sdk_send_v2"),
+        sdk_send_batch_v2: compile_schema(&sdk_send_batch_v2, "rpc/sdk_send_batch_v2"),
         sdk_status_v2: compile_schema(&sdk_status_v2, "rpc/sdk_status_v2"),
         sdk_configure_v2: compile_schema(&sdk_configure_v2, "rpc/sdk_configure_v2"),
         sdk_poll_events_v2: compile_schema(&sdk_poll_events_v2, "rpc/sdk_poll_events_v2"),
@@ -305,6 +309,10 @@ fn load_openrpc_core_schemas() -> OpenRpcCoreSchemaSet {
             &openrpc_component_schema(&document, "SdkSendV2Envelope"),
             "openrpc/SdkSendV2Envelope",
         ),
+        sdk_send_batch_v2: compile_schema(
+            &openrpc_component_schema(&document, "SdkSendBatchV2Envelope"),
+            "openrpc/SdkSendBatchV2Envelope",
+        ),
         sdk_status_v2: compile_schema(
             &openrpc_component_schema(&document, "SdkStatusV2Envelope"),
             "openrpc/SdkStatusV2Envelope",
@@ -400,6 +408,7 @@ fn validate_openrpc_document(document: &JsonValue) {
     let expected_core_methods = [
         "sdk_negotiate_v2",
         "sdk_send_v2",
+        "sdk_send_batch_v2",
         "sdk_status_v2",
         "sdk_configure_v2",
         "sdk_poll_events_v2",
@@ -445,6 +454,7 @@ fn validate_openrpc_document(document: &JsonValue) {
     for name in [
         "SdkNegotiateV2Envelope",
         "SdkSendV2Envelope",
+        "SdkSendBatchV2Envelope",
         "SdkStatusV2Envelope",
         "SdkConfigureV2Envelope",
         "SdkPollEventsV2Envelope",

--- a/crates/libs/test-support/src/sdk_schema/rpc_core_tests.rs
+++ b/crates/libs/test-support/src/sdk_schema/rpc_core_tests.rs
@@ -46,6 +46,26 @@ fn sdk_rpc_core_schema_valid_fixtures_pass_contract_checks() {
         &fixture("docs/fixtures/sdk-v2/rpc/sdk_send_v2.response.valid.json"),
     );
     assert_schema_valid(
+        &schemas.sdk_send_batch_v2,
+        "docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.valid.json",
+        &fixture("docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.valid.json"),
+    );
+    assert_schema_valid(
+        &openrpc_schemas.sdk_send_batch_v2,
+        "docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.valid.json",
+        &fixture("docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.valid.json"),
+    );
+    assert_schema_valid(
+        &schemas.sdk_send_batch_v2,
+        "docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.response.valid.json",
+        &fixture("docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.response.valid.json"),
+    );
+    assert_schema_valid(
+        &openrpc_schemas.sdk_send_batch_v2,
+        "docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.response.valid.json",
+        &fixture("docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.response.valid.json"),
+    );
+    assert_schema_valid(
         &schemas.sdk_status_v2,
         "docs/fixtures/sdk-v2/rpc/sdk_status_v2.request.valid.json",
         &fixture("docs/fixtures/sdk-v2/rpc/sdk_status_v2.request.valid.json"),
@@ -191,6 +211,16 @@ fn sdk_rpc_core_schema_invalid_fixtures_are_rejected() {
         &openrpc_schemas.sdk_send_v2,
         "docs/fixtures/sdk-v2/rpc/sdk_send_v2.request.invalid.json",
         &fixture("docs/fixtures/sdk-v2/rpc/sdk_send_v2.request.invalid.json"),
+    );
+    assert_schema_invalid(
+        &schemas.sdk_send_batch_v2,
+        "docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.invalid.json",
+        &fixture("docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.invalid.json"),
+    );
+    assert_schema_invalid(
+        &openrpc_schemas.sdk_send_batch_v2,
+        "docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.invalid.json",
+        &fixture("docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.invalid.json"),
     );
     assert_schema_invalid(
         &schemas.sdk_status_v2,

--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -1412,6 +1412,21 @@
       "sha256": "f95fbdb4378ddf3a2c981253396b44da0b0c7d5cbbbc9ec7a4e8587c2bfa0cb4"
     },
     {
+      "path": "docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.invalid.json",
+      "bytes": 134,
+      "sha256": "dee63650c15cfb918f4ef5938aa0f1df43b04b2fcd5f6d317599a33f7f776d1c"
+    },
+    {
+      "path": "docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.valid.json",
+      "bytes": 514,
+      "sha256": "d18c489babc9294f174f5cb5e6b74282e7c5e9dc7591fbba7b15f43e0c7e3749"
+    },
+    {
+      "path": "docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.response.valid.json",
+      "bytes": 349,
+      "sha256": "8443d08c7c931f4b7d2836975523c15b117633e09d135fa293d42bcfc2acbb58"
+    },
+    {
       "path": "docs/fixtures/sdk-v2/rpc/sdk_send_v2.request.invalid.json",
       "bytes": 147,
       "sha256": "8c53c9de7817ff74acd0166b62fd3baedfc7dc653dc8492941e83565c4f1ba3b"
@@ -1518,8 +1533,8 @@
     },
     {
       "path": "docs/schemas/sdk/v2/clients/smoke-requests.json",
-      "bytes": 1814,
-      "sha256": "1e0cda69fc5548b8b0fb95f8f011ab6efd07e87f0a7227123f37f868c92526d6"
+      "bytes": 2151,
+      "sha256": "8792f0679b06ceb992c60812cc2a4cacc4ab899ab9071b3572d057acb55a3574"
     },
     {
       "path": "docs/schemas/sdk/v2/command-plugin.schema.json",
@@ -1590,6 +1605,11 @@
       "path": "docs/schemas/sdk/v2/rpc/sdk_release_c_methods.schema.json",
       "bytes": 16326,
       "sha256": "2b09ff3873499692277dcba0588b143b047aa30159b45a9cf8a2dfe5f5f5b556"
+    },
+    {
+      "path": "docs/schemas/sdk/v2/rpc/sdk_send_batch_v2.schema.json",
+      "bytes": 5365,
+      "sha256": "67f4052fd719ec38e43b1360265f6ea6eb19fa50575e63c0bfdd59b1596806c8"
     },
     {
       "path": "docs/schemas/sdk/v2/rpc/sdk_send_v2.schema.json",

--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -8,8 +8,8 @@
     },
     {
       "path": "docs/contracts/baselines/lxmf-sdk-public-api.txt",
-      "bytes": 242441,
-      "sha256": "4b37a4bb332017d9d91fc0333011ddcaba77e2e1866111feaafbb6baf81a8895"
+      "bytes": 243872,
+      "sha256": "47ac80f9a38c0df34fcbb034abf763e89f4eb8cd5ad911ecd2175f755d829042"
     },
     {
       "path": "docs/contracts/baselines/schema-client-generation-baseline.json",
@@ -1393,8 +1393,8 @@
     },
     {
       "path": "docs/fixtures/sdk-v2/rpc/sdk_negotiate_v2.response.valid.json",
-      "bytes": 284,
-      "sha256": "8fee757a4e27e3f25aba1a79b500a2df96635ddd559002e096b0925b408bb575"
+      "bytes": 973,
+      "sha256": "de5eaab3b747560588009045d4dc7277622f956b4388f830fcc1134c63bb3dbc"
     },
     {
       "path": "docs/fixtures/sdk-v2/rpc/sdk_poll_events_v2.request.invalid.json",
@@ -1453,8 +1453,8 @@
     },
     {
       "path": "docs/fixtures/sdk-v2/rpc/sdk_snapshot_v2.response.valid.json",
-      "bytes": 328,
-      "sha256": "79968ba49f07110e3ed3eb70504b11c783ebb46fad3d0b6ae71760083c6f6376"
+      "bytes": 735,
+      "sha256": "f132da1b0e974b9ce1135227beddfbdcc5b52d31a17122648d7504e7518ab1aa"
     },
     {
       "path": "docs/fixtures/sdk-v2/rpc/sdk_status_v2.request.invalid.json",
@@ -1468,8 +1468,8 @@
     },
     {
       "path": "docs/fixtures/sdk-v2/rpc/sdk_status_v2.response.valid.json",
-      "bytes": 108,
-      "sha256": "f3973cc465e6fd646e982cc9a88d37d14fdb62838be2ee64607fdebee5ece6ac"
+      "bytes": 515,
+      "sha256": "51fd83d6a4c4ea7ba6f3734f32f1ee3a5141bc98c79725c46b734df924a341ba"
     },
     {
       "path": "docs/fixtures/sdk-v2/telemetry.point.valid.json",
@@ -1573,8 +1573,8 @@
     },
     {
       "path": "docs/schemas/sdk/v2/rpc/sdk_negotiate_v2.schema.json",
-      "bytes": 5100,
-      "sha256": "513234a47c8b692f1275c7d82d1f3bee4d91cab6301c664520ff55b461906ffd"
+      "bytes": 6543,
+      "sha256": "309b6dbf5e553a5b90c6fe5b4c532bfee06def53a1e31af30e787f3ab4833da0"
     },
     {
       "path": "docs/schemas/sdk/v2/rpc/sdk_poll_events_v2.schema.json",
@@ -1603,13 +1603,13 @@
     },
     {
       "path": "docs/schemas/sdk/v2/rpc/sdk_snapshot_v2.schema.json",
-      "bytes": 4164,
-      "sha256": "f3314d3b584aba3d326498c401c96f1900ced64e4f2aea29c779e18ecd2bde31"
+      "bytes": 5381,
+      "sha256": "06cac91ff1fede79302769ba3043e7f1a5f8907522a00e5d66a79d78eb0606cb"
     },
     {
       "path": "docs/schemas/sdk/v2/rpc/sdk_status_v2.schema.json",
-      "bytes": 3103,
-      "sha256": "0ded28a3bdfc9e78ce5d93326d10f61e1837586aa5f0844166662dbc077700df"
+      "bytes": 4320,
+      "sha256": "d7d4ddd7eec9cdcf573ac541cd450efbd03dcf1ff1d68a0a2c82cc507b7b168f"
     },
     {
       "path": "docs/schemas/sdk/v2/telemetry.schema.json",

--- a/docs/contracts/baselines/lxmf-sdk-public-api.txt
+++ b/docs/contracts/baselines/lxmf-sdk-public-api.txt
@@ -595,8 +595,16 @@ pub lxmf_sdk::capability::NegotiationResponse::active_contract_version: u16
 pub lxmf_sdk::capability::NegotiationResponse::contract_release: alloc::string::String
 pub lxmf_sdk::capability::NegotiationResponse::effective_capabilities: alloc::vec::Vec<alloc::string::String>
 pub lxmf_sdk::capability::NegotiationResponse::effective_limits: lxmf_sdk::capability::EffectiveLimits
+pub lxmf_sdk::capability::NegotiationResponse::python_reference: lxmf_sdk::capability::ParityReference
 pub lxmf_sdk::capability::NegotiationResponse::runtime_id: alloc::string::String
 pub lxmf_sdk::capability::NegotiationResponse::schema_namespace: alloc::string::String
+pub lxmf_sdk::capability::NegotiationResponse::sdk_version: alloc::string::String
+#[non_exhaustive] pub struct lxmf_sdk::capability::ParityReference
+pub lxmf_sdk::capability::ParityReference::python_lxmf_ref: alloc::string::String
+pub lxmf_sdk::capability::ParityReference::python_reticulum_ref: alloc::string::String
+pub lxmf_sdk::capability::ParityReference::reticulum_conformance_ref: alloc::string::String
+impl core::default::Default for lxmf_sdk::capability::ParityReference
+pub fn lxmf_sdk::capability::ParityReference::default() -> Self
 #[non_exhaustive] pub struct lxmf_sdk::capability::PluginDescriptor
 pub lxmf_sdk::capability::PluginDescriptor::optional_capabilities: alloc::vec::Vec<alloc::string::String>
 pub lxmf_sdk::capability::PluginDescriptor::plugin_id: alloc::string::String
@@ -2050,8 +2058,16 @@ pub lxmf_sdk::NegotiationResponse::active_contract_version: u16
 pub lxmf_sdk::NegotiationResponse::contract_release: alloc::string::String
 pub lxmf_sdk::NegotiationResponse::effective_capabilities: alloc::vec::Vec<alloc::string::String>
 pub lxmf_sdk::NegotiationResponse::effective_limits: lxmf_sdk::capability::EffectiveLimits
+pub lxmf_sdk::NegotiationResponse::python_reference: lxmf_sdk::capability::ParityReference
 pub lxmf_sdk::NegotiationResponse::runtime_id: alloc::string::String
 pub lxmf_sdk::NegotiationResponse::schema_namespace: alloc::string::String
+pub lxmf_sdk::NegotiationResponse::sdk_version: alloc::string::String
+#[non_exhaustive] pub struct lxmf_sdk::ParityReference
+pub lxmf_sdk::ParityReference::python_lxmf_ref: alloc::string::String
+pub lxmf_sdk::ParityReference::python_reticulum_ref: alloc::string::String
+pub lxmf_sdk::ParityReference::reticulum_conformance_ref: alloc::string::String
+impl core::default::Default for lxmf_sdk::capability::ParityReference
+pub fn lxmf_sdk::capability::ParityReference::default() -> Self
 pub struct lxmf_sdk::PaperMessageEnvelope
 pub lxmf_sdk::PaperMessageEnvelope::destination_hint: core::option::Option<alloc::string::String>
 pub lxmf_sdk::PaperMessageEnvelope::extensions: alloc::collections::btree::map::BTreeMap<alloc::string::String, serde_json::value::Value>
@@ -2392,7 +2408,11 @@ pub lxmf_sdk::VoiceSessionUpdateRequest::extensions: alloc::collections::btree::
 pub lxmf_sdk::VoiceSessionUpdateRequest::session_id: lxmf_sdk::domain::VoiceSessionId
 pub lxmf_sdk::VoiceSessionUpdateRequest::state: lxmf_sdk::domain::VoiceSessionState
 pub const lxmf_sdk::CONTRACT_RELEASE: &str
+pub const lxmf_sdk::PYTHON_LXMF_REFERENCE_REF: &str
+pub const lxmf_sdk::PYTHON_RETICULUM_REFERENCE_REF: &str
+pub const lxmf_sdk::RETICULUM_CONFORMANCE_REFERENCE_REF: &str
 pub const lxmf_sdk::SCHEMA_NAMESPACE: &str
+pub const lxmf_sdk::SDK_VERSION: &str
 pub trait lxmf_sdk::LxmfSdk
 pub fn lxmf_sdk::LxmfSdk::cancel(&self, id: lxmf_sdk::MessageId) -> core::result::Result<lxmf_sdk::CancelResult, lxmf_sdk::SdkError>
 pub fn lxmf_sdk::LxmfSdk::configure(&self, expected_revision: u64, patch: lxmf_sdk::ConfigPatch) -> core::result::Result<lxmf_sdk::Ack, lxmf_sdk::SdkError>

--- a/docs/fixtures/sdk-v2/rpc/sdk_negotiate_v2.response.valid.json
+++ b/docs/fixtures/sdk-v2/rpc/sdk_negotiate_v2.response.valid.json
@@ -8,6 +8,23 @@
       "max_poll_events": 256
     },
     "contract_release": "v2.5",
-    "schema_namespace": "v2"
+    "schema_namespace": "v2",
+    "sdk_version": "0.2.1",
+    "python_reference": {
+      "reticulum_conformance_ref": "0319444b20e0815f26c6b9ceeba8fa44de037c9b",
+      "python_reticulum_ref": "15320e4d2cfabb143c1db20ca887e275fd521585",
+      "python_lxmf_ref": "727830cefda83d9c6e3982b48675425f3f988f9c"
+    },
+    "meta": {
+      "contract_version": "v2",
+      "profile": "desktop-full",
+      "sdk_version": "0.2.1",
+      "python_reference": {
+        "reticulum_conformance_ref": "0319444b20e0815f26c6b9ceeba8fa44de037c9b",
+        "python_reticulum_ref": "15320e4d2cfabb143c1db20ca887e275fd521585",
+        "python_lxmf_ref": "727830cefda83d9c6e3982b48675425f3f988f9c"
+      },
+      "rpc_endpoint": null
+    }
   }
 }

--- a/docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.invalid.json
+++ b/docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.invalid.json
@@ -1,0 +1,9 @@
+{
+  "id": 22,
+  "method": "sdk_send_batch_v2",
+  "params": {
+    "batch_id": "batch-1",
+    "source": "src",
+    "messages": []
+  }
+}

--- a/docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.valid.json
+++ b/docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.request.valid.json
@@ -1,0 +1,25 @@
+{
+  "id": 22,
+  "method": "sdk_send_batch_v2",
+  "params": {
+    "batch_id": "batch-1",
+    "source": "src",
+    "messages": [
+      {
+        "id": "batch-msg-1",
+        "destination": "dst-a",
+        "title": "hello a",
+        "content": "payload a"
+      },
+      {
+        "id": "batch-msg-2",
+        "destination": "dst-b",
+        "title": "hello b",
+        "content": "payload b",
+        "method": "direct",
+        "include_ticket": false,
+        "try_propagation_on_fail": true
+      }
+    ]
+  }
+}

--- a/docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.response.valid.json
+++ b/docs/fixtures/sdk-v2/rpc/sdk_send_batch_v2.response.valid.json
@@ -1,0 +1,20 @@
+{
+  "id": 22,
+  "result": {
+    "batch_id": "batch-1",
+    "accepted_count": 2,
+    "rejected_count": 0,
+    "results": [
+      {
+        "id": "batch-msg-1",
+        "message_id": "batch-msg-1",
+        "accepted": true
+      },
+      {
+        "id": "batch-msg-2",
+        "message_id": "batch-msg-2",
+        "accepted": true
+      }
+    ]
+  }
+}

--- a/docs/fixtures/sdk-v2/rpc/sdk_snapshot_v2.response.valid.json
+++ b/docs/fixtures/sdk-v2/rpc/sdk_snapshot_v2.response.valid.json
@@ -10,6 +10,17 @@
     "effective_capabilities": [],
     "queued_messages": 0,
     "in_flight_messages": 0,
-    "counts_included": true
+    "counts_included": true,
+    "meta": {
+      "contract_version": "v2",
+      "profile": "desktop-full",
+      "sdk_version": "0.2.1",
+      "python_reference": {
+        "reticulum_conformance_ref": "0319444b20e0815f26c6b9ceeba8fa44de037c9b",
+        "python_reticulum_ref": "15320e4d2cfabb143c1db20ca887e275fd521585",
+        "python_lxmf_ref": "727830cefda83d9c6e3982b48675425f3f988f9c"
+      },
+      "rpc_endpoint": null
+    }
   }
 }

--- a/docs/fixtures/sdk-v2/rpc/sdk_status_v2.response.valid.json
+++ b/docs/fixtures/sdk-v2/rpc/sdk_status_v2.response.valid.json
@@ -4,6 +4,17 @@
     "message": {
       "id": "msg-1",
       "receipt_status": "sent"
+    },
+    "meta": {
+      "contract_version": "v2",
+      "profile": "desktop-full",
+      "sdk_version": "0.2.1",
+      "python_reference": {
+        "reticulum_conformance_ref": "0319444b20e0815f26c6b9ceeba8fa44de037c9b",
+        "python_reticulum_ref": "15320e4d2cfabb143c1db20ca887e275fd521585",
+        "python_lxmf_ref": "727830cefda83d9c6e3982b48675425f3f988f9c"
+      },
+      "rpc_endpoint": null
     }
   }
 }

--- a/docs/openrpc/sdk-v2.openrpc.json
+++ b/docs/openrpc/sdk-v2.openrpc.json
@@ -813,6 +813,57 @@
           }
         }
       },
+      "PythonReference": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "reticulum_conformance_ref",
+          "python_reticulum_ref",
+          "python_lxmf_ref"
+        ],
+        "properties": {
+          "reticulum_conformance_ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "python_reticulum_ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "python_lxmf_ref": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "ResponseMeta": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "contract_version": {
+            "type": "string",
+            "minLength": 1
+          },
+          "profile": {
+            "type": "string",
+            "minLength": 1
+          },
+          "rpc_endpoint": {
+            "type": [
+              "object",
+              "string",
+              "null"
+            ]
+          },
+          "python_reference": {
+            "$ref": "#/components/schemas/PythonReference"
+          },
+          "sdk_version": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
       "SdkNegotiateV2Params": {
         "type": "object",
         "additionalProperties": true,
@@ -889,7 +940,9 @@
           "effective_capabilities",
           "effective_limits",
           "contract_release",
-          "schema_namespace"
+          "schema_namespace",
+          "python_reference",
+          "sdk_version"
         ],
         "properties": {
           "runtime_id": {
@@ -916,6 +969,16 @@
             "minLength": 1
           },
           "schema_namespace": {
+            "type": "string",
+            "minLength": 1
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
+          },
+          "python_reference": {
+            "$ref": "#/components/schemas/PythonReference"
+          },
+          "sdk_version": {
             "type": "string",
             "minLength": 1
           }
@@ -1153,6 +1216,9 @@
               "null"
             ],
             "additionalProperties": true
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
           }
         }
       },
@@ -1598,6 +1664,9 @@
           },
           "counts_included": {
             "type": "boolean"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
           }
         }
       },

--- a/docs/openrpc/sdk-v2.openrpc.json
+++ b/docs/openrpc/sdk-v2.openrpc.json
@@ -45,6 +45,25 @@
       }
     },
     {
+      "name": "sdk_send_batch_v2",
+      "summary": "Queue a batch of outbound messages for delivery.",
+      "params": [
+        {
+          "name": "params",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SdkSendBatchV2Params"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "$ref": "#/components/schemas/SdkSendBatchV2Result"
+        }
+      }
+    },
+    {
       "name": "sdk_status_v2",
       "summary": "Read the status for a message.",
       "params": [
@@ -1187,6 +1206,209 @@
           },
           {
             "$ref": "#/components/schemas/SdkSendV2ResponseErrorEnvelope"
+          }
+        ]
+      },
+      "SdkSendBatchV2Message": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "destination",
+          "content"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "destination": {
+            "type": "string",
+            "minLength": 1
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string",
+            "minLength": 1
+          },
+          "fields": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true
+          },
+          "method": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "stamp_cost": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "include_ticket": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "try_propagation_on_fail": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      "SdkSendBatchV2Params": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "batch_id",
+          "source",
+          "messages"
+        ],
+        "properties": {
+          "batch_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1
+          },
+          "messages": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/SdkSendBatchV2Message"
+            }
+          }
+        }
+      },
+      "SdkSendBatchV2ResultItem": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "accepted"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "message_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "accepted": {
+            "type": "boolean"
+          },
+          "error": {
+            "$ref": "#/components/schemas/RpcError"
+          }
+        }
+      },
+      "SdkSendBatchV2Result": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "batch_id",
+          "accepted_count",
+          "rejected_count",
+          "results"
+        ],
+        "properties": {
+          "batch_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "accepted_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "rejected_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SdkSendBatchV2ResultItem"
+            }
+          }
+        }
+      },
+      "SdkSendBatchV2RequestEnvelope": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "method",
+          "params"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RpcId"
+          },
+          "method": {
+            "const": "sdk_send_batch_v2"
+          },
+          "params": {
+            "$ref": "#/components/schemas/SdkSendBatchV2Params"
+          }
+        }
+      },
+      "SdkSendBatchV2ResponseOkEnvelope": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "result"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RpcId"
+          },
+          "result": {
+            "$ref": "#/components/schemas/SdkSendBatchV2Result"
+          }
+        }
+      },
+      "SdkSendBatchV2ResponseErrorEnvelope": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "error"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RpcId"
+          },
+          "error": {
+            "$ref": "#/components/schemas/RpcError"
+          }
+        }
+      },
+      "SdkSendBatchV2Envelope": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SdkSendBatchV2RequestEnvelope"
+          },
+          {
+            "$ref": "#/components/schemas/SdkSendBatchV2ResponseOkEnvelope"
+          },
+          {
+            "$ref": "#/components/schemas/SdkSendBatchV2ResponseErrorEnvelope"
           }
         ]
       },

--- a/docs/runbooks/queue-pressure-tuning.md
+++ b/docs/runbooks/queue-pressure-tuning.md
@@ -9,8 +9,29 @@ This runbook defines queue defaults, overflow behavior, and production tuning st
 | Legacy event queue (`event_queue`) | `32` events | hard cap in daemon push path |
 | SDK sequenced event log (`sdk_event_log`) | `1024` events | hard cap in daemon push path |
 | Broadcast channel (`events`) | `64` events | Tokio broadcast channel capacity |
+| Outbound delivery scheduler | `LXMD_DELIVERY_QUEUE_CAPACITY`, default `16384` messages | semaphore-backed admission bound in `reticulumd` |
 
 These queues are intentionally bounded and must never grow unbounded in-process.
+
+## Outbound delivery scheduler
+
+`reticulumd` accepts `sdk_send_v2` into a persistent delivery scheduler instead
+of spawning a new OS thread and Tokio runtime for each message. Direct delivery
+reuses an active per-peer link and defaults to ordered one-at-a-time delivery per
+destination while still allowing concurrency across destinations.
+
+Tune with environment variables before starting `reticulumd`:
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `LXMD_DELIVERY_QUEUE_CAPACITY` | `16384` | Maximum accepted delivery work retained in the daemon |
+| `LXMD_DELIVERY_GLOBAL_CONCURRENCY` | `32` | Maximum delivery tasks actively sending at once |
+| `LXMD_DELIVERY_PER_PEER_IN_FLIGHT` | `1` | Maximum active delivery tasks for one destination |
+
+Inspect `delivery_pipeline` in `daemon_status_ex`, `sdk_snapshot_v2`, or
+`sdk_status_v2` for `queued_total`, `queued_by_peer`, `in_flight_total`,
+`in_flight_by_peer`, `accepted_total`, `completed_total`, and
+`rejected_queue_full_total`.
 
 ## Overflow policy semantics
 

--- a/docs/runbooks/release-readiness.md
+++ b/docs/runbooks/release-readiness.md
@@ -67,6 +67,15 @@ reference compatibility. It runs:
 - ignored live Rust/Python channel, paper, compatibility-matrix, and LXMD
   remote-relay interop tests with the pinned checkouts.
 
+The SDK reports the parity checkpoint as its crate version plus the pinned
+reference revisions from `.github/workflows/python-interop.yml`: Reticulum
+conformance `0319444b20e0815f26c6b9ceeba8fa44de037c9b`, Python Reticulum
+`15320e4d2cfabb143c1db20ca887e275fd521585`, and Python LXMF
+`727830cefda83d9c6e3982b48675425f3f988f9c`. The latest GitHub metadata checked
+on 2026-05-29 showed the newest `Python reference interop` run failing on
+`switch_to_tracing`, with the latest successful run on 2026-05-28 for
+`udp-multicast`; do not encode transient run IDs in runtime SDK responses.
+
 The commands below remain useful release checks, but they are not currently
 enforced by pull-request CI unless and until `.github/workflows/ci.yml` is
 expanded.

--- a/docs/schemas/sdk/v2/clients/smoke-requests.json
+++ b/docs/schemas/sdk/v2/clients/smoke-requests.json
@@ -34,6 +34,21 @@
       }
     },
     {
+      "language": "javascript",
+      "method": "sdk_send_batch_v2",
+      "request": {
+        "batch_id": "batch-1",
+        "source": "source-a",
+        "messages": [
+          {
+            "id": "msg-id-2",
+            "destination": "destination-b",
+            "content": "hello batch"
+          }
+        ]
+      }
+    },
+    {
       "language": "python",
       "method": "sdk_snapshot_v2",
       "request": {

--- a/docs/schemas/sdk/v2/rpc/sdk_negotiate_v2.schema.json
+++ b/docs/schemas/sdk/v2/rpc/sdk_negotiate_v2.schema.json
@@ -119,6 +119,57 @@
       ],
       "type": "object"
     },
+    "python_reference": {
+      "additionalProperties": false,
+      "properties": {
+        "python_lxmf_ref": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "python_reticulum_ref": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "reticulum_conformance_ref": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "python_lxmf_ref",
+        "python_reticulum_ref",
+        "reticulum_conformance_ref"
+      ],
+      "type": "object"
+    },
+    "response_meta": {
+      "additionalProperties": true,
+      "properties": {
+        "contract_version": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "profile": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "python_reference": {
+          "$ref": "#/$defs/python_reference"
+        },
+        "rpc_endpoint": {
+          "type": [
+            "object",
+            "string",
+            "null"
+          ]
+        },
+        "sdk_version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "result": {
       "additionalProperties": true,
       "properties": {
@@ -141,11 +192,21 @@
           "additionalProperties": true,
           "type": "object"
         },
+        "meta": {
+          "$ref": "#/$defs/response_meta"
+        },
+        "python_reference": {
+          "$ref": "#/$defs/python_reference"
+        },
         "runtime_id": {
           "minLength": 1,
           "type": "string"
         },
         "schema_namespace": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "sdk_version": {
           "minLength": 1,
           "type": "string"
         }
@@ -155,8 +216,10 @@
         "contract_release",
         "effective_capabilities",
         "effective_limits",
+        "python_reference",
         "runtime_id",
-        "schema_namespace"
+        "schema_namespace",
+        "sdk_version"
       ],
       "type": "object"
     },

--- a/docs/schemas/sdk/v2/rpc/sdk_negotiate_v2.schema.json
+++ b/docs/schemas/sdk/v2/rpc/sdk_negotiate_v2.schema.json
@@ -67,6 +67,29 @@
       ],
       "type": "object"
     },
+    "python_reference": {
+      "additionalProperties": false,
+      "properties": {
+        "python_lxmf_ref": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "python_reticulum_ref": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "reticulum_conformance_ref": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "python_lxmf_ref",
+        "python_reticulum_ref",
+        "reticulum_conformance_ref"
+      ],
+      "type": "object"
+    },
     "request": {
       "additionalProperties": false,
       "properties": {
@@ -103,45 +126,6 @@
       ],
       "type": "object"
     },
-    "response_ok": {
-      "additionalProperties": false,
-      "properties": {
-        "id": {
-          "$ref": "#/$defs/rpc_id"
-        },
-        "result": {
-          "$ref": "#/$defs/result"
-        }
-      },
-      "required": [
-        "id",
-        "result"
-      ],
-      "type": "object"
-    },
-    "python_reference": {
-      "additionalProperties": false,
-      "properties": {
-        "python_lxmf_ref": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "python_reticulum_ref": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "reticulum_conformance_ref": {
-          "minLength": 1,
-          "type": "string"
-        }
-      },
-      "required": [
-        "python_lxmf_ref",
-        "python_reticulum_ref",
-        "reticulum_conformance_ref"
-      ],
-      "type": "object"
-    },
     "response_meta": {
       "additionalProperties": true,
       "properties": {
@@ -168,6 +152,22 @@
           "type": "string"
         }
       },
+      "type": "object"
+    },
+    "response_ok": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/rpc_id"
+        },
+        "result": {
+          "$ref": "#/$defs/result"
+        }
+      },
+      "required": [
+        "id",
+        "result"
+      ],
       "type": "object"
     },
     "result": {

--- a/docs/schemas/sdk/v2/rpc/sdk_send_batch_v2.schema.json
+++ b/docs/schemas/sdk/v2/rpc/sdk_send_batch_v2.schema.json
@@ -1,63 +1,5 @@
 {
   "$defs": {
-    "message": {
-      "additionalProperties": false,
-      "properties": {
-        "content": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "destination": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "fields": {
-          "additionalProperties": true,
-          "type": [
-            "object",
-            "null"
-          ]
-        },
-        "id": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "include_ticket": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "method": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "stamp_cost": {
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "title": {
-          "type": "string"
-        },
-        "try_propagation_on_fail": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "content",
-        "destination",
-        "id"
-      ],
-      "type": "object"
-    },
     "params": {
       "additionalProperties": false,
       "properties": {
@@ -67,7 +9,7 @@
         },
         "messages": {
           "items": {
-            "$ref": "#/$defs/message"
+            "$ref": "#/$defs/send_batch_message"
           },
           "minItems": 1,
           "type": "array"
@@ -153,7 +95,7 @@
         },
         "results": {
           "items": {
-            "$ref": "#/$defs/result_item"
+            "$ref": "#/$defs/send_batch_result_item"
           },
           "type": "array"
         }
@@ -163,30 +105,6 @@
         "batch_id",
         "rejected_count",
         "results"
-      ],
-      "type": "object"
-    },
-    "result_item": {
-      "additionalProperties": false,
-      "properties": {
-        "accepted": {
-          "type": "boolean"
-        },
-        "error": {
-          "$ref": "#/$defs/rpc_error"
-        },
-        "id": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "message_id": {
-          "minLength": 1,
-          "type": "string"
-        }
-      },
-      "required": [
-        "accepted",
-        "id"
       ],
       "type": "object"
     },
@@ -245,6 +163,88 @@
           "type": "integer"
         }
       ]
+    },
+    "send_batch_message": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "destination": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "fields": {
+          "additionalProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "include_ticket": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "method": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "stamp_cost": {
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "title": {
+          "type": "string"
+        },
+        "try_propagation_on_fail": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "destination",
+        "id"
+      ],
+      "type": "object"
+    },
+    "send_batch_result_item": {
+      "additionalProperties": false,
+      "properties": {
+        "accepted": {
+          "type": "boolean"
+        },
+        "error": {
+          "$ref": "#/$defs/rpc_error"
+        },
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "message_id": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "accepted",
+        "id"
+      ],
+      "type": "object"
     }
   },
   "$id": "https://weft.tak/contracts/sdk/v2/rpc/sdk_send_batch_v2.schema.json",

--- a/docs/schemas/sdk/v2/rpc/sdk_send_batch_v2.schema.json
+++ b/docs/schemas/sdk/v2/rpc/sdk_send_batch_v2.schema.json
@@ -1,0 +1,264 @@
+{
+  "$defs": {
+    "message": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "destination": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "fields": {
+          "additionalProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "include_ticket": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "method": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "stamp_cost": {
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "title": {
+          "type": "string"
+        },
+        "try_propagation_on_fail": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "content",
+        "destination",
+        "id"
+      ],
+      "type": "object"
+    },
+    "params": {
+      "additionalProperties": false,
+      "properties": {
+        "batch_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "messages": {
+          "items": {
+            "$ref": "#/$defs/message"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "source": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "batch_id",
+        "messages",
+        "source"
+      ],
+      "type": "object"
+    },
+    "request": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/rpc_id"
+        },
+        "method": {
+          "const": "sdk_send_batch_v2"
+        },
+        "params": {
+          "$ref": "#/$defs/params"
+        }
+      },
+      "required": [
+        "id",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "response_error": {
+      "additionalProperties": false,
+      "properties": {
+        "error": {
+          "$ref": "#/$defs/rpc_error"
+        },
+        "id": {
+          "$ref": "#/$defs/rpc_id"
+        }
+      },
+      "required": [
+        "error",
+        "id"
+      ],
+      "type": "object"
+    },
+    "response_ok": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/rpc_id"
+        },
+        "result": {
+          "$ref": "#/$defs/result"
+        }
+      },
+      "required": [
+        "id",
+        "result"
+      ],
+      "type": "object"
+    },
+    "result": {
+      "additionalProperties": false,
+      "properties": {
+        "accepted_count": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "batch_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "rejected_count": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "results": {
+          "items": {
+            "$ref": "#/$defs/result_item"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "accepted_count",
+        "batch_id",
+        "rejected_count",
+        "results"
+      ],
+      "type": "object"
+    },
+    "result_item": {
+      "additionalProperties": false,
+      "properties": {
+        "accepted": {
+          "type": "boolean"
+        },
+        "error": {
+          "$ref": "#/$defs/rpc_error"
+        },
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "message_id": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "accepted",
+        "id"
+      ],
+      "type": "object"
+    },
+    "rpc_error": {
+      "additionalProperties": false,
+      "properties": {
+        "category": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "cause_code": {
+          "pattern": "^SDK_[A-Z]+_[A-Z0-9_]+$",
+          "type": "string"
+        },
+        "code": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "details": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "extensions": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "is_user_actionable": {
+          "type": "boolean"
+        },
+        "machine_code": {
+          "pattern": "^SDK_[A-Z]+_[A-Z0-9_]+$",
+          "type": "string"
+        },
+        "message": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "retryable": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "rpc_id": {
+      "oneOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "minimum": 0,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "$id": "https://weft.tak/contracts/sdk/v2/rpc/sdk_send_batch_v2.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/request"
+    },
+    {
+      "$ref": "#/$defs/response_ok"
+    },
+    {
+      "$ref": "#/$defs/response_error"
+    }
+  ],
+  "title": "LXMF SDK RPC sdk_send_batch_v2 v2"
+}

--- a/docs/schemas/sdk/v2/rpc/sdk_snapshot_v2.schema.json
+++ b/docs/schemas/sdk/v2/rpc/sdk_snapshot_v2.schema.json
@@ -64,6 +64,57 @@
       ],
       "type": "object"
     },
+    "python_reference": {
+      "additionalProperties": false,
+      "properties": {
+        "python_lxmf_ref": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "python_reticulum_ref": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "reticulum_conformance_ref": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "python_lxmf_ref",
+        "python_reticulum_ref",
+        "reticulum_conformance_ref"
+      ],
+      "type": "object"
+    },
+    "response_meta": {
+      "additionalProperties": true,
+      "properties": {
+        "contract_version": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "profile": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "python_reference": {
+          "$ref": "#/$defs/python_reference"
+        },
+        "rpc_endpoint": {
+          "type": [
+            "object",
+            "string",
+            "null"
+          ]
+        },
+        "sdk_version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "result": {
       "additionalProperties": true,
       "properties": {
@@ -92,6 +143,9 @@
         "in_flight_messages": {
           "minimum": 0,
           "type": "integer"
+        },
+        "meta": {
+          "$ref": "#/$defs/response_meta"
         },
         "profile": {
           "minLength": 1,

--- a/docs/schemas/sdk/v2/rpc/sdk_snapshot_v2.schema.json
+++ b/docs/schemas/sdk/v2/rpc/sdk_snapshot_v2.schema.json
@@ -12,6 +12,29 @@
       ],
       "type": "object"
     },
+    "python_reference": {
+      "additionalProperties": false,
+      "properties": {
+        "python_lxmf_ref": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "python_reticulum_ref": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "reticulum_conformance_ref": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "python_lxmf_ref",
+        "python_reticulum_ref",
+        "reticulum_conformance_ref"
+      ],
+      "type": "object"
+    },
     "request": {
       "additionalProperties": false,
       "properties": {
@@ -48,45 +71,6 @@
       ],
       "type": "object"
     },
-    "response_ok": {
-      "additionalProperties": false,
-      "properties": {
-        "id": {
-          "$ref": "#/$defs/rpc_id"
-        },
-        "result": {
-          "$ref": "#/$defs/result"
-        }
-      },
-      "required": [
-        "id",
-        "result"
-      ],
-      "type": "object"
-    },
-    "python_reference": {
-      "additionalProperties": false,
-      "properties": {
-        "python_lxmf_ref": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "python_reticulum_ref": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "reticulum_conformance_ref": {
-          "minLength": 1,
-          "type": "string"
-        }
-      },
-      "required": [
-        "python_lxmf_ref",
-        "python_reticulum_ref",
-        "reticulum_conformance_ref"
-      ],
-      "type": "object"
-    },
     "response_meta": {
       "additionalProperties": true,
       "properties": {
@@ -113,6 +97,22 @@
           "type": "string"
         }
       },
+      "type": "object"
+    },
+    "response_ok": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/rpc_id"
+        },
+        "result": {
+          "$ref": "#/$defs/result"
+        }
+      },
+      "required": [
+        "id",
+        "result"
+      ],
       "type": "object"
     },
     "result": {

--- a/docs/schemas/sdk/v2/rpc/sdk_status_v2.schema.json
+++ b/docs/schemas/sdk/v2/rpc/sdk_status_v2.schema.json
@@ -13,6 +13,29 @@
       ],
       "type": "object"
     },
+    "python_reference": {
+      "additionalProperties": false,
+      "properties": {
+        "python_lxmf_ref": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "python_reticulum_ref": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "reticulum_conformance_ref": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "python_lxmf_ref",
+        "python_reticulum_ref",
+        "reticulum_conformance_ref"
+      ],
+      "type": "object"
+    },
     "request": {
       "additionalProperties": false,
       "properties": {
@@ -49,45 +72,6 @@
       ],
       "type": "object"
     },
-    "response_ok": {
-      "additionalProperties": false,
-      "properties": {
-        "id": {
-          "$ref": "#/$defs/rpc_id"
-        },
-        "result": {
-          "$ref": "#/$defs/result"
-        }
-      },
-      "required": [
-        "id",
-        "result"
-      ],
-      "type": "object"
-    },
-    "python_reference": {
-      "additionalProperties": false,
-      "properties": {
-        "python_lxmf_ref": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "python_reticulum_ref": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "reticulum_conformance_ref": {
-          "minLength": 1,
-          "type": "string"
-        }
-      },
-      "required": [
-        "python_lxmf_ref",
-        "python_reticulum_ref",
-        "reticulum_conformance_ref"
-      ],
-      "type": "object"
-    },
     "response_meta": {
       "additionalProperties": true,
       "properties": {
@@ -116,18 +100,34 @@
       },
       "type": "object"
     },
+    "response_ok": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/rpc_id"
+        },
+        "result": {
+          "$ref": "#/$defs/result"
+        }
+      },
+      "required": [
+        "id",
+        "result"
+      ],
+      "type": "object"
+    },
     "result": {
       "additionalProperties": true,
       "properties": {
-        "meta": {
-          "$ref": "#/$defs/response_meta"
-        },
         "message": {
           "additionalProperties": true,
           "type": [
             "object",
             "null"
           ]
+        },
+        "meta": {
+          "$ref": "#/$defs/response_meta"
         }
       },
       "required": [

--- a/docs/schemas/sdk/v2/rpc/sdk_status_v2.schema.json
+++ b/docs/schemas/sdk/v2/rpc/sdk_status_v2.schema.json
@@ -65,9 +65,63 @@
       ],
       "type": "object"
     },
+    "python_reference": {
+      "additionalProperties": false,
+      "properties": {
+        "python_lxmf_ref": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "python_reticulum_ref": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "reticulum_conformance_ref": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "python_lxmf_ref",
+        "python_reticulum_ref",
+        "reticulum_conformance_ref"
+      ],
+      "type": "object"
+    },
+    "response_meta": {
+      "additionalProperties": true,
+      "properties": {
+        "contract_version": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "profile": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "python_reference": {
+          "$ref": "#/$defs/python_reference"
+        },
+        "rpc_endpoint": {
+          "type": [
+            "object",
+            "string",
+            "null"
+          ]
+        },
+        "sdk_version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "result": {
       "additionalProperties": true,
       "properties": {
+        "meta": {
+          "$ref": "#/$defs/response_meta"
+        },
         "message": {
           "additionalProperties": true,
           "type": [

--- a/generated/clients/spec/openapi.json
+++ b/generated/clients/spec/openapi.json
@@ -94,6 +94,29 @@
           }
         ]
       },
+      "PythonReference": {
+        "additionalProperties": false,
+        "properties": {
+          "python_lxmf_ref": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "python_reticulum_ref": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "reticulum_conformance_ref": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "python_lxmf_ref",
+          "python_reticulum_ref",
+          "reticulum_conformance_ref"
+        ],
+        "type": "object"
+      },
       "RPCError": {
         "additionalProperties": false,
         "properties": {
@@ -269,6 +292,34 @@
           "id",
           "result"
         ],
+        "type": "object"
+      },
+      "ResponseMeta": {
+        "additionalProperties": true,
+        "properties": {
+          "contract_version": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "profile": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "python_reference": {
+            "$ref": "#/components/schemas/PythonReference"
+          },
+          "rpc_endpoint": {
+            "type": [
+              "object",
+              "string",
+              "null"
+            ]
+          },
+          "sdk_version": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
         "type": "object"
       },
       "SdkCancelMessageV2Params": {
@@ -556,11 +607,21 @@
             "additionalProperties": true,
             "type": "object"
           },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
+          },
+          "python_reference": {
+            "$ref": "#/components/schemas/PythonReference"
+          },
           "runtime_id": {
             "minLength": 1,
             "type": "string"
           },
           "schema_namespace": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "sdk_version": {
             "minLength": 1,
             "type": "string"
           }
@@ -570,8 +631,10 @@
           "contract_release",
           "effective_capabilities",
           "effective_limits",
+          "python_reference",
           "runtime_id",
-          "schema_namespace"
+          "schema_namespace",
+          "sdk_version"
         ],
         "type": "object"
       },
@@ -939,6 +1002,9 @@
             "minimum": 0,
             "type": "integer"
           },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
+          },
           "profile": {
             "minLength": 1,
             "type": "string"
@@ -1035,6 +1101,9 @@
               "object",
               "null"
             ]
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
           }
         },
         "required": [

--- a/generated/clients/spec/openapi.json
+++ b/generated/clients/spec/openapi.json
@@ -13,6 +13,7 @@
           "sdk_configure_v2",
           "sdk_negotiate_v2",
           "sdk_poll_events_v2",
+          "sdk_send_batch_v2",
           "sdk_send_v2",
           "sdk_shutdown_v2",
           "sdk_snapshot_v2",
@@ -23,6 +24,7 @@
           "sdk_configure_v2",
           "sdk_negotiate_v2",
           "sdk_poll_events_v2",
+          "sdk_send_batch_v2",
           "sdk_send_v2",
           "sdk_shutdown_v2",
           "sdk_snapshot_v2",
@@ -229,6 +231,9 @@
             "$ref": "#/components/schemas/SdkPollEventsV2Request"
           },
           {
+            "$ref": "#/components/schemas/SdkSendBatchV2Request"
+          },
+          {
             "$ref": "#/components/schemas/SdkSendV2Request"
           },
           {
@@ -258,6 +263,9 @@
           },
           {
             "$ref": "#/components/schemas/SdkPollEventsV2Response"
+          },
+          {
+            "$ref": "#/components/schemas/SdkSendBatchV2Response"
           },
           {
             "$ref": "#/components/schemas/SdkSendV2Response"
@@ -320,6 +328,50 @@
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "RpcError": {
+        "additionalProperties": false,
+        "properties": {
+          "category": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "cause_code": {
+            "pattern": "^SDK_[A-Z]+_[A-Z0-9_]+$",
+            "type": "string"
+          },
+          "code": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "details": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "extensions": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "is_user_actionable": {
+            "type": "boolean"
+          },
+          "machine_code": {
+            "pattern": "^SDK_[A-Z]+_[A-Z0-9_]+$",
+            "type": "string"
+          },
+          "message": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "retryable": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
         "type": "object"
       },
       "SdkCancelMessageV2Params": {
@@ -724,6 +776,187 @@
           "dropped_count",
           "events",
           "next_cursor"
+        ],
+        "type": "object"
+      },
+      "SdkSendBatchV2Message": {
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "destination": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "fields": {
+            "additionalProperties": true,
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "include_ticket": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "method": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "stamp_cost": {
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "try_propagation_on_fail": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "content",
+          "destination",
+          "id"
+        ],
+        "type": "object"
+      },
+      "SdkSendBatchV2Params": {
+        "additionalProperties": false,
+        "properties": {
+          "batch_id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/SdkSendBatchV2Message"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "source": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "batch_id",
+          "messages",
+          "source"
+        ],
+        "type": "object"
+      },
+      "SdkSendBatchV2Request": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RPCRequest"
+          },
+          {
+            "properties": {
+              "method": {
+                "enum": [
+                  "sdk_send_batch_v2"
+                ],
+                "type": "string"
+              },
+              "params": {
+                "$ref": "#/components/schemas/SdkSendBatchV2Params"
+              }
+            },
+            "required": [
+              "method",
+              "params"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "SdkSendBatchV2Response": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RPCSuccess"
+          },
+          {
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/SdkSendBatchV2Result"
+              }
+            },
+            "required": [
+              "result"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "SdkSendBatchV2Result": {
+        "additionalProperties": false,
+        "properties": {
+          "accepted_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "batch_id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "rejected_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/SdkSendBatchV2ResultItem"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "accepted_count",
+          "batch_id",
+          "rejected_count",
+          "results"
+        ],
+        "type": "object"
+      },
+      "SdkSendBatchV2ResultItem": {
+        "additionalProperties": false,
+        "properties": {
+          "accepted": {
+            "type": "boolean"
+          },
+          "error": {
+            "$ref": "#/components/schemas/RpcError"
+          },
+          "id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "message_id": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "accepted",
+          "id"
         ],
         "type": "object"
       },

--- a/xtask/src/client_codegen.rs
+++ b/xtask/src/client_codegen.rs
@@ -792,12 +792,18 @@ fn legacy_projection_extra_components(
 ) -> Result<Vec<(&'static str, &'static str)>> {
     let response_meta_ref = "#/components/schemas/ResponseMeta";
     let python_reference_ref = "#/components/schemas/PythonReference";
+    let send_batch_message_ref = "#/components/schemas/SdkSendBatchV2Message";
+    let send_batch_result_item_ref = "#/components/schemas/SdkSendBatchV2ResultItem";
     let mut needs_response_meta = false;
     let mut needs_python_reference = false;
+    let mut needs_send_batch_message = false;
+    let mut needs_send_batch_result_item = false;
     for component in root_components {
         let schema = component_schema(components, component)?;
         needs_response_meta |= schema_mentions_ref(&schema, response_meta_ref);
         needs_python_reference |= schema_mentions_ref(&schema, python_reference_ref);
+        needs_send_batch_message |= schema_mentions_ref(&schema, send_batch_message_ref);
+        needs_send_batch_result_item |= schema_mentions_ref(&schema, send_batch_result_item_ref);
     }
     if needs_response_meta {
         let response_meta = component_schema(components, "ResponseMeta")?;
@@ -810,6 +816,12 @@ fn legacy_projection_extra_components(
     }
     if needs_response_meta {
         extras.push(("ResponseMeta", "response_meta"));
+    }
+    if needs_send_batch_message {
+        extras.push(("SdkSendBatchV2Message", "send_batch_message"));
+    }
+    if needs_send_batch_result_item {
+        extras.push(("SdkSendBatchV2ResultItem", "send_batch_result_item"));
     }
     Ok(extras)
 }
@@ -3173,7 +3185,7 @@ mod tests {
         let openrpc = serde_json::from_str::<Value>(&fs::read_to_string(openrpc_path)?)?;
         let projected = project_legacy_rpc_schemas(&openrpc)?;
 
-        assert_eq!(projected.len(), 10, "expected 8 core + release B + release C projections");
+        assert_eq!(projected.len(), 11, "expected 9 core + release B + release C projections");
 
         for artifact in projected {
             let committed_path = workspace.join(&artifact.path);

--- a/xtask/src/client_codegen.rs
+++ b/xtask/src/client_codegen.rs
@@ -719,25 +719,56 @@ fn project_core_legacy_rpc_schema(
     components: &Map<String, Value>,
 ) -> Result<LegacyRpcSchemaArtifact> {
     let method_id = to_pascal_case(method_name);
-    let ref_map = BTreeMap::from([
+    let params_component = format!("{method_id}Params");
+    let result_component = format!("{method_id}Result");
+    let request_component = format!("{method_id}RequestEnvelope");
+    let response_ok_component = format!("{method_id}ResponseOkEnvelope");
+    let response_error_component = format!("{method_id}ResponseErrorEnvelope");
+    let mut ref_map = BTreeMap::from([
         (format!("#/components/schemas/{method_id}Params"), "#/$defs/params".to_string()),
         (format!("#/components/schemas/{method_id}Result"), "#/$defs/result".to_string()),
         ("#/components/schemas/RpcId".to_string(), "#/$defs/rpc_id".to_string()),
         ("#/components/schemas/RpcError".to_string(), "#/$defs/rpc_error".to_string()),
     ]);
+    let extra_components = legacy_projection_extra_components(
+        components,
+        &[
+            params_component.as_str(),
+            result_component.as_str(),
+            request_component.as_str(),
+            response_ok_component.as_str(),
+            response_error_component.as_str(),
+        ],
+    )?;
+    for (component, def_key) in &extra_components {
+        ref_map.insert(format!("#/components/schemas/{component}"), format!("#/$defs/{def_key}"));
+    }
 
-    let request = rewrite_schema_refs(
-        component_schema(components, &format!("{method_id}RequestEnvelope"))?,
-        &ref_map,
-    )?;
-    let response_ok = rewrite_schema_refs(
-        component_schema(components, &format!("{method_id}ResponseOkEnvelope"))?,
-        &ref_map,
-    )?;
-    let response_error = rewrite_schema_refs(
-        component_schema(components, &format!("{method_id}ResponseErrorEnvelope"))?,
-        &ref_map,
-    )?;
+    let request = rewrite_schema_refs(component_schema(components, &request_component)?, &ref_map)?;
+    let response_ok =
+        rewrite_schema_refs(component_schema(components, &response_ok_component)?, &ref_map)?;
+    let response_error =
+        rewrite_schema_refs(component_schema(components, &response_error_component)?, &ref_map)?;
+    let mut defs = Map::new();
+    defs.insert("rpc_id".to_string(), component_schema(components, "RpcId")?);
+    defs.insert("rpc_error".to_string(), component_schema(components, "RpcError")?);
+    defs.insert(
+        "params".to_string(),
+        rewrite_schema_refs(component_schema(components, &params_component)?, &ref_map)?,
+    );
+    defs.insert(
+        "result".to_string(),
+        rewrite_schema_refs(component_schema(components, &result_component)?, &ref_map)?,
+    );
+    for (component, def_key) in extra_components {
+        defs.insert(
+            def_key.to_string(),
+            rewrite_schema_refs(component_schema(components, component)?, &ref_map)?,
+        );
+    }
+    defs.insert("request".to_string(), request);
+    defs.insert("response_ok".to_string(), response_ok);
+    defs.insert("response_error".to_string(), response_error);
 
     Ok(LegacyRpcSchemaArtifact {
         path: Path::new(LEGACY_RPC_SCHEMA_DIR).join(format!("{method_name}.schema.json")),
@@ -750,17 +781,48 @@ fn project_core_legacy_rpc_schema(
                 { "$ref": "#/$defs/response_ok" },
                 { "$ref": "#/$defs/response_error" }
             ],
-            "$defs": {
-                "rpc_id": component_schema(components, "RpcId")?,
-                "rpc_error": component_schema(components, "RpcError")?,
-                "params": rewrite_schema_refs(component_schema(components, &format!("{method_id}Params"))?, &ref_map)?,
-                "result": rewrite_schema_refs(component_schema(components, &format!("{method_id}Result"))?, &ref_map)?,
-                "request": request,
-                "response_ok": response_ok,
-                "response_error": response_error
-            }
+            "$defs": defs
         }),
     })
+}
+
+fn legacy_projection_extra_components(
+    components: &Map<String, Value>,
+    root_components: &[&str],
+) -> Result<Vec<(&'static str, &'static str)>> {
+    let response_meta_ref = "#/components/schemas/ResponseMeta";
+    let python_reference_ref = "#/components/schemas/PythonReference";
+    let mut needs_response_meta = false;
+    let mut needs_python_reference = false;
+    for component in root_components {
+        let schema = component_schema(components, component)?;
+        needs_response_meta |= schema_mentions_ref(&schema, response_meta_ref);
+        needs_python_reference |= schema_mentions_ref(&schema, python_reference_ref);
+    }
+    if needs_response_meta {
+        let response_meta = component_schema(components, "ResponseMeta")?;
+        needs_python_reference |= schema_mentions_ref(&response_meta, python_reference_ref);
+    }
+
+    let mut extras = Vec::new();
+    if needs_python_reference {
+        extras.push(("PythonReference", "python_reference"));
+    }
+    if needs_response_meta {
+        extras.push(("ResponseMeta", "response_meta"));
+    }
+    Ok(extras)
+}
+
+fn schema_mentions_ref(schema: &Value, target_ref: &str) -> bool {
+    match schema {
+        Value::Object(map) => {
+            map.get("$ref").and_then(Value::as_str) == Some(target_ref)
+                || map.values().any(|value| schema_mentions_ref(value, target_ref))
+        }
+        Value::Array(items) => items.iter().any(|value| schema_mentions_ref(value, target_ref)),
+        _ => false,
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1463,7 +1463,8 @@ fn build_interop_artifacts_manifest() -> Result<InteropArtifactsManifest> {
         if path == Path::new(INTEROP_BASELINE_PATH) {
             continue;
         }
-        let bytes = fs::read(&path).with_context(|| format!("read {}", path.display()))?;
+        let raw_bytes = fs::read(&path).with_context(|| format!("read {}", path.display()))?;
+        let bytes = normalize_interop_artifact_bytes(raw_bytes);
         let mut hasher = Sha256::new();
         hasher.update(&bytes);
         let sha256 = hex::encode(hasher.finalize());
@@ -1481,6 +1482,24 @@ fn build_interop_artifacts_manifest() -> Result<InteropArtifactsManifest> {
     entries.sort_by(|left, right| left.path.cmp(&right.path));
 
     Ok(InteropArtifactsManifest { version: 1, files: entries })
+}
+
+fn normalize_interop_artifact_bytes(bytes: Vec<u8>) -> Vec<u8> {
+    bytes
+        .split(|byte| *byte == b'\n')
+        .enumerate()
+        .flat_map(|(index, line)| {
+            let mut normalized = if line.last() == Some(&b'\r') {
+                line[..line.len() - 1].to_vec()
+            } else {
+                line.to_vec()
+            };
+            if index > 0 {
+                normalized.insert(0, b'\n');
+            }
+            normalized
+        })
+        .collect()
 }
 
 fn collect_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<()> {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -384,6 +384,8 @@ enum XtaskCommand {
     Ci {
         #[arg(long)]
         stage: Option<CiStage>,
+        #[arg(long)]
+        timeout_secs: Option<u64>,
     },
     ReleaseCheck,
     PackageDaemonBundle {
@@ -438,7 +440,10 @@ enum XtaskCommand {
         undo: bool,
     },
     CompatKitCheck,
-    E2eCompatibility,
+    E2eCompatibility {
+        #[arg(long)]
+        timeout_secs: Option<u64>,
+    },
     MeshSim,
     SdkProfileBuild,
     SdkExamplesCheck,
@@ -606,7 +611,7 @@ enum PublishWave {
 fn main() -> Result<()> {
     let xtask = Xtask::parse();
     match xtask.command {
-        XtaskCommand::Ci { stage } => run_ci(stage),
+        XtaskCommand::Ci { stage, timeout_secs } => run_ci(stage, timeout_secs),
         XtaskCommand::ReleaseCheck => run_release_check(),
         XtaskCommand::PackageDaemonBundle { version } => run_package_daemon_bundle(version),
         XtaskCommand::ApiDiff => run_api_diff(),
@@ -642,7 +647,7 @@ fn main() -> Result<()> {
             run_yank_crate(&package, &version, undo)
         }
         XtaskCommand::CompatKitCheck => run_compat_kit_check(),
-        XtaskCommand::E2eCompatibility => run_e2e_compatibility(),
+        XtaskCommand::E2eCompatibility { timeout_secs } => run_e2e_compatibility(timeout_secs),
         XtaskCommand::MeshSim => run_mesh_sim(),
         XtaskCommand::SdkProfileBuild => run_sdk_profile_build(),
         XtaskCommand::SdkExamplesCheck => run_sdk_examples_check(),
@@ -698,9 +703,9 @@ fn main() -> Result<()> {
     }
 }
 
-fn run_ci(stage: Option<CiStage>) -> Result<()> {
+fn run_ci(stage: Option<CiStage>, timeout_secs: Option<u64>) -> Result<()> {
     if let Some(stage) = stage {
-        return run_ci_stage(stage);
+        return run_ci_stage(stage, timeout_secs);
     }
 
     run_pr_core_ci()
@@ -733,7 +738,7 @@ fn run_pr_core_ci() -> Result<()> {
     Ok(())
 }
 
-fn run_ci_stage(stage: CiStage) -> Result<()> {
+fn run_ci_stage(stage: CiStage, timeout_secs: Option<u64>) -> Result<()> {
     match stage {
         CiStage::LintFormat => run("cargo", &["fmt", "--all", "--", "--check"]),
         CiStage::BuildMatrix => run("cargo", &["build", "--workspace", "--all-targets"]),
@@ -767,7 +772,7 @@ fn run_ci_stage(stage: CiStage) -> Result<()> {
         CiStage::SchemaClientCheck => run_schema_client_check(),
         CiStage::CompatKitCheck => run_compat_kit_check(),
         CiStage::CertificationReportCheck => run_certification_report_check(),
-        CiStage::E2eCompatibility => run_e2e_compatibility(),
+        CiStage::E2eCompatibility => run_e2e_compatibility(timeout_secs),
         CiStage::SdkProfileBuild => run_sdk_profile_build(),
         CiStage::SdkExamplesCheck => run_sdk_examples_check(),
         CiStage::SdkApiBreak => run_sdk_api_break(),
@@ -851,7 +856,7 @@ fn run_release_check() -> Result<()> {
     run_schema_client_check()?;
     run_compat_kit_check()?;
     run_certification_report_check()?;
-    run_e2e_compatibility()?;
+    run_e2e_compatibility(None)?;
     run_sdk_conformance()?;
     run_sdk_profile_build()?;
     run_sdk_examples_check()?;
@@ -5009,9 +5014,13 @@ fn run_compat_kit_check() -> Result<()> {
     run("bash", &["tools/scripts/compatibility-kit.sh", "--dry-run"])
 }
 
-fn run_e2e_compatibility() -> Result<()> {
+fn run_e2e_compatibility(timeout_secs: Option<u64>) -> Result<()> {
     run("cargo", &["build", "-p", "reticulumd", "--bin", "reticulumd"])?;
-    run("cargo", &["run", "-p", "rns-tools", "--bin", "rnx", "--", "e2e", "--timeout-secs", "20"])
+    let timeout_secs = timeout_secs.unwrap_or(20).to_string();
+    run(
+        "cargo",
+        &["run", "-p", "rns-tools", "--bin", "rnx", "--", "e2e", "--timeout-secs", &timeout_secs],
+    )
 }
 
 fn run_mesh_sim() -> Result<()> {


### PR DESCRIPTION
﻿## Summary
- report SDK parity/reference metadata in negotiation responses and schema fixtures
- add SDK batch-send schema/fixtures and daemon-side batch routing support
- replace per-message daemon delivery threads with a persistent bounded delivery scheduler
- reuse direct links for repeated sends to the same peer and drain receipt bursts before yielding
- expose `delivery_pipeline` counters through daemon/runtime status responses and document queue tuning

## Validation
- PASS `cargo test -p reticulumd scheduler_metrics_record_admission_and_queue_pressure -- --nocapture`
- PASS `cargo test -p reticulum-rs-rpc sdk_status_v2_includes_delivery_pipeline_status_when_bridge_reports_it -- --nocapture`
- PASS `cargo test -p reticulumd`
- PASS `cargo test -p reticulum-rs-rpc`
- PASS `cargo clippy -p reticulumd -p reticulum-rs-rpc --all-targets -- -D warnings`
- PASS `cargo build -p reticulumd --bin reticulumd --features zmq-pipeline-rpc`
- PASS `cargo fmt -p reticulumd -p reticulum-rs-rpc -- --check`
- PASS `git diff --check`

## Downstream RCH validation
- PASS `cargo +1.85.0 fmt --all -- --check`
- PASS `cargo +1.85.0 clippy --workspace --all-targets -- -D warnings`
- PASS `cargo +1.85.0 test --workspace`
- PASS fake 10,000-message single-request load: `10000` requested, `10000` `sdk_send_v2`, `10001` RPC requests captured, `3795 ms`, `2634.8 msg/s`
- PASS live 1,000-message local daemon load: `1000` accepted, `1000` received, `2041 ms` submit phase, `13299 ms` full end-to-end, `489.9 msg/s` submit, `75.2 msg/s` end-to-end

## Notes
- The scheduler defaults to `LXMD_DELIVERY_QUEUE_CAPACITY=16384`, `LXMD_DELIVERY_GLOBAL_CONCURRENCY=32`, and `LXMD_DELIVERY_PER_PEER_IN_FLIGHT=1`.
- Per-peer in-flight remains ordered by default while allowing global fan-out concurrency across destinations.