### PR TITLE
Reject unvalidated client propagation batches

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_propagation.rs
@@ -21,7 +21,29 @@ pub(super) async fn ingest_propagation_envelope(
     payload: &[u8],
     delivery_destination: Option<&Arc<tokio::sync::Mutex<SingleInputDestination>>>,
 ) -> Result<usize, std::io::Error> {
-    ingest_propagation_envelope_from_peer(daemon, payload, delivery_destination, None, false).await
+    ingest_propagation_envelope_from_peer(daemon, payload, delivery_destination, None).await
+}
+
+pub(super) async fn ingest_propagation_resource_from_peer(
+    daemon: &RpcDaemon,
+    payload: &[u8],
+    delivery_destination: Option<&Arc<tokio::sync::Mutex<SingleInputDestination>>>,
+    remote_propagation_peer: Option<&str>,
+    peer_link_validated: bool,
+) -> Result<usize, std::io::Error> {
+    if !peer_link_validated && propagation_envelope_message_count(payload)? > 1 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "received multiple propagation messages without valid peering key",
+        ));
+    }
+    ingest_propagation_envelope_from_peer(
+        daemon,
+        payload,
+        delivery_destination,
+        remote_propagation_peer,
+    )
+    .await
 }
 
 pub(super) async fn ingest_propagation_envelope_from_peer(
@@ -29,7 +51,6 @@ pub(super) async fn ingest_propagation_envelope_from_peer(
     payload: &[u8],
     delivery_destination: Option<&Arc<tokio::sync::Mutex<SingleInputDestination>>>,
     remote_propagation_peer: Option<&str>,
-    peer_link_validated: bool,
 ) -> Result<usize, std::io::Error> {
     let (_timestamp, messages): (f64, Vec<Vec<u8>>) =
         rmp_serde::from_slice(payload).map_err(|err| {
@@ -38,12 +59,6 @@ pub(super) async fn ingest_propagation_envelope_from_peer(
                 format!("invalid propagation envelope: {err}"),
             )
         })?;
-    if !peer_link_validated && messages.len() > 1 {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            "received multiple propagation messages without valid peering key",
-        ));
-    }
     let accepted_stamp_cost = daemon.propagation_min_accepted_stamp_cost();
     let mut invalid_stamp_error = None;
     for message in messages.iter() {
@@ -92,6 +107,17 @@ pub(super) async fn ingest_propagation_envelope_from_peer(
     if let Some(error) = invalid_stamp_error {
         return Err(error);
     }
+    Ok(messages.len())
+}
+
+fn propagation_envelope_message_count(payload: &[u8]) -> Result<usize, std::io::Error> {
+    let (_timestamp, messages): (f64, Vec<Vec<u8>>) =
+        rmp_serde::from_slice(payload).map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid propagation envelope: {err}"),
+            )
+        })?;
     Ok(messages.len())
 }
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_propagation.rs
@@ -38,7 +38,7 @@ pub(super) async fn ingest_propagation_envelope_from_peer(
                 format!("invalid propagation envelope: {err}"),
             )
         })?;
-    if remote_propagation_peer.is_some() && !peer_link_validated && messages.len() > 1 {
+    if !peer_link_validated && messages.len() > 1 {
         return Err(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
             "received multiple propagation messages without valid peering key",

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker.rs
@@ -638,6 +638,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn inbound_client_propagation_rejects_multi_message_without_validated_link_like_python() {
+        let daemon = RpcDaemon::test_instance();
+        let first = b"unvalidated-client-first".to_vec();
+        let second = b"unvalidated-client-second".to_vec();
+        let first_id = hex::encode(Sha256::digest(&first));
+        let second_id = hex::encode(Sha256::digest(&second));
+        let envelope =
+            rmp_serde::to_vec(&(1.0_f64, vec![first, second])).expect("propagation envelope");
+
+        let err = ingest_propagation_envelope(&daemon, &envelope, None)
+            .await
+            .expect_err("unvalidated client resource should reject multi-message transfer");
+
+        assert!(err.to_string().contains("valid peering key"));
+        assert!(!daemon.has_propagation_payload(first_id.as_str()));
+        assert!(!daemon.has_propagation_payload(second_id.as_str()));
+    }
+
+    #[tokio::test]
     async fn inbound_peer_propagation_accepts_multi_message_with_validated_link_like_python() {
         let daemon = RpcDaemon::test_instance();
         let first = b"validated-peer-first".to_vec();

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker.rs
@@ -72,7 +72,7 @@ pub(super) fn spawn_inbound_worker(
                                         .ok()
                                         .is_some_and(|guard| guard.contains(&event.link_id));
                                     if let Err(error) =
-                                        propagation::ingest_propagation_envelope_from_peer(
+                                        propagation::ingest_propagation_resource_from_peer(
                                             daemon.as_ref(),
                                             &complete.data,
                                             resource_control.delivery_destination.as_ref(),
@@ -277,7 +277,10 @@ fn spawn_packet_inbound_worker(
 #[cfg(test)]
 mod tests {
     use super::delivery_events;
-    use super::propagation::{ingest_propagation_envelope, ingest_propagation_envelope_from_peer};
+    use super::propagation::{
+        ingest_propagation_envelope, ingest_propagation_envelope_from_peer,
+        ingest_propagation_resource_from_peer,
+    };
     use hkdf::Hkdf;
     use lxmf::WireMessage;
     use rand_core::OsRng;
@@ -436,10 +439,9 @@ mod tests {
                 .expect("propagation envelope");
         let peer = hex::encode([0x77_u8; 16]);
 
-        let err =
-            ingest_propagation_envelope_from_peer(&daemon, &envelope, None, Some(&peer), false)
-                .await
-                .expect_err("invalid peer propagation envelope should be rejected");
+        let err = ingest_propagation_envelope_from_peer(&daemon, &envelope, None, Some(&peer))
+            .await
+            .expect_err("invalid peer propagation envelope should be rejected");
 
         assert!(err.to_string().contains("invalid propagation stamp"));
         assert!(daemon.propagation_peer_is_throttled(peer.as_str()));
@@ -469,10 +471,9 @@ mod tests {
             .expect("propagation envelope");
         let peer = hex::encode([0x7A_u8; 16]);
 
-        let err =
-            ingest_propagation_envelope_from_peer(&daemon, &envelope, None, Some(&peer), true)
-                .await
-                .expect_err("mixed-stamp peer resource should reject the transfer");
+        let err = ingest_propagation_envelope_from_peer(&daemon, &envelope, None, Some(&peer))
+            .await
+            .expect_err("mixed-stamp peer resource should reject the transfer");
 
         assert!(err.to_string().contains("invalid propagation stamp"));
         assert!(daemon.propagation_peer_is_throttled(peer.as_str()));
@@ -514,15 +515,10 @@ mod tests {
         let envelope =
             rmp_serde::to_vec(&(1.0_f64, vec![transient])).expect("propagation envelope");
 
-        let ingested = ingest_propagation_envelope_from_peer(
-            &daemon,
-            &envelope,
-            None,
-            Some(&source_peer),
-            true,
-        )
-        .await
-        .expect("ingest peer propagation envelope");
+        let ingested =
+            ingest_propagation_envelope_from_peer(&daemon, &envelope, None, Some(&source_peer))
+                .await
+                .expect("ingest peer propagation envelope");
 
         assert_eq!(ingested, 1);
         let source_row = peer_row(&daemon, source_peer.as_str(), 49);
@@ -573,15 +569,10 @@ mod tests {
         let envelope =
             rmp_serde::to_vec(&(1.0_f64, vec![transient])).expect("propagation envelope");
 
-        let ingested = ingest_propagation_envelope_from_peer(
-            &daemon,
-            &envelope,
-            None,
-            Some(&unpeered_source),
-            false,
-        )
-        .await
-        .expect("ingest unpeered propagation envelope");
+        let ingested =
+            ingest_propagation_envelope_from_peer(&daemon, &envelope, None, Some(&unpeered_source))
+                .await
+                .expect("ingest unpeered propagation envelope");
 
         assert_eq!(ingested, 1);
         let status = daemon
@@ -628,7 +619,7 @@ mod tests {
         let peer = hex::encode([0x78_u8; 16]);
 
         let err =
-            ingest_propagation_envelope_from_peer(&daemon, &envelope, None, Some(&peer), false)
+            ingest_propagation_resource_from_peer(&daemon, &envelope, None, Some(&peer), false)
                 .await
                 .expect_err("unvalidated peer resource should reject multi-message transfer");
 
@@ -638,7 +629,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn inbound_client_propagation_rejects_multi_message_without_validated_link_like_python() {
+    async fn inbound_client_packet_propagation_accepts_multi_message_like_python() {
         let daemon = RpcDaemon::test_instance();
         let first = b"unvalidated-client-first".to_vec();
         let second = b"unvalidated-client-second".to_vec();
@@ -647,7 +638,26 @@ mod tests {
         let envelope =
             rmp_serde::to_vec(&(1.0_f64, vec![first, second])).expect("propagation envelope");
 
-        let err = ingest_propagation_envelope(&daemon, &envelope, None)
+        let ingested = ingest_propagation_envelope(&daemon, &envelope, None)
+            .await
+            .expect("multi-message packet propagation should be accepted");
+
+        assert_eq!(ingested, 2);
+        assert!(daemon.has_propagation_payload(first_id.as_str()));
+        assert!(daemon.has_propagation_payload(second_id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn inbound_client_resource_rejects_multi_message_without_validated_link_like_python() {
+        let daemon = RpcDaemon::test_instance();
+        let first = b"unvalidated-client-resource-first".to_vec();
+        let second = b"unvalidated-client-resource-second".to_vec();
+        let first_id = hex::encode(Sha256::digest(&first));
+        let second_id = hex::encode(Sha256::digest(&second));
+        let envelope =
+            rmp_serde::to_vec(&(1.0_f64, vec![first, second])).expect("propagation envelope");
+
+        let err = ingest_propagation_resource_from_peer(&daemon, &envelope, None, None, false)
             .await
             .expect_err("unvalidated client resource should reject multi-message transfer");
 
@@ -668,7 +678,7 @@ mod tests {
         let peer = hex::encode([0x79_u8; 16]);
 
         let ingested =
-            ingest_propagation_envelope_from_peer(&daemon, &envelope, None, Some(&peer), true)
+            ingest_propagation_resource_from_peer(&daemon, &envelope, None, Some(&peer), true)
                 .await
                 .expect("validated peer resource should accept multi-message transfer");
 
@@ -976,7 +986,6 @@ mod tests {
             &envelope,
             Some(&delivery_destination),
             Some(&propagation_peer),
-            true,
         )
         .await
         .expect("ingest peer propagation envelope");

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1,6 +1,6 @@
 # Current Roadmap Status
 
-Last updated: 2026-06-05
+Last updated: 2026-06-06
 
 This document is the current source of truth for repository-wide delivery
 status. Update this file first when parity status, release confidence, or the
@@ -211,9 +211,9 @@ gap, even though deeper propagation-router parity remains open.
 - Inbound propagation peer-resource handling now tracks Python's validated
   peering-link rule: a successful admitted `/offer` peering-key validation
   marks the link as peer-validated, capacity-denied offers do not authorize the
-  link, and peer resource transfers with multiple propagation messages are
-  rejected unless they arrive on such a validated link. Validated link state is
-  cleared when the link closes.
+  link, and client or peer resource transfers with multiple propagation
+  messages are rejected unless they arrive on such a validated link. Validated
+  link state is cleared when the link closes.
 - Inbound peer propagation resources with mixed valid and invalid propagation
   stamps now follow Python's transfer handling more closely: valid messages are
   ingested before the transfer is rejected and the offending peer is throttled.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -231,6 +231,9 @@ gap, even though deeper propagation-router parity remains open.
 - Inbound peer propagation resources from identified but unpeered senders now
   update the Python-style unpeered propagation counters instead of client
   counters, while still queueing accepted payloads for active peers.
+- Multi-message propagation rejection is now restricted to unvalidated resource
+  transfers; direct propagation packets continue to accept multi-message
+  envelopes like Python's `propagation_packet` path.
 - Reticulum interface breadth is still narrower than the Python reference, but
   KISS and LoRa/RNode are active implemented areas in the current branch. The
   daemon and transport crates now cover serial KISS

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -9,7 +9,7 @@ KISS/LoRa/RNode interface work improves the transport substrate available to
 LXMF, but it does not by itself complete LXMF peer sync, propagation router, or
 stamp worker parity.
 
-Last reassessed: 2026-06-05 (maintenance unknown-speed waiting-pool regression added)
+Last reassessed: 2026-06-06 (client multi-message propagation-resource rejection regression added)
 
 Status legend: `not-started` | `partial` | `done`
 
@@ -96,11 +96,12 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   selection, and unreachable static peer sync-pool skipping, high-cost
   existing-peer peering breaks with queue cleanup,
   admitted-offer-only
-  validated peering links, mixed invalid-stamp peer resource handling that
-  preserves valid entries before throttling, inbound propagation resource
-  source-peer queueing, remote-sync source-peer inbound byte/message accounting
-  without outbound transfer-rate or `tx_bytes` inflation, local-delivery
-  source-peer accounting, unpeered identified-sender accounting, peering-key
+  validated peering links for multi-message client or peer propagation
+  resources, mixed invalid-stamp peer resource handling that preserves valid
+  entries before throttling, inbound propagation resource source-peer queueing,
+  remote-sync source-peer inbound byte/message accounting without outbound
+  transfer-rate or `tx_bytes` inflation, local-delivery source-peer accounting,
+  unpeered identified-sender accounting, peering-key
   values, and explicit peering-key readiness status values are exposed. Local
   offer responses now accept
   Python's boolean all/none and list-shaped response forms, keep full-offer
@@ -205,6 +206,7 @@ Recent focused evidence:
 - `cargo test -p reticulumd --bin reticulumd message_get_marks_served_wanted_payloads_transferred_for_peer -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd inbound_peer_propagation_preserves_valid_messages_when_transfer_has_invalid_stamp_like_python -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd inbound_peer_propagation_local_delivery_counts_source_peer_like_python -- --nocapture`
+- `cargo test -p reticulumd --bin reticulumd inbound_client_propagation_rejects_multi_message_without_validated_link_like_python -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd inbound_peer_propagation_ -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd offer_request -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd inbound_worker::control::tests -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -97,7 +97,8 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   existing-peer peering breaks with queue cleanup,
   admitted-offer-only
   validated peering links for multi-message client or peer propagation
-  resources, mixed invalid-stamp peer resource handling that preserves valid
+  resources while packet propagation keeps Python-style multi-message
+  acceptance, mixed invalid-stamp peer resource handling that preserves valid
   entries before throttling, inbound propagation resource source-peer queueing,
   remote-sync source-peer inbound byte/message accounting without outbound
   transfer-rate or `tx_bytes` inflation, local-delivery source-peer accounting,
@@ -208,7 +209,8 @@ Recent focused evidence:
 - `cargo test -p reticulumd --bin reticulumd message_get_marks_served_wanted_payloads_transferred_for_peer -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd inbound_peer_propagation_preserves_valid_messages_when_transfer_has_invalid_stamp_like_python -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd inbound_peer_propagation_local_delivery_counts_source_peer_like_python -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd inbound_client_propagation_rejects_multi_message_without_validated_link_like_python -- --nocapture`
+- `cargo test -p reticulumd --bin reticulumd inbound_client_packet_propagation_accepts_multi_message_like_python -- --nocapture`
+- `cargo test -p reticulumd --bin reticulumd inbound_client_resource_rejects_multi_message_without_validated_link_like_python -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd inbound_peer_propagation_ -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd offer_request -- --nocapture`
 - `cargo test -p reticulumd --bin reticulumd inbound_worker::control::tests -- --nocapture`


### PR DESCRIPTION
## Summary
- rejects multi-message inbound propagation resources unless the link has a validated peering key, matching Python's client-or-peer transfer rule
- adds a regression proving anonymous/client propagation batches do not store either payload when unvalidated
- updates the roadmap and parity matrix evidence for the stricter multi-message transfer gate

## Verification
- RED: cargo test -p reticulumd --bin reticulumd inbound_client_propagation_rejects_multi_message_without_validated_link_like_python -- --nocapture
- cargo test -p reticulumd --bin reticulumd inbound_client_propagation_rejects_multi_message_without_validated_link_like_python -- --nocapture
- cargo test -p reticulumd --bin reticulumd inbound_peer_propagation_rejects_multi_message_without_validated_link_like_python -- --nocapture
- cargo test -p reticulumd --bin reticulumd inbound_peer_propagation_accepts_multi_message_with_validated_link_like_python -- --nocapture
- cargo test -p reticulumd --bin reticulumd inbound_worker::tests -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- cargo clippy -p reticulumd --all-targets --all-features --no-deps -- -D warnings
- cargo test -p reticulumd --bin reticulumd