### PR TITLE
Mark local peer propagation deliveries handled

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_propagation.rs
@@ -69,7 +69,9 @@ pub(super) async fn ingest_propagation_envelope_from_peer(
         )
         .await?
         {
-            if remote_propagation_peer.is_none() {
+            if let Some(peer) = remote_propagation_peer {
+                daemon.record_peer_received_propagation(peer, transient_id.as_str())?;
+            } else {
                 daemon.note_client_propagation_messages_received(1);
             }
             continue;

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker.rs
@@ -935,7 +935,7 @@ mod tests {
             None,
         )
         .expect("wire");
-        let (envelope, transient_len) = {
+        let (envelope, transient_id, transient_len) = {
             let destination = delivery_destination.lock().await;
             let message = WireMessage::unpack(&wire).expect("wire unpack");
             let (transient, transient_id) = message
@@ -948,6 +948,7 @@ mod tests {
             (
                 WireMessage::pack_propagation_envelope(1.0, &transient, Some(&stamp))
                     .expect("propagation envelope"),
+                hex::encode(transient_id),
                 transient.len(),
             )
         };
@@ -966,6 +967,15 @@ mod tests {
         let peer = peer_row(&daemon, propagation_peer.as_str(), 48);
         assert_eq!(peer["messages"]["incoming"].as_u64(), Some(1));
         assert_eq!(peer["rx_bytes"].as_u64(), Some(transient_len as u64));
+        assert!(
+            daemon
+                .has_peer_completed_propagation_mark(
+                    propagation_peer.as_str(),
+                    transient_id.as_str()
+                )
+                .expect("completed propagation mark lookup"),
+            "locally delivered peer propagation payloads should still mark the source peer handled"
+        );
 
         let status = daemon
             .handle_rpc(RpcRequest {

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -744,6 +744,19 @@ impl RpcDaemon {
             .map_err(std::io::Error::other)
     }
 
+    pub fn has_peer_completed_propagation_mark(
+        &self,
+        peer: &str,
+        transient_id: &str,
+    ) -> Result<bool, std::io::Error> {
+        self.store
+            .peer_completed_propagation_mark_exists(
+                peer,
+                normalize_propagation_transient_key(transient_id).as_str(),
+            )
+            .map_err(std::io::Error::other)
+    }
+
     pub fn record_peer_transferred_propagation(
         &self,
         peer: &str,

--- a/crates/libs/rns-rpc/src/storage/messages.rs
+++ b/crates/libs/rns-rpc/src/storage/messages.rs
@@ -1037,6 +1037,27 @@ impl MessagesStore {
         })
     }
 
+    pub fn peer_completed_propagation_mark_exists(
+        &self,
+        peer: &str,
+        transient_id: &str,
+    ) -> rusqlite::Result<bool> {
+        self.with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT EXISTS(
+                    SELECT 1
+                    FROM propagation_peer_entries
+                    WHERE peer = ?1
+                      AND transient_id = ?2
+                      AND state IN ('handled', 'transferred', 'received', 'transfer_limited')
+                    LIMIT 1
+                 )",
+                params![peer, normalize_hex_key(transient_id)],
+                |row| row.get(0),
+            )
+        })
+    }
+
     pub fn list_peer_unhandled_propagation_ids(&self, peer: &str) -> rusqlite::Result<Vec<String>> {
         self.with_read_conn(|conn| {
             let mut stmt = conn.prepare(

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1,6 +1,6 @@
 # Current Roadmap Status
 
-Last updated: 2026-06-05
+Last updated: 2026-06-06
 
 This document is the current source of truth for repository-wide delivery
 status. Update this file first when parity status, release confidence, or the
@@ -222,8 +222,9 @@ gap, even though deeper propagation-router parity remains open.
   and records inbound bytes, while newly ingested propagation entries are queued
   only for other active peers.
 - Inbound peer propagation resources that locally deliver a payload now credit
-  the propagation source peer's inbound counters instead of treating the
-  transfer as a client propagation receive.
+  the propagation source peer's inbound counters and mark the source peer
+  received/handled instead of treating the transfer as a client propagation
+  receive.
 - Inbound peer propagation resources from identified but unpeered senders now
   update the Python-style unpeered propagation counters instead of client
   counters, while still queueing accepted payloads for active peers.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -2,14 +2,14 @@
 
 Status: historical parity snapshot; check `docs/status/current-roadmap.md` for
 current repo-wide status before relying on this file for active execution order.
-As of 2026-06-05, the live Python-reference interop workflow is green for the
+As of 2026-06-06, the live Python-reference interop workflow is green for the
 current branch, but that checkpoint does not convert the partial peer, router,
 propagation, and stamper rows below into full parity. The Reticulum
 KISS/LoRa/RNode interface work improves the transport substrate available to
 LXMF, but it does not by itself complete LXMF peer sync, propagation router, or
 stamp worker parity.
 
-Last reassessed: 2026-06-05 (maintenance unknown-speed waiting-pool regression added)
+Last reassessed: 2026-06-06 (local-delivery source-peer queue mark regression added)
 
 Status legend: `not-started` | `partial` | `done`
 
@@ -100,7 +100,7 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   preserves valid entries before throttling, inbound propagation resource
   source-peer queueing, remote-sync source-peer inbound byte/message accounting
   without outbound transfer-rate or `tx_bytes` inflation, local-delivery
-  source-peer accounting, unpeered identified-sender accounting, peering-key
+  source-peer accounting and queue marks, unpeered identified-sender accounting, peering-key
   values, and explicit peering-key readiness status values are exposed. Local
   offer responses now accept
   Python's boolean all/none and list-shaped response forms, keep full-offer


### PR DESCRIPTION
## Summary
- mark locally delivered peer propagation resources as received/handled for the source peer
- add a regression that verifies the completed peer queue mark while preserving local-delivery accounting
- update the roadmap and LXMF parity matrix for the new queue-state behavior

## Verification
- cargo test -p reticulumd --bin reticulumd inbound_peer_propagation_local_delivery_counts_source_peer_like_python -- --nocapture
- cargo test -p reticulumd --bin reticulumd inbound_worker::tests -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- cargo clippy -p reticulumd --all-targets --all-features --no-deps -- -D warnings
- cargo test -p reticulumd --bin reticulumd