### PR TITLE
Preserve peer-sync parity queue behavior

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control.rs
@@ -257,6 +257,37 @@ mod tests {
         }
     }
 
+    fn ready_propagation_daemon() -> RpcDaemon {
+        RpcDaemon::test_instance_with_identity(hex::encode([2u8; 16]))
+    }
+
+    fn make_ready_propagation_peer(daemon: &RpcDaemon, peer_seed: u8) -> String {
+        let peer = hex::encode([peer_seed; 16]);
+        daemon
+            .accept_announce_with_metadata(
+                peer.clone(),
+                1_700_000_606 + i64::from(peer_seed),
+                None,
+                None,
+                None,
+                Some(vec!["propagation".to_string()]),
+                None,
+                None,
+                None,
+                Some(1),
+                Some(Some(1)),
+                Some(Some(1)),
+                None,
+                Some(1),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("accept ready propagation peer announce");
+        peer
+    }
+
     fn control_request(path: &str, data: rmpv::Value) -> Vec<u8> {
         rmp_serde::to_vec_named(&rmpv::Value::Array(vec![
             rmpv::Value::Nil,
@@ -566,8 +597,8 @@ mod tests {
 
     #[test]
     fn python_status_reports_peer_sync_transfer_rate_counter() {
-        let peer = "peer-sync-transfer-rate".to_string();
-        let daemon = RpcDaemon::test_instance();
+        let daemon = ready_propagation_daemon();
+        let peer = make_ready_propagation_peer(&daemon, 0x91);
         daemon
             .handle_rpc(RpcRequest {
                 id: 1,
@@ -615,8 +646,8 @@ mod tests {
 
     #[test]
     fn python_status_reports_peer_propagation_message_ids() {
-        let peer = "peer-message-ids".to_string();
-        let daemon = RpcDaemon::test_instance();
+        let daemon = ready_propagation_daemon();
+        let peer = make_ready_propagation_peer(&daemon, 0x92);
         daemon
             .handle_rpc(RpcRequest {
                 id: 1,
@@ -683,8 +714,8 @@ mod tests {
 
     #[test]
     fn python_status_reports_peer_message_counters_at_top_level() {
-        let peer = "peer-top-level-status-counters".to_string();
-        let daemon = RpcDaemon::test_instance();
+        let daemon = ready_propagation_daemon();
+        let peer = make_ready_propagation_peer(&daemon, 0x93);
         daemon
             .handle_rpc(RpcRequest {
                 id: 1,

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_peer.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_peer.rs
@@ -92,6 +92,33 @@ mod tests {
     const ERROR_INVALID_DATA: u8 = 0xF4;
     const ERROR_NOT_FOUND: u8 = 0xFD;
 
+    fn make_ready_propagation_peer(daemon: &RpcDaemon, peer_seed: u8) -> String {
+        let peer = hex::encode([peer_seed; 16]);
+        daemon
+            .accept_announce_with_metadata(
+                peer.clone(),
+                1_700_000_606 + i64::from(peer_seed),
+                None,
+                None,
+                None,
+                Some(vec!["propagation".to_string()]),
+                None,
+                None,
+                None,
+                Some(1),
+                Some(Some(1)),
+                Some(Some(1)),
+                None,
+                Some(1),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("accept ready propagation peer announce");
+        peer
+    }
+
     #[test]
     fn peer_command_returns_none_for_unhandled_path() {
         let daemon = RpcDaemon::test_instance();
@@ -181,7 +208,7 @@ mod tests {
         let peer_bytes = [0xC7; 16];
         let peer_hex = hex::encode(peer_bytes);
         let payload_hex = format!("{}{}", "23".repeat(16), "45".repeat(24));
-        let daemon = RpcDaemon::test_instance();
+        let daemon = RpcDaemon::test_instance_with_identity(hex::encode([2u8; 16]));
         daemon
             .handle_rpc(RpcRequest {
                 id: 1,
@@ -192,6 +219,7 @@ mod tests {
                 })),
             })
             .expect("enable propagation");
+        assert_eq!(make_ready_propagation_peer(&daemon, 0xC7), peer_hex);
         let ingest = daemon
             .handle_rpc(RpcRequest {
                 id: 2,

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -760,8 +760,11 @@ impl RpcDaemon {
                         wanted_ids.as_ref(),
                         sync_limit_bytes,
                     );
+                let peer_response_requests_transfer =
+                    wanted_ids.as_ref().is_some_and(PeerSyncWantedIds::requests_transfer);
                 let peer_policy_required = remaining_policy_relevant > 0
                     && (!explicit_peer_sync_selection
+                        || peer_response_requests_transfer
                         || remaining_policy_relevant_has_stamp
                         || peer_stamp_policy_partially_known(&record));
                 if peer_policy_required && !peer_stamp_policy_known(&record) {
@@ -1781,6 +1784,13 @@ impl PeerSyncWantedIds {
 
     fn wants_none(&self) -> bool {
         matches!(self, Self::Selected(ids) if ids.is_empty())
+    }
+
+    fn requests_transfer(&self) -> bool {
+        match self {
+            Self::All => true,
+            Self::Selected(ids) => !ids.is_empty(),
+        }
     }
 
     fn requires_offer_validation(&self) -> bool {

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -641,10 +641,8 @@ impl RpcDaemon {
                 self.queue_existing_propagation_for_peer(record.peer.as_str())?;
                 let record_transfer_limit_bytes =
                     record.propagation_transfer_limit.map(|limit| limit as usize);
-                let explicit_peer_sync_selection = requested_transfer_limit_bytes.is_some()
-                    || wanted_ids
-                        .as_ref()
-                        .is_some_and(PeerSyncWantedIds::requires_offer_validation);
+                let explicit_peer_sync_selection =
+                    wanted_ids.as_ref().is_some_and(PeerSyncWantedIds::requires_offer_validation);
                 let transfer_limit_bytes =
                     match (record_transfer_limit_bytes, requested_transfer_limit_bytes) {
                         (Some(record_limit), Some(requested_limit)) => {

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -566,6 +566,8 @@ impl RpcDaemon {
                     ));
                 }
                 let wanted_ids = canonical_peer_sync_wanted_ids(parsed.wanted_ids.as_ref())?;
+                let requested_transfer_limit_bytes =
+                    parsed.transfer_limit_kb.map(|limit| (limit.max(0.0) * 1000.0) as usize);
 
                 let timestamp = now_i64();
                 let existing_peer =
@@ -573,8 +575,6 @@ impl RpcDaemon {
                 if existing_peer.is_none()
                     && wanted_ids.as_ref().is_some_and(PeerSyncWantedIds::requires_offer_validation)
                 {
-                    let requested_transfer_limit_bytes =
-                        parsed.transfer_limit_kb.map(|limit| (limit.max(0.0) * 1000.0) as usize);
                     let mut prospective_propagation = self
                         .store
                         .list_peer_prospective_unhandled_propagation(peer_id)
@@ -593,6 +593,33 @@ impl RpcDaemon {
                         requested_transfer_limit_bytes,
                         requested_transfer_limit_bytes,
                     )?;
+                }
+                if let Some(record) = existing_peer.as_ref() {
+                    let record_transfer_limit_bytes =
+                        record.propagation_transfer_limit.map(|limit| limit as usize);
+                    let transfer_limit_bytes =
+                        match (record_transfer_limit_bytes, requested_transfer_limit_bytes) {
+                            (Some(record_limit), Some(requested_limit)) => {
+                                Some(record_limit.min(requested_limit))
+                            }
+                            (Some(record_limit), None) => Some(record_limit),
+                            (None, Some(requested_limit)) => Some(requested_limit),
+                            (None, None) => None,
+                        };
+                    let sync_limit_bytes = record
+                        .propagation_sync_limit
+                        .map(|limit| limit as usize)
+                        .or(transfer_limit_bytes);
+                    if record.next_sync_attempt > 0 && timestamp < record.next_sync_attempt {
+                        return Ok(self.postponed_peer_sync_response(
+                            request.id,
+                            record,
+                            timestamp,
+                            "backoff",
+                            transfer_limit_bytes,
+                            sync_limit_bytes,
+                        ));
+                    }
                 }
                 let existing_peer_type =
                     existing_peer.as_ref().and_then(|record| record.peer_type.clone());
@@ -614,8 +641,6 @@ impl RpcDaemon {
                 self.queue_existing_propagation_for_peer(record.peer.as_str())?;
                 let record_transfer_limit_bytes =
                     record.propagation_transfer_limit.map(|limit| limit as usize);
-                let requested_transfer_limit_bytes =
-                    parsed.transfer_limit_kb.map(|limit| (limit.max(0.0) * 1000.0) as usize);
                 let explicit_peer_sync_selection =
                     wanted_ids.is_some() || requested_transfer_limit_bytes.is_some();
                 let transfer_limit_bytes =

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -760,11 +760,9 @@ impl RpcDaemon {
                         wanted_ids.as_ref(),
                         sync_limit_bytes,
                     );
-                let peer_response_requests_transfer =
-                    wanted_ids.as_ref().is_some_and(PeerSyncWantedIds::requests_transfer);
                 let peer_policy_required = remaining_policy_relevant > 0
                     && (!explicit_peer_sync_selection
-                        || peer_response_requests_transfer
+                        || wanted_ids.is_some()
                         || remaining_policy_relevant_has_stamp
                         || peer_stamp_policy_partially_known(&record));
                 if peer_policy_required && !peer_stamp_policy_known(&record) {
@@ -1751,10 +1749,10 @@ fn peer_sync_policy_relevance(
     let mut policy_relevant_pending = 0usize;
     let mut policy_relevant_has_stamp = false;
     let mut policy_relevant_size = 24usize;
-    for entry in pending_propagation
-        .iter()
-        .filter(|entry| wanted_ids.map_or(true, |ids| ids.wants(entry.transient_id.as_str())))
-    {
+    let policy_wanted_ids = wanted_ids.filter(|ids| !ids.wants_none());
+    for entry in pending_propagation.iter().filter(|entry| {
+        policy_wanted_ids.map_or(true, |ids| ids.wants(entry.transient_id.as_str()))
+    }) {
         let entry_size = usize::try_from(entry.size_bytes).unwrap_or(usize::MAX);
         let transfer_size = entry_size.saturating_add(16);
         let next_size = policy_relevant_size.saturating_add(transfer_size);
@@ -1784,13 +1782,6 @@ impl PeerSyncWantedIds {
 
     fn wants_none(&self) -> bool {
         matches!(self, Self::Selected(ids) if ids.is_empty())
-    }
-
-    fn requests_transfer(&self) -> bool {
-        match self {
-            Self::All => true,
-            Self::Selected(ids) => !ids.is_empty(),
-        }
     }
 
     fn requires_offer_validation(&self) -> bool {

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -641,8 +641,10 @@ impl RpcDaemon {
                 self.queue_existing_propagation_for_peer(record.peer.as_str())?;
                 let record_transfer_limit_bytes =
                     record.propagation_transfer_limit.map(|limit| limit as usize);
-                let explicit_peer_sync_selection =
-                    wanted_ids.is_some() || requested_transfer_limit_bytes.is_some();
+                let explicit_peer_sync_selection = requested_transfer_limit_bytes.is_some()
+                    || wanted_ids
+                        .as_ref()
+                        .is_some_and(PeerSyncWantedIds::requires_offer_validation);
                 let transfer_limit_bytes =
                     match (record_transfer_limit_bytes, requested_transfer_limit_bytes) {
                         (Some(record_limit), Some(requested_limit)) => {

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -979,7 +979,7 @@ impl RpcDaemon {
             "propagation_peer_maintenance" => {
                 let timestamp = now_i64();
                 let culled_peers = self.cull_unreachable_non_static_peers(timestamp)?;
-                let rotated_peers = self.rotate_low_acceptance_autopeers()?;
+                let rotated_peers = self.rotate_low_acceptance_non_static_peers()?;
                 Ok(RpcResponse {
                     id: request.id,
                     result: Some(json!({

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -979,12 +979,15 @@ impl RpcDaemon {
             "propagation_peer_maintenance" => {
                 let timestamp = now_i64();
                 let culled_peers = self.cull_unreachable_non_static_peers(timestamp)?;
+                let rotated_peers = self.rotate_low_acceptance_autopeers()?;
                 Ok(RpcResponse {
                     id: request.id,
                     result: Some(json!({
                         "timestamp": timestamp,
                         "culled": culled_peers.len(),
                         "culled_peers": culled_peers,
+                        "rotated": rotated_peers.len(),
+                        "rotated_peers": rotated_peers,
                         "max_unreachable_secs": super::init::LXMF_PEER_MAX_UNREACHABLE_SECS,
                     })),
                     error: None,

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -980,6 +980,18 @@ impl RpcDaemon {
                 let timestamp = now_i64();
                 let culled_peers = self.cull_unreachable_non_static_peers(timestamp)?;
                 let rotated_peers = self.rotate_low_acceptance_non_static_peers()?;
+                let synced_peer = self.select_peer_for_maintenance_sync(timestamp)?;
+                let peer_sync = if let Some(peer) = synced_peer.as_ref() {
+                    self.handle_rpc(RpcRequest {
+                        id: request.id,
+                        method: "peer_sync".to_string(),
+                        params: Some(json!({ "peer": peer })),
+                    })?
+                    .result
+                    .unwrap_or(JsonValue::Null)
+                } else {
+                    JsonValue::Null
+                };
                 Ok(RpcResponse {
                     id: request.id,
                     result: Some(json!({
@@ -988,6 +1000,8 @@ impl RpcDaemon {
                         "culled_peers": culled_peers,
                         "rotated": rotated_peers.len(),
                         "rotated_peers": rotated_peers,
+                        "synced_peer": synced_peer,
+                        "peer_sync": peer_sync,
                         "max_unreachable_secs": super::init::LXMF_PEER_MAX_UNREACHABLE_SECS,
                     })),
                     error: None,

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -3,6 +3,8 @@ use super::*;
 
 pub(super) const LXMF_PEER_SYNC_BACKOFF_STEP_SECS: u32 = 12 * 60;
 pub(super) const LXMF_PEER_MAX_UNREACHABLE_SECS: i64 = 14 * 24 * 60 * 60;
+const LXMF_PEER_ROTATION_HEADROOM_PCT: usize = 10;
+const LXMF_PEER_ROTATION_ACCEPTANCE_RATE_MAX: f64 = 0.5;
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct PeerPropagationState {
@@ -1423,6 +1425,100 @@ impl RpcDaemon {
         Ok(removed)
     }
 
+    pub(super) fn rotate_low_acceptance_autopeers(&self) -> Result<Vec<String>, std::io::Error> {
+        let (max_peers, static_peers) = {
+            let propagation = self.propagation_state.lock().expect("propagation mutex poisoned");
+            let Some(max_peers) = propagation.max_peers else {
+                return Ok(Vec::new());
+            };
+            (max_peers as usize, propagation.static_peers.clone())
+        };
+        if max_peers == 0 {
+            return Ok(Vec::new());
+        }
+        let headroom = ((max_peers * LXMF_PEER_ROTATION_HEADROOM_PCT) / 100).max(1);
+        let active_peers = {
+            let guard = self.peers.lock().expect("peers mutex poisoned");
+            guard
+                .values()
+                .filter(|record| record.peer_type.as_deref() != Some("unpeered"))
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+        let required_drops = active_peers.len().saturating_sub(max_peers.saturating_sub(headroom));
+        if required_drops == 0 || active_peers.len().saturating_sub(required_drops) <= 1 {
+            return Ok(Vec::new());
+        }
+        let untested_count =
+            active_peers.iter().filter(|record| record.last_sync_attempt == 0).count();
+        if untested_count >= headroom {
+            return Ok(Vec::new());
+        }
+
+        let mut peer_stats = Vec::with_capacity(active_peers.len());
+        for record in active_peers {
+            let stats = self
+                .store
+                .peer_propagation_message_stats(record.peer.as_str())
+                .map_err(std::io::Error::other)?;
+            peer_stats.push((record, stats.unhandled));
+        }
+        if peer_stats.iter().any(|(_, unhandled)| *unhandled == 0) {
+            peer_stats.retain(|(_, unhandled)| *unhandled == 0);
+        }
+
+        let mut unresponsive = Vec::new();
+        let mut waiting = Vec::new();
+        for (record, _unhandled) in peer_stats {
+            let is_static =
+                static_peers.iter().any(|peer| peer.eq_ignore_ascii_case(record.peer.as_str()));
+            if is_static || record.peer_type.as_deref() != Some("auto") {
+                continue;
+            }
+            if record.alive {
+                if record.offered > 0 {
+                    waiting.push(record);
+                }
+            } else {
+                unresponsive.push(record);
+            }
+        }
+
+        let mut drop_pool = Vec::new();
+        if unresponsive.is_empty() {
+            drop_pool.extend(waiting);
+        } else {
+            drop_pool.extend(unresponsive);
+            drop_pool.extend(waiting);
+        }
+        drop_pool.sort_by(|left, right| {
+            peer_rotation_acceptance_rate(left)
+                .total_cmp(&peer_rotation_acceptance_rate(right))
+                .then_with(|| left.peer.cmp(&right.peer))
+        });
+
+        let mut removed = Vec::new();
+        for record in drop_pool.into_iter().take(required_drops) {
+            if peer_rotation_acceptance_rate(&record) >= LXMF_PEER_ROTATION_ACCEPTANCE_RATE_MAX {
+                continue;
+            }
+            let cleanup = self.unpeer_local_state(record.peer.as_str())?;
+            if cleanup.removed {
+                self.publish_event(RpcEvent {
+                    event_type: "peer_unpeer".into(),
+                    payload: policy_unpeer_event_payload(
+                        record.peer.as_str(),
+                        "peer_rotation",
+                        &cleanup,
+                    ),
+                });
+                removed.push(record.peer);
+            }
+        }
+        removed.sort();
+        Ok(removed)
+    }
+
     pub(super) fn ensure_peer_admission_allowed(
         &self,
         peer: &str,
@@ -1664,4 +1760,12 @@ fn policy_unpeer_event_payload(
         "incoming": incoming,
         "messages": cleanup.messages.clone(),
     })
+}
+
+fn peer_rotation_acceptance_rate(peer: &PeerRecord) -> f64 {
+    if peer.offered == 0 {
+        0.0
+    } else {
+        (peer.outgoing as f64 / peer.offered as f64).clamp(0.0, 1.0)
+    }
 }

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -1575,8 +1575,12 @@ impl RpcDaemon {
             return Ok(peer_pool.into_iter().nth(selected_index).map(|record| record.peer));
         }
 
-        unresponsive.sort_by(|left, right| left.peer.cmp(&right.peer));
-        Ok(unresponsive.into_iter().next().map(|record| record.peer))
+        if !unresponsive.is_empty() {
+            unresponsive.sort_by(|left, right| left.peer.cmp(&right.peer));
+            let selected_index = timestamp.rem_euclid(unresponsive.len() as i64) as usize;
+            return Ok(unresponsive.into_iter().nth(selected_index).map(|record| record.peer));
+        }
+        Ok(None)
     }
 
     pub(super) fn ensure_peer_admission_allowed(

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -1537,6 +1537,9 @@ impl RpcDaemon {
         let mut waiting = Vec::new();
         let mut unresponsive = Vec::new();
         for record in active_peers {
+            if timestamp > record.last_seen.saturating_add(LXMF_PEER_MAX_UNREACHABLE_SECS) {
+                continue;
+            }
             let stats = self
                 .store
                 .peer_propagation_message_stats(record.peer.as_str())

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -1425,7 +1425,9 @@ impl RpcDaemon {
         Ok(removed)
     }
 
-    pub(super) fn rotate_low_acceptance_autopeers(&self) -> Result<Vec<String>, std::io::Error> {
+    pub(super) fn rotate_low_acceptance_non_static_peers(
+        &self,
+    ) -> Result<Vec<String>, std::io::Error> {
         let (max_peers, static_peers) = {
             let propagation = self.propagation_state.lock().expect("propagation mutex poisoned");
             let Some(max_peers) = propagation.max_peers else {
@@ -1472,7 +1474,7 @@ impl RpcDaemon {
         for (record, _unhandled) in peer_stats {
             let is_static =
                 static_peers.iter().any(|peer| peer.eq_ignore_ascii_case(record.peer.as_str()));
-            if is_static || record.peer_type.as_deref() != Some("auto") {
+            if is_static {
                 continue;
             }
             if record.alive {

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -1521,6 +1521,50 @@ impl RpcDaemon {
         Ok(removed)
     }
 
+    pub(super) fn select_peer_for_maintenance_sync(
+        &self,
+        timestamp: i64,
+    ) -> Result<Option<String>, std::io::Error> {
+        let active_peers = {
+            let guard = self.peers.lock().expect("peers mutex poisoned");
+            guard
+                .values()
+                .filter(|record| record.peer_type.as_deref() != Some("unpeered"))
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+
+        let mut waiting = Vec::new();
+        let mut unresponsive = Vec::new();
+        for record in active_peers {
+            let stats = self
+                .store
+                .peer_propagation_message_stats(record.peer.as_str())
+                .map_err(std::io::Error::other)?;
+            if stats.unhandled == 0 {
+                continue;
+            }
+            if record.alive {
+                waiting.push(record);
+            } else if timestamp > record.next_sync_attempt {
+                unresponsive.push(record);
+            }
+        }
+
+        if !waiting.is_empty() {
+            waiting.sort_by(|left, right| {
+                right
+                    .sync_transfer_rate
+                    .total_cmp(&left.sync_transfer_rate)
+                    .then_with(|| left.peer.cmp(&right.peer))
+            });
+            return Ok(waiting.into_iter().next().map(|record| record.peer));
+        }
+
+        unresponsive.sort_by(|left, right| left.peer.cmp(&right.peer));
+        Ok(unresponsive.into_iter().next().map(|record| record.peer))
+    }
+
     pub(super) fn ensure_peer_admission_allowed(
         &self,
         peer: &str,

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -3,6 +3,7 @@ use super::*;
 
 pub(super) const LXMF_PEER_SYNC_BACKOFF_STEP_SECS: u32 = 12 * 60;
 pub(super) const LXMF_PEER_MAX_UNREACHABLE_SECS: i64 = 14 * 24 * 60 * 60;
+const LXMF_PEER_FASTEST_RANDOM_POOL: usize = 2;
 const LXMF_PEER_ROTATION_HEADROOM_PCT: usize = 10;
 const LXMF_PEER_ROTATION_ACCEPTANCE_RATE_MAX: f64 = 0.5;
 
@@ -1561,7 +1562,17 @@ impl RpcDaemon {
                     .total_cmp(&left.sync_transfer_rate)
                     .then_with(|| left.peer.cmp(&right.peer))
             });
-            return Ok(waiting.into_iter().next().map(|record| record.peer));
+            let fastest_count = LXMF_PEER_FASTEST_RANDOM_POOL.min(waiting.len());
+            let mut peer_pool = waiting.iter().take(fastest_count).cloned().collect::<Vec<_>>();
+            peer_pool.extend(
+                waiting
+                    .iter()
+                    .filter(|record| record.sync_transfer_rate == 0.0)
+                    .take(fastest_count)
+                    .cloned(),
+            );
+            let selected_index = timestamp.rem_euclid(peer_pool.len() as i64) as usize;
+            return Ok(peer_pool.into_iter().nth(selected_index).map(|record| record.peer));
         }
 
         unresponsive.sort_by(|left, right| left.peer.cmp(&right.peer));

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -1564,13 +1564,8 @@ impl RpcDaemon {
             });
             let fastest_count = LXMF_PEER_FASTEST_RANDOM_POOL.min(waiting.len());
             let mut peer_pool = waiting.iter().take(fastest_count).cloned().collect::<Vec<_>>();
-            peer_pool.extend(
-                waiting
-                    .iter()
-                    .filter(|record| record.sync_transfer_rate == 0.0)
-                    .take(fastest_count)
-                    .cloned(),
-            );
+            peer_pool
+                .extend(waiting.iter().filter(|record| record.sync_transfer_rate == 0.0).cloned());
             let selected_index = timestamp.rem_euclid(peer_pool.len() as i64) as usize;
             return Ok(peer_pool.into_iter().nth(selected_index).map(|record| record.peer));
         }

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -931,7 +931,7 @@ impl RpcDaemon {
         let is_static = self.is_static_peer(peer.as_str());
         let remote_peering_cost_allowed = self.remote_peering_cost_allowed(peering_cost);
         if !is_static && !remote_peering_cost_allowed {
-            self.remove_autopeered_peer_if_stale_or_expensive(peer.as_str(), timestamp)?;
+            self.remove_peer_if_stale_or_expensive(peer.as_str(), timestamp)?;
         }
         if !is_static && propagation_enabled == Some(false) {
             self.remove_autopeered_peer_if_propagation_disabled(
@@ -1644,7 +1644,7 @@ impl RpcDaemon {
         }
     }
 
-    pub(super) fn remove_autopeered_peer_if_stale_or_expensive(
+    pub(super) fn remove_peer_if_stale_or_expensive(
         &self,
         peer: &str,
         timestamp: i64,
@@ -1656,9 +1656,8 @@ impl RpcDaemon {
         let unhandled_ids =
             self.store.list_peer_unhandled_propagation_ids(peer).map_err(std::io::Error::other)?;
         let mut guard = self.peers.lock().expect("peers mutex poisoned");
-        let should_remove = guard.get(peer).is_some_and(|existing| {
-            existing.peer_type.as_deref() == Some("auto") && timestamp >= existing.peering_timebase
-        });
+        let should_remove =
+            guard.get(peer).is_some_and(|existing| timestamp >= existing.peering_timebase);
         if !should_remove {
             return Ok(());
         }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/release_domains.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/release_domains.rs
@@ -2383,6 +2383,8 @@ fn sdk_backup_restore_drill_recovers_snapshot_and_messages() {
         .join(format!("lxmf-rs-sdk-drill-{run_id}-{}.sqlite", std::process::id()));
     let backup_path = std::env::temp_dir()
         .join(format!("lxmf-rs-sdk-drill-{run_id}-{}.sqlite.backup", std::process::id()));
+    let restored_path = std::env::temp_dir()
+        .join(format!("lxmf-rs-sdk-drill-{run_id}-{}.sqlite.restored", std::process::id()));
 
     let baseline_topic_id: String;
     let baseline_message_id = "drill-baseline-msg-1";
@@ -2458,10 +2460,11 @@ fn sdk_backup_restore_drill_recovers_snapshot_and_messages() {
         assert!(drift_inbound.error.is_none());
     }
 
-    restore_sqlite_file(backup_path.as_path(), db_path.as_path());
+    restore_sqlite_file(backup_path.as_path(), restored_path.as_path());
 
     {
-        let store = MessagesStore::open(db_path.as_path()).expect("open restored sqlite store");
+        let store =
+            MessagesStore::open(restored_path.as_path()).expect("open restored sqlite store");
         let daemon = RpcDaemon::with_store(store, "drill-node".to_string());
 
         let baseline_topic = daemon
@@ -2511,10 +2514,14 @@ fn sdk_backup_restore_drill_recovers_snapshot_and_messages() {
 
     let _ = std::fs::remove_file(&db_path);
     let _ = std::fs::remove_file(&backup_path);
+    let _ = std::fs::remove_file(&restored_path);
     for sidecar in sqlite_sidecar_paths(db_path.as_path()) {
         let _ = std::fs::remove_file(sidecar);
     }
     for sidecar in sqlite_sidecar_paths(backup_path.as_path()) {
+        let _ = std::fs::remove_file(sidecar);
+    }
+    for sidecar in sqlite_sidecar_paths(restored_path.as_path()) {
         let _ = std::fs::remove_file(sidecar);
     }
 }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -70,6 +70,35 @@ fn daemon_status_ex_reads_cached_status_snapshot() {
     assert_eq!(result["stamp_policy"]["enforce"].as_bool(), Some(true));
 }
 
+fn ready_propagation_peer_daemon(peer_seed: u8) -> (RpcDaemon, String) {
+    let store = MessagesStore::in_memory().expect("store");
+    let daemon = RpcDaemon::with_store(store, hex::encode([2u8; 16]));
+    let peer = hex::encode([peer_seed; 16]);
+    daemon
+        .accept_announce_with_metadata(
+            peer.clone(),
+            1_700_000_606 + i64::from(peer_seed),
+            None,
+            None,
+            None,
+            Some(vec!["propagation".to_string()]),
+            None,
+            None,
+            None,
+            Some(1),
+            Some(Some(1)),
+            Some(Some(1)),
+            None,
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("accept ready propagation peer announce");
+    (daemon, peer)
+}
+
 #[test]
 fn propagation_policy_is_reported_and_enforced_for_new_peers() {
     let daemon = RpcDaemon::test_instance();
@@ -3116,16 +3145,13 @@ fn peer_sync_without_offers_preserves_liveness_when_not_backing_off_like_python(
 
 #[test]
 fn peer_sync_during_backoff_postpones_skipped_offers() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": "peer-backoff-skipped" })))
-        .expect("initial peer sync");
+    let (daemon, peer) = ready_propagation_peer_daemon(0x47);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-backoff-skipped").expect("peer record");
-        peer.propagation_sync_limit = Some(1_000);
-        peer.peering_timebase = 1_700_000_000;
-        peer.network_distance = 3;
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some(1_000);
+        record.peering_timebase = 1_700_000_000;
+        record.network_distance = 3;
     }
     let previous_transfer = PropagationEntryRecord {
         transient_id: "ed".repeat(32),
@@ -3139,7 +3165,7 @@ fn peer_sync_during_backoff_postpones_skipped_offers() {
     daemon
         .store
         .mark_peer_unhandled_propagation(
-            "peer-backoff-skipped",
+            peer.as_str(),
             previous_transfer.transient_id.as_str(),
         )
         .expect("mark previous transfer unhandled");
@@ -3148,18 +3174,18 @@ fn peer_sync_during_backoff_postpones_skipped_offers() {
             53,
             "peer_sync",
             json!({
-                "peer": "peer-backoff-skipped",
+                "peer": peer.as_str(),
                 "transfer_limit_kb": 1.0,
             }),
         ))
         .expect("peer sync with previous transfer");
     let previous_resource_bytes =
         rmp_serde::to_vec(&(1.0_f64, vec![vec![0x19; 40]])).expect("pack sync resource").len();
-    daemon.record_outbound_peer_activity("peer-backoff-skipped", 64, false);
+    daemon.record_outbound_peer_activity(peer.as_str(), 64, false);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-backoff-skipped").expect("peer record");
-        peer.propagation_sync_limit = Some(24);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some(24);
     }
     let entry = PropagationEntryRecord {
         transient_id: "ee".repeat(32),
@@ -3172,7 +3198,7 @@ fn peer_sync_during_backoff_postpones_skipped_offers() {
     daemon.store.upsert_propagation_entry(&entry).expect("store entry");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-backoff-skipped", entry.transient_id.as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
         .expect("mark unhandled");
 
     let before = daemon
@@ -3184,7 +3210,7 @@ fn peer_sync_during_backoff_postpones_skipped_offers() {
         .as_array()
         .expect("peer rows")
         .iter()
-        .find(|row| row["peer"].as_str() == Some("peer-backoff-skipped"))
+        .find(|row| row["peer"].as_str() == Some(peer.as_str()))
         .expect("peer row");
     let sync_backoff = before_row["sync_backoff"].as_u64().expect("sync backoff");
     let next_sync_attempt =
@@ -3193,7 +3219,7 @@ fn peer_sync_during_backoff_postpones_skipped_offers() {
     assert!(next_sync_attempt > 0);
 
     let result = daemon
-        .handle_rpc(rpc_request(54, "peer_sync", json!({ "peer": "peer-backoff-skipped" })))
+        .handle_rpc(rpc_request(54, "peer_sync", json!({ "peer": peer.as_str() })))
         .expect("skipped peer sync")
         .result
         .expect("peer sync result");
@@ -3247,7 +3273,7 @@ fn peer_sync_during_backoff_postpones_skipped_offers() {
         .as_array()
         .expect("peer rows")
         .iter()
-        .find(|row| row["peer"].as_str() == Some("peer-backoff-skipped"))
+        .find(|row| row["peer"].as_str() == Some(peer.as_str()))
         .expect("peer row");
     assert_eq!(after_row["sync_backoff"].as_u64(), Some(sync_backoff));
     assert_eq!(after_row["next_sync_attempt"].as_i64(), Some(next_sync_attempt));
@@ -3557,6 +3583,64 @@ fn peer_sync_requires_stamp_policy_for_ordinary_limited_peer_like_python() {
     let unhandled = daemon
         .store
         .list_peer_unhandled_propagation("peer-limited-policy")
+        .expect("list unhandled");
+    assert_eq!(unhandled.len(), 1);
+    assert_eq!(unhandled[0].transient_id, entry.transient_id);
+}
+
+#[test]
+fn peer_sync_request_transfer_limit_keeps_full_offer_policy_gates_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": "peer-request-limit-policy" })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let peer = peers.get_mut("peer-request-limit-policy").expect("peer record");
+        peer.propagation_sync_limit = Some(1_000);
+        peer.propagation_stamp_cost = None;
+        peer.propagation_stamp_cost_flexibility = None;
+        peer.peering_cost = None;
+    }
+    let entry = PropagationEntryRecord {
+        transient_id: "e7".repeat(32),
+        destination: "17".repeat(16),
+        payload_hex: "17".repeat(20),
+        received_at: 1_700_000_625,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation("peer-request-limit-policy", entry.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let result = daemon
+        .handle_rpc(rpc_request(
+            54,
+            "peer_sync",
+            json!({
+                "peer": "peer-request-limit-policy",
+                "transfer_limit_kb": 1.0,
+            }),
+        ))
+        .expect("policy-gated request-limited peer sync")
+        .result
+        .expect("peer sync result");
+    assert_eq!(result["synced"].as_bool(), Some(false));
+    assert_eq!(result["postponed"].as_bool(), Some(true));
+    assert_eq!(result["postpone_reason"].as_str(), Some("stamp_policy"));
+    assert_eq!(result["transfer_limit"].as_u64(), Some(1_000));
+    assert_eq!(result["propagation"]["transfer_limit"].as_u64(), Some(1_000));
+    assert_eq!(result["propagation"]["offered"].as_u64(), Some(0));
+    assert_eq!(result["propagation"]["handled"].as_u64(), Some(0));
+    assert_eq!(result["propagation"]["skipped"].as_u64(), Some(0));
+    assert_eq!(result["propagation"]["transfer_limited"].as_u64(), Some(0));
+
+    let unhandled = daemon
+        .store
+        .list_peer_unhandled_propagation("peer-request-limit-policy")
         .expect("list unhandled");
     assert_eq!(unhandled.len(), 1);
     assert_eq!(unhandled[0].transient_id, entry.transient_id);
@@ -4018,7 +4102,7 @@ fn list_peers_exposes_python_style_message_counters() {
 
 #[test]
 fn peer_sync_marks_unhandled_propagation_entries_handled() {
-    let daemon = RpcDaemon::test_instance();
+    let (daemon, peer) = ready_propagation_peer_daemon(0x41);
     let entry = PropagationEntryRecord {
         transient_id: "ab".repeat(32),
         destination: "12".repeat(16),
@@ -4030,28 +4114,28 @@ fn peer_sync_marks_unhandled_propagation_entries_handled() {
     daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-propagation-sync", entry.transient_id.as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
         .expect("mark propagation unhandled");
 
     daemon
         .handle_rpc(rpc_request(
             55,
             "peer_sync",
-            json!({ "peer": "peer-propagation-sync", "transfer_limit_kb": 1 }),
+            json!({ "peer": peer.as_str(), "transfer_limit_kb": 1 }),
         ))
         .expect("peer sync");
 
     assert!(
         daemon
             .store
-            .list_peer_unhandled_propagation("peer-propagation-sync")
+            .list_peer_unhandled_propagation(peer.as_str())
             .expect("list unhandled")
             .is_empty()
     );
     assert_eq!(
         daemon
             .store
-            .list_peer_handled_propagation_ids("peer-propagation-sync")
+            .list_peer_handled_propagation_ids(peer.as_str())
             .expect("list handled"),
         vec![entry.transient_id]
     );
@@ -4059,7 +4143,19 @@ fn peer_sync_marks_unhandled_propagation_entries_handled() {
 
 #[test]
 fn peer_sync_queues_existing_entries_for_new_manual_peer() {
-    let daemon = RpcDaemon::test_instance();
+    let store = MessagesStore::in_memory().expect("store");
+    let daemon = RpcDaemon::with_store(store, hex::encode([2u8; 16]));
+    let peer = hex::encode([0x42_u8; 16]);
+    daemon
+        .handle_rpc(rpc_request(54, "peer_sync", json!({ "peer": peer.as_str() })))
+        .expect("seed manual peer");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_stamp_cost = Some(1);
+        record.propagation_stamp_cost_flexibility = Some(1);
+        record.peering_cost = Some(1);
+    }
     let entry = PropagationEntryRecord {
         transient_id: "ac".repeat(32),
         destination: "12".repeat(16),
@@ -4074,7 +4170,7 @@ fn peer_sync_queues_existing_entries_for_new_manual_peer() {
         .handle_rpc(rpc_request(
             55,
             "peer_sync",
-            json!({ "peer": "peer-manual-queue", "transfer_limit_kb": 1 }),
+            json!({ "peer": peer.as_str(), "transfer_limit_kb": 1 }),
         ))
         .expect("peer sync")
         .result
@@ -4768,14 +4864,11 @@ fn peer_sync_keeps_sync_limited_entries_queued_when_peer_wants_none() {
 
 #[test]
 fn peer_sync_ignores_stamp_policy_for_entries_skipped_by_cumulative_sync_limit() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": "peer-stamped-skipped" })))
-        .expect("initial peer sync");
+    let (daemon, peer) = ready_propagation_peer_daemon(0x48);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-stamped-skipped").expect("peer record");
-        peer.propagation_sync_limit = Some(80);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some(80);
     }
     let transferable = PropagationEntryRecord {
         transient_id: "a6".repeat(32),
@@ -4797,7 +4890,7 @@ fn peer_sync_ignores_stamp_policy_for_entries_skipped_by_cumulative_sync_limit()
         daemon.store.upsert_propagation_entry(entry).expect("store propagation entry");
         daemon
             .store
-            .mark_peer_unhandled_propagation("peer-stamped-skipped", entry.transient_id.as_str())
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
             .expect("mark unhandled");
     }
 
@@ -4806,7 +4899,7 @@ fn peer_sync_ignores_stamp_policy_for_entries_skipped_by_cumulative_sync_limit()
             55,
             "peer_sync",
             json!({
-                "peer": "peer-stamped-skipped",
+                "peer": peer.as_str(),
                 "transfer_limit_kb": 1.0,
             }),
         ))
@@ -4833,14 +4926,14 @@ fn peer_sync_ignores_stamp_policy_for_entries_skipped_by_cumulative_sync_limit()
     assert_eq!(
         daemon
             .store
-            .list_peer_handled_propagation_ids("peer-stamped-skipped")
+            .list_peer_handled_propagation_ids(peer.as_str())
             .expect("handled ids"),
         vec![transferable.transient_id]
     );
     assert_eq!(
         daemon
             .store
-            .list_peer_unhandled_propagation("peer-stamped-skipped")
+            .list_peer_unhandled_propagation(peer.as_str())
             .expect("pending propagation"),
         vec![skipped]
     );
@@ -5117,7 +5210,7 @@ fn list_peers_top_level_message_counters_match_python_sync_accounting() {
 
 #[test]
 fn peer_sync_result_reports_cumulative_acceptance_rate_like_python() {
-    let daemon = RpcDaemon::test_instance();
+    let (daemon, peer) = ready_propagation_peer_daemon(0x43);
     let first = PropagationEntryRecord {
         transient_id: "b1".repeat(32),
         destination: "12".repeat(16),
@@ -5129,13 +5222,13 @@ fn peer_sync_result_reports_cumulative_acceptance_rate_like_python() {
     daemon.store.upsert_propagation_entry(&first).expect("store first entry");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-cumulative-acceptance", first.transient_id.as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), first.transient_id.as_str())
         .expect("mark first unhandled");
     daemon
         .handle_rpc(rpc_request(
             57,
             "peer_sync",
-            json!({ "peer": "peer-cumulative-acceptance", "transfer_limit_kb": 1 }),
+            json!({ "peer": peer.as_str(), "transfer_limit_kb": 1 }),
         ))
         .expect("initial peer sync");
     daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
@@ -5160,10 +5253,7 @@ fn peer_sync_result_reports_cumulative_acceptance_rate_like_python() {
         daemon.store.upsert_propagation_entry(entry).expect("store propagation entry");
         daemon
             .store
-            .mark_peer_unhandled_propagation(
-                "peer-cumulative-acceptance",
-                entry.transient_id.as_str(),
-            )
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
             .expect("mark unhandled");
     }
 
@@ -5172,7 +5262,7 @@ fn peer_sync_result_reports_cumulative_acceptance_rate_like_python() {
             58,
             "peer_sync",
             json!({
-                "peer": "peer-cumulative-acceptance",
+                "peer": peer.as_str(),
                 "wanted_ids": [wanted.transient_id.as_str()],
             }),
         ))
@@ -5378,14 +5468,11 @@ fn list_peers_ignores_stale_handled_propagation_marks() {
 
 #[test]
 fn peer_sync_applies_per_peer_propagation_sync_limit() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(56, "peer_sync", json!({ "peer": "peer-sync-budget" })))
-        .expect("initial peer sync");
+    let (daemon, peer) = ready_propagation_peer_daemon(0x44);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-sync-budget").expect("peer record");
-        peer.propagation_sync_limit = Some((24 + 20 + 32 + 16 + 1) as u32);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some((24 + 20 + 32 + 16 + 1) as u32);
     }
 
     let small = PropagationEntryRecord {
@@ -5409,7 +5496,7 @@ fn peer_sync_applies_per_peer_propagation_sync_limit() {
     for entry in [&small, &large] {
         daemon
             .store
-            .mark_peer_unhandled_propagation("peer-sync-budget", entry.transient_id.as_str())
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
             .expect("mark unhandled");
     }
 
@@ -5418,7 +5505,7 @@ fn peer_sync_applies_per_peer_propagation_sync_limit() {
             57,
             "peer_sync",
             json!({
-                "peer": "peer-sync-budget",
+                "peer": peer,
                 "transfer_limit_kb": 1.0,
             }),
         ))
@@ -5426,12 +5513,12 @@ fn peer_sync_applies_per_peer_propagation_sync_limit() {
 
     let handled = daemon
         .store
-        .list_peer_handled_propagation_ids("peer-sync-budget")
+        .list_peer_handled_propagation_ids(peer.as_str())
         .expect("handled ids");
     assert_eq!(handled, vec![small.transient_id]);
     let pending = daemon
         .store
-        .list_peer_unhandled_propagation("peer-sync-budget")
+        .list_peer_unhandled_propagation(peer.as_str())
         .expect("pending propagation");
     assert_eq!(pending, vec![large]);
 }
@@ -5492,14 +5579,11 @@ fn peer_sync_skips_entry_at_exact_sync_limit_like_python() {
 
 #[test]
 fn peer_sync_applies_python_per_message_overhead_for_sync_limit() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(56, "peer_sync", json!({ "peer": "peer-sync-overhead" })))
-        .expect("initial peer sync");
+    let (daemon, peer) = ready_propagation_peer_daemon(0x45);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-sync-overhead").expect("peer record");
-        peer.propagation_sync_limit = Some((24 + 40 + 16 + 1) as u32);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some((24 + 40 + 16 + 1) as u32);
     }
 
     let entry = PropagationEntryRecord {
@@ -5513,7 +5597,7 @@ fn peer_sync_applies_python_per_message_overhead_for_sync_limit() {
     daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-sync-overhead", entry.transient_id.as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
         .expect("mark unhandled");
 
     let result = daemon
@@ -5521,7 +5605,7 @@ fn peer_sync_applies_python_per_message_overhead_for_sync_limit() {
             57,
             "peer_sync",
             json!({
-                "peer": "peer-sync-overhead",
+                "peer": peer.as_str(),
                 "transfer_limit_kb": 1.0,
             }),
         ))
@@ -5537,22 +5621,19 @@ fn peer_sync_applies_python_per_message_overhead_for_sync_limit() {
 
     let handled = daemon
         .store
-        .list_peer_handled_propagation_ids("peer-sync-overhead")
+        .list_peer_handled_propagation_ids(peer.as_str())
         .expect("handled ids");
     assert_eq!(handled, vec![entry.transient_id]);
 }
 
 #[test]
 fn peer_sync_uses_transfer_limit_when_sync_limit_is_absent() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(58, "peer_sync", json!({ "peer": "peer-transfer-budget" })))
-        .expect("initial peer sync");
+    let (daemon, peer) = ready_propagation_peer_daemon(0x46);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-transfer-budget").expect("peer record");
-        peer.propagation_transfer_limit = Some((24 + 20 + 32 + 16 + 1) as u32);
-        peer.propagation_sync_limit = None;
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_transfer_limit = Some((24 + 20 + 32 + 16 + 1) as u32);
+        record.propagation_sync_limit = None;
     }
 
     let small = PropagationEntryRecord {
@@ -5576,7 +5657,7 @@ fn peer_sync_uses_transfer_limit_when_sync_limit_is_absent() {
     for entry in [&small, &large] {
         daemon
             .store
-            .mark_peer_unhandled_propagation("peer-transfer-budget", entry.transient_id.as_str())
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
             .expect("mark unhandled");
     }
 
@@ -5585,7 +5666,7 @@ fn peer_sync_uses_transfer_limit_when_sync_limit_is_absent() {
             59,
             "peer_sync",
             json!({
-                "peer": "peer-transfer-budget",
+                "peer": peer.as_str(),
                 "transfer_limit_kb": 1.0,
             }),
         ))
@@ -5593,12 +5674,12 @@ fn peer_sync_uses_transfer_limit_when_sync_limit_is_absent() {
 
     let handled = daemon
         .store
-        .list_peer_handled_propagation_ids("peer-transfer-budget")
+        .list_peer_handled_propagation_ids(peer.as_str())
         .expect("handled ids");
     assert_eq!(handled, vec![small.transient_id]);
     let pending = daemon
         .store
-        .list_peer_unhandled_propagation("peer-transfer-budget")
+        .list_peer_unhandled_propagation(peer.as_str())
         .expect("pending propagation");
     assert_eq!(pending, vec![large]);
 }
@@ -5985,14 +6066,11 @@ fn postponed_peer_sync_reports_request_transfer_limit() {
 
 #[test]
 fn peer_sync_orders_offers_by_python_weight_before_sync_limit() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(62, "peer_sync", json!({ "peer": "peer-weight-order" })))
-        .expect("initial peer sync");
+    let (daemon, peer) = ready_propagation_peer_daemon(0x49);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-weight-order").expect("peer record");
-        peer.propagation_sync_limit = Some(152);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some(152);
     }
 
     let older_large = PropagationEntryRecord {
@@ -6015,7 +6093,7 @@ fn peer_sync_orders_offers_by_python_weight_before_sync_limit() {
         daemon.store.upsert_propagation_entry(entry).expect("store propagation entry");
         daemon
             .store
-            .mark_peer_unhandled_propagation("peer-weight-order", entry.transient_id.as_str())
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
             .expect("mark unhandled");
     }
 
@@ -6024,7 +6102,7 @@ fn peer_sync_orders_offers_by_python_weight_before_sync_limit() {
             63,
             "peer_sync",
             json!({
-                "peer": "peer-weight-order",
+                "peer": peer.as_str(),
                 "transfer_limit_kb": 1.0,
             }),
         ))
@@ -6042,27 +6120,24 @@ fn peer_sync_orders_offers_by_python_weight_before_sync_limit() {
 
     let handled = daemon
         .store
-        .list_peer_handled_propagation_ids("peer-weight-order")
+        .list_peer_handled_propagation_ids(peer.as_str())
         .expect("handled ids");
     assert_eq!(handled, vec![newer_small.transient_id]);
     let pending = daemon
         .store
-        .list_peer_unhandled_propagation("peer-weight-order")
+        .list_peer_unhandled_propagation(peer.as_str())
         .expect("pending propagation");
     assert_eq!(pending, vec![older_large]);
 }
 
 #[test]
 fn peer_sync_reports_propagation_transfer_accounting() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(60, "peer_sync", json!({ "peer": "peer-sync-report" })))
-        .expect("initial peer sync");
+    let (daemon, peer) = ready_propagation_peer_daemon(0x4a);
     daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-sync-report").expect("peer record");
-        peer.propagation_sync_limit = Some((24 + 20 + 32 + 16 + 1) as u32);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some((24 + 20 + 32 + 16 + 1) as u32);
     }
 
     let small = PropagationEntryRecord {
@@ -6086,7 +6161,7 @@ fn peer_sync_reports_propagation_transfer_accounting() {
     for entry in [&small, &large] {
         daemon
             .store
-            .mark_peer_unhandled_propagation("peer-sync-report", entry.transient_id.as_str())
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
             .expect("mark unhandled");
     }
 
@@ -6095,7 +6170,7 @@ fn peer_sync_reports_propagation_transfer_accounting() {
             61,
             "peer_sync",
             json!({
-                "peer": "peer-sync-report",
+                "peer": peer.as_str(),
                 "transfer_limit_kb": 1.0,
             }),
         ))
@@ -6173,7 +6248,7 @@ fn peer_sync_reports_propagation_transfer_accounting() {
         .as_array()
         .expect("peer rows")
         .iter()
-        .find(|row| row["peer"].as_str() == Some("peer-sync-report"))
+        .find(|row| row["peer"].as_str() == Some(peer.as_str()))
         .expect("peer row");
     assert_eq!(row["tx_bytes"].as_u64(), Some(expected_resource_bytes as u64));
     assert_eq!(row["messages"]["offered"].as_u64(), Some(1));
@@ -6185,14 +6260,11 @@ fn peer_sync_reports_propagation_transfer_accounting() {
 
 #[test]
 fn peer_sync_updates_transfer_rate_from_transferred_bytes() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(63, "peer_sync", json!({ "peer": "peer-sync-rate" })))
-        .expect("initial peer sync");
+    let (daemon, peer) = ready_propagation_peer_daemon(0x4b);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-sync-rate").expect("peer record");
-        peer.propagation_sync_limit = Some(1_000);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some(1_000);
     }
 
     let entry = PropagationEntryRecord {
@@ -6206,7 +6278,7 @@ fn peer_sync_updates_transfer_rate_from_transferred_bytes() {
     daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-sync-rate", entry.transient_id.as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
         .expect("mark unhandled");
 
     let result = daemon
@@ -6214,7 +6286,7 @@ fn peer_sync_updates_transfer_rate_from_transferred_bytes() {
             64,
             "peer_sync",
             json!({
-                "peer": "peer-sync-rate",
+                "peer": peer.as_str(),
                 "transfer_limit_kb": 1.0,
             }),
         ))
@@ -6236,7 +6308,7 @@ fn peer_sync_updates_transfer_rate_from_transferred_bytes() {
         .as_array()
         .expect("peer rows")
         .iter()
-        .find(|row| row["peer"].as_str() == Some("peer-sync-rate"))
+        .find(|row| row["peer"].as_str() == Some(peer.as_str()))
         .expect("peer row");
     assert_eq!(row["sync_transfer_rate"].as_f64(), Some(expected_resource_bytes as f64));
     assert_eq!(row["str"].as_u64(), Some(expected_resource_bytes as u64));
@@ -6244,14 +6316,11 @@ fn peer_sync_updates_transfer_rate_from_transferred_bytes() {
 
 #[test]
 fn peer_sync_preserves_transfer_rate_when_no_offers_remain_like_python() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(63, "peer_sync", json!({ "peer": "peer-sync-rate-empty" })))
-        .expect("initial peer sync");
+    let (daemon, peer) = ready_propagation_peer_daemon(0x4c);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-sync-rate-empty").expect("peer record");
-        peer.propagation_sync_limit = Some(1_000);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some(1_000);
     }
 
     let entry = PropagationEntryRecord {
@@ -6265,14 +6334,14 @@ fn peer_sync_preserves_transfer_rate_when_no_offers_remain_like_python() {
     daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-sync-rate-empty", entry.transient_id.as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
         .expect("mark unhandled");
     daemon
         .handle_rpc(rpc_request(
             64,
             "peer_sync",
             json!({
-                "peer": "peer-sync-rate-empty",
+                "peer": peer.as_str(),
                 "transfer_limit_kb": 1.0,
             }),
         ))
@@ -6281,7 +6350,7 @@ fn peer_sync_preserves_transfer_rate_when_no_offers_remain_like_python() {
         rmp_serde::to_vec(&(1.0_f64, vec![vec![0x30; 48]])).expect("pack sync resource").len();
 
     let result = daemon
-        .handle_rpc(rpc_request(65, "peer_sync", json!({ "peer": "peer-sync-rate-empty" })))
+        .handle_rpc(rpc_request(65, "peer_sync", json!({ "peer": peer.as_str() })))
         .expect("peer sync without offers")
         .result
         .expect("peer sync result");
@@ -6299,7 +6368,7 @@ fn peer_sync_preserves_transfer_rate_when_no_offers_remain_like_python() {
         .as_array()
         .expect("peer rows")
         .iter()
-        .find(|row| row["peer"].as_str() == Some("peer-sync-rate-empty"))
+        .find(|row| row["peer"].as_str() == Some(peer.as_str()))
         .expect("peer row");
     assert_eq!(row["sync_transfer_rate"].as_f64(), Some(expected_resource_bytes as f64));
     assert_eq!(row["str"].as_u64(), Some(expected_resource_bytes as u64));
@@ -6307,14 +6376,11 @@ fn peer_sync_preserves_transfer_rate_when_no_offers_remain_like_python() {
 
 #[test]
 fn peer_sync_preserves_transfer_rate_when_offers_are_skipped_or_transfer_limited() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(63, "peer_sync", json!({ "peer": "peer-sync-rate-skipped" })))
-        .expect("initial peer sync");
+    let (daemon, peer) = ready_propagation_peer_daemon(0x4d);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-sync-rate-skipped").expect("peer record");
-        peer.propagation_sync_limit = Some(1_000);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some(1_000);
     }
 
     let handled = PropagationEntryRecord {
@@ -6328,14 +6394,14 @@ fn peer_sync_preserves_transfer_rate_when_offers_are_skipped_or_transfer_limited
     daemon.store.upsert_propagation_entry(&handled).expect("store handled entry");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-sync-rate-skipped", handled.transient_id.as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), handled.transient_id.as_str())
         .expect("mark handled unhandled");
     daemon
         .handle_rpc(rpc_request(
             64,
             "peer_sync",
             json!({
-                "peer": "peer-sync-rate-skipped",
+                "peer": peer.as_str(),
                 "transfer_limit_kb": 1.0,
             }),
         ))
@@ -6345,8 +6411,8 @@ fn peer_sync_preserves_transfer_rate_when_offers_are_skipped_or_transfer_limited
 
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-sync-rate-skipped").expect("peer record");
-        peer.propagation_sync_limit = Some(24 + 40 + 16);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some(24 + 40 + 16);
     }
     let skipped = PropagationEntryRecord {
         transient_id: "d9".repeat(32),
@@ -6359,7 +6425,7 @@ fn peer_sync_preserves_transfer_rate_when_offers_are_skipped_or_transfer_limited
     daemon.store.upsert_propagation_entry(&skipped).expect("store skipped entry");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-sync-rate-skipped", skipped.transient_id.as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), skipped.transient_id.as_str())
         .expect("mark skipped unhandled");
 
     let result = daemon
@@ -6367,7 +6433,7 @@ fn peer_sync_preserves_transfer_rate_when_offers_are_skipped_or_transfer_limited
             65,
             "peer_sync",
             json!({
-                "peer": "peer-sync-rate-skipped",
+                "peer": peer.as_str(),
                 "transfer_limit_kb": 1.0,
             }),
         ))
@@ -6388,18 +6454,18 @@ fn peer_sync_preserves_transfer_rate_when_offers_are_skipped_or_transfer_limited
         .as_array()
         .expect("peer rows")
         .iter()
-        .find(|row| row["peer"].as_str() == Some("peer-sync-rate-skipped"))
+        .find(|row| row["peer"].as_str() == Some(peer.as_str()))
         .expect("peer row");
     assert_eq!(row["sync_transfer_rate"].as_f64(), Some(first_resource_bytes as f64));
     assert_eq!(row["str"].as_u64(), Some(first_resource_bytes as u64));
 
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-sync-rate-skipped").expect("peer record");
-        peer.propagation_transfer_limit = None;
-        peer.propagation_sync_limit = Some(1_000);
-        peer.next_sync_attempt = 0;
-        peer.sync_backoff = 0;
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_transfer_limit = None;
+        record.propagation_sync_limit = Some(1_000);
+        record.next_sync_attempt = 0;
+        record.sync_backoff = 0;
     }
     let second_handled = PropagationEntryRecord {
         transient_id: "da".repeat(32),
@@ -6413,7 +6479,7 @@ fn peer_sync_preserves_transfer_rate_when_offers_are_skipped_or_transfer_limited
     daemon
         .store
         .mark_peer_unhandled_propagation(
-            "peer-sync-rate-skipped",
+            peer.as_str(),
             second_handled.transient_id.as_str(),
         )
         .expect("mark second handled unhandled");
@@ -6422,7 +6488,7 @@ fn peer_sync_preserves_transfer_rate_when_offers_are_skipped_or_transfer_limited
             67,
             "peer_sync",
             json!({
-                "peer": "peer-sync-rate-skipped",
+                "peer": peer.as_str(),
                 "transfer_limit_kb": 1.0,
             }),
         ))
@@ -6433,9 +6499,9 @@ fn peer_sync_preserves_transfer_rate_when_offers_are_skipped_or_transfer_limited
 
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-sync-rate-skipped").expect("peer record");
-        peer.propagation_transfer_limit = Some(80);
-        peer.propagation_sync_limit = Some(1_000);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_transfer_limit = Some(80);
+        record.propagation_sync_limit = Some(1_000);
     }
     let transfer_limited = PropagationEntryRecord {
         transient_id: "db".repeat(32),
@@ -6452,7 +6518,7 @@ fn peer_sync_preserves_transfer_rate_when_offers_are_skipped_or_transfer_limited
     daemon
         .store
         .mark_peer_unhandled_propagation(
-            "peer-sync-rate-skipped",
+            peer.as_str(),
             transfer_limited.transient_id.as_str(),
         )
         .expect("mark transfer limited unhandled");
@@ -6462,7 +6528,7 @@ fn peer_sync_preserves_transfer_rate_when_offers_are_skipped_or_transfer_limited
             68,
             "peer_sync",
             json!({
-                "peer": "peer-sync-rate-skipped",
+                "peer": peer.as_str(),
                 "transfer_limit_kb": 1.0,
             }),
         ))

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -2399,6 +2399,7 @@ fn propagation_peer_maintenance_culls_unreachable_non_static_peers_like_python()
             peers.get_mut("peer-static-unreachable-retained").expect("static peer");
         static_peer.last_seen = stale_last_seen;
         static_peer.alive = false;
+        static_peer.next_sync_attempt = i64::MAX;
     }
     daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
 
@@ -2413,6 +2414,7 @@ fn propagation_peer_maintenance_culls_unreachable_non_static_peers_like_python()
         result["culled_peers"].as_array().expect("culled peers"),
         &[json!("peer-auto-unreachable-cull")]
     );
+    assert_eq!(result["synced_peer"].as_str(), None);
     let peers = daemon
         .handle_rpc(RpcRequest { id: 43, method: "list_peers".to_string(), params: None })
         .expect("list peers")
@@ -2638,6 +2640,73 @@ fn propagation_peer_maintenance_rotates_low_acceptance_non_static_peers_like_pyt
         .expect("rotation unpeer event");
     assert_eq!(event.payload["peer"].as_str(), Some("peer-rotation-manual-low"));
     assert_eq!(event.payload["reason"].as_str(), Some("peer_rotation"));
+}
+
+#[test]
+fn propagation_peer_maintenance_syncs_one_waiting_peer_like_python() {
+    let (daemon, peer) = ready_propagation_peer_daemon(0x53);
+    let entry = PropagationEntryRecord {
+        transient_id: "d5".repeat(32),
+        destination: "18".repeat(16),
+        payload_hex: "24".repeat(32),
+        received_at: 1_700_000_618,
+        size_bytes: 32,
+        stamp_value: Some(12),
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
+        .expect("mark unhandled");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.alive = true;
+        record.last_seen = now_i64();
+        record.last_sync_attempt = record.last_seen.saturating_sub(1);
+        record.next_sync_attempt = 0;
+        record.sync_transfer_rate = 1024.0;
+    }
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let result = daemon
+        .handle_rpc(rpc_request(52, "propagation_peer_maintenance", json!({})))
+        .expect("peer maintenance")
+        .result
+        .expect("peer maintenance result");
+
+    assert_eq!(result["culled"].as_u64(), Some(0));
+    assert_eq!(result["rotated"].as_u64(), Some(0));
+    assert_eq!(result["synced_peer"].as_str(), Some(peer.as_str()));
+    assert_eq!(result["peer_sync"]["peer"].as_str(), Some(peer.as_str()));
+    assert_eq!(result["peer_sync"]["propagation"]["transferred"].as_u64(), Some(1));
+    assert_eq!(
+        result["peer_sync"]["propagation"]["transferred_ids"]
+            .as_array()
+            .expect("transferred ids"),
+        &[json!(entry.transient_id.as_str())]
+    );
+
+    assert!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer.as_str())
+            .expect("list unhandled")
+            .is_empty()
+    );
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_handled_propagation_ids(peer.as_str())
+            .expect("handled ids"),
+        vec![entry.transient_id]
+    );
+
+    let event = std::iter::from_fn(|| daemon.take_event())
+        .find(|event| event.event_type == "peer_sync")
+        .expect("maintenance peer sync event");
+    assert_eq!(event.payload["peer"].as_str(), Some(peer.as_str()));
+    assert_eq!(event.payload["propagation"]["transferred"].as_u64(), Some(1));
 }
 
 #[test]

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -3256,6 +3256,67 @@ fn peer_sync_during_backoff_postpones_skipped_offers() {
 }
 
 #[test]
+fn peer_sync_during_backoff_does_not_queue_new_existing_entries_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": "peer-backoff-no-queue" })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let peer = peers.get_mut("peer-backoff-no-queue").expect("peer record");
+        peer.sync_backoff = 12 * 60;
+        peer.next_sync_attempt = now_i64().saturating_add(12 * 60);
+    }
+    let entry = PropagationEntryRecord {
+        transient_id: "e8".repeat(32),
+        destination: "18".repeat(16),
+        payload_hex: "18".repeat(20),
+        received_at: 1_700_000_615,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store entry");
+
+    let result = daemon
+        .handle_rpc(rpc_request(54, "peer_sync", json!({ "peer": "peer-backoff-no-queue" })))
+        .expect("backoff peer sync")
+        .result
+        .expect("peer sync result");
+    assert_eq!(result["synced"].as_bool(), Some(false));
+    assert_eq!(result["postponed"].as_bool(), Some(true));
+    assert_eq!(result["postpone_reason"].as_str(), Some("backoff"));
+    assert_eq!(result["propagation"]["offered"].as_u64(), Some(0));
+
+    assert!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation("peer-backoff-no-queue")
+            .expect("pending propagation")
+            .is_empty()
+    );
+    assert!(
+        daemon
+            .store
+            .list_peer_handled_propagation_ids("peer-backoff-no-queue")
+            .expect("handled ids")
+            .is_empty()
+    );
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 55, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some("peer-backoff-no-queue"))
+        .expect("peer row");
+    assert_eq!(row["messages"]["unhandled"].as_u64(), Some(0));
+}
+
+#[test]
 fn peer_sync_postpones_offers_until_stamp_policy_is_known() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -2452,6 +2452,100 @@ fn propagation_peer_maintenance_culls_unreachable_non_static_peers_like_python()
 }
 
 #[test]
+fn propagation_peer_maintenance_rotates_low_acceptance_autopeers_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(
+            44,
+            "propagation_enable",
+            json!({
+                "enabled": true,
+                "autopeer": true,
+                "max_peers": 3,
+            }),
+        ))
+        .expect("enable propagation");
+
+    for (peer, timestamp) in [
+        ("peer-rotation-low", 1_700_000_610),
+        ("peer-rotation-keep-a", 1_700_000_611),
+        ("peer-rotation-keep-b", 1_700_000_612),
+    ] {
+        daemon
+            .accept_announce_with_metadata(
+                peer.to_string(),
+                timestamp,
+                Some(peer.to_string()),
+                Some("announce".to_string()),
+                None,
+                Some(vec!["propagation".to_string()]),
+                None,
+                None,
+                None,
+                Some(1),
+                Some(Some(0)),
+                Some(Some(1)),
+                None,
+                Some(1),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("accept autopeer announce");
+    }
+
+    let recent = now_i64();
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        for peer in [
+            "peer-rotation-low",
+            "peer-rotation-keep-a",
+            "peer-rotation-keep-b",
+        ] {
+            let record = peers.get_mut(peer).expect("peer record");
+            record.last_seen = recent;
+            record.alive = true;
+            record.last_sync_attempt = recent - 1;
+            record.offered = 10;
+        }
+        peers.get_mut("peer-rotation-low").expect("low-rate peer").outgoing = 0;
+        peers.get_mut("peer-rotation-keep-a").expect("kept peer").outgoing = 9;
+        peers.get_mut("peer-rotation-keep-b").expect("kept peer").outgoing = 10;
+    }
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let result = daemon
+        .handle_rpc(rpc_request(45, "propagation_peer_maintenance", json!({})))
+        .expect("peer maintenance")
+        .result
+        .expect("peer maintenance result");
+
+    assert_eq!(result["culled"].as_u64(), Some(0));
+    assert_eq!(result["rotated"].as_u64(), Some(1));
+    assert_eq!(
+        result["rotated_peers"].as_array().expect("rotated peers"),
+        &[json!("peer-rotation-low")]
+    );
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 46, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let rows = peers["peers"].as_array().expect("peer rows");
+    assert!(rows.iter().all(|row| row["peer"].as_str() != Some("peer-rotation-low")));
+    assert!(rows.iter().any(|row| row["peer"].as_str() == Some("peer-rotation-keep-a")));
+    assert!(rows.iter().any(|row| row["peer"].as_str() == Some("peer-rotation-keep-b")));
+
+    let event = std::iter::from_fn(|| daemon.take_event())
+        .find(|event| event.event_type == "peer_unpeer")
+        .expect("rotation unpeer event");
+    assert_eq!(event.payload["peer"].as_str(), Some("peer-rotation-low"));
+    assert_eq!(event.payload["reason"].as_str(), Some("peer_rotation"));
+}
+
+#[test]
 fn stale_announce_does_not_regress_propagation_peer_state() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -4491,8 +4491,68 @@ fn peer_sync_selected_wanted_ids_keep_full_offer_policy_gates_like_python() {
 }
 
 #[test]
-fn peer_sync_boolean_wanted_ids_false_handles_all_offered_messages_like_python() {
+fn peer_sync_empty_wanted_ids_keep_full_offer_policy_gates_like_python() {
     let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": "peer-wants-none-policy" })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let peer = peers.get_mut("peer-wants-none-policy").expect("peer record");
+        peer.propagation_sync_limit = Some(1_000);
+        peer.propagation_stamp_cost = None;
+        peer.propagation_stamp_cost_flexibility = None;
+        peer.peering_cost = None;
+    }
+    let entry = PropagationEntryRecord {
+        transient_id: "b9".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "19".repeat(24),
+        received_at: 1_700_000_611,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation("peer-wants-none-policy", entry.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let result = daemon
+        .handle_rpc(rpc_request(
+            55,
+            "peer_sync",
+            json!({
+                "peer": "peer-wants-none-policy",
+                "wanted_ids": [],
+            }),
+        ))
+        .expect("peer sync")
+        .result
+        .expect("peer sync result");
+
+    assert_eq!(result["synced"].as_bool(), Some(false));
+    assert_eq!(result["postponed"].as_bool(), Some(true));
+    assert_eq!(result["postpone_reason"].as_str(), Some("stamp_policy"));
+    assert_eq!(result["propagation"]["postponed"].as_bool(), Some(true));
+    assert_eq!(
+        result["propagation"]["postpone_reason"].as_str(),
+        Some("stamp_policy")
+    );
+    assert_eq!(result["propagation"]["offered"].as_u64(), Some(0));
+    assert_eq!(result["propagation"]["handled"].as_u64(), Some(0));
+
+    let unhandled = daemon
+        .store
+        .list_peer_unhandled_propagation("peer-wants-none-policy")
+        .expect("pending propagation");
+    assert_eq!(unhandled.len(), 1);
+    assert_eq!(unhandled[0].transient_id, entry.transient_id);
+}
+
+#[test]
+fn peer_sync_boolean_wanted_ids_false_handles_all_offered_messages_like_python() {
+    let (daemon, peer) = ready_propagation_peer_daemon(0xb5);
     let already_known = PropagationEntryRecord {
         transient_id: "b5".repeat(32),
         destination: "12".repeat(16),
@@ -4504,7 +4564,7 @@ fn peer_sync_boolean_wanted_ids_false_handles_all_offered_messages_like_python()
     daemon.store.upsert_propagation_entry(&already_known).expect("store propagation entry");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-wants-none-bool", already_known.transient_id.as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), already_known.transient_id.as_str())
         .expect("mark unhandled");
 
     let result = daemon
@@ -4512,7 +4572,7 @@ fn peer_sync_boolean_wanted_ids_false_handles_all_offered_messages_like_python()
             55,
             "peer_sync",
             json!({
-                "peer": "peer-wants-none-bool",
+                "peer": peer.as_str(),
                 "wanted_ids": false,
             }),
         ))
@@ -4527,7 +4587,7 @@ fn peer_sync_boolean_wanted_ids_false_handles_all_offered_messages_like_python()
     assert_eq!(
         daemon
             .store
-            .list_peer_handled_propagation_ids("peer-wants-none-bool")
+            .list_peer_handled_propagation_ids(peer.as_str())
             .expect("handled ids"),
         vec![already_known.transient_id]
     );
@@ -4575,18 +4635,12 @@ fn peer_sync_matches_wanted_ids_by_canonical_transient_id() {
 }
 
 #[test]
-fn peer_sync_handles_unwanted_stamped_entries_without_peering_key() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": "peer-unwanted-no-key" })))
-        .expect("initial peer sync");
+fn peer_sync_handles_unwanted_stamped_entries_without_transfer() {
+    let (daemon, peer) = ready_propagation_peer_daemon(0xa2);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-unwanted-no-key").expect("peer record");
-        peer.propagation_sync_limit = Some(1_000);
-        peer.propagation_stamp_cost = Some(1);
-        peer.propagation_stamp_cost_flexibility = Some(1);
-        peer.peering_cost = Some(1);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some(1_000);
     }
     let already_known = PropagationEntryRecord {
         transient_id: "a2".repeat(32),
@@ -4599,7 +4653,7 @@ fn peer_sync_handles_unwanted_stamped_entries_without_peering_key() {
     daemon.store.upsert_propagation_entry(&already_known).expect("store propagation entry");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-unwanted-no-key", already_known.transient_id.as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), already_known.transient_id.as_str())
         .expect("mark unhandled");
 
     let result = daemon
@@ -4607,7 +4661,7 @@ fn peer_sync_handles_unwanted_stamped_entries_without_peering_key() {
             55,
             "peer_sync",
             json!({
-                "peer": "peer-unwanted-no-key",
+                "peer": peer.as_str(),
                 "wanted_ids": [],
             }),
         ))
@@ -4616,7 +4670,6 @@ fn peer_sync_handles_unwanted_stamped_entries_without_peering_key() {
         .expect("peer sync result");
 
     assert_eq!(result["synced"].as_bool(), Some(true));
-    assert_eq!(result["peering_key"], JsonValue::Null);
     assert_eq!(result["propagation"]["postponed"].as_bool(), Some(false));
     assert_eq!(result["propagation"]["handled"].as_u64(), Some(1));
     assert_eq!(result["propagation"]["transferred"].as_u64(), Some(0));
@@ -4632,7 +4685,7 @@ fn peer_sync_handles_unwanted_stamped_entries_without_peering_key() {
     assert_eq!(
         daemon
             .store
-            .list_peer_handled_propagation_ids("peer-unwanted-no-key")
+            .list_peer_handled_propagation_ids(peer.as_str())
             .expect("handled ids"),
         vec![already_known.transient_id]
     );
@@ -4640,19 +4693,16 @@ fn peer_sync_handles_unwanted_stamped_entries_without_peering_key() {
 
 #[test]
 fn peer_sync_unwanted_offer_response_does_not_revive_unheard_peer_like_python() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": "peer-unwanted-unheard" })))
-        .expect("initial peer sync");
+    let (daemon, peer) = ready_propagation_peer_daemon(0xa9);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-unwanted-unheard").expect("peer record");
-        peer.alive = false;
-        peer.last_seen = 0;
-        peer.sync_backoff = 0;
-        peer.next_sync_attempt = 0;
-        peer.acceptance_rate = 0.75;
-        peer.sync_transfer_rate = 12_345.0;
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.alive = false;
+        record.last_seen = 0;
+        record.sync_backoff = 0;
+        record.next_sync_attempt = 0;
+        record.acceptance_rate = 0.75;
+        record.sync_transfer_rate = 12_345.0;
     }
     let already_known = PropagationEntryRecord {
         transient_id: "a9".repeat(32),
@@ -4666,7 +4716,7 @@ fn peer_sync_unwanted_offer_response_does_not_revive_unheard_peer_like_python() 
     daemon
         .store
         .mark_peer_unhandled_propagation(
-            "peer-unwanted-unheard",
+            peer.as_str(),
             already_known.transient_id.as_str(),
         )
         .expect("mark unhandled");
@@ -4676,7 +4726,7 @@ fn peer_sync_unwanted_offer_response_does_not_revive_unheard_peer_like_python() 
             55,
             "peer_sync",
             json!({
-                "peer": "peer-unwanted-unheard",
+                "peer": peer.as_str(),
                 "wanted_ids": [],
             }),
         ))
@@ -4702,7 +4752,7 @@ fn peer_sync_unwanted_offer_response_does_not_revive_unheard_peer_like_python() 
         .as_array()
         .expect("peer rows")
         .iter()
-        .find(|row| row["peer"].as_str() == Some("peer-unwanted-unheard"))
+        .find(|row| row["peer"].as_str() == Some(peer.as_str()))
         .cloned()
         .expect("peer row");
     assert_eq!(row["alive"].as_bool(), Some(false));
@@ -4712,15 +4762,12 @@ fn peer_sync_unwanted_offer_response_does_not_revive_unheard_peer_like_python() 
 
 #[test]
 fn peer_sync_transfer_limits_unwanted_oversized_entries_before_offer_response() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": "peer-unwanted-oversized" })))
-        .expect("initial peer sync");
+    let (daemon, peer) = ready_propagation_peer_daemon(0xa4);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-unwanted-oversized").expect("peer record");
-        peer.propagation_transfer_limit = Some(80);
-        peer.propagation_sync_limit = Some(1_000);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_transfer_limit = Some(80);
+        record.propagation_sync_limit = Some(1_000);
     }
     let already_known = PropagationEntryRecord {
         transient_id: "a4".repeat(32),
@@ -4733,7 +4780,7 @@ fn peer_sync_transfer_limits_unwanted_oversized_entries_before_offer_response() 
     daemon.store.upsert_propagation_entry(&already_known).expect("store propagation entry");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-unwanted-oversized", already_known.transient_id.as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), already_known.transient_id.as_str())
         .expect("mark unhandled");
 
     let result = daemon
@@ -4741,7 +4788,7 @@ fn peer_sync_transfer_limits_unwanted_oversized_entries_before_offer_response() 
             55,
             "peer_sync",
             json!({
-                "peer": "peer-unwanted-oversized",
+                "peer": peer.as_str(),
                 "wanted_ids": [],
             }),
         ))
@@ -4771,14 +4818,14 @@ fn peer_sync_transfer_limits_unwanted_oversized_entries_before_offer_response() 
     assert_eq!(
         daemon
             .store
-            .list_peer_handled_propagation_ids("peer-unwanted-oversized")
+            .list_peer_handled_propagation_ids(peer.as_str())
             .expect("handled ids"),
         vec![already_known.transient_id]
     );
     assert!(
         daemon
             .store
-            .list_peer_unhandled_propagation("peer-unwanted-oversized")
+            .list_peer_unhandled_propagation(peer.as_str())
             .expect("pending propagation")
             .is_empty()
     );
@@ -4855,14 +4902,11 @@ fn peer_sync_keeps_unwanted_sync_limited_entries_queued() {
 
 #[test]
 fn peer_sync_keeps_sync_limited_entries_queued_when_peer_wants_none() {
-    let daemon = RpcDaemon::test_instance();
-    daemon
-        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": "peer-unwanted-skipped" })))
-        .expect("initial peer sync");
+    let (daemon, peer) = ready_propagation_peer_daemon(0xb1);
     {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
-        let peer = peers.get_mut("peer-unwanted-skipped").expect("peer record");
-        peer.propagation_sync_limit = Some(80);
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some(80);
     }
     let offered = PropagationEntryRecord {
         transient_id: "b1".repeat(32),
@@ -4884,7 +4928,7 @@ fn peer_sync_keeps_sync_limited_entries_queued_when_peer_wants_none() {
         daemon.store.upsert_propagation_entry(entry).expect("store entry");
         daemon
             .store
-            .mark_peer_unhandled_propagation("peer-unwanted-skipped", entry.transient_id.as_str())
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
             .expect("mark unhandled");
     }
 
@@ -4893,7 +4937,7 @@ fn peer_sync_keeps_sync_limited_entries_queued_when_peer_wants_none() {
             55,
             "peer_sync",
             json!({
-                "peer": "peer-unwanted-skipped",
+                "peer": peer.as_str(),
                 "wanted_ids": [],
             }),
         ))
@@ -4918,13 +4962,13 @@ fn peer_sync_keeps_sync_limited_entries_queued_when_peer_wants_none() {
     assert_eq!(
         daemon
             .store
-            .list_peer_handled_propagation_ids("peer-unwanted-skipped")
+            .list_peer_handled_propagation_ids(peer.as_str())
             .expect("handled ids"),
         vec![offered.transient_id]
     );
     let pending = daemon
         .store
-        .list_peer_unhandled_propagation("peer-unwanted-skipped")
+        .list_peer_unhandled_propagation(peer.as_str())
         .expect("pending propagation");
     assert_eq!(pending, vec![skipped]);
 }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -2710,6 +2710,90 @@ fn propagation_peer_maintenance_syncs_one_waiting_peer_like_python() {
 }
 
 #[test]
+fn propagation_peer_maintenance_does_not_sync_unreachable_static_peer_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(
+            53,
+            "propagation_enable",
+            json!({
+                "enabled": true,
+                "static_peers": ["peer-static-unreachable-sync-skip"],
+            }),
+        ))
+        .expect("enable propagation");
+
+    let entry = PropagationEntryRecord {
+        transient_id: "d6".repeat(32),
+        destination: "19".repeat(16),
+        payload_hex: "25".repeat(32),
+        received_at: 1_700_000_619,
+        size_bytes: 32,
+        stamp_value: Some(12),
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(
+            "peer-static-unreachable-sync-skip",
+            entry.transient_id.as_str(),
+        )
+        .expect("mark unhandled");
+    daemon
+        .accept_announce_with_metadata(
+            "peer-static-unreachable-sync-skip".to_string(),
+            1_700_000_619,
+            Some("Static Unreachable".to_string()),
+            Some("announce".to_string()),
+            None,
+            Some(vec!["propagation".to_string()]),
+            None,
+            None,
+            None,
+            Some(1),
+            Some(Some(0)),
+            Some(Some(1)),
+            None,
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("accept static peer announce");
+    let stale_last_seen = now_i64() - (14 * 24 * 60 * 60) - 1;
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers
+            .get_mut("peer-static-unreachable-sync-skip")
+            .expect("static peer");
+        record.alive = false;
+        record.last_seen = stale_last_seen;
+        record.next_sync_attempt = 0;
+    }
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let result = daemon
+        .handle_rpc(rpc_request(54, "propagation_peer_maintenance", json!({})))
+        .expect("peer maintenance")
+        .result
+        .expect("peer maintenance result");
+
+    assert_eq!(result["culled"].as_u64(), Some(0));
+    assert_eq!(result["synced_peer"].as_str(), None);
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation("peer-static-unreachable-sync-skip")
+            .expect("list unhandled"),
+        vec![entry]
+    );
+    assert!(
+        std::iter::from_fn(|| daemon.take_event()).all(|event| event.event_type != "peer_sync")
+    );
+}
+
+#[test]
 fn stale_announce_does_not_regress_propagation_peer_state() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -70,9 +70,7 @@ fn daemon_status_ex_reads_cached_status_snapshot() {
     assert_eq!(result["stamp_policy"]["enforce"].as_bool(), Some(true));
 }
 
-fn ready_propagation_peer_daemon(peer_seed: u8) -> (RpcDaemon, String) {
-    let store = MessagesStore::in_memory().expect("store");
-    let daemon = RpcDaemon::with_store(store, hex::encode([2u8; 16]));
+fn make_ready_propagation_peer(daemon: &RpcDaemon, peer_seed: u8) -> String {
     let peer = hex::encode([peer_seed; 16]);
     daemon
         .accept_announce_with_metadata(
@@ -96,6 +94,13 @@ fn ready_propagation_peer_daemon(peer_seed: u8) -> (RpcDaemon, String) {
             None,
         )
         .expect("accept ready propagation peer announce");
+    peer
+}
+
+fn ready_propagation_peer_daemon(peer_seed: u8) -> (RpcDaemon, String) {
+    let store = MessagesStore::in_memory().expect("store");
+    let daemon = RpcDaemon::with_store(store, hex::encode([2u8; 16]));
+    let peer = make_ready_propagation_peer(&daemon, peer_seed);
     (daemon, peer)
 }
 
@@ -549,7 +554,8 @@ fn propagation_enable_static_only_unpeers_existing_non_static_peers() {
 
 #[test]
 fn propagation_enable_queues_existing_entries_for_static_peers() {
-    let daemon = RpcDaemon::test_instance();
+    let daemon = RpcDaemon::test_instance_with_identity(hex::encode([2u8; 16]));
+    let peer = hex::encode([0x51_u8; 16]);
     let entry = PropagationEntryRecord {
         transient_id: "a7".repeat(32),
         destination: "12".repeat(16),
@@ -566,10 +572,11 @@ fn propagation_enable_queues_existing_entries_for_static_peers() {
             "propagation_enable",
             json!({
                 "enabled": true,
-                "static_peers": ["peer-static-queue"],
+                "static_peers": [peer.as_str()],
             }),
         ))
         .expect("enable propagation");
+    assert_eq!(make_ready_propagation_peer(&daemon, 0x51), peer);
 
     let peers = daemon
         .handle_rpc(RpcRequest { id: 27, method: "list_peers".to_string(), params: None })
@@ -580,7 +587,7 @@ fn propagation_enable_queues_existing_entries_for_static_peers() {
         .as_array()
         .expect("peer rows")
         .iter()
-        .find(|row| row["peer"].as_str() == Some("peer-static-queue"))
+        .find(|row| row["peer"].as_str() == Some(peer.as_str()))
         .expect("peer row");
     assert_eq!(row["messages"]["offered"].as_u64(), Some(0));
     assert_eq!(row["messages"]["unhandled"].as_u64(), Some(1));
@@ -593,7 +600,7 @@ fn propagation_enable_queues_existing_entries_for_static_peers() {
         .handle_rpc(rpc_request(
             28,
             "peer_sync",
-            json!({ "peer": "peer-static-queue", "transfer_limit_kb": 1 }),
+            json!({ "peer": peer.as_str(), "transfer_limit_kb": 1 }),
         ))
         .expect("peer sync")
         .result
@@ -11277,9 +11284,9 @@ fn peer_sync_reactivates_persisted_unpeered_record() {
 
 #[test]
 fn peer_unpeer_clears_persisted_propagation_queue_marks() {
-    let daemon = RpcDaemon::test_instance();
+    let (daemon, peer) = ready_propagation_peer_daemon(0x52);
     daemon
-        .handle_rpc(rpc_request(90, "peer_sync", json!({ "peer": "peer-unpeer-queue" })))
+        .handle_rpc(rpc_request(90, "peer_sync", json!({ "peer": peer.as_str() })))
         .expect("sync peer");
     let entry = PropagationEntryRecord {
         transient_id: "ee".repeat(32),
@@ -11292,15 +11299,15 @@ fn peer_unpeer_clears_persisted_propagation_queue_marks() {
     daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-unpeer-queue", entry.transient_id.as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
         .expect("mark unhandled");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-unpeer-queue", "fa".repeat(32).as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), "fa".repeat(32).as_str())
         .expect("mark stale unhandled");
 
     let unpeer = daemon
-        .handle_rpc(rpc_request(91, "peer_unpeer", json!({ "peer": "peer-unpeer-queue" })))
+        .handle_rpc(rpc_request(91, "peer_unpeer", json!({ "peer": peer.as_str() })))
         .expect("unpeer peer")
         .result
         .expect("unpeer result");
@@ -11312,16 +11319,17 @@ fn peer_unpeer_clears_persisted_propagation_queue_marks() {
     assert!(
         daemon
             .store
-            .list_peer_unhandled_propagation("peer-unpeer-queue")
+            .list_peer_unhandled_propagation(peer.as_str())
             .expect("list unhandled")
             .is_empty()
     );
 
+    make_ready_propagation_peer(&daemon, 0x52);
     daemon
         .handle_rpc(rpc_request(
             92,
             "peer_sync",
-            json!({ "peer": "peer-unpeer-queue", "transfer_limit_kb": 1 }),
+            json!({ "peer": peer.as_str(), "transfer_limit_kb": 1 }),
         ))
         .expect("resync peer");
     let peers = daemon

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -2710,6 +2710,50 @@ fn propagation_peer_maintenance_syncs_one_waiting_peer_like_python() {
 }
 
 #[test]
+fn propagation_peer_maintenance_candidate_pool_includes_unknown_speed_peers_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let fast_peer = make_ready_propagation_peer(&daemon, 0x54);
+    let slower_peer = make_ready_propagation_peer(&daemon, 0x55);
+    let unknown_speed_peer = make_ready_propagation_peer(&daemon, 0x56);
+    let entry = PropagationEntryRecord {
+        transient_id: "d7".repeat(32),
+        destination: "1a".repeat(16),
+        payload_hex: "26".repeat(32),
+        received_at: 1_700_000_620,
+        size_bytes: 32,
+        stamp_value: Some(12),
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    for peer in [&fast_peer, &slower_peer, &unknown_speed_peer] {
+        daemon
+            .store
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
+            .expect("mark unhandled");
+    }
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        for (peer, rate) in [
+            (fast_peer.as_str(), 2_048.0),
+            (slower_peer.as_str(), 1_024.0),
+            (unknown_speed_peer.as_str(), 0.0),
+        ] {
+            let record = peers.get_mut(peer).expect("peer record");
+            record.alive = true;
+            record.last_seen = 1_700_000_621;
+            record.last_sync_attempt = record.last_seen.saturating_sub(1);
+            record.next_sync_attempt = 0;
+            record.sync_transfer_rate = rate;
+        }
+    }
+
+    let selected = daemon
+        .select_peer_for_maintenance_sync(1_700_000_621)
+        .expect("select maintenance sync peer");
+
+    assert_eq!(selected.as_deref(), Some(unknown_speed_peer.as_str()));
+}
+
+#[test]
 fn propagation_peer_maintenance_does_not_sync_unreachable_static_peer_like_python() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -7932,7 +7932,7 @@ fn stale_high_cost_announce_does_not_remove_newer_autopeer() {
 }
 
 #[test]
-fn high_cost_announce_does_not_remove_manual_peer() {
+fn high_cost_announce_breaks_existing_manual_peer_like_python() {
     let daemon = RpcDaemon::test_instance();
     daemon
         .handle_rpc(rpc_request(
@@ -7949,6 +7949,21 @@ fn high_cost_announce_does_not_remove_manual_peer() {
     daemon
         .handle_rpc(rpc_request(58, "peer_sync", json!({ "peer": "peer-manual" })))
         .expect("manual peer sync");
+
+    let entry = PropagationEntryRecord {
+        transient_id: "ef".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_499,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation("peer-manual", entry.transient_id.as_str())
+        .expect("mark manual peer propagation unhandled");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
 
     daemon
         .accept_announce_with_metadata(
@@ -7978,9 +7993,29 @@ fn high_cost_announce_does_not_remove_manual_peer() {
         .expect("list peers")
         .result
         .expect("list peers result");
-    let row = peers["peers"].as_array().and_then(|rows| rows.first()).expect("peer row");
-    assert_eq!(row["peer"].as_str(), Some("peer-manual"));
-    assert_eq!(row["peer_type"].as_str(), Some("manual"));
+    assert_eq!(peers["peers"].as_array().map(|rows| rows.len()), Some(0));
+    assert!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation("peer-manual")
+            .expect("manual peer propagation marks after break")
+            .is_empty(),
+        "breaking a manual peer should clear stale propagation queue marks"
+    );
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_unpeer")
+        .cloned()
+        .expect("manual peer removal event");
+    assert_eq!(event.payload["peer"].as_str(), Some("peer-manual"));
+    assert_eq!(event.payload["removed"].as_bool(), Some(true));
+    assert_eq!(event.payload["reason"].as_str(), Some("peering_cost_policy"));
+    assert_eq!(event.payload["propagation_cleared"].as_u64(), Some(1));
+    assert_eq!(event.payload["propagation_cleared_bytes"].as_u64(), Some(24));
 }
 
 include!("status_snapshot_propagation_ingest.rs");

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -2546,6 +2546,101 @@ fn propagation_peer_maintenance_rotates_low_acceptance_autopeers_like_python() {
 }
 
 #[test]
+fn propagation_peer_maintenance_rotates_low_acceptance_non_static_peers_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(
+            47,
+            "propagation_enable",
+            json!({
+                "enabled": true,
+                "autopeer": true,
+                "max_peers": 3,
+                "static_peers": ["peer-rotation-static"],
+            }),
+        ))
+        .expect("enable propagation");
+
+    daemon
+        .handle_rpc(rpc_request(48, "peer_sync", json!({ "peer": "peer-rotation-manual-low" })))
+        .expect("create manual peer");
+    daemon
+        .handle_rpc(rpc_request(49, "peer_sync", json!({ "peer": "peer-rotation-static" })))
+        .expect("create static peer");
+    daemon
+        .accept_announce_with_metadata(
+            "peer-rotation-auto-keep".to_string(),
+            1_700_000_613,
+            Some("peer-rotation-auto-keep".to_string()),
+            Some("announce".to_string()),
+            None,
+            Some(vec!["propagation".to_string()]),
+            None,
+            None,
+            None,
+            Some(1),
+            Some(Some(0)),
+            Some(Some(1)),
+            None,
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("accept autopeer announce");
+
+    let recent = now_i64();
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        for (peer, outgoing) in [
+            ("peer-rotation-manual-low", 0),
+            ("peer-rotation-static", 10),
+            ("peer-rotation-auto-keep", 10),
+        ] {
+            let record = peers.get_mut(peer).expect("peer record");
+            record.last_seen = recent;
+            record.alive = true;
+            record.last_sync_attempt = recent - 1;
+            record.offered = 10;
+            record.outgoing = outgoing;
+        }
+    }
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let result = daemon
+        .handle_rpc(rpc_request(50, "propagation_peer_maintenance", json!({})))
+        .expect("peer maintenance")
+        .result
+        .expect("peer maintenance result");
+
+    assert_eq!(result["culled"].as_u64(), Some(0));
+    assert_eq!(result["rotated"].as_u64(), Some(1));
+    assert_eq!(
+        result["rotated_peers"].as_array().expect("rotated peers"),
+        &[json!("peer-rotation-manual-low")]
+    );
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 51, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let rows = peers["peers"].as_array().expect("peer rows");
+    assert!(
+        rows.iter().all(|row| row["peer"].as_str() != Some("peer-rotation-manual-low"))
+    );
+    assert!(rows.iter().any(|row| row["peer"].as_str() == Some("peer-rotation-static")));
+    assert!(rows.iter().any(|row| row["peer"].as_str() == Some("peer-rotation-auto-keep")));
+
+    let event = std::iter::from_fn(|| daemon.take_event())
+        .find(|event| event.event_type == "peer_unpeer")
+        .expect("rotation unpeer event");
+    assert_eq!(event.payload["peer"].as_str(), Some("peer-rotation-manual-low"));
+    assert_eq!(event.payload["reason"].as_str(), Some("peer_rotation"));
+}
+
+#[test]
 fn stale_announce_does_not_regress_propagation_peer_state() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -2754,6 +2754,60 @@ fn propagation_peer_maintenance_candidate_pool_includes_unknown_speed_peers_like
 }
 
 #[test]
+fn propagation_peer_maintenance_candidate_pool_includes_all_unknown_speed_peers_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let fast_peer = make_ready_propagation_peer(&daemon, 0x5a);
+    let slower_peer = make_ready_propagation_peer(&daemon, 0x5b);
+    let first_unknown_peer = make_ready_propagation_peer(&daemon, 0x5c);
+    let second_unknown_peer = make_ready_propagation_peer(&daemon, 0x5d);
+    let third_unknown_peer = make_ready_propagation_peer(&daemon, 0x5e);
+    let entry = PropagationEntryRecord {
+        transient_id: "da".repeat(32),
+        destination: "1c".repeat(16),
+        payload_hex: "28".repeat(32),
+        received_at: 1_700_000_624,
+        size_bytes: 32,
+        stamp_value: Some(12),
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    for peer in [
+        &fast_peer,
+        &slower_peer,
+        &first_unknown_peer,
+        &second_unknown_peer,
+        &third_unknown_peer,
+    ] {
+        daemon
+            .store
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
+            .expect("mark unhandled");
+    }
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        for (peer, rate) in [
+            (fast_peer.as_str(), 2_048.0),
+            (slower_peer.as_str(), 1_024.0),
+            (first_unknown_peer.as_str(), 0.0),
+            (second_unknown_peer.as_str(), 0.0),
+            (third_unknown_peer.as_str(), 0.0),
+        ] {
+            let record = peers.get_mut(peer).expect("peer record");
+            record.alive = true;
+            record.last_seen = 1_700_000_624;
+            record.last_sync_attempt = record.last_seen.saturating_sub(1);
+            record.next_sync_attempt = 0;
+            record.sync_transfer_rate = rate;
+        }
+    }
+
+    let selected = daemon
+        .select_peer_for_maintenance_sync(1_700_000_624)
+        .expect("select maintenance sync peer");
+
+    assert_eq!(selected.as_deref(), Some(third_unknown_peer.as_str()));
+}
+
+#[test]
 fn propagation_peer_maintenance_unresponsive_pool_does_not_starve_later_peers_like_python() {
     let daemon = RpcDaemon::test_instance();
     let first_peer = make_ready_propagation_peer(&daemon, 0x57);

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -4185,7 +4185,31 @@ fn peer_sync_offer_response_only_transfers_wanted_messages_like_python() {
 
 #[test]
 fn peer_sync_boolean_wanted_ids_true_transfers_all_offered_messages_like_python() {
-    let daemon = RpcDaemon::test_instance();
+    let store = MessagesStore::in_memory().expect("store");
+    let daemon = RpcDaemon::with_store(store, hex::encode([2u8; 16]));
+    let peer = hex::encode([3u8; 16]);
+    daemon
+        .accept_announce_with_metadata(
+            peer.clone(),
+            1_700_000_606,
+            None,
+            None,
+            None,
+            Some(vec!["propagation".to_string()]),
+            None,
+            None,
+            None,
+            Some(1),
+            Some(Some(1)),
+            Some(Some(1)),
+            None,
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("accept ready propagation peer announce");
     let first = PropagationEntryRecord {
         transient_id: "b3".repeat(32),
         destination: "12".repeat(16),
@@ -4206,7 +4230,7 @@ fn peer_sync_boolean_wanted_ids_true_transfers_all_offered_messages_like_python(
         daemon.store.upsert_propagation_entry(entry).expect("store propagation entry");
         daemon
             .store
-            .mark_peer_unhandled_propagation("peer-wants-all", entry.transient_id.as_str())
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
             .expect("mark unhandled");
     }
 
@@ -4215,7 +4239,7 @@ fn peer_sync_boolean_wanted_ids_true_transfers_all_offered_messages_like_python(
             55,
             "peer_sync",
             json!({
-                "peer": "peer-wants-all",
+                "peer": peer,
                 "wanted_ids": true,
             }),
         ))
@@ -4236,10 +4260,71 @@ fn peer_sync_boolean_wanted_ids_true_transfers_all_offered_messages_like_python(
     assert!(
         daemon
             .store
-            .list_peer_unhandled_propagation("peer-wants-all")
+            .list_peer_unhandled_propagation(peer.as_str())
             .expect("pending propagation")
             .is_empty()
     );
+}
+
+#[test]
+fn peer_sync_boolean_wanted_ids_true_keeps_full_offer_policy_gates_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": "peer-wants-all-policy" })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let peer = peers.get_mut("peer-wants-all-policy").expect("peer record");
+        peer.propagation_sync_limit = Some(1_000);
+        peer.propagation_stamp_cost = None;
+        peer.propagation_stamp_cost_flexibility = None;
+        peer.peering_cost = None;
+    }
+    let entry = PropagationEntryRecord {
+        transient_id: "b7".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "17".repeat(24),
+        received_at: 1_700_000_609,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation("peer-wants-all-policy", entry.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let result = daemon
+        .handle_rpc(rpc_request(
+            55,
+            "peer_sync",
+            json!({
+                "peer": "peer-wants-all-policy",
+                "wanted_ids": true,
+            }),
+        ))
+        .expect("peer sync")
+        .result
+        .expect("peer sync result");
+
+    assert_eq!(result["synced"].as_bool(), Some(false));
+    assert_eq!(result["postponed"].as_bool(), Some(true));
+    assert_eq!(result["postpone_reason"].as_str(), Some("stamp_policy"));
+    assert_eq!(result["propagation"]["postponed"].as_bool(), Some(true));
+    assert_eq!(
+        result["propagation"]["postpone_reason"].as_str(),
+        Some("stamp_policy")
+    );
+    assert_eq!(result["propagation"]["offered"].as_u64(), Some(0));
+    assert_eq!(result["propagation"]["handled"].as_u64(), Some(0));
+    assert_eq!(result["propagation"]["skipped"].as_u64(), Some(0));
+
+    let unhandled = daemon
+        .store
+        .list_peer_unhandled_propagation("peer-wants-all-policy")
+        .expect("pending propagation");
+    assert_eq!(unhandled.len(), 1);
+    assert_eq!(unhandled[0].transient_id, entry.transient_id);
 }
 
 #[test]

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -4198,7 +4198,7 @@ fn peer_sync_queues_existing_entries_for_new_manual_peer() {
 
 #[test]
 fn peer_sync_offer_response_only_transfers_wanted_messages_like_python() {
-    let daemon = RpcDaemon::test_instance();
+    let (daemon, peer) = ready_propagation_peer_daemon(0xad);
     let wanted = PropagationEntryRecord {
         transient_id: "ad".repeat(32),
         destination: "12".repeat(16),
@@ -4219,7 +4219,7 @@ fn peer_sync_offer_response_only_transfers_wanted_messages_like_python() {
         daemon.store.upsert_propagation_entry(entry).expect("store propagation entry");
         daemon
             .store
-            .mark_peer_unhandled_propagation("peer-offer-response", entry.transient_id.as_str())
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
             .expect("mark unhandled");
     }
 
@@ -4228,7 +4228,7 @@ fn peer_sync_offer_response_only_transfers_wanted_messages_like_python() {
             55,
             "peer_sync",
             json!({
-                "peer": "peer-offer-response",
+                "peer": peer.as_str(),
                 "wanted_ids": [wanted.transient_id.as_str()],
             }),
         ))
@@ -4258,14 +4258,14 @@ fn peer_sync_offer_response_only_transfers_wanted_messages_like_python() {
     assert_eq!(
         daemon
             .store
-            .list_peer_handled_propagation_ids("peer-offer-response")
+            .list_peer_handled_propagation_ids(peer.as_str())
             .expect("handled ids"),
         vec![wanted.transient_id, already_known.transient_id]
     );
     assert!(
         daemon
             .store
-            .list_peer_unhandled_propagation("peer-offer-response")
+            .list_peer_unhandled_propagation(peer.as_str())
             .expect("pending propagation")
             .is_empty()
     );
@@ -4431,6 +4431,66 @@ fn peer_sync_boolean_wanted_ids_true_keeps_full_offer_policy_gates_like_python()
 }
 
 #[test]
+fn peer_sync_selected_wanted_ids_keep_full_offer_policy_gates_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": "peer-selected-policy" })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let peer = peers.get_mut("peer-selected-policy").expect("peer record");
+        peer.propagation_sync_limit = Some(1_000);
+        peer.propagation_stamp_cost = None;
+        peer.propagation_stamp_cost_flexibility = None;
+        peer.peering_cost = None;
+    }
+    let entry = PropagationEntryRecord {
+        transient_id: "b8".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "18".repeat(24),
+        received_at: 1_700_000_610,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation("peer-selected-policy", entry.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let result = daemon
+        .handle_rpc(rpc_request(
+            55,
+            "peer_sync",
+            json!({
+                "peer": "peer-selected-policy",
+                "wanted_ids": [entry.transient_id.as_str()],
+            }),
+        ))
+        .expect("peer sync")
+        .result
+        .expect("peer sync result");
+
+    assert_eq!(result["synced"].as_bool(), Some(false));
+    assert_eq!(result["postponed"].as_bool(), Some(true));
+    assert_eq!(result["postpone_reason"].as_str(), Some("stamp_policy"));
+    assert_eq!(result["propagation"]["postponed"].as_bool(), Some(true));
+    assert_eq!(
+        result["propagation"]["postpone_reason"].as_str(),
+        Some("stamp_policy")
+    );
+    assert_eq!(result["propagation"]["offered"].as_u64(), Some(0));
+    assert_eq!(result["propagation"]["handled"].as_u64(), Some(0));
+
+    let unhandled = daemon
+        .store
+        .list_peer_unhandled_propagation("peer-selected-policy")
+        .expect("pending propagation");
+    assert_eq!(unhandled.len(), 1);
+    assert_eq!(unhandled[0].transient_id, entry.transient_id);
+}
+
+#[test]
 fn peer_sync_boolean_wanted_ids_false_handles_all_offered_messages_like_python() {
     let daemon = RpcDaemon::test_instance();
     let already_known = PropagationEntryRecord {
@@ -4475,7 +4535,7 @@ fn peer_sync_boolean_wanted_ids_false_handles_all_offered_messages_like_python()
 
 #[test]
 fn peer_sync_matches_wanted_ids_by_canonical_transient_id() {
-    let daemon = RpcDaemon::test_instance();
+    let (daemon, peer) = ready_propagation_peer_daemon(0xa1);
     let wanted = PropagationEntryRecord {
         transient_id: "a1".repeat(32),
         destination: "12".repeat(16),
@@ -4487,7 +4547,7 @@ fn peer_sync_matches_wanted_ids_by_canonical_transient_id() {
     daemon.store.upsert_propagation_entry(&wanted).expect("store propagation entry");
     daemon
         .store
-        .mark_peer_unhandled_propagation("peer-canonical-wanted", wanted.transient_id.as_str())
+        .mark_peer_unhandled_propagation(peer.as_str(), wanted.transient_id.as_str())
         .expect("mark unhandled");
 
     let result = daemon
@@ -4495,7 +4555,7 @@ fn peer_sync_matches_wanted_ids_by_canonical_transient_id() {
             55,
             "peer_sync",
             json!({
-                "peer": "peer-canonical-wanted",
+                "peer": peer.as_str(),
                 "wanted_ids": [format!("  {}  ", wanted.transient_id.to_ascii_uppercase())],
             }),
         ))
@@ -5159,7 +5219,7 @@ fn peer_sync_rejects_transfer_limited_wanted_ids_without_mutating_queue() {
 
 #[test]
 fn list_peers_top_level_message_counters_match_python_sync_accounting() {
-    let daemon = RpcDaemon::test_instance();
+    let (daemon, peer) = ready_propagation_peer_daemon(0xaf);
     let wanted = PropagationEntryRecord {
         transient_id: "af".repeat(32),
         destination: "12".repeat(16),
@@ -5180,7 +5240,7 @@ fn list_peers_top_level_message_counters_match_python_sync_accounting() {
         daemon.store.upsert_propagation_entry(entry).expect("store propagation entry");
         daemon
             .store
-            .mark_peer_unhandled_propagation("peer-top-level-counters", entry.transient_id.as_str())
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
             .expect("mark unhandled");
     }
 
@@ -5189,7 +5249,7 @@ fn list_peers_top_level_message_counters_match_python_sync_accounting() {
             55,
             "peer_sync",
             json!({
-                "peer": "peer-top-level-counters",
+                "peer": peer.as_str(),
                 "wanted_ids": [wanted.transient_id.as_str()],
             }),
         ))
@@ -5204,7 +5264,7 @@ fn list_peers_top_level_message_counters_match_python_sync_accounting() {
         .as_array()
         .expect("peer rows")
         .iter()
-        .find(|row| row["peer"].as_str() == Some("peer-top-level-counters"))
+        .find(|row| row["peer"].as_str() == Some(peer.as_str()))
         .expect("peer row");
 
     assert_eq!(row["messages"]["offered"].as_u64(), Some(2));
@@ -5304,7 +5364,7 @@ fn peer_sync_result_reports_cumulative_acceptance_rate_like_python() {
 
 #[test]
 fn peer_sync_persists_counters_after_propagation_entries_are_purged_like_python() {
-    let daemon = RpcDaemon::test_instance();
+    let (daemon, peer) = ready_propagation_peer_daemon(0xb4);
     let wanted = PropagationEntryRecord {
         transient_id: "b4".repeat(32),
         destination: "12".repeat(16),
@@ -5326,7 +5386,7 @@ fn peer_sync_persists_counters_after_propagation_entries_are_purged_like_python(
         daemon
             .store
             .mark_peer_unhandled_propagation(
-                "peer-persistent-counters",
+                peer.as_str(),
                 entry.transient_id.as_str(),
             )
             .expect("mark unhandled");
@@ -5337,7 +5397,7 @@ fn peer_sync_persists_counters_after_propagation_entries_are_purged_like_python(
             59,
             "peer_sync",
             json!({
-                "peer": "peer-persistent-counters",
+                "peer": peer.as_str(),
                 "wanted_ids": [wanted.transient_id.as_str()],
             }),
         ))
@@ -5365,7 +5425,7 @@ fn peer_sync_persists_counters_after_propagation_entries_are_purged_like_python(
         .as_array()
         .expect("peer rows")
         .iter()
-        .find(|row| row["peer"].as_str() == Some("peer-persistent-counters"))
+        .find(|row| row["peer"].as_str() == Some(peer.as_str()))
         .expect("peer row");
     assert_eq!(row["messages"]["offered"].as_u64(), Some(2));
     assert_eq!(row["messages"]["outgoing"].as_u64(), Some(1));

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -2754,6 +2754,45 @@ fn propagation_peer_maintenance_candidate_pool_includes_unknown_speed_peers_like
 }
 
 #[test]
+fn propagation_peer_maintenance_unresponsive_pool_does_not_starve_later_peers_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let first_peer = make_ready_propagation_peer(&daemon, 0x57);
+    let second_peer = make_ready_propagation_peer(&daemon, 0x58);
+    let third_peer = make_ready_propagation_peer(&daemon, 0x59);
+    let entry = PropagationEntryRecord {
+        transient_id: "d8".repeat(32),
+        destination: "1b".repeat(16),
+        payload_hex: "27".repeat(32),
+        received_at: 1_700_000_621,
+        size_bytes: 32,
+        stamp_value: Some(12),
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    for peer in [&first_peer, &second_peer, &third_peer] {
+        daemon
+            .store
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
+            .expect("mark unhandled");
+    }
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        for peer in [&first_peer, &second_peer, &third_peer] {
+            let record = peers.get_mut(peer.as_str()).expect("peer record");
+            record.alive = false;
+            record.last_seen = 1_700_000_621;
+            record.last_sync_attempt = record.last_seen.saturating_sub(1);
+            record.next_sync_attempt = 0;
+        }
+    }
+
+    let selected = daemon
+        .select_peer_for_maintenance_sync(1_700_000_623)
+        .expect("select maintenance sync peer");
+
+    assert_eq!(selected.as_deref(), Some(second_peer.as_str()));
+}
+
+#[test]
 fn propagation_peer_maintenance_does_not_sync_unreachable_static_peer_like_python() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -113,8 +113,8 @@
     },
     {
       "path": "docs/contracts/rpc-contract.md",
-      "bytes": 12145,
-      "sha256": "da787f4e88cba076b9247bbfe019c697fc80bdac285920a6a83b78e224aebb81"
+      "bytes": 12332,
+      "sha256": "1e021a07457f534d7c244c1068ab2b6427a676dae5c255da025dc19f15106375"
     },
     {
       "path": "docs/contracts/schema-driven-clients.md",

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -156,6 +156,10 @@ gap, even though deeper propagation-router parity remains open.
   stay on Python's full-offer policy path: non-empty list-shaped `wanted_ids`
   wait for stamp-policy and peering-key readiness before mutating queue state or
   transferring payloads.
+- Local peer sync no-transfer offer responses now also stay on Python's
+  full-offer policy path: `wanted_ids: false` and `wanted_ids: []` wait for
+  stamp-policy and peering-key readiness before marking offered queue entries
+  handled without resource transfer.
 - Empty local peer sync now follows Python's no-unhandled-messages path: a
   clean peer with no pending propagation entries records the attempt but
   preserves liveness and the previous sync transfer rate, and avoids synthetic

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -145,6 +145,10 @@ gap, even though deeper propagation-router parity remains open.
   `wanted_ids: true` transfers every offered message, while `wanted_ids: false`
   and `wanted_ids: []` mark the whole offer handled without resource transfer,
   preserving the no-transfer liveness and transfer-rate behavior.
+- Local peer sync now also keeps Python's full-offer policy gates for
+  `wanted_ids: true`: a boolean wants-all response waits for stamp-policy and
+  peering-key readiness like the original offer path instead of bypassing those
+  gates as an explicit selected-ID response.
 - Empty local peer sync now follows Python's no-unhandled-messages path: a
   clean peer with no pending propagation entries records the attempt but
   preserves liveness and the previous sync transfer rate, and avoids synthetic

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -151,6 +151,9 @@ gap, even though deeper propagation-router parity remains open.
   failure backoff, while existing failure backoff remains intact.
 - Postponed local peer sync now also preserves the previous sync transfer rate
   instead of clearing transfer accounting before any offer/resource path runs.
+- Postponed local peer sync now honors existing peer backoff before the local
+  queue-fill path: a backed-off peer does not opportunistically gain new
+  unhandled propagation marks until the sync attempt is eligible to run.
 - Local peer sync now preserves the previous sync transfer rate when pending
   offers are only skipped by sync limits or marked transfer-limited, matching
   Python's resource-completion-only transfer-rate updates.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -149,6 +149,9 @@ gap, even though deeper propagation-router parity remains open.
   `wanted_ids: true`: a boolean wants-all response waits for stamp-policy and
   peering-key readiness like the original offer path instead of bypassing those
   gates as an explicit selected-ID response.
+- Local peer sync request-only transfer limits now also stay on Python's
+  full-offer policy path: `transfer_limit_kb` constrains offer construction
+  but does not by itself bypass stamp-policy or peering-key readiness.
 - Empty local peer sync now follows Python's no-unhandled-messages path: a
   clean peer with no pending propagation entries records the attempt but
   preserves liveness and the previous sync transfer rate, and avoids synthetic

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -117,6 +117,10 @@ gap, even though deeper propagation-router parity remains open.
   peer sync through the existing local `peer_sync` path, so Python
   `sync_peers()`-style maintenance mutates queue marks and transfer accounting
   instead of only reporting cull/rotation status.
+- Propagation peer maintenance also follows Python's sync-pool boundary for
+  retained static peers: static peers past `LXMPeer.MAX_UNREACHABLE` are kept
+  peered, but are not selected for waiting or retry-ready sync in that
+  maintenance pass.
 - Propagation offer handling now follows Python's invalid propagation-stamp
   throttle: peer resource transfers containing invalid propagation stamps mark
   that propagation peer throttled for Python's `PN_STAMP_THROTTLE` window, and

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -152,6 +152,10 @@ gap, even though deeper propagation-router parity remains open.
 - Local peer sync request-only transfer limits now also stay on Python's
   full-offer policy path: `transfer_limit_kb` constrains offer construction
   but does not by itself bypass stamp-policy or peering-key readiness.
+- Local peer sync selected-ID offer responses that request a transfer now also
+  stay on Python's full-offer policy path: non-empty list-shaped `wanted_ids`
+  wait for stamp-policy and peering-key readiness before mutating queue state or
+  transferring payloads.
 - Empty local peer sync now follows Python's no-unhandled-messages path: a
   clean peer with no pending propagation entries records the attempt but
   preserves liveness and the previous sync transfer rate, and avoids synthetic

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -121,6 +121,10 @@ gap, even though deeper propagation-router parity remains open.
   peer sync through the existing local `peer_sync` path, so Python
   `sync_peers()`-style maintenance mutates queue marks and transfer accounting
   instead of only reporting cull/rotation status.
+- Propagation peer maintenance selection now also mirrors Python's waiting
+  peer candidate pool: the fastest two waiting peers remain candidates, and
+  zero-transfer-rate peers are added so unknown-speed peers are not starved by
+  previously measured peers.
 - Propagation peer maintenance also follows Python's sync-pool boundary for
   retained static peers: static peers past `LXMPeer.MAX_UNREACHABLE` are kept
   peered, but are not selected for waiting or retry-ready sync in that

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -113,6 +113,10 @@ gap, even though deeper propagation-router parity remains open.
   headroom, tested non-static peers below the acceptance-rate threshold can be
   unpeered with queue cleanup while static and higher-acceptance peers remain
   peered.
+- Propagation peer maintenance now starts one eligible waiting or retry-ready
+  peer sync through the existing local `peer_sync` path, so Python
+  `sync_peers()`-style maintenance mutates queue marks and transfer accounting
+  instead of only reporting cull/rotation status.
 - Propagation offer handling now follows Python's invalid propagation-stamp
   throttle: peer resource transfers containing invalid propagation stamps mark
   that propagation peer throttled for Python's `PN_STAMP_THROTTLE` window, and

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -108,6 +108,10 @@ gap, even though deeper propagation-router parity remains open.
   `sync_peers()`-style unreachable-peer culling: non-static peers unheard for
   `LXMPeer.MAX_UNREACHABLE` are unpeered and have their propagation queue marks
   cleared, while configured static peers are retained.
+- Propagation peer maintenance now also mirrors Python `rotate_peers()` for
+  low-acceptance autopeers: when configured peer capacity needs headroom, tested
+  non-static autopeers below the acceptance-rate threshold can be unpeered with
+  queue cleanup while higher-acceptance peers remain peered.
 - Propagation offer handling now follows Python's invalid propagation-stamp
   throttle: peer resource transfers containing invalid propagation stamps mark
   that propagation peer throttled for Python's `PN_STAMP_THROTTLE` window, and

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -109,9 +109,10 @@ gap, even though deeper propagation-router parity remains open.
   `LXMPeer.MAX_UNREACHABLE` are unpeered and have their propagation queue marks
   cleared, while configured static peers are retained.
 - Propagation peer maintenance now also mirrors Python `rotate_peers()` for
-  low-acceptance autopeers: when configured peer capacity needs headroom, tested
-  non-static autopeers below the acceptance-rate threshold can be unpeered with
-  queue cleanup while higher-acceptance peers remain peered.
+  low-acceptance non-static peers: when configured peer capacity needs
+  headroom, tested non-static peers below the acceptance-rate threshold can be
+  unpeered with queue cleanup while static and higher-acceptance peers remain
+  peered.
 - Propagation offer handling now follows Python's invalid propagation-stamp
   throttle: peer resource transfers containing invalid propagation stamps mark
   that propagation peer throttled for Python's `PN_STAMP_THROTTLE` window, and

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -104,6 +104,10 @@ gap, even though deeper propagation-router parity remains open.
   ordering: equal-timebase announces are retained in the announce log but no
   longer overwrite the active peer's propagation limits, costs, or peering
   policy fields.
+- Propagation peer admission now mirrors Python's high-cost peering policy for
+  existing non-static peers: a newer announce above `remote_peering_cost_max`
+  breaks manual or auto peering and clears propagation queue marks, while stale
+  high-cost announces are ignored.
 - Propagation peer maintenance now has an explicit RPC path for Python
   `sync_peers()`-style unreachable-peer culling: non-static peers unheard for
   `LXMPeer.MAX_UNREACHABLE` are unpeered and have their propagation queue marks

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -125,6 +125,10 @@ gap, even though deeper propagation-router parity remains open.
   peer candidate pool: the fastest two waiting peers remain candidates, and
   zero-transfer-rate peers are added so unknown-speed peers are not starved by
   previously measured peers.
+- Propagation peer maintenance retry selection now mirrors Python's
+  unresponsive-peer pool behavior as well: when no live waiting peer is
+  eligible, retry-ready unresponsive peers are selected from the whole due pool
+  instead of always retrying the first sorted peer.
 - Propagation peer maintenance also follows Python's sync-pool boundary for
   retained static peers: static peers past `LXMPeer.MAX_UNREACHABLE` are kept
   peered, but are not selected for waiting or retry-ready sync in that

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -125,6 +125,9 @@ gap, even though deeper propagation-router parity remains open.
   peer candidate pool: the fastest two waiting peers remain candidates, and
   zero-transfer-rate peers are added so unknown-speed peers are not starved by
   previously measured peers.
+- Propagation peer maintenance waiting-pool selection now includes every
+  zero-transfer-rate waiting peer like Python, instead of capping unknown-speed
+  additions to the fastest-pool size and starving later unknown-speed peers.
 - Propagation peer maintenance retry selection now mirrors Python's
   unresponsive-peer pool behavior as well: when no live waiting peer is
   eligible, retry-ready unresponsive peers are selected from the whole due pool

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -9,7 +9,7 @@ KISS/LoRa/RNode interface work improves the transport substrate available to
 LXMF, but it does not by itself complete LXMF peer sync, propagation router, or
 stamp worker parity.
 
-Last reassessed: 2026-06-05 (unreachable static peer maintenance sync skip regression added)
+Last reassessed: 2026-06-05 (high-cost manual peer peering-break regression added)
 
 Status legend: `not-started` | `partial` | `done`
 
@@ -92,7 +92,8 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   strict peering-timebase config refresh, Python-style unreachable-peer
   maintenance culling, low-acceptance non-static peer rotation,
   maintenance-driven waiting peer sync, and unreachable static peer sync-pool
-  skipping, admitted-offer-only
+  skipping, high-cost existing-peer peering breaks with queue cleanup,
+  admitted-offer-only
   validated peering links, mixed invalid-stamp peer resource handling that
   preserves valid entries before throttling, inbound propagation resource
   source-peer queueing, remote-sync source-peer inbound byte/message accounting
@@ -179,6 +180,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib autopeered_announce_records_propagation_peer_state -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib low_value_stamped_entries -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib equal_timebase_announce_does_not_refresh_propagation_peer_state_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib high_cost_announce_breaks_existing_manual_peer_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_culls_unreachable_non_static_peers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_autopeers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_non_static_peers_like_python -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -9,7 +9,7 @@ KISS/LoRa/RNode interface work improves the transport substrate available to
 LXMF, but it does not by itself complete LXMF peer sync, propagation router, or
 stamp worker parity.
 
-Last reassessed: 2026-06-05 (boolean offer-response peer-sync regressions added)
+Last reassessed: 2026-06-05 (offer-response peer-sync gate regressions added)
 
 Status legend: `not-started` | `partial` | `done`
 
@@ -99,9 +99,9 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   readiness status values are exposed. Local offer responses now accept
   Python's boolean all/none and list-shaped response forms, keep full-offer
   stamp-policy and peering-key gates for boolean wants-all, request-limited,
-  and selected-ID transfer responses, and reject valid-looking wanted transient
-  IDs outside the current offer before mutating queue state or creating a new
-  peer queue.
+  selected-ID transfer, and no-transfer responses, and reject valid-looking
+  wanted transient IDs outside the current offer before mutating queue state or
+  creating a new peer queue.
   Existing peers in local sync
   backoff now also postpone before the local existing-entry queue-fill path,
   but the active workspace does not yet match Python `LXMPeer` queueing,
@@ -159,6 +159,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_boolean_wanted_ids_true_keeps_full_offer_policy_gates_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_request_transfer_limit_keeps_full_offer_policy_gates_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_selected_wanted_ids_keep_full_offer_policy_gates_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib peer_sync_empty_wanted_ids_keep_full_offer_policy_gates_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_during_backoff_does_not_queue_new_existing_entries_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_remote_fetch -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -99,8 +99,10 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   readiness status values are exposed. Local offer responses now accept
   Python's boolean all/none and list-shaped response forms and reject
   valid-looking wanted transient IDs outside the current offer before mutating
-  queue state or creating a new peer queue, but the active workspace does not
-  yet match Python `LXMPeer` queueing, transfer, and peering behavior.
+  queue state or creating a new peer queue. Existing peers in local sync
+  backoff now also postpone before the local existing-entry queue-fill path,
+  but the active workspace does not yet match Python `LXMPeer` queueing,
+  transfer, and peering behavior.
 - Paper-command baseline is implemented for bridge-backed `reticulumd`: SDK
   paper encode/decode uses canonical `lxmf-wire` paper URI helpers and tests
   reject the old placeholder `lxm://{destination}/{message_id}` path. Broader
@@ -151,6 +153,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects_unknown_wanted_ids_without_creating_new_peer_queue -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects_transfer_limited_wanted_ids_without_mutating_queue -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_boolean -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib peer_sync_during_backoff_does_not_queue_new_existing_entries_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_remote_fetch -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_remote_download -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -97,7 +97,8 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   `tx_bytes` inflation, local-delivery source-peer accounting, unpeered
   identified-sender accounting, peering-key values, and explicit peering-key
   readiness status values are exposed. Local offer responses now accept
-  Python's boolean all/none and list-shaped response forms and reject
+  Python's boolean all/none and list-shaped response forms, keep full-offer
+  stamp-policy and peering-key gates for boolean wants-all responses, and reject
   valid-looking wanted transient IDs outside the current offer before mutating
   queue state or creating a new peer queue. Existing peers in local sync
   backoff now also postpone before the local existing-entry queue-fill path,
@@ -153,6 +154,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects_unknown_wanted_ids_without_creating_new_peer_queue -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects_transfer_limited_wanted_ids_without_mutating_queue -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_boolean -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib peer_sync_boolean_wanted_ids_true_keeps_full_offer_policy_gates_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_during_backoff_does_not_queue_new_existing_entries_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_remote_fetch -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -9,7 +9,7 @@ KISS/LoRa/RNode interface work improves the transport substrate available to
 LXMF, but it does not by itself complete LXMF peer sync, propagation router, or
 stamp worker parity.
 
-Last reassessed: 2026-06-05 (maintenance-driven waiting peer sync regression added)
+Last reassessed: 2026-06-05 (unreachable static peer maintenance sync skip regression added)
 
 Status legend: `not-started` | `partial` | `done`
 
@@ -90,8 +90,9 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   accounting, per-peer propagation transfer/sync limits, propagation stamp
   policy, Python-compatible low-value stamped peer-offer handling,
   strict peering-timebase config refresh, Python-style unreachable-peer
-  maintenance culling, low-acceptance non-static peer rotation, and
-  maintenance-driven waiting peer sync, admitted-offer-only
+  maintenance culling, low-acceptance non-static peer rotation,
+  maintenance-driven waiting peer sync, and unreachable static peer sync-pool
+  skipping, admitted-offer-only
   validated peering links, mixed invalid-stamp peer resource handling that
   preserves valid entries before throttling, inbound propagation resource
   source-peer queueing, remote-sync source-peer inbound byte/message accounting
@@ -182,6 +183,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_autopeers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_non_static_peers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_syncs_one_waiting_peer_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_does_not_sync_unreachable_static_peer_like_python -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_value -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_status -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd peer_sync_command_reports_peering_key_status -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -91,7 +91,8 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   policy, Python-compatible low-value stamped peer-offer handling,
   strict peering-timebase config refresh, Python-style unreachable-peer
   maintenance culling, low-acceptance non-static peer rotation,
-  maintenance-driven waiting peer sync, and unreachable static peer sync-pool
+  maintenance-driven waiting peer sync, Python-style maintenance candidate
+  pooling for unknown-speed peers, and unreachable static peer sync-pool
   skipping, high-cost existing-peer peering breaks with queue cleanup,
   admitted-offer-only
   validated peering links, mixed invalid-stamp peer resource handling that
@@ -185,6 +186,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_autopeers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_non_static_peers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_syncs_one_waiting_peer_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_candidate_pool_includes_unknown_speed_peers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_does_not_sync_unreachable_static_peer_like_python -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_value -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_status -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -98,9 +98,10 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   identified-sender accounting, peering-key values, and explicit peering-key
   readiness status values are exposed. Local offer responses now accept
   Python's boolean all/none and list-shaped response forms, keep full-offer
-  stamp-policy and peering-key gates for boolean wants-all responses, and reject
-  valid-looking wanted transient IDs outside the current offer before mutating
-  queue state or creating a new peer queue. Existing peers in local sync
+  stamp-policy and peering-key gates for boolean wants-all and request-limited
+  full-offer responses, and reject valid-looking wanted transient IDs outside
+  the current offer before mutating queue state or creating a new peer queue.
+  Existing peers in local sync
   backoff now also postpone before the local existing-entry queue-fill path,
   but the active workspace does not yet match Python `LXMPeer` queueing,
   transfer, and peering behavior.
@@ -155,6 +156,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects_transfer_limited_wanted_ids_without_mutating_queue -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_boolean -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_boolean_wanted_ids_true_keeps_full_offer_policy_gates_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib peer_sync_request_transfer_limit_keeps_full_offer_policy_gates_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_during_backoff_does_not_queue_new_existing_entries_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_remote_fetch -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -9,7 +9,7 @@ KISS/LoRa/RNode interface work improves the transport substrate available to
 LXMF, but it does not by itself complete LXMF peer sync, propagation router, or
 stamp worker parity.
 
-Last reassessed: 2026-06-05 (peer maintenance rotation regression added)
+Last reassessed: 2026-06-05 (non-static peer maintenance rotation regression added)
 
 Status legend: `not-started` | `partial` | `done`
 
@@ -90,7 +90,7 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   accounting, per-peer propagation transfer/sync limits, propagation stamp
   policy, Python-compatible low-value stamped peer-offer handling,
   strict peering-timebase config refresh, Python-style unreachable-peer
-  maintenance culling and low-acceptance autopeer rotation, admitted-offer-only
+  maintenance culling and low-acceptance non-static peer rotation, admitted-offer-only
   validated peering links, mixed invalid-stamp peer resource handling that
   preserves valid entries before throttling, inbound propagation resource
   source-peer queueing, remote-sync source-peer inbound byte/message accounting
@@ -179,6 +179,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib equal_timebase_announce_does_not_refresh_propagation_peer_state_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_culls_unreachable_non_static_peers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_autopeers_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_non_static_peers_like_python -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_value -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_status -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd peer_sync_command_reports_peering_key_status -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -9,7 +9,7 @@ KISS/LoRa/RNode interface work improves the transport substrate available to
 LXMF, but it does not by itself complete LXMF peer sync, propagation router, or
 stamp worker parity.
 
-Last reassessed: 2026-06-05 (high-cost manual peer peering-break regression added)
+Last reassessed: 2026-06-05 (maintenance unknown-speed waiting-pool regression added)
 
 Status legend: `not-started` | `partial` | `done`
 
@@ -92,7 +92,7 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   strict peering-timebase config refresh, Python-style unreachable-peer
   maintenance culling, low-acceptance non-static peer rotation,
   maintenance-driven waiting peer sync, Python-style maintenance candidate
-  pooling for unknown-speed peers, retry-ready unresponsive-peer pool
+  pooling for all unknown-speed peers, retry-ready unresponsive-peer pool
   selection, and unreachable static peer sync-pool skipping, high-cost
   existing-peer peering breaks with queue cleanup,
   admitted-offer-only
@@ -188,6 +188,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_non_static_peers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_syncs_one_waiting_peer_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_candidate_pool_includes_unknown_speed_peers_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_candidate_pool_includes_all_unknown_speed_peers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_unresponsive_pool_does_not_starve_later_peers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_does_not_sync_unreachable_static_peer_like_python -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_value -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -98,9 +98,10 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   identified-sender accounting, peering-key values, and explicit peering-key
   readiness status values are exposed. Local offer responses now accept
   Python's boolean all/none and list-shaped response forms, keep full-offer
-  stamp-policy and peering-key gates for boolean wants-all and request-limited
-  full-offer responses, and reject valid-looking wanted transient IDs outside
-  the current offer before mutating queue state or creating a new peer queue.
+  stamp-policy and peering-key gates for boolean wants-all, request-limited,
+  and selected-ID transfer responses, and reject valid-looking wanted transient
+  IDs outside the current offer before mutating queue state or creating a new
+  peer queue.
   Existing peers in local sync
   backoff now also postpone before the local existing-entry queue-fill path,
   but the active workspace does not yet match Python `LXMPeer` queueing,
@@ -157,6 +158,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_boolean -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_boolean_wanted_ids_true_keeps_full_offer_policy_gates_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_request_transfer_limit_keeps_full_offer_policy_gates_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib peer_sync_selected_wanted_ids_keep_full_offer_policy_gates_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_during_backoff_does_not_queue_new_existing_entries_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_remote_fetch -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -9,7 +9,7 @@ KISS/LoRa/RNode interface work improves the transport substrate available to
 LXMF, but it does not by itself complete LXMF peer sync, propagation router, or
 stamp worker parity.
 
-Last reassessed: 2026-06-05 (non-static peer maintenance rotation regression added)
+Last reassessed: 2026-06-05 (maintenance-driven waiting peer sync regression added)
 
 Status legend: `not-started` | `partial` | `done`
 
@@ -90,7 +90,8 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   accounting, per-peer propagation transfer/sync limits, propagation stamp
   policy, Python-compatible low-value stamped peer-offer handling,
   strict peering-timebase config refresh, Python-style unreachable-peer
-  maintenance culling and low-acceptance non-static peer rotation, admitted-offer-only
+  maintenance culling, low-acceptance non-static peer rotation, and
+  maintenance-driven waiting peer sync, admitted-offer-only
   validated peering links, mixed invalid-stamp peer resource handling that
   preserves valid entries before throttling, inbound propagation resource
   source-peer queueing, remote-sync source-peer inbound byte/message accounting
@@ -180,6 +181,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_culls_unreachable_non_static_peers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_autopeers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_non_static_peers_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_syncs_one_waiting_peer_like_python -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_value -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_status -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd peer_sync_command_reports_peering_key_status -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -92,8 +92,9 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   strict peering-timebase config refresh, Python-style unreachable-peer
   maintenance culling, low-acceptance non-static peer rotation,
   maintenance-driven waiting peer sync, Python-style maintenance candidate
-  pooling for unknown-speed peers, and unreachable static peer sync-pool
-  skipping, high-cost existing-peer peering breaks with queue cleanup,
+  pooling for unknown-speed peers, retry-ready unresponsive-peer pool
+  selection, and unreachable static peer sync-pool skipping, high-cost
+  existing-peer peering breaks with queue cleanup,
   admitted-offer-only
   validated peering links, mixed invalid-stamp peer resource handling that
   preserves valid entries before throttling, inbound propagation resource
@@ -187,6 +188,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_non_static_peers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_syncs_one_waiting_peer_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_candidate_pool_includes_unknown_speed_peers_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_unresponsive_pool_does_not_starve_later_peers_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_does_not_sync_unreachable_static_peer_like_python -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_value -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_status -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -9,7 +9,7 @@ KISS/LoRa/RNode interface work improves the transport substrate available to
 LXMF, but it does not by itself complete LXMF peer sync, propagation router, or
 stamp worker parity.
 
-Last reassessed: 2026-06-05 (offer-response peer-sync gate regressions added)
+Last reassessed: 2026-06-05 (peer maintenance rotation regression added)
 
 Status legend: `not-started` | `partial` | `done`
 
@@ -90,13 +90,14 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   accounting, per-peer propagation transfer/sync limits, propagation stamp
   policy, Python-compatible low-value stamped peer-offer handling,
   strict peering-timebase config refresh, Python-style unreachable-peer
-  maintenance culling, admitted-offer-only validated peering links, mixed
-  invalid-stamp peer resource handling that preserves valid entries before
-  throttling, inbound propagation resource source-peer queueing, remote-sync
-  source-peer inbound byte/message accounting without outbound transfer-rate or
-  `tx_bytes` inflation, local-delivery source-peer accounting, unpeered
-  identified-sender accounting, peering-key values, and explicit peering-key
-  readiness status values are exposed. Local offer responses now accept
+  maintenance culling and low-acceptance autopeer rotation, admitted-offer-only
+  validated peering links, mixed invalid-stamp peer resource handling that
+  preserves valid entries before throttling, inbound propagation resource
+  source-peer queueing, remote-sync source-peer inbound byte/message accounting
+  without outbound transfer-rate or `tx_bytes` inflation, local-delivery
+  source-peer accounting, unpeered identified-sender accounting, peering-key
+  values, and explicit peering-key readiness status values are exposed. Local
+  offer responses now accept
   Python's boolean all/none and list-shaped response forms, keep full-offer
   stamp-policy and peering-key gates for boolean wants-all, request-limited,
   selected-ID transfer, and no-transfer responses, and reject valid-looking
@@ -177,6 +178,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib low_value_stamped_entries -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib equal_timebase_announce_does_not_refresh_propagation_peer_state_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_culls_unreachable_non_static_peers_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_autopeers_like_python -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_value -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_status -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd peer_sync_command_reports_peering_key_status -- --nocapture`


### PR DESCRIPTION
## Summary
- updates the interop artifact manifest for the peer_sync RPC contract change already on main
- keeps local peer sync backoff ahead of the existing-entry queue-fill path, so backed-off peers postpone without opportunistically gaining new unhandled propagation marks
- keeps boolean `wanted_ids: true` on the full-offer policy path, so wants-all responses wait for stamp-policy and peering-key readiness instead of bypassing those gates as selected-ID responses
- keeps request-only `transfer_limit_kb` syncs on the same full-offer policy path, so transfer limits constrain offer construction without bypassing stamp-policy or peering-key readiness
- keeps non-empty list-shaped `wanted_ids` transfer responses on the same full-offer policy path, so selected-ID transfers cannot mutate queues or send payloads before stamp-policy and peering-key readiness
- keeps no-transfer `wanted_ids: false` and `wanted_ids: []` responses on the same full-offer policy path, so they cannot mark offered queue entries handled before stamp-policy and peering-key readiness
- hardens affected reticulumd/rns-rpc fixtures to use ready peers now that offer-response limits no longer bypass policy gates
- rotates low-acceptance peers during propagation peer maintenance, matching Python `rotate_peers()` headroom behavior while preserving static and higher-acceptance peers
- syncs one eligible waiting propagation peer during maintenance through the existing peer_sync path, matching Python sync_peers queue and transfer side effects
- includes all unknown-speed waiting peers in the propagation-maintenance candidate pool, matching Python sync_peers behavior that adds every zero-transfer-rate peer alongside the fastest measured peers
- selects retry-ready unresponsive propagation peers from the full due pool when no live waiting peers are available, avoiding the Rust-only first-peer retry starvation path
- keeps unreachable static peers out of maintenance sync pools while retaining them as peered, matching Python sync_peers queue selection boundaries
- breaks existing non-static peers on newer high-cost propagation announces, clearing propagation queue marks like Python peering policy
- records the new local peer-sync queueing/offer-gate, peer-maintenance rotation/sync/pooling, and high-cost peering-break parity evidence in the roadmap and parity matrix

## Verification
- cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_candidate_pool_includes_all_unknown_speed_peers_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_candidate_pool -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance -- --nocapture
- cargo test -p reticulum-rs-rpc --lib peer_sync_empty_wanted_ids_keep_full_offer_policy_gates_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib peer_sync_selected_wanted_ids_keep_full_offer_policy_gates_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib list_peers_top_level_message_counters_match_python_sync_accounting -- --nocapture
- cargo test -p reticulum-rs-rpc --lib peer_sync_request_transfer_limit_keeps_full_offer_policy_gates_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib request_transfer_limit -- --nocapture
- cargo test -p reticulum-rs-rpc --lib peer_sync_boolean_wanted_ids_true_keeps_full_offer_policy_gates_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib peer_sync_boolean -- --nocapture
- cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_autopeers_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_non_static_peers_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_syncs_one_waiting_peer_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_candidate_pool_includes_unknown_speed_peers_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_unresponsive_pool_does_not_starve_later_peers_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_does_not_sync_unreachable_static_peer_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib high_cost_announce_breaks_existing_manual_peer_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib peering_cost -- --nocapture
- cargo test -p reticulum-rs-rpc --lib high_cost -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- cargo test -p reticulum-rs-rpc --lib
- cargo clippy -p reticulum-rs-rpc --all-targets --all-features --no-deps -- -D warnings
- cargo test -p reticulumd --bin reticulumd
- cargo test --workspace --lib --bins -- --test-threads=1
- cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
- cargo run -p xtask -- ci --stage interop-artifacts