### PR TITLE
Apply priority weighting to peer sync offers

### DIFF
--- a/crates/apps/reticulumd/tests/python_compat_matrix.rs
+++ b/crates/apps/reticulumd/tests/python_compat_matrix.rs
@@ -3,7 +3,7 @@ mod python_compat_cases;
 
 use python_compat_cases::{
     assert_cases_are_dispatchable_by_harness_and_smoke_script, assert_required_modes_covered,
-    run_case,
+    assert_smoke_rpc_call_retries_transient_connection_refusals, run_case,
 };
 
 #[test]
@@ -86,4 +86,9 @@ fn python_compat_lxm_interchange() {
 #[test]
 fn compatibility_cases_are_dispatchable_by_harness_and_smoke_script() {
     assert_cases_are_dispatchable_by_harness_and_smoke_script();
+}
+
+#[test]
+fn smoke_rpc_call_retries_transient_connection_refusals() {
+    assert_smoke_rpc_call_retries_transient_connection_refusals();
 }

--- a/crates/apps/reticulumd/tests/support/python_compat_cases.rs
+++ b/crates/apps/reticulumd/tests/support/python_compat_cases.rs
@@ -156,6 +156,21 @@ pub(crate) fn assert_cases_are_dispatchable_by_harness_and_smoke_script() {
     }
 }
 
+pub(crate) fn assert_smoke_rpc_call_retries_transient_connection_refusals() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..");
+    let smoke = fs::read_to_string(repo_root.join("tools/scripts/python-lxmd-rust-lxmd-smoke.sh"))
+        .expect("smoke dispatcher should be readable");
+
+    assert!(
+        smoke.contains("except OSError as exc:"),
+        "smoke rpc_call should catch transient socket failures before exhausting retries"
+    );
+    assert!(
+        smoke.contains("ConnectionRefusedError"),
+        "smoke rpc_call should retry connection refusals while Rust RPC starts accepting"
+    );
+}
+
 fn assert_case_present(case_id: &str) {
     assert!(
         COMPATIBILITY_CASES.iter().any(|case| case.id == case_id && !case.description.is_empty()),

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -570,6 +570,12 @@ impl RpcDaemon {
                     parsed.transfer_limit_kb.map(|limit| (limit.max(0.0) * 1000.0) as usize);
 
                 let timestamp = now_i64();
+                let prioritised_destinations = self
+                    .delivery_policy
+                    .lock()
+                    .expect("policy mutex poisoned")
+                    .prioritised_destinations
+                    .clone();
                 let existing_peer =
                     self.peers.lock().expect("peers mutex poisoned").get(peer_id).cloned();
                 if existing_peer.is_none()
@@ -580,8 +586,16 @@ impl RpcDaemon {
                         .list_peer_prospective_unhandled_propagation(peer_id)
                         .map_err(std::io::Error::other)?;
                     prospective_propagation.sort_by(|left, right| {
-                        let left_weight = propagation_peer_sync_weight(left, timestamp);
-                        let right_weight = propagation_peer_sync_weight(right, timestamp);
+                        let left_weight = propagation_peer_sync_weight(
+                            left,
+                            timestamp,
+                            prioritised_destinations.as_slice(),
+                        );
+                        let right_weight = propagation_peer_sync_weight(
+                            right,
+                            timestamp,
+                            prioritised_destinations.as_slice(),
+                        );
                         left_weight
                             .partial_cmp(&right_weight)
                             .unwrap_or(std::cmp::Ordering::Equal)
@@ -680,8 +694,16 @@ impl RpcDaemon {
                 let mut propagation_rejected_bytes = 0u64;
                 let mut propagation_rejected_ids = Vec::new();
                 pending_propagation.sort_by(|left, right| {
-                    let left_weight = propagation_peer_sync_weight(left, timestamp);
-                    let right_weight = propagation_peer_sync_weight(right, timestamp);
+                    let left_weight = propagation_peer_sync_weight(
+                        left,
+                        timestamp,
+                        prioritised_destinations.as_slice(),
+                    );
+                    let right_weight = propagation_peer_sync_weight(
+                        right,
+                        timestamp,
+                        prioritised_destinations.as_slice(),
+                    );
                     left_weight
                         .partial_cmp(&right_weight)
                         .unwrap_or(std::cmp::Ordering::Equal)
@@ -1877,12 +1899,24 @@ fn peer_sync_resource_data_size(payloads: &[Vec<u8>]) -> Result<u64, std::io::Er
     Ok(packed.len() as u64)
 }
 
-fn propagation_peer_sync_weight(entry: &PropagationEntryRecord, now: i64) -> f64 {
+fn propagation_peer_sync_weight(
+    entry: &PropagationEntryRecord,
+    now: i64,
+    prioritised_destinations: &[String],
+) -> f64 {
     const FOUR_DAYS_SECS: f64 = 4.0 * 24.0 * 60.0 * 60.0;
 
     let age_secs = now.saturating_sub(entry.received_at) as f64;
     let age_weight = (age_secs / FOUR_DAYS_SECS).max(1.0);
-    age_weight * entry.size_bytes as f64
+    let priority_weight = if prioritised_destinations
+        .iter()
+        .any(|destination| entry.destination.eq_ignore_ascii_case(destination.trim()))
+    {
+        0.1
+    } else {
+        1.0
+    };
+    priority_weight * age_weight * entry.size_bytes as f64
 }
 
 fn decode_truncated_hash(value: &str) -> Option<Vec<u8>> {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -6721,6 +6721,82 @@ fn peer_sync_orders_offers_by_python_weight_before_sync_limit() {
 }
 
 #[test]
+fn peer_sync_prioritised_destinations_reduce_offer_weight_like_python() {
+    let (daemon, peer) = ready_propagation_peer_daemon(0x4a);
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.propagation_sync_limit = Some(152);
+    }
+    daemon
+        .handle_rpc(rpc_request(
+            63,
+            "set_delivery_policy",
+            json!({
+                "prioritised_destinations": ["17".repeat(16)],
+            }),
+        ))
+        .expect("set delivery policy");
+
+    let prioritised_large = PropagationEntryRecord {
+        transient_id: "c6".repeat(32),
+        destination: "17".repeat(16),
+        payload_hex: "17".repeat(80),
+        received_at: 1_700_000_614,
+        size_bytes: 80,
+        stamp_value: None,
+    };
+    let normal_small = PropagationEntryRecord {
+        transient_id: "c7".repeat(32),
+        destination: "18".repeat(16),
+        payload_hex: "18".repeat(20),
+        received_at: 1_700_000_615,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    for entry in [&prioritised_large, &normal_small] {
+        daemon.store.upsert_propagation_entry(entry).expect("store propagation entry");
+        daemon
+            .store
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
+            .expect("mark unhandled");
+    }
+
+    let result = daemon
+        .handle_rpc(rpc_request(
+            64,
+            "peer_sync",
+            json!({
+                "peer": peer.as_str(),
+                "transfer_limit_kb": 1.0,
+            }),
+        ))
+        .expect("peer sync")
+        .result
+        .expect("peer sync result");
+
+    assert_eq!(
+        result["propagation"]["handled_ids"].as_array().expect("handled ids"),
+        &[json!(prioritised_large.transient_id.as_str())]
+    );
+    assert_eq!(
+        result["propagation"]["skipped_ids"].as_array().expect("skipped ids"),
+        &[json!(normal_small.transient_id.as_str())]
+    );
+
+    let handled = daemon
+        .store
+        .list_peer_handled_propagation_ids(peer.as_str())
+        .expect("handled ids");
+    assert_eq!(handled, vec![prioritised_large.transient_id]);
+    let pending = daemon
+        .store
+        .list_peer_unhandled_propagation(peer.as_str())
+        .expect("pending propagation");
+    assert_eq!(pending, vec![normal_small]);
+}
+
+#[test]
 fn peer_sync_reports_propagation_transfer_accounting() {
     let (daemon, peer) = ready_propagation_peer_daemon(0x4a);
     daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1,6 +1,6 @@
 # Current Roadmap Status
 
-Last updated: 2026-06-05
+Last updated: 2026-06-06
 
 This document is the current source of truth for repository-wide delivery
 status. Update this file first when parity status, release confidence, or the
@@ -208,6 +208,10 @@ gap, even though deeper propagation-router parity remains open.
   not part of the current peer offer before mutating queue state, avoiding the
   false completion path where an out-of-offer request marked pending messages
   handled or created a new peer queue from existing propagation entries.
+- Local peer sync offer ordering now also applies Python's prioritised
+  destination weighting before sync-limit selection, so propagation entries for
+  prioritised destinations are offered ahead of lower raw-weight entries when
+  only one payload fits.
 - Inbound propagation peer-resource handling now tracks Python's validated
   peering-link rule: a successful admitted `/offer` peering-key validation
   marks the link as peer-validated, capacity-denied offers do not authorize the

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -9,7 +9,7 @@ KISS/LoRa/RNode interface work improves the transport substrate available to
 LXMF, but it does not by itself complete LXMF peer sync, propagation router, or
 stamp worker parity.
 
-Last reassessed: 2026-06-05 (maintenance unknown-speed waiting-pool regression added)
+Last reassessed: 2026-06-06 (prioritised destination peer-offer weighting regression added)
 
 Status legend: `not-started` | `partial` | `done`
 
@@ -107,7 +107,8 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   stamp-policy and peering-key gates for boolean wants-all, request-limited,
   selected-ID transfer, and no-transfer responses, and reject valid-looking
   wanted transient IDs outside the current offer before mutating queue state or
-  creating a new peer queue.
+  creating a new peer queue. Local peer sync offer ordering now applies
+  Python's prioritised destination weighting before sync-limit selection.
   Existing peers in local sync
   backoff now also postpone before the local existing-entry queue-fill path,
   but the active workspace does not yet match Python `LXMPeer` queueing,
@@ -167,6 +168,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_selected_wanted_ids_keep_full_offer_policy_gates_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_empty_wanted_ids_keep_full_offer_policy_gates_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_during_backoff_does_not_queue_new_existing_entries_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib peer_sync_prioritised_destinations_reduce_offer_weight_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_remote_fetch -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_remote_download -- --nocapture`

--- a/tools/scripts/python-lxmd-rust-lxmd-smoke.sh
+++ b/tools/scripts/python-lxmd-rust-lxmd-smoke.sh
@@ -158,6 +158,7 @@ rpc_call() {
   local params_json="${3:-null}"
   "${PYTHON_BIN}" - <<'PY' "${rpc_addr}" "${method}" "${params_json}"
 import json
+import errno
 import socket
 import sys
 import time
@@ -177,6 +178,16 @@ def is_rate_limited(error):
         return error.get("code") == "SDK_SECURITY_RATE_LIMITED"
     return False
 
+def is_retryable_socket_error(exc):
+    if isinstance(exc, (ConnectionRefusedError, TimeoutError, socket.timeout)):
+        return True
+    return getattr(exc, "errno", None) in {
+        errno.ECONNREFUSED,
+        errno.ECONNRESET,
+        errno.EPIPE,
+        errno.ETIMEDOUT,
+    }
+
 for attempt in range(60):
     payload = {"id": 1, "method": method, "params": params}
     packed = msgpack.packb(payload)
@@ -187,14 +198,20 @@ for attempt in range(60):
         f"Content-Length: {len(frame)}\r\n"
         f"Connection: close\r\n\r\n"
     ).encode("utf-8") + frame
-    with socket.create_connection((host, int(port)), timeout=30) as sock:
-        sock.sendall(request)
-        response = bytearray()
-        while True:
-            chunk = sock.recv(65536)
-            if not chunk:
-                break
-            response.extend(chunk)
+    try:
+        with socket.create_connection((host, int(port)), timeout=30) as sock:
+            sock.sendall(request)
+            response = bytearray()
+            while True:
+                chunk = sock.recv(65536)
+                if not chunk:
+                    break
+                response.extend(chunk)
+    except OSError as exc:
+        if is_retryable_socket_error(exc) and attempt + 1 < 60:
+            time.sleep(1)
+            continue
+        raise
     header_end = response.find(b"\r\n\r\n")
     if header_end < 0:
         raise SystemExit("missing rpc response body")


### PR DESCRIPTION
## Summary
- applies Python LXMRouter prioritised destination weighting to local peer_sync offer ordering before sync-limit selection
- keeps selected wanted-id validation on the same weighted offer order
- records the new LXMPeer queue-ordering parity evidence in the roadmap and LXMF parity matrix

## Verification
- cargo fmt --all -- --check
- git diff --check origin/main..HEAD
- cargo test -p reticulum-rs-rpc --lib peer_sync_prioritised_destinations_reduce_offer_weight_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib peer_sync_orders_offers_by_python_weight_before_sync_limit -- --nocapture
- cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture
- cargo test -p reticulum-rs-rpc --lib
- cargo clippy -p reticulum-rs-rpc --all-targets --all-features --no-deps -- -D warnings