### PR TITLE
ResourceSender propagates packet-build failure to caller

### DIFF
--- a/crates/libs/rns-transport/src/resource/sender.rs
+++ b/crates/libs/rns-transport/src/resource/sender.rs
@@ -178,6 +178,7 @@ impl ResourceSender {
                 self.last_part_sent = now;
                 OutboundResourcePoll::None
             }
+            ResourceStatus::Failed => return OutboundResourcePoll::Failed,
             _ => OutboundResourcePoll::None,
         }
     }
@@ -210,7 +211,8 @@ impl ResourceSender {
                         sent_any = true;
                         packets.push(scratch_packet);
                     } else {
-                        log::warn!("failed to build resource packet");
+                        self.status = ResourceStatus::Failed;
+                        return;
                     }
                 }
             } else {
@@ -249,7 +251,7 @@ impl ResourceSender {
                             ) {
                                 packets.push(packet);
                             } else {
-                                log::warn!("failed to build hash update packet");
+                                self.status = ResourceStatus::Failed;
                             }
                         }
                     }

--- a/crates/libs/rns-transport/src/resource/sender.rs
+++ b/crates/libs/rns-transport/src/resource/sender.rs
@@ -178,7 +178,7 @@ impl ResourceSender {
                 self.last_part_sent = now;
                 OutboundResourcePoll::None
             }
-            ResourceStatus::Failed => return OutboundResourcePoll::Failed,
+            ResourceStatus::Failed => OutboundResourcePoll::Failed,
             _ => OutboundResourcePoll::None,
         }
     }

--- a/crates/libs/rns-transport/src/resource/tests_timeouts.rs
+++ b/crates/libs/rns-transport/src/resource/tests_timeouts.rs
@@ -302,6 +302,42 @@ fn resource_manager_removes_link_scoped_state_on_link_close() {
 }
 
 #[test]
+fn resource_sender_emits_outbound_failed_when_status_is_failed() {
+    // Covers the new `ResourceStatus::Failed => OutboundResourcePoll::Failed` arm
+    // in poll().  The same path is exercised when handle_request_into() fails to
+    // build a packet and sets self.status = Failed.
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination = DestinationDesc {
+        identity,
+        address_hash: identity.address_hash,
+        name: DestinationName::new("lxmf", "resource"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(1);
+    let link = Link::new(destination, tx);
+
+    let mut manager = ResourceManager::new_with_config(Duration::from_secs(1), 2);
+    let (resource_hash, _) =
+        manager.start_send(&link, b"fail me".to_vec(), None).expect("start sender");
+    manager.confirm_outbound_dispatch(resource_hash, true);
+
+    assert!(manager.outgoing.contains_key(&resource_hash));
+    assert!(manager.drain_events().is_empty());
+
+    manager.outgoing.get_mut(&resource_hash).unwrap().status = ResourceStatus::Failed;
+
+    let packets = manager.poll_outgoing(Instant::now());
+    assert!(packets.is_empty());
+    assert!(!manager.outgoing.contains_key(&resource_hash));
+
+    let events = manager.drain_events();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].hash, resource_hash);
+    assert_eq!(events[0].link_id, *link.id());
+    assert!(matches!(events[0].kind, ResourceEventKind::OutboundFailed));
+}
+
+#[test]
 fn resource_manager_link_close_allows_later_resource_on_new_link() {
     let signer = PrivateIdentity::new_from_rand(OsRng);
     let identity = *signer.as_identity();

--- a/crates/libs/rns-transport/src/transport/jobs.rs
+++ b/crates/libs/rns-transport/src/transport/jobs.rs
@@ -405,6 +405,8 @@ pub(super) async fn manage_transport(
                         for (_link_id, packet) in advertisements {
                             handler.send_packet(packet).await;
                         }
+                        let events = handler.resource_manager.drain_events();
+                        super::resource_wire::publish_resource_events(&handler, events);
                     }
                 }
             }

--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -113,8 +113,8 @@
     },
     {
       "path": "docs/contracts/rpc-contract.md",
-      "bytes": 12145,
-      "sha256": "da787f4e88cba076b9247bbfe019c697fc80bdac285920a6a83b78e224aebb81"
+      "bytes": 12332,
+      "sha256": "1e021a07457f534d7c244c1068ab2b6427a676dae5c255da025dc19f15106375"
     },
     {
       "path": "docs/contracts/schema-driven-clients.md",


### PR DESCRIPTION


## What breaks

When `ResourceSender::handle_request_into()` fails to build a resource-part packet (for example, the link's encryption key is no longer valid), the failure was silently swallowed with a `log::warn!` and the transfer continued indefinitely. The caller—and therefore the application—received no event and had no signal to give up, reconnect, or otherwise recover.

The same silent-failure pattern existed for hash-update packets in the same function.

---

## Root cause

`poll()` in `sender.rs` handled `ResourceStatus::Failed` via the `_ => OutboundResourcePoll::None` catch-all, so it returned `None` instead of `Failed`. Even if the status had been set to `Failed`, the `poll_outgoing()` loop in `manager.rs` would never have seen an `OutboundResourcePoll::Failed` return and never emitted a `ResourceEventKind::OutboundFailed` event.

Additionally, on a build error, the code kept `self.status` unchanged (still `Transferring` or `AwaitingProof`), so the sender continued to exist in `outgoing` without ever making progress.

---

## Effect

Once `handle_request_into()` fails to build any packet, the sender transitions to `Failed`. On the next `poll_outgoing()` tick the sender is removed from `outgoing` and a `ResourceEventKind::OutboundFailed` event is delivered to the caller. The application can then choose to reconnect, retry, or give up.

---

## Regression test

`resource_sender_emits_outbound_failed_when_status_is_failed` in `tests_timeouts.rs`:

- Starts a send, confirms dispatch
- Directly sets `sender.status = ResourceStatus::Failed` (simulating a build-error transition)
- Calls `poll_outgoing(now)`
- Asserts sender removed from `outgoing` and `drain_events()` returns exactly one `OutboundFailed` event


## Summary

Contributor guide: `CONTRIBUTING.md`

## Type
- [ ] breaking
- [ ] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `make test`
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [ ] `cargo doc --workspace --no-deps`
- [ ] `cargo deny check`
- [ ] `cargo audit`

## Compatibility
- [ ] Updated compatibility matrix / contract docs (if needed)
