### PR TITLE
Auto-validate `LinkIdentify` in `rns-transport`, emit `LinkEvent::PeerIdentified`

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control.rs
@@ -32,7 +32,7 @@ pub(super) fn spawn_control_worker(
                 LinkEvent::PeerIdentified(identity) => {
                     if is_control_request || is_propagation_request {
                         if let Ok(mut guard) = identified.lock() {
-                            guard.insert(event.id, identity);
+                            guard.insert(event.id, *identity);
                         }
                     }
                 }
@@ -58,39 +58,34 @@ pub(super) fn spawn_control_worker(
                     if !is_control_request && !is_propagation_request {
                         continue;
                     }
-                    match payload.context() {
-                        PacketContext::Request => {
-                            let Some(request_id) = payload.request_id() else {
-                                continue;
-                            };
-                            let remote_identity = identified
-                                .lock()
-                                .ok()
-                                .and_then(|guard| guard.get(&event.id).cloned());
-                            let response = handle_control_request(
-                                daemon.as_ref(),
-                                &control,
-                                payload.as_slice(),
-                                remote_identity.as_ref(),
+                    if payload.context() == PacketContext::Request {
+                        let Some(request_id) = payload.request_id() else {
+                            continue;
+                        };
+                        let remote_identity =
+                            identified.lock().ok().and_then(|guard| guard.get(&event.id).cloned());
+                        let response = handle_control_request(
+                            daemon.as_ref(),
+                            &control,
+                            payload.as_slice(),
+                            remote_identity.as_ref(),
+                            is_propagation_request,
+                        );
+                        if let Err(err) = response::send_control_response(
+                            transport.as_ref(),
+                            &event.id,
+                            request_id,
+                            response,
+                        )
+                        .await
+                        {
+                            log::error!(
+                                "[daemon-control] failed to send response link={} propagation_request={} error={}",
+                                event.id,
                                 is_propagation_request,
+                                err
                             );
-                            if let Err(err) = response::send_control_response(
-                                transport.as_ref(),
-                                &event.id,
-                                request_id,
-                                response,
-                            )
-                            .await
-                            {
-                                log::error!(
-                                    "[daemon-control] failed to send response link={} propagation_request={} error={}",
-                                    event.id,
-                                    is_propagation_request,
-                                    err
-                                );
-                            }
                         }
-                        _ => {}
                     }
                 }
                 _ => {}

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control.rs
@@ -23,91 +23,80 @@ pub(super) fn spawn_control_worker(
             let Ok(event) = rx.recv().await else {
                 break;
             };
-            let LinkEvent::Data(payload) = event.event else {
-                continue;
-            };
             let destination_hex = hex::encode(event.address_hash.as_slice());
             let is_control_request =
                 control.control_destination_hash_hex.as_deref() == Some(destination_hex.as_str());
             let is_propagation_request = control.propagation_destination_hash_hex.as_deref()
                 == Some(destination_hex.as_str());
-            if std::env::var("RETICULUMD_DIAGNOSTICS").ok().is_some_and(|value| {
-                matches!(
-                    value.trim().to_ascii_lowercase().as_str(),
-                    "1" | "true" | "yes" | "on" | "debug"
-                )
-            }) {
-                log::debug!(
-                    "[daemon-control] link_data link={} destination={} context={:02x} propagation_destination={:?} control_destination={:?} is_propagation={} is_control={} len={}",
-                    event.id,
-                    destination_hex,
-                    payload.context() as u8,
-                    control.propagation_destination_hash_hex,
-                    control.control_destination_hash_hex,
-                    is_propagation_request,
-                    is_control_request,
-                    payload.len(),
-                );
-            }
-            if !is_control_request && !is_propagation_request {
-                continue;
-            }
-            match payload.context() {
-                PacketContext::LinkIdentify => {
-                    if let Some(identity) =
-                        parse_link_identify_payload(payload.as_slice(), &event.id)
-                    {
+            match event.event {
+                LinkEvent::PeerIdentified(identity) => {
+                    if is_control_request || is_propagation_request {
                         if let Ok(mut guard) = identified.lock() {
                             guard.insert(event.id, identity);
                         }
                     }
                 }
-                PacketContext::Request => {
-                    let Some(request_id) = payload.request_id() else {
-                        continue;
-                    };
-                    let remote_identity =
-                        identified.lock().ok().and_then(|guard| guard.get(&event.id).cloned());
-                    let response = handle_control_request(
-                        daemon.as_ref(),
-                        &control,
-                        payload.as_slice(),
-                        remote_identity.as_ref(),
-                        is_propagation_request,
-                    );
-                    if let Err(err) = response::send_control_response(
-                        transport.as_ref(),
-                        &event.id,
-                        request_id,
-                        response,
-                    )
-                    .await
-                    {
-                        log::error!(
-                            "[daemon-control] failed to send response link={} propagation_request={} error={}",
+                LinkEvent::Data(payload) => {
+                    if std::env::var("RETICULUMD_DIAGNOSTICS").ok().is_some_and(|value| {
+                        matches!(
+                            value.trim().to_ascii_lowercase().as_str(),
+                            "1" | "true" | "yes" | "on" | "debug"
+                        )
+                    }) {
+                        log::debug!(
+                            "[daemon-control] link_data link={} destination={} context={:02x} propagation_destination={:?} control_destination={:?} is_propagation={} is_control={} len={}",
                             event.id,
+                            destination_hex,
+                            payload.context() as u8,
+                            control.propagation_destination_hash_hex,
+                            control.control_destination_hash_hex,
                             is_propagation_request,
-                            err
+                            is_control_request,
+                            payload.len(),
                         );
+                    }
+                    if !is_control_request && !is_propagation_request {
+                        continue;
+                    }
+                    match payload.context() {
+                        PacketContext::Request => {
+                            let Some(request_id) = payload.request_id() else {
+                                continue;
+                            };
+                            let remote_identity = identified
+                                .lock()
+                                .ok()
+                                .and_then(|guard| guard.get(&event.id).cloned());
+                            let response = handle_control_request(
+                                daemon.as_ref(),
+                                &control,
+                                payload.as_slice(),
+                                remote_identity.as_ref(),
+                                is_propagation_request,
+                            );
+                            if let Err(err) = response::send_control_response(
+                                transport.as_ref(),
+                                &event.id,
+                                request_id,
+                                response,
+                            )
+                            .await
+                            {
+                                log::error!(
+                                    "[daemon-control] failed to send response link={} propagation_request={} error={}",
+                                    event.id,
+                                    is_propagation_request,
+                                    err
+                                );
+                            }
+                        }
+                        _ => {}
                     }
                 }
                 _ => {}
             }
         }
     });
-}
-
-fn parse_link_identify_payload(payload: &[u8], link_id: &AddressHash) -> Option<Identity> {
-    if payload.len() < 32 + 32 + 64 {
-        return None;
-    }
-    let identity = Identity::new_from_slices(&payload[..32], &payload[32..64]);
-    let signature = ed25519_dalek::Signature::from_slice(&payload[64..128]).ok()?;
-    let mut signed = Vec::with_capacity(16 + 64);
-    signed.extend_from_slice(link_id.as_slice());
-    signed.extend_from_slice(&payload[..64]);
-    identity.verify(&signed, &signature).ok()?;
-    Some(identity)
 }
 
 fn handle_control_request(

--- a/crates/apps/reticulumd/tests/python_channel_interop.rs
+++ b/crates/apps/reticulumd/tests/python_channel_interop.rs
@@ -836,9 +836,8 @@ async fn python_to_rust_link_identify_roundtrip() {
         Duration::from_secs(8),
     )
     .await;
-    let mut received = transport.received_data_events();
     let remote_identity =
-        wait_for_link_identify(&mut received, link_id, Duration::from_secs(8)).await;
+        wait_for_link_identify(&mut in_events, link_id, Duration::from_secs(8)).await;
     assert_ne!(remote_identity.address_hash, *rust_identity.address_hash());
 
     let destination_hash = { destination.lock().await.desc.address_hash };

--- a/crates/apps/reticulumd/tests/support/python_channel_protocol.rs
+++ b/crates/apps/reticulumd/tests/support/python_channel_protocol.rs
@@ -2,9 +2,9 @@ use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
-use rns_transport::destination::link::Link;
+use rns_transport::destination::link::{Link, LinkEvent, LinkEventData};
 use rns_transport::hash::{address_hash, AddressHash};
-use rns_transport::identity::{lxmf_sign, lxmf_verify, Identity, PUBLIC_KEY_LENGTH};
+use rns_transport::identity::{lxmf_sign, Identity, PUBLIC_KEY_LENGTH};
 use rns_transport::packet::{
     ContextFlag, DestinationType, Header, HeaderType, IfacFlag, Packet, PacketContext,
     PacketDataBuffer, PacketType, PropagationType,
@@ -13,20 +13,18 @@ use rns_transport::resource::{ResourceComplete, ResourceEvent, ResourceEventKind
 use rns_transport::transport::{ReceivedData, SendPacketOutcome, Transport};
 use tokio::time::timeout;
 
-const SIGNATURE_LENGTH: usize = ed25519_dalek::SIGNATURE_LENGTH;
-
 pub(super) async fn wait_for_link_identify(
-    events: &mut tokio::sync::broadcast::Receiver<ReceivedData>,
+    events: &mut tokio::sync::broadcast::Receiver<LinkEventData>,
     link_id: AddressHash,
     duration: Duration,
 ) -> Identity {
     timeout(duration, async {
         loop {
-            let event = events.recv().await.expect("received data event");
-            if event.destination != link_id || event.context != Some(PacketContext::LinkIdentify) {
+            let event = events.recv().await.expect("link event");
+            if event.id != link_id {
                 continue;
             }
-            if let Some(identity) = parse_link_identify_payload(link_id, event.data.as_slice()) {
+            if let LinkEvent::PeerIdentified(identity) = event.event {
                 return identity;
             }
         }
@@ -51,22 +49,6 @@ pub(super) fn build_link_identify_payload(
     let mut payload = public_key;
     payload.extend_from_slice(&signature);
     payload
-}
-
-fn parse_link_identify_payload(link_id: AddressHash, bytes: &[u8]) -> Option<Identity> {
-    if bytes.len() != PUBLIC_KEY_LENGTH * 2 + SIGNATURE_LENGTH {
-        return None;
-    }
-    let public_key = &bytes[..PUBLIC_KEY_LENGTH];
-    let verifying_key = &bytes[PUBLIC_KEY_LENGTH..PUBLIC_KEY_LENGTH * 2];
-    let signature = &bytes[PUBLIC_KEY_LENGTH * 2..];
-    let identity = Identity::new_from_slices(public_key, verifying_key);
-
-    let mut signed_data = Vec::with_capacity(link_id.as_slice().len() + PUBLIC_KEY_LENGTH * 2);
-    signed_data.extend_from_slice(link_id.as_slice());
-    signed_data.extend_from_slice(&bytes[..PUBLIC_KEY_LENGTH * 2]);
-
-    lxmf_verify(&identity, &signed_data, signature).then_some(identity)
 }
 
 pub(super) fn build_link_request_payload(

--- a/crates/apps/reticulumd/tests/support/python_channel_protocol.rs
+++ b/crates/apps/reticulumd/tests/support/python_channel_protocol.rs
@@ -25,7 +25,7 @@ pub(super) async fn wait_for_link_identify(
                 continue;
             }
             if let LinkEvent::PeerIdentified(identity) = event.event {
-                return identity;
+                return *identity;
             }
         }
     })

--- a/crates/libs/rns-transport/src/destination/link.rs
+++ b/crates/libs/rns-transport/src/destination/link.rs
@@ -1308,8 +1308,10 @@ fn link_close_line(id: &AddressHash) -> String {
 
 include!("link/proof.rs");
 
+const LINK_IDENTIFY_PAYLOAD_LENGTH: usize = PUBLIC_KEY_LENGTH * 2 + SIGNATURE_LENGTH;
+
 fn parse_link_identify_payload(payload: &[u8], link_id: &AddressHash) -> Option<Identity> {
-    if payload.len() < PUBLIC_KEY_LENGTH * 2 + SIGNATURE_LENGTH {
+    if payload.len() != LINK_IDENTIFY_PAYLOAD_LENGTH {
         return None;
     }
     let identity = Identity::new_from_slices(
@@ -2393,6 +2395,15 @@ mod tests {
     fn parse_link_identify_rejects_short_payload() {
         let link_id = AddressHash::new([0x01; ADDRESS_HASH_SIZE]);
         assert!(parse_link_identify_payload(&[0u8; 64], &link_id).is_none());
+    }
+
+    #[test]
+    fn parse_link_identify_rejects_trailing_bytes() {
+        let link_id = AddressHash::new([0xAB; ADDRESS_HASH_SIZE]);
+        let private = PrivateIdentity::new_from_rand(OsRng);
+        let mut payload = build_test_identify_payload(&private, &link_id);
+        payload.push(0x00);
+        assert!(parse_link_identify_payload(&payload, &link_id).is_none());
     }
 
     #[test]

--- a/crates/libs/rns-transport/src/destination/link.rs
+++ b/crates/libs/rns-transport/src/destination/link.rs
@@ -582,6 +582,12 @@ impl Link {
         self.packet_with_context(data, PacketContext::Channel)
     }
 
+    /// Build a link peer identification packet (context = 0xFB LinkIdentify).
+    /// The payload should be built with `build_link_identify_payload`.
+    pub fn identify_packet(&self, payload: &[u8]) -> Result<Packet, RnsError> {
+        self.packet_with_context(payload, PacketContext::LinkIdentify)
+    }
+
     pub fn register_channel_handler<F>(&mut self, msg_type: u16, handler: F) -> HandlerId
     where
         F: FnMut(ChannelEnvelope) -> bool + Send + 'static,

--- a/crates/libs/rns-transport/src/destination/link.rs
+++ b/crates/libs/rns-transport/src/destination/link.rs
@@ -122,6 +122,7 @@ pub enum LinkWatchdogAction {
 pub enum LinkEvent {
     Activated,
     Data(Box<LinkPayload>),
+    PeerIdentified(Identity),
     Closed,
 }
 
@@ -420,10 +421,21 @@ impl Link {
                 }
                 return LinkHandleResult::Proof(proof);
             }
+            PacketContext::LinkIdentify => {
+                let mut buffer = [0u8; PACKET_MDU];
+                if let Ok(plain_text) = self.decrypt(packet.data.as_slice(), &mut buffer[..]) {
+                    if let Some(identity) = parse_link_identify_payload(plain_text, &self.id) {
+                        self.post_event(LinkEvent::PeerIdentified(identity));
+                    } else {
+                        log::warn!("link({}): invalid identify payload, dropping", self.id);
+                    }
+                } else {
+                    log::error!("link({}): can't decrypt identify packet", self.id);
+                }
+            }
             PacketContext::None
             | PacketContext::Request
-            | PacketContext::Response
-            | PacketContext::LinkIdentify => {
+            | PacketContext::Response => {
                 let mut buffer = [0u8; PACKET_MDU];
                 if let Ok(plain_text) = self.decrypt(packet.data.as_slice(), &mut buffer[..]) {
                     log::trace!("link({}): data {}B", self.id, plain_text.len());
@@ -1291,6 +1303,24 @@ fn link_close_line(id: &AddressHash) -> String {
 }
 
 include!("link/proof.rs");
+
+fn parse_link_identify_payload(payload: &[u8], link_id: &AddressHash) -> Option<Identity> {
+    if payload.len() < PUBLIC_KEY_LENGTH * 2 + SIGNATURE_LENGTH {
+        return None;
+    }
+    let identity = Identity::new_from_slices(
+        &payload[..PUBLIC_KEY_LENGTH],
+        &payload[PUBLIC_KEY_LENGTH..PUBLIC_KEY_LENGTH * 2],
+    );
+    let signature =
+        Signature::from_slice(&payload[PUBLIC_KEY_LENGTH * 2..PUBLIC_KEY_LENGTH * 2 + SIGNATURE_LENGTH])
+            .ok()?;
+    let mut signed = Vec::with_capacity(ADDRESS_HASH_SIZE + PUBLIC_KEY_LENGTH * 2);
+    signed.extend_from_slice(link_id.as_slice());
+    signed.extend_from_slice(&payload[..PUBLIC_KEY_LENGTH * 2]);
+    identity.verify(&signed, &signature).ok()?;
+    Some(identity)
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/libs/rns-transport/src/destination/link.rs
+++ b/crates/libs/rns-transport/src/destination/link.rs
@@ -122,7 +122,7 @@ pub enum LinkWatchdogAction {
 pub enum LinkEvent {
     Activated,
     Data(Box<LinkPayload>),
-    PeerIdentified(Identity),
+    PeerIdentified(Box<Identity>),
     Closed,
 }
 
@@ -425,7 +425,7 @@ impl Link {
                 let mut buffer = [0u8; PACKET_MDU];
                 if let Ok(plain_text) = self.decrypt(packet.data.as_slice(), &mut buffer[..]) {
                     if let Some(identity) = parse_link_identify_payload(plain_text, &self.id) {
-                        self.post_event(LinkEvent::PeerIdentified(identity));
+                        self.post_event(LinkEvent::PeerIdentified(Box::new(identity)));
                     } else {
                         log::warn!("link({}): invalid identify payload, dropping", self.id);
                     }
@@ -433,9 +433,7 @@ impl Link {
                     log::error!("link({}): can't decrypt identify packet", self.id);
                 }
             }
-            PacketContext::None
-            | PacketContext::Request
-            | PacketContext::Response => {
+            PacketContext::None | PacketContext::Request | PacketContext::Response => {
                 let mut buffer = [0u8; PACKET_MDU];
                 if let Ok(plain_text) = self.decrypt(packet.data.as_slice(), &mut buffer[..]) {
                     log::trace!("link({}): data {}B", self.id, plain_text.len());
@@ -1312,9 +1310,10 @@ fn parse_link_identify_payload(payload: &[u8], link_id: &AddressHash) -> Option<
         &payload[..PUBLIC_KEY_LENGTH],
         &payload[PUBLIC_KEY_LENGTH..PUBLIC_KEY_LENGTH * 2],
     );
-    let signature =
-        Signature::from_slice(&payload[PUBLIC_KEY_LENGTH * 2..PUBLIC_KEY_LENGTH * 2 + SIGNATURE_LENGTH])
-            .ok()?;
+    let signature = Signature::from_slice(
+        &payload[PUBLIC_KEY_LENGTH * 2..PUBLIC_KEY_LENGTH * 2 + SIGNATURE_LENGTH],
+    )
+    .ok()?;
     let mut signed = Vec::with_capacity(ADDRESS_HASH_SIZE + PUBLIC_KEY_LENGTH * 2);
     signed.extend_from_slice(link_id.as_slice());
     signed.extend_from_slice(&payload[..PUBLIC_KEY_LENGTH * 2]);
@@ -2360,5 +2359,51 @@ mod tests {
 
         assert_eq!(link.check_watchdog(true), LinkWatchdogAction::SendKeepAlive);
         assert_eq!(link.status, LinkStatus::Active);
+    }
+
+    fn build_test_identify_payload(private: &PrivateIdentity, link_id: &AddressHash) -> Vec<u8> {
+        let identity = private.as_identity();
+        let mut payload = Vec::with_capacity(PUBLIC_KEY_LENGTH * 2 + SIGNATURE_LENGTH);
+        payload.extend_from_slice(identity.public_key_bytes());
+        payload.extend_from_slice(identity.verifying_key_bytes());
+        let mut signed = Vec::with_capacity(ADDRESS_HASH_SIZE + PUBLIC_KEY_LENGTH * 2);
+        signed.extend_from_slice(link_id.as_slice());
+        signed.extend_from_slice(identity.public_key_bytes());
+        signed.extend_from_slice(identity.verifying_key_bytes());
+        payload.extend_from_slice(&private.sign(&signed).to_bytes());
+        payload
+    }
+
+    #[test]
+    fn parse_link_identify_accepts_valid_proof() {
+        let link_id = AddressHash::new([0xAB; ADDRESS_HASH_SIZE]);
+        let private = PrivateIdentity::new_from_rand(OsRng);
+        let payload = build_test_identify_payload(&private, &link_id);
+        let result = parse_link_identify_payload(&payload, &link_id);
+        assert_eq!(result.map(|i| i.address_hash), Some(private.as_identity().address_hash));
+    }
+
+    #[test]
+    fn parse_link_identify_rejects_short_payload() {
+        let link_id = AddressHash::new([0x01; ADDRESS_HASH_SIZE]);
+        assert!(parse_link_identify_payload(&[0u8; 64], &link_id).is_none());
+    }
+
+    #[test]
+    fn parse_link_identify_rejects_corrupted_signature() {
+        let link_id = AddressHash::new([0xAB; ADDRESS_HASH_SIZE]);
+        let private = PrivateIdentity::new_from_rand(OsRng);
+        let mut payload = build_test_identify_payload(&private, &link_id);
+        payload[PUBLIC_KEY_LENGTH * 2] ^= 0xFF;
+        assert!(parse_link_identify_payload(&payload, &link_id).is_none());
+    }
+
+    #[test]
+    fn parse_link_identify_rejects_wrong_link_id() {
+        let link_id_a = AddressHash::new([0xAA; ADDRESS_HASH_SIZE]);
+        let link_id_b = AddressHash::new([0xBB; ADDRESS_HASH_SIZE]);
+        let private = PrivateIdentity::new_from_rand(OsRng);
+        let payload = build_test_identify_payload(&private, &link_id_a);
+        assert!(parse_link_identify_payload(&payload, &link_id_b).is_none());
     }
 }


### PR DESCRIPTION
## Problem

Previously, when a peer sent a `LinkIdentify` packet, `rns-transport` decrypted it and
delivered a raw `LinkEvent::Data(payload)` with `context == PacketContext::LinkIdentify`.
Signature validation was the caller's responsibility.

This left a security gap: any consumer of the library had to re-implement the Ed25519
proof verification themselves or silently accept unverified identities. The validation
logic (`parse_link_identify_payload`) was duplicated as a private function in two places
inside `reticulumd` and was absent from the library entirely.

## Python reference alignment

### 1. Python always validates before surfacing identity to the app

From [`RNS/Link.py:1014-1030`](https://github.com/markqvist/Reticulum/blob/1.1.4/RNS/Link.py#L1014-L1030)
(Reticulum v1.1.4, the version used in this repo's test environment), the incoming
`LINKIDENTIFY` packet handler:

```python
elif packet.context == RNS.Packet.LINKIDENTIFY:
    plaintext = self.decrypt(packet.data)
    if plaintext != None:
        if not self.initiator and len(plaintext) == RNS.Identity.KEYSIZE//8 + RNS.Identity.SIGLENGTH//8:
            public_key  = plaintext[:RNS.Identity.KEYSIZE//8]
            signed_data = self.link_id + public_key
            signature   = plaintext[RNS.Identity.KEYSIZE//8:RNS.Identity.KEYSIZE//8+RNS.Identity.SIGLENGTH//8]
            identity    = RNS.Identity(create_keys=False)
            identity.load_public_key(public_key)

            if identity.validate(signature, signed_data):        # <-- gate
                self.__remote_identity = identity
                if self.callbacks.remote_identified != None:
                    self.callbacks.remote_identified(self, self.__remote_identity)
```

The callback is inside `if identity.validate(...)`. A packet that fails the Ed25519
check sets no state and invokes no callback — the app layer never sees it.

The signed data is `link_id (16 B) || public_key (64 B)`, which is exactly what
`parse_link_identify_payload` in this PR signs and verifies.

### 2. `Link.identify()` is a public method in Python

The sender side calls `Link.identify(identity)` explicitly after link establishment —
it is a documented public method, not an internal detail. Our test harness confirms this
([`python_channel_endpoint.py:230`](crates/apps/reticulumd/tests/support/python_channel_endpoint.py#L230)):

```python
active_link.identify(self.identity)
```

`Link::identify_packet()` is the direct Rust counterpart. Both sides treat *sending* as
an explicit app decision and *receiving* as something the library validates automatically
before surfacing.

## Changes

### `rns-transport` — library

- Exposed `Link::identify_packet(&self, payload: &[u8]) -> Result<Packet, RnsError>` as
  a public method (context = `0xFB LinkIdentify`). Previously the only way to send an
  identify packet was to hand-craft the context flag outside the library. The counterpart
  in Python is the public `Link.identify(identity)` method
  ([`RNS/Link.py:459`](https://github.com/markqvist/Reticulum/blob/1.1.4/RNS/Link.py#L459)).
- Added `LinkEvent::PeerIdentified(Box<Identity>)` variant. The `Box` keeps the enum
  size in line with the existing `Data(Box<LinkPayload>)` variant.
- `handle_data_packet` now handles `PacketContext::LinkIdentify` in its own arm:
  decrypts the payload, validates the Ed25519 proof (link_id + public keys), and emits
  `PeerIdentified` on success. Invalid proofs are logged and dropped — the app never
  sees them.
- Added private `parse_link_identify_payload` helper (mirrors the validation logic that
  was previously duplicated in `reticulumd`).
- Added four unit tests covering: valid proof accepted, short payload rejected, corrupted
  signature rejected, wrong link ID rejected.

### `reticulumd` — application

- `inbound_control.rs`: replaced manual `PacketContext::LinkIdentify` handling and the
  private `parse_link_identify_payload` function with a match arm on
  `LinkEvent::PeerIdentified(identity)`.
- `tests/support/python_channel_protocol.rs`: updated `wait_for_link_identify` to
  subscribe to `in_link_events()` and match on `LinkEvent::PeerIdentified` instead of
  listening on the raw `received_data_events()` channel and parsing manually. Removed
  the local copy of the validation function.
- `tests/python_channel_interop.rs`: updated call site accordingly.

## Follow-up: add `rns-transport` to the contracts baseline check

`run_api_diff` in xtask already runs `cargo public-api` on `rns-transport`, but only
prints the output — it does not compare against a baseline or fail CI on drift. This
means removing `identify_packet` or `PeerIdentified` in a future PR would go undetected
by the contracts job.

The `lxmf-sdk` baseline check (`run_sdk_api_break`) is the model. Extending it to cover
`rns-transport` requires:

1. Generate the baseline once:
   `cargo +nightly public-api --manifest-path crates/libs/rns-transport/Cargo.toml -sss --color never > docs/contracts/baselines/rns-transport-public-api.txt`
2. Add ~20 lines to `xtask/src/main.rs`: a `run_transport_api_break` function (copy of
   `run_sdk_api_break`, omitting the `lxmf-sdk`-specific stability-class check), a new
   `XtaskCommand` variant, and a dispatch arm.
3. Add one line to the `contracts` job in `.github/workflows/ci.yml`.

All helpers (`capture_public_api`, `normalize_public_api`, toolchain wiring) are already
generic and reusable. No new dependencies or tools needed.

## Test plan

- `cargo test -p reticulum-rs-transport parse_link_identify` — four new unit tests, all
  pass without Python.
- `cargo test -p reticulumd -- python_to_rust_link_identify_roundtrip
  rust_to_python_link_identify_roundtrip` — existing interop tests confirm end-to-end
  identify still works with a real Python Reticulum peer.

## Type
- [ ] breaking
- [x] refactor
- [ ] reliability
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `make test`
- [x] `make test-all` (optional compatibility pass)
- [x] `make test-full-targets` (optional full-target parity check)
- [x] `cargo doc --workspace --no-deps`
- [x] `cargo deny check`
- [x] `cargo audit`

## Compatibility
- [ ] Updated compatibility matrix / contract docs (if needed)
