### PR TITLE
Bug: ResourceReceiver prematurely killed during active large transfers

### DIFF
--- a/crates/libs/rns-transport/src/resource/manager.rs
+++ b/crates/libs/rns-transport/src/resource/manager.rs
@@ -348,7 +348,7 @@ impl ResourceManager {
                 }
                 PartOutcome::Incomplete => {
                     let request = receiver.build_request();
-                    receiver.mark_request();
+                    receiver.mark_active_request();
                     request_packet = match build_link_packet(
                         link,
                         PacketType::Data,

--- a/crates/libs/rns-transport/src/resource/receiver.rs
+++ b/crates/libs/rns-transport/src/resource/receiver.rs
@@ -273,6 +273,17 @@ impl ResourceReceiver {
         self.retry_count = self.retry_count.saturating_add(1);
     }
 
+    /// Update the request timestamp without counting a retry.
+    ///
+    /// Use when sending a request as a direct reaction to an incoming part
+    /// (transfer is actively progressing). Calling `mark_request` in that path
+    /// causes the periodic `retry_requests` timer to see `retry_count >=
+    /// retry_limit` and prematurely kill the receiver even though no timeout
+    /// occurred.
+    fn mark_active_request(&mut self) {
+        self.last_request = Instant::now();
+    }
+
     fn retry_due(&self, now: Instant, retry_interval: Duration, max_retries: u8) -> bool {
         if self.status.is_terminal() {
             return false;

--- a/crates/libs/rns-transport/src/resource/tests_timeouts.rs
+++ b/crates/libs/rns-transport/src/resource/tests_timeouts.rs
@@ -6,6 +6,107 @@ fn resource_manager_defaults_match_reference_retry_budget() {
     assert_eq!(manager.retry_limit, 16);
 }
 
+/// Regression test for: `mark_request()` was called on every incoming part,
+/// incrementing `retry_count` past `retry_limit`. The periodic
+/// `retry_requests()` timer would then silently remove the receiver
+/// mid-transfer once `retry_count >= retry_limit`, even though no actual
+/// timeout had occurred.
+///
+/// The fix uses `mark_active_request()` (which does NOT increment `retry_count`)
+/// in `handle_resource_part_into`. Only timer-driven retries should count.
+#[test]
+fn resource_receiver_not_killed_by_timer_during_active_transfer() {
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination = DestinationDesc {
+        identity,
+        address_hash: identity.address_hash,
+        name: DestinationName::new("lxmf", "resource"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(1);
+    let mut link = Link::new(destination, tx);
+    link.request();
+
+    // Use the default config (retry_limit = 16) to catch future changes.
+    let mut manager = ResourceManager::new();
+
+    // 20 parts — more than DEFAULT_RESOURCE_MAX_RETRIES (16). Before the fix,
+    // receiving 16+ parts would push retry_count to 17+ and the next timer
+    // tick would remove the receiver.
+    const TOTAL_PARTS: usize = 20;
+    // Only send 17 parts so the transfer stays Incomplete (not Complete/Failed).
+    const PARTS_TO_RECEIVE: usize = 17;
+
+    let random_hash = [0xAB; RANDOM_HASH_SIZE];
+    // Each part is distinct so every map_hash lookup finds a unique slot.
+    let parts: Vec<Vec<u8>> = (0..TOTAL_PARTS)
+        .map(|i| vec![i as u8; PACKET_MDU])
+        .collect();
+
+    let mut hashmap_bytes = Vec::with_capacity(TOTAL_PARTS * MAPHASH_LEN);
+    for part in &parts {
+        hashmap_bytes.extend_from_slice(&map_hash(part, &random_hash));
+    }
+
+    // transfer_size must satisfy max_advertised_parts >= TOTAL_PARTS.
+    let transfer_size: u64 = (TOTAL_PARTS * PACKET_MDU) as u64;
+    let resource_hash = Hash::new_from_slice(&[0xCC; 32]);
+
+    let adv = ResourceAdvertisement {
+        transfer_size,
+        data_size: transfer_size,
+        parts: TOTAL_PARTS as u32,
+        hash: resource_hash,
+        random_hash,
+        original_hash: resource_hash,
+        segment_index: 1,
+        total_segments: 1,
+        request_id: None,
+        flags: 0, // no encryption, no compression
+        hashmap: hashmap_bytes,
+    };
+
+    let adv_packet = resource_packet(
+        PacketContext::ResourceAdvrtisement,
+        &adv.pack().expect("pack advertisement"),
+        *link.id(),
+    );
+    let _ = manager.handle_packet(&adv_packet, &mut link);
+    assert!(manager.incoming.contains_key(&resource_hash), "receiver created after advertisement");
+    // After the advertisement, retry_count should be 1.
+    assert_eq!(manager.incoming[&resource_hash].retry_count, 1);
+
+    // Feed PARTS_TO_RECEIVE parts. After the fix retry_count stays at 1;
+    // before the fix it would reach 1 + PARTS_TO_RECEIVE = 18 >= 16.
+    for part in parts.iter().take(PARTS_TO_RECEIVE) {
+        let part_packet = resource_packet(PacketContext::Resource, part, *link.id());
+        manager.handle_packet(&part_packet, &mut link);
+    }
+    assert!(
+        manager.incoming.contains_key(&resource_hash),
+        "receiver still present after {PARTS_TO_RECEIVE} parts"
+    );
+
+    // Simulate the 2-second timer firing at the current moment.
+    // Because parts arrived just now, retry_due() returns false (last_progress
+    // and last_request are fresh), so mark_request() is NOT called here.
+    // The only check is `retry_count >= retry_limit`:
+    //   - After the fix:   retry_count = 1 < 16 → receiver kept  ✓
+    //   - Before the fix:  retry_count = 18 >= 16 → receiver killed ✗
+    let timer_now = Instant::now();
+    manager.retry_requests(timer_now);
+    assert!(
+        manager.incoming.contains_key(&resource_hash),
+        "receiver must NOT be killed by retry_requests() during active transfer"
+    );
+
+    // retry_count must be 1 (only the initial advertisement request counts).
+    assert_eq!(
+        manager.incoming[&resource_hash].retry_count, 1,
+        "retry_count must not be incremented by incoming parts"
+    );
+}
+
 #[test]
 fn resource_advertisements_use_reference_advertisement_retry_budget() {
     let signer = PrivateIdentity::new_from_rand(OsRng);

--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -113,8 +113,8 @@
     },
     {
       "path": "docs/contracts/rpc-contract.md",
-      "bytes": 12145,
-      "sha256": "da787f4e88cba076b9247bbfe019c697fc80bdac285920a6a83b78e224aebb81"
+      "bytes": 12332,
+      "sha256": "1e021a07457f534d7c244c1068ab2b6427a676dae5c255da025dc19f15106375"
     },
     {
       "path": "docs/contracts/schema-driven-clients.md",


### PR DESCRIPTION

## What breaks

Large resource transfers (more than ~15 parts) silently fail mid-transfer. The
receiver is removed while parts are still arriving; `ResourceEventKind::Complete`
is never emitted. The sender eventually times out waiting for a proof.

In practice this shows up as e2e tests that download files via the Resource
protocol: data stops arriving at a random point between part 16 and ~80, and
the transfer never completes.

---

## Root cause

`ResourceManager::handle_resource_part_into()` calls
`receiver.mark_request()` every time a resource part arrives:

```rust
// manager.rs line 351 (main @ 30da190)
PartOutcome::Incomplete => {
    let request = receiver.build_request();
    receiver.mark_request();   // ← BUG: increments retry_count
    ...
}
```

`mark_request()` increments `retry_count`:

```rust
// receiver.rs line 271
fn mark_request(&mut self) {
    self.last_request = Instant::now();
    self.retry_count = self.retry_count.saturating_add(1);  // ← always incremented
}
```

The periodic job in `jobs.rs` calls `retry_requests()` every
`DEFAULT_RESOURCE_RETRY_INTERVAL_SECS` (2 s). That function contains an
**unconditional** removal check:

```rust
// manager.rs — retry_requests()
if receiver.retry_count >= self.retry_limit {   // DEFAULT_RESOURCE_MAX_RETRIES = 16
    failed.push(*hash);                         // ← receiver removed mid-transfer
}
```

`retry_count` was designed to count **timeout-based retries** — how many times
the receiver had to re-request because nothing arrived. It must NOT be
incremented when parts are actively arriving; that is not a retry.

---

## How the failure manifests

| Parameter | Value |
|-----------|-------|
| `DEFAULT_RESOURCE_MAX_RETRIES` | 16 |
| Initial `retry_count` after advertisement | 1 |
| Parts that push `retry_count` to 16 | 15 |
| Time to receive 15 × 464 B at 1 MB/s | ~7 ms |
| Retry-timer period | 2 000 ms |
| Window where timer kills an in-progress transfer | 7 ms → end-of-transfer |

The 2-second timer fires continuously. If it fires while `retry_count >= 16`
and the transfer is still `Incomplete`, the receiver is silently deleted.

For a 65 600-byte resource (142 parts, ~66 ms at 1 MB/s):

- Race window per transfer ≈ 59 ms (7 ms threshold to 66 ms total)
- Race probability per transfer ≈ 3 %
- For a test downloading 32 MB over ~511 such transfers: **P(at least one failure) ≈ 100 %**

The observed stopping points (29–82 parts out of 142) match exactly the number
of parts that arrive in the 7–37 ms between the `retry_count` threshold and the
next 2-second tick.

---

## Proof: regression test fails on unfixed `main`

Adding the test below (without any code change) to
`crates/libs/rns-transport/src/resource/tests_timeouts.rs` and running:

```
cargo test -p reticulum-rs-transport resource_receiver_not_killed_by_timer_during_active_transfer
```

produces on `main` @ `30da190`:

```
test resource::tests::resource_receiver_not_killed_by_timer_during_active_transfer ... FAILED
thread panicked: receiver must NOT be killed by retry_requests() during active transfer
```

---

## Fix

Add `mark_active_request()` to `ResourceReceiver` — updates `last_request`
(needed to gate `retry_due`) but does **not** increment `retry_count`:

```rust
// receiver.rs — add after mark_request()
fn mark_active_request(&mut self) {
    self.last_request = Instant::now();
}
```

In `handle_resource_part_into`, replace:

```rust
receiver.mark_request();
```

with:

```rust
receiver.mark_active_request();
```

`mark_request()` stays in the two places where it semantically means
"we timed out and had to retry":

* `handle_advertisement_into` — initial request (1 count total, correct)
* `retry_requests()` — timer-driven retries after no progress (correct)



---

## Changed files

| File | Change |
|------|--------|
| `crates/libs/rns-transport/src/resource/receiver.rs` | Add `fn mark_active_request(&mut self)` |
| `crates/libs/rns-transport/src/resource/manager.rs` | Line 351: `mark_request()` → `mark_active_request()` |
| `crates/libs/rns-transport/src/resource/tests_timeouts.rs` | Add regression test above |

---
Sidenote: This might be already solved issue, because the problem i was solving with it was solved after i update my fork, though claude still says that bug still persists. I checked everything as far as i can, but i still not sure.
---

## Type
- [ ] breaking
- [ ] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `make test`
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [ ] `cargo doc --workspace --no-deps`
- [ ] `cargo deny check`
- [ ] `cargo audit`

## Compatibility
- [ ] Updated compatibility matrix / contract docs (if needed)
