### PR TITLE
Adaptive fragment request scheduling for active resource transfers

### DIFF
--- a/crates/libs/rns-transport/src/resource.rs
+++ b/crates/libs/rns-transport/src/resource.rs
@@ -44,6 +44,7 @@ const MAX_INBOUND_RESOURCE_TRANSFER_SIZE: u64 = AUTO_COMPRESS_MAX_SIZE as u64;
 pub const DEFAULT_RESOURCE_RETRY_INTERVAL_SECS: u64 = 2;
 pub const DEFAULT_RESOURCE_MAX_RETRIES: u8 = 16;
 const DEFAULT_RESOURCE_MAX_ADV_RETRIES: u8 = 4;
+pub(crate) const RESOURCE_REQUEST_COOLDOWN: Duration = Duration::from_millis(50);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResourceStatus {

--- a/crates/libs/rns-transport/src/resource.rs
+++ b/crates/libs/rns-transport/src/resource.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io::Read;
 use tokio::time::{Duration, Instant};
 
@@ -44,7 +44,44 @@ const MAX_INBOUND_RESOURCE_TRANSFER_SIZE: u64 = AUTO_COMPRESS_MAX_SIZE as u64;
 pub const DEFAULT_RESOURCE_RETRY_INTERVAL_SECS: u64 = 2;
 pub const DEFAULT_RESOURCE_MAX_RETRIES: u8 = 16;
 const DEFAULT_RESOURCE_MAX_ADV_RETRIES: u8 = 4;
-pub(crate) const RESOURCE_REQUEST_COOLDOWN: Duration = Duration::from_millis(50);
+
+/// Exponentially weighted moving average: alpha = 7/8.
+pub(crate) fn ewma(old: Duration, sample: Duration) -> Duration {
+    let micros =
+        (old.as_micros() as u64).saturating_mul(7).saturating_add(sample.as_micros() as u64) / 8;
+    Duration::from_micros(micros)
+}
+
+/// Per-link adaptive statistics used to decide when to re-request lost fragments.
+#[derive(Debug, Clone)]
+pub(crate) struct LinkStats {
+    /// EWMA of round-trip time (request → part arrival).
+    pub(crate) rtt: Duration,
+    /// EWMA of inter-arrival interval between consecutive received parts.
+    pub(crate) arrival_interval: Duration,
+    pub(crate) last_arrival: Option<Instant>,
+}
+
+impl LinkStats {
+    pub(crate) fn new() -> Self {
+        Self {
+            rtt: Duration::from_millis(500),
+            arrival_interval: Duration::from_millis(100),
+            last_arrival: None,
+        }
+    }
+
+    pub(crate) fn update_rtt(&mut self, sample: Duration) {
+        self.rtt = ewma(self.rtt, sample);
+    }
+
+    pub(crate) fn record_arrival(&mut self, now: Instant) {
+        if let Some(last) = self.last_arrival {
+            self.arrival_interval = ewma(self.arrival_interval, now.duration_since(last));
+        }
+        self.last_arrival = Some(now);
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResourceStatus {

--- a/crates/libs/rns-transport/src/resource/manager.rs
+++ b/crates/libs/rns-transport/src/resource/manager.rs
@@ -347,20 +347,23 @@ impl ResourceManager {
                     break;
                 }
                 PartOutcome::Incomplete => {
-                    let request = receiver.build_request();
-                    receiver.mark_request();
-                    request_packet = match build_link_packet(
-                        link,
-                        PacketType::Data,
-                        PacketContext::ResourceRequest,
-                        &request.encode(),
-                    ) {
-                        Ok(packet) => Some(packet),
-                        Err(_) => {
-                            log::warn!("failed to build request packet");
-                            None
-                        }
-                    };
+                    let now = Instant::now();
+                    if receiver.immediate_request_due(now) {
+                        let request = receiver.build_request();
+                        receiver.mark_request();
+                        request_packet = match build_link_packet(
+                            link,
+                            PacketType::Data,
+                            PacketContext::ResourceRequest,
+                            &request.encode(),
+                        ) {
+                            Ok(packet) => Some(packet),
+                            Err(_) => {
+                                log::warn!("failed to build request packet");
+                                None
+                            }
+                        };
+                    }
                     if receiver.received > before_received {
                         resource_diag(&format!(
                             "progress hash={} received={}/{} bytes={}/{}",

--- a/crates/libs/rns-transport/src/resource/manager.rs
+++ b/crates/libs/rns-transport/src/resource/manager.rs
@@ -112,6 +112,7 @@ impl ResourceManager {
         self.pending_outgoing.retain(|_, sender| sender.link_id != link_id);
         self.outgoing.retain(|_, sender| sender.link_id != link_id);
         self.incoming.retain(|_, receiver| receiver.link_id != link_id);
+        self.link_stats.remove(&link_id);
     }
 
     pub fn drain_events(&mut self) -> Vec<ResourceEvent> {

--- a/crates/libs/rns-transport/src/resource/manager.rs
+++ b/crates/libs/rns-transport/src/resource/manager.rs
@@ -6,6 +6,7 @@ pub struct ResourceManager {
     events: Vec<ResourceEvent>,
     retry_interval: Duration,
     retry_limit: u8,
+    link_stats: HashMap<AddressHash, LinkStats>,
 }
 
 impl ResourceManager {
@@ -24,6 +25,7 @@ impl ResourceManager {
             events: Vec::new(),
             retry_interval,
             retry_limit,
+            link_stats: HashMap::new(),
         }
     }
 
@@ -126,9 +128,14 @@ impl ResourceManager {
         let mut failed = Vec::new();
         for (hash, receiver) in self.incoming.iter_mut() {
             if receiver.retry_due(now, self.retry_interval, self.retry_limit) {
-                let request = receiver.build_request();
-                receiver.mark_request();
-                requests.push((receiver.link_id, request));
+                let rtt = self.link_stats.get(&receiver.link_id)
+                    .map(|s| s.rtt)
+                    .unwrap_or(LinkStats::new().rtt);
+                let request = receiver.build_request(now, rtt);
+                if !request.requested_hashes.is_empty() || request.hashmap_exhausted {
+                    receiver.mark_request();
+                    requests.push((receiver.link_id, request));
+                }
             }
             if receiver.retry_count >= self.retry_limit {
                 failed.push(*hash);
@@ -238,7 +245,9 @@ impl ResourceManager {
             resource_diag("reject_advertisement unreasonable");
             return;
         };
-        let request = receiver.build_request();
+        let adv_now = Instant::now();
+        let rtt = self.link_stats.entry(*link.id()).or_insert_with(LinkStats::new).rtt;
+        let request = receiver.build_request(adv_now, rtt);
         resource_diag(&format!(
             "request_parts hash={} requested={} exhausted={}",
             resource_hash,
@@ -300,7 +309,11 @@ impl ResourceManager {
         };
         if let Some(receiver) = self.incoming.get_mut(&update.resource_hash) {
             receiver.handle_hash_update(&update);
-            let request = receiver.build_request();
+            let update_now = Instant::now();
+            let rtt = self.link_stats.get(&receiver.link_id)
+                .map(|s| s.rtt)
+                .unwrap_or(LinkStats::new().rtt);
+            let request = receiver.build_request(update_now, rtt);
             match build_link_packet(
                 link,
                 PacketType::Data,
@@ -348,23 +361,17 @@ impl ResourceManager {
                 }
                 PartOutcome::Incomplete => {
                     let now = Instant::now();
-                    if receiver.immediate_request_due(now) {
-                        let request = receiver.build_request();
-                        receiver.mark_request();
-                        request_packet = match build_link_packet(
-                            link,
-                            PacketType::Data,
-                            PacketContext::ResourceRequest,
-                            &request.encode(),
-                        ) {
-                            Ok(packet) => Some(packet),
-                            Err(_) => {
-                                log::warn!("failed to build request packet");
-                                None
-                            }
-                        };
+                    let stats = self.link_stats
+                        .entry(receiver.link_id)
+                        .or_insert_with(LinkStats::new);
+
+                    // Collect RTT sample measured during handle_part (if any).
+                    if let Some(rtt) = receiver.last_rtt_sample.take() {
+                        stats.update_rtt(rtt);
                     }
+
                     if receiver.received > before_received {
+                        stats.record_arrival(now);
                         resource_diag(&format!(
                             "progress hash={} received={}/{} bytes={}/{}",
                             hash,
@@ -379,16 +386,41 @@ impl ResourceManager {
                             kind: ResourceEventKind::Progress(receiver.progress()),
                         });
                     }
+
+                    let rtt = stats.rtt;
+                    let request = receiver.build_request(now, rtt);
+                    if !request.requested_hashes.is_empty() || request.hashmap_exhausted {
+                        receiver.last_request = now;
+                        request_packet = match build_link_packet(
+                            link,
+                            PacketType::Data,
+                            PacketContext::ResourceRequest,
+                            &request.encode(),
+                        ) {
+                            Ok(packet) => Some(packet),
+                            Err(_) => {
+                                log::warn!("failed to build request packet");
+                                None
+                            }
+                        };
+                    }
                     break;
                 }
             }
         }
         if let Some(hash) = failed {
             self.incoming.remove(&hash);
+            // Reset arrival timing so a gap between resources doesn't skew the EWMA.
+            if let Some(stats) = self.link_stats.get_mut(link.id()) {
+                stats.last_arrival = None;
+            }
             return;
         }
         if let Some(hash) = completed {
             self.incoming.remove(&hash);
+            if let Some(stats) = self.link_stats.get_mut(link.id()) {
+                stats.last_arrival = None;
+            }
             if let Some(payload) = payload {
                 self.events.push(ResourceEvent {
                     hash,

--- a/crates/libs/rns-transport/src/resource/manager.rs
+++ b/crates/libs/rns-transport/src/resource/manager.rs
@@ -410,7 +410,11 @@ impl ResourceManager {
         }
         if let Some(hash) = failed {
             self.incoming.remove(&hash);
-            // Reset arrival timing so a gap between resources doesn't skew the EWMA.
+            // Reset so the inter-resource gap doesn't skew the arrival EWMA.
+            // TODO: a better approach is to schedule a delayed reset — wait
+            // arrival_interval * 2, and only reset if no new part has arrived by
+            // then. This preserves the estimate when the next resource starts
+            // immediately after this one finishes.
             if let Some(stats) = self.link_stats.get_mut(link.id()) {
                 stats.last_arrival = None;
             }
@@ -418,6 +422,7 @@ impl ResourceManager {
         }
         if let Some(hash) = completed {
             self.incoming.remove(&hash);
+            // Same TODO as the failed path above.
             if let Some(stats) = self.link_stats.get_mut(link.id()) {
                 stats.last_arrival = None;
             }

--- a/crates/libs/rns-transport/src/resource/receiver.rs
+++ b/crates/libs/rns-transport/src/resource/receiver.rs
@@ -20,6 +20,14 @@ struct ResourceReceiver {
     last_request: Instant,
     retry_count: u8,
     status: ResourceStatus,
+    /// Indices of fragments not yet requested, in hashmap order.
+    request_queue: VecDeque<usize>,
+    /// Ordered by send time (front = oldest). Used to detect timed-out fragments in O(1).
+    in_flight_queue: VecDeque<(Instant, usize)>,
+    /// Maps fragment index → time it was last requested, for RTT measurement.
+    in_flight_set: HashMap<usize, Instant>,
+    /// RTT sample from the most recently matched received part; read once by the manager.
+    last_rtt_sample: Option<Duration>,
 }
 
 #[derive(Debug, Clone)]
@@ -68,6 +76,10 @@ impl ResourceReceiver {
             last_request: now,
             retry_count: 0,
             status: ResourceStatus::Advertised,
+            request_queue: VecDeque::new(),
+            in_flight_queue: VecDeque::new(),
+            in_flight_set: HashMap::new(),
+            last_rtt_sample: None,
         };
         receiver.apply_hashmap_segment(adv.segment_index.saturating_sub(1) as usize, &adv.hashmap);
         Ok(receiver)
@@ -80,29 +92,64 @@ impl ResourceReceiver {
             let mut entry = [0u8; MAPHASH_LEN];
             entry.copy_from_slice(&bytes[start..start + MAPHASH_LEN]);
             let idx = segment * HASHMAP_MAX_LEN + i;
-            if idx < self.hashmap.len() {
+            if idx < self.hashmap.len() && self.hashmap[idx].is_none() {
                 self.hashmap[idx] = Some(entry);
+                self.request_queue.push_back(idx);
             }
         }
     }
 
-    fn build_request(&self) -> ResourceRequest {
-        let mut requested = Vec::new();
-        let mut last_known: Option<[u8; MAPHASH_LEN]> = None;
-        let mut hashmap_exhausted = false;
+    fn build_request(&mut self, now: Instant, rtt: Duration) -> ResourceRequest {
+        let loss_threshold = rtt.saturating_mul(2);
 
-        for (idx, entry) in self.hashmap.iter().enumerate() {
-            if let Some(hash) = entry {
-                last_known = Some(*hash);
-                if self.parts[idx].is_none() {
-                    requested.push(*hash);
-                    if requested.len() >= WINDOW {
+        // Drain the front of in_flight_queue (front = oldest, since we append in time order).
+        // Received entries are lazily pruned; entries older than 2×rtt are declared lost
+        // and pushed to the front of request_queue for priority re-request.
+        loop {
+            match self.in_flight_queue.front() {
+                None => break,
+                Some(&(sent_at, idx)) => {
+                    if self.parts[idx].is_some() {
+                        self.in_flight_set.remove(&idx);
+                        self.in_flight_queue.pop_front();
+                    } else if now.duration_since(sent_at) > loss_threshold {
+                        self.in_flight_set.remove(&idx);
+                        self.in_flight_queue.pop_front();
+                        self.request_queue.push_front(idx);
+                    } else {
                         break;
                     }
                 }
-            } else {
-                hashmap_exhausted = true;
-                break;
+            }
+        }
+
+        // Detect hashmap exhaustion: scan for the first None entry.
+        let mut last_known = None;
+        let mut hashmap_exhausted = false;
+        for entry in &self.hashmap {
+            match entry {
+                Some(h) => last_known = Some(*h),
+                None => { hashmap_exhausted = true; break; }
+            }
+        }
+
+        // Fill available window slots. Lost fragments are at the front of request_queue
+        // (pushed there above) so they get priority over new fragments.
+        let window_space = WINDOW.saturating_sub(self.in_flight_set.len());
+        let mut requested = Vec::new();
+        while requested.len() < window_space {
+            match self.request_queue.pop_front() {
+                None => break,
+                Some(idx) => {
+                    if self.parts[idx].is_none() && !self.in_flight_set.contains_key(&idx) {
+                        if let Some(hash) = self.hashmap[idx] {
+                            requested.push(hash);
+                            self.in_flight_set.insert(idx, now);
+                            self.in_flight_queue.push_back((now, idx));
+                        }
+                    }
+                    // Received or already in-flight — skip.
+                }
             }
         }
 
@@ -137,7 +184,12 @@ impl ResourceReceiver {
             self.parts[index] = Some(part.to_vec());
             self.received += 1;
             self.received_bytes = self.received_bytes.saturating_add(part.len() as u64);
-            self.last_progress = Instant::now();
+            let now = Instant::now();
+            self.last_progress = now;
+            // Measure RTT: if this fragment was in-flight, record how long it took.
+            if let Some(sent_at) = self.in_flight_set.remove(&index) {
+                self.last_rtt_sample = Some(now.duration_since(sent_at));
+            }
         }
 
         if self.received == self.parts.len() && !self.parts.is_empty() {
@@ -271,14 +323,6 @@ impl ResourceReceiver {
     fn mark_request(&mut self) {
         self.last_request = Instant::now();
         self.retry_count = self.retry_count.saturating_add(1);
-    }
-
-    fn immediate_request_due(&self, now: Instant) -> bool {
-        let remaining = self.parts.len().saturating_sub(self.received);
-        if remaining < WINDOW {
-            return false;
-        }
-        now.duration_since(self.last_request) >= RESOURCE_REQUEST_COOLDOWN
     }
 
     fn retry_due(&self, now: Instant, retry_interval: Duration, max_retries: u8) -> bool {

--- a/crates/libs/rns-transport/src/resource/receiver.rs
+++ b/crates/libs/rns-transport/src/resource/receiver.rs
@@ -273,6 +273,14 @@ impl ResourceReceiver {
         self.retry_count = self.retry_count.saturating_add(1);
     }
 
+    fn immediate_request_due(&self, now: Instant) -> bool {
+        let remaining = self.parts.len().saturating_sub(self.received);
+        if remaining < WINDOW {
+            return false;
+        }
+        now.duration_since(self.last_request) >= RESOURCE_REQUEST_COOLDOWN
+    }
+
     fn retry_due(&self, now: Instant, retry_interval: Duration, max_retries: u8) -> bool {
         if self.status.is_terminal() {
             return false;

--- a/crates/libs/rns-transport/src/resource/receiver.rs
+++ b/crates/libs/rns-transport/src/resource/receiver.rs
@@ -100,6 +100,13 @@ impl ResourceReceiver {
     }
 
     fn build_request(&mut self, now: Instant, rtt: Duration) -> ResourceRequest {
+        // TODO: the loss threshold (2×rtt) and EWMA alpha (7/8) are intuition-based
+        // and have not been formally tuned or proven. On links with high jitter the
+        // 2×rtt multiplier may be too tight (causing spurious re-requests); on links
+        // with asymmetric delay it may be too loose. The EWMA alpha controls how
+        // quickly the estimate tracks changes — a higher alpha (closer to 1) gives
+        // more weight to history and reacts more slowly to sudden changes. Both
+        // values should be validated against real-world Reticulum traffic traces.
         let loss_threshold = rtt.saturating_mul(2);
 
         // Drain the front of in_flight_queue (front = oldest, since we append in time order).

--- a/crates/libs/rns-transport/src/resource/tests_timeouts.rs
+++ b/crates/libs/rns-transport/src/resource/tests_timeouts.rs
@@ -302,11 +302,11 @@ fn resource_manager_removes_link_scoped_state_on_link_close() {
 }
 
 #[test]
-fn resource_receiver_sends_no_redundant_requests_during_fast_transfer() {
-    // Before fix: N parts arriving → N request packets (one per Incomplete outcome).
-    // After fix:  N parts arriving in <<50ms → 0 request packets (cooldown not elapsed).
-    // The remaining<WINDOW guard is also exercised: parts 8-9 leave 2-1 parts
-    // remaining (<WINDOW=4), so immediate_request_due returns false regardless of time.
+fn resource_receiver_slides_window_without_redundant_requests() {
+    // With adaptive in-flight tracking the receiver keeps at most WINDOW fragments
+    // in flight at any time. Each received part opens one slot, so exactly one new
+    // fragment is requested per arrived part once the pipeline is full — never the
+    // same fragment twice while it is still in flight.
     let signer = PrivateIdentity::new_from_rand(OsRng);
     let identity = *signer.as_identity();
     let destination = DestinationDesc {
@@ -352,20 +352,31 @@ fn resource_receiver_sends_no_redundant_requests_during_fast_transfer() {
     let _ = manager.handle_packet(&adv_packet, &mut link);
     assert!(manager.incoming.contains_key(&adv.hash));
 
-    // Feed 9 of 10 parts in a tight loop — all arrive within microseconds.
-    let mut request_count = 0usize;
+    // Feed 9 of 10 parts. Verify window-sliding behaviour:
+    // at most 1 new request per received part (window opens by 1 slot each time),
+    // and the total number of request packets is bounded by TOTAL_PARTS - WINDOW
+    // (WINDOW fragments were already requested in the advertisement response).
+    let mut total_request_packets = 0usize;
     for part in parts.iter().take(TOTAL_PARTS - 1) {
         let p = resource_packet(PacketContext::Resource, part, *link.id());
         let responses = manager.handle_packet(&p, &mut link);
-        request_count += responses
+        let req_packets: Vec<_> = responses
             .iter()
             .filter(|p| p.context == PacketContext::ResourceRequest)
-            .count();
+            .collect();
+        assert!(
+            req_packets.len() <= 1,
+            "expected at most 1 request per received part, got {}",
+            req_packets.len()
+        );
+        total_request_packets += req_packets.len();
     }
 
-    assert_eq!(
-        request_count, 0,
-        "expected no redundant request packets during fast transfer, got {request_count}"
+    assert!(
+        total_request_packets <= TOTAL_PARTS - WINDOW,
+        "total request packets {} exceeds TOTAL_PARTS - WINDOW = {}",
+        total_request_packets,
+        TOTAL_PARTS - WINDOW
     );
 }
 

--- a/crates/libs/rns-transport/src/resource/tests_timeouts.rs
+++ b/crates/libs/rns-transport/src/resource/tests_timeouts.rs
@@ -302,6 +302,74 @@ fn resource_manager_removes_link_scoped_state_on_link_close() {
 }
 
 #[test]
+fn resource_receiver_sends_no_redundant_requests_during_fast_transfer() {
+    // Before fix: N parts arriving → N request packets (one per Incomplete outcome).
+    // After fix:  N parts arriving in <<50ms → 0 request packets (cooldown not elapsed).
+    // The remaining<WINDOW guard is also exercised: parts 8-9 leave 2-1 parts
+    // remaining (<WINDOW=4), so immediate_request_due returns false regardless of time.
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination = DestinationDesc {
+        identity,
+        address_hash: identity.address_hash,
+        name: DestinationName::new("lxmf", "resource"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(1);
+    let mut link = Link::new(destination, tx);
+    link.request();
+
+    let mut manager = ResourceManager::new();
+
+    const TOTAL_PARTS: usize = 10;
+    let random_hash = [0xAB; RANDOM_HASH_SIZE];
+    let parts: Vec<Vec<u8>> = (0..TOTAL_PARTS)
+        .map(|i| vec![i as u8; PACKET_MDU])
+        .collect();
+    let mut hashmap_bytes = Vec::with_capacity(TOTAL_PARTS * MAPHASH_LEN);
+    for part in &parts {
+        hashmap_bytes.extend_from_slice(&map_hash(part, &random_hash));
+    }
+
+    let adv = ResourceAdvertisement {
+        transfer_size: (TOTAL_PARTS * PACKET_MDU) as u64,
+        data_size: (TOTAL_PARTS * PACKET_MDU) as u64,
+        parts: TOTAL_PARTS as u32,
+        hash: Hash::new_from_slice(&[0xCC; 32]),
+        random_hash,
+        original_hash: Hash::new_from_slice(&[0xCC; 32]),
+        segment_index: 1,
+        total_segments: 1,
+        request_id: None,
+        flags: 0,
+        hashmap: hashmap_bytes,
+    };
+
+    let adv_packet = resource_packet(
+        PacketContext::ResourceAdvrtisement,
+        &adv.pack().expect("pack"),
+        *link.id(),
+    );
+    let _ = manager.handle_packet(&adv_packet, &mut link);
+    assert!(manager.incoming.contains_key(&adv.hash));
+
+    // Feed 9 of 10 parts in a tight loop — all arrive within microseconds.
+    let mut request_count = 0usize;
+    for part in parts.iter().take(TOTAL_PARTS - 1) {
+        let p = resource_packet(PacketContext::Resource, part, *link.id());
+        let responses = manager.handle_packet(&p, &mut link);
+        request_count += responses
+            .iter()
+            .filter(|p| p.context == PacketContext::ResourceRequest)
+            .count();
+    }
+
+    assert_eq!(
+        request_count, 0,
+        "expected no redundant request packets during fast transfer, got {request_count}"
+    );
+}
+
+#[test]
 fn resource_manager_link_close_allows_later_resource_on_new_link() {
     let signer = PrivateIdentity::new_from_rand(OsRng);
     let identity = *signer.as_identity();

--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -113,8 +113,8 @@
     },
     {
       "path": "docs/contracts/rpc-contract.md",
-      "bytes": 12145,
-      "sha256": "da787f4e88cba076b9247bbfe019c697fc80bdac285920a6a83b78e224aebb81"
+      "bytes": 12332,
+      "sha256": "1e021a07457f534d7c244c1068ab2b6427a676dae5c255da025dc19f15106375"
     },
     {
       "path": "docs/contracts/schema-driven-clients.md",


### PR DESCRIPTION

## What breaks

`handle_resource_part_into()` unconditionally fires a `ResourceRequest` for every incoming part that leaves the transfer `Incomplete`. For a 100-part resource this produces 99 outgoing request packets, all asking for overlapping sets of the same first four missing fragments — bandwidth proportional to transfer size rather than to actual loss.

Even with different fragments requested each time, there was no concept of "in flight": the same fragment could be re-requested before the sender had time to respond.

---

## Root cause

`build_request()` scanned the hashmap from index 0 on every call, always returning the first `WINDOW` missing fragments regardless of whether they had already been requested and were still in transit. Combined with the unconditional call in the `Incomplete` arm, this produced O(N) requests for N received parts.

---

## Fix (two fixes)

### Commit 1 — just add a little timeout

### Commit 2 -- rotating request queue

`apply_hashmap_segment` populates a `VecDeque<usize>` (`request_queue`) as hashmap entries arrive. `build_request` pops indices from the front, skips received ones, and does not put them back — fragments are only queued once. This stops repeated requests for the same window.

### Commit 2 — per-link RTT EWMA and in-flight window

**`resource.rs`** — `LinkStats` (stored per link in `ResourceManager`):
- `rtt: Duration` — EWMA of measured round-trip time, α = 7/8
- `arrival_interval: Duration` — EWMA of inter-arrival time between received parts
- `last_arrival` resets to `None` on resource completion so inter-resource gaps don't pollute the estimate

**`receiver.rs`** — two new fields on `ResourceReceiver`:
- `in_flight_queue: VecDeque<(Instant, usize)>` — entries in send order; front = oldest, giving O(1) loss detection
- `in_flight_set: HashMap<usize, Instant>` — maps index → send time for O(1) RTT sampling on arrival

`build_request(now, rtt)` drains the front of `in_flight_queue`:
- Received entries are lazily pruned
- Entries older than `2 × rtt` are declared lost and pushed to the **front** of `request_queue` for immediate priority re-request

It then fills `WINDOW − in_flight_set.len()` slots from `request_queue`. A fragment already in `in_flight_set` is never requested twice.

**`receiver.rs` — `handle_part`**: when a tracked fragment arrives, `in_flight_set.remove(&index)` yields the send time; the RTT sample is stored in `last_rtt_sample` for the manager to read.

**`manager.rs`** — `Incomplete` arm:
```rust
PartOutcome::Incomplete => {
    // read RTT sample → update link stats
    // record arrival → update arrival_interval EWMA
    let request = receiver.build_request(now, stats.rtt);
    if !request.requested_hashes.is_empty() || request.hashmap_exhausted {
        receiver.last_request = now;   // no retry_count increment
        request_packet = Some(...);
    }
}
```

The 2-second `retry_requests()` timer is unchanged and remains the fallback for complete stalls.

---

## Effect

| Scenario | Before | After |
|----------|--------|-------|
| 100 parts, lossless, fast link | 99 request packets, all for same 4 fragments | 0–6 packets, each for a new fragment; window slides |
| Fragment lost (no arrival for `2×rtt`) | Re-requested only by 2 s timer | Detected immediately, re-queued with priority |
| Fragment in flight, new part arrives | Possibly re-requested | Never re-requested while in `in_flight_set` |

---

## Merge note

https://github.com/FreeTAKTeam/LXMF-rs/pull/218 needed to be closed before merging this PR: `mark_request()` then should be changed in `Incomplete` for `mark_active_request()`. 

---

## Regression test

`resource_receiver_slides_window_without_redundant_requests` in `tests_timeouts.rs`:

- 10-part resource; feeds 9 parts sequentially
- Asserts ≤ 1 request packet per received part (window opens one slot at a time)
- Asserts total request packets ≤ `TOTAL_PARTS − WINDOW`


## Type
- [ ] breaking
- [ ] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `make test`
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [ ] `cargo doc --workspace --no-deps`
- [ ] `cargo deny check`
- [ ] `cargo audit`

## Compatibility
- [ ] Updated compatibility matrix / contract docs (if needed)
