### PR TITLE
Reject new peer offer responses

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -572,27 +572,11 @@ impl RpcDaemon {
                 let timestamp = now_i64();
                 let existing_peer =
                     self.peers.lock().expect("peers mutex poisoned").get(peer_id).cloned();
-                if existing_peer.is_none()
-                    && wanted_ids.as_ref().is_some_and(PeerSyncWantedIds::requires_offer_validation)
-                {
-                    let mut prospective_propagation = self
-                        .store
-                        .list_peer_prospective_unhandled_propagation(peer_id)
-                        .map_err(std::io::Error::other)?;
-                    prospective_propagation.sort_by(|left, right| {
-                        let left_weight = propagation_peer_sync_weight(left, timestamp);
-                        let right_weight = propagation_peer_sync_weight(right, timestamp);
-                        left_weight
-                            .partial_cmp(&right_weight)
-                            .unwrap_or(std::cmp::Ordering::Equal)
-                            .then_with(|| left.transient_id.cmp(&right.transient_id))
-                    });
-                    validate_peer_sync_wanted_ids_in_offer(
-                        wanted_ids.as_ref(),
-                        prospective_propagation.as_slice(),
-                        requested_transfer_limit_bytes,
-                        requested_transfer_limit_bytes,
-                    )?;
+                if existing_peer.is_none() && wanted_ids.is_some() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "wanted_ids require an existing peer offer matching the current peer offer",
+                    ));
                 }
                 if let Some(record) = existing_peer.as_ref() {
                     let record_transfer_limit_bytes =

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -5683,6 +5683,65 @@ fn peer_sync_rejects_unknown_wanted_ids_without_creating_new_peer_queue() {
 }
 
 #[test]
+fn peer_sync_rejects_offer_response_without_existing_peer_queue() {
+    let daemon = RpcDaemon::test_instance();
+    let existing = PropagationEntryRecord {
+        transient_id: "ab".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_607,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&existing).expect("store propagation entry");
+
+    let error = daemon
+        .handle_rpc(rpc_request(
+            55,
+            "peer_sync",
+            json!({
+                "peer": "peer-new-valid-wanted",
+                "wanted_ids": [existing.transient_id.as_str()],
+            }),
+        ))
+        .expect_err("offer response should require an existing peer offer");
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(
+        error.to_string().contains("existing peer offer"),
+        "unexpected error: {error}"
+    );
+
+    assert!(
+        daemon
+            .store
+            .list_peer_handled_propagation_ids("peer-new-valid-wanted")
+            .expect("handled ids")
+            .is_empty()
+    );
+    assert!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation("peer-new-valid-wanted")
+            .expect("pending propagation")
+            .is_empty(),
+        "rejected offer response must not queue existing propagation for a new peer"
+    );
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 56, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    assert!(
+        peers["peers"]
+            .as_array()
+            .expect("peer rows")
+            .iter()
+            .all(|row| row["peer"].as_str() != Some("peer-new-valid-wanted")),
+        "rejected offer response must not create a peer record"
+    );
+}
+
+#[test]
 fn peer_sync_rejects_transfer_limited_wanted_ids_without_mutating_queue() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -208,6 +208,10 @@ gap, even though deeper propagation-router parity remains open.
   not part of the current peer offer before mutating queue state, avoiding the
   false completion path where an out-of-offer request marked pending messages
   handled or created a new peer queue from existing propagation entries.
+- Local offer-response handling now also rejects explicit `wanted_ids` for
+  brand-new peers before peer creation or queue fill, so a response without an
+  existing peer offer cannot manufacture handled, transferred, or unhandled
+  propagation marks.
 - Inbound propagation peer-resource handling now tracks Python's validated
   peering-link rule: a successful admitted `/offer` peering-key validation
   marks the link as peer-validated, capacity-denied offers do not authorize the

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -2,14 +2,14 @@
 
 Status: historical parity snapshot; check `docs/status/current-roadmap.md` for
 current repo-wide status before relying on this file for active execution order.
-As of 2026-06-05, the live Python-reference interop workflow is green for the
+As of 2026-06-06, the live Python-reference interop workflow is green for the
 current branch, but that checkpoint does not convert the partial peer, router,
 propagation, and stamper rows below into full parity. The Reticulum
 KISS/LoRa/RNode interface work improves the transport substrate available to
 LXMF, but it does not by itself complete LXMF peer sync, propagation router, or
 stamp worker parity.
 
-Last reassessed: 2026-06-05 (maintenance unknown-speed waiting-pool regression added)
+Last reassessed: 2026-06-06 (new-peer offer-response queue guard added)
 
 Status legend: `not-started` | `partial` | `done`
 
@@ -106,8 +106,8 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   Python's boolean all/none and list-shaped response forms, keep full-offer
   stamp-policy and peering-key gates for boolean wants-all, request-limited,
   selected-ID transfer, and no-transfer responses, and reject valid-looking
-  wanted transient IDs outside the current offer before mutating queue state or
-  creating a new peer queue.
+  wanted transient IDs outside an existing current offer before mutating queue
+  state or creating a new peer queue.
   Existing peers in local sync
   backoff now also postpone before the local existing-entry queue-fill path,
   but the active workspace does not yet match Python `LXMPeer` queueing,
@@ -160,6 +160,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib propagation_remote_sync_counts_source_incoming_after_prior_transfer_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects_unknown_wanted_ids_without_mutating_queue -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects_unknown_wanted_ids_without_creating_new_peer_queue -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects_offer_response_without_existing_peer_queue -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects_transfer_limited_wanted_ids_without_mutating_queue -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_boolean -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_boolean_wanted_ids_true_keeps_full_offer_policy_gates_like_python -- --nocapture`

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -111,22 +111,16 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   transfer-rate or `tx_bytes` inflation, local-delivery source-peer accounting,
   unpeered identified-sender accounting, peering-key
   values, and explicit peering-key readiness status values are exposed. Local
-  offer responses now accept
-  Python's boolean all/none and list-shaped response forms, keep full-offer
-  stamp-policy and peering-key gates for boolean wants-all, request-limited,
-  selected-ID transfer, and no-transfer responses, preserve previous
-  last-heard/seen-count values for no-transfer responses, and reject
-  valid-looking wanted transient IDs outside the current offer before mutating
-  queue state or creating a new peer queue.
-  selected-ID transfer, and no-transfer responses, and reject valid-looking
-  wanted transient IDs outside an existing current offer before mutating queue
-  state or creating a new peer queue. Local peer sync offer ordering now applies
-  wanted transient IDs outside the current offer before mutating queue state or
-  creating a new peer queue.
-  Local peer sync also persists Python-style cumulative acceptance-rate cache
-  values after multiple offer responses.
-  creating a new peer queue. Local peer sync offer ordering now applies
-  Python's prioritised destination weighting before sync-limit selection.
+  offer responses now accept Python's boolean all/none and list-shaped response
+  forms, keep full-offer stamp-policy and peering-key gates for boolean
+  wants-all, request-limited, selected-ID transfer, and no-transfer responses,
+  and preserve previous last-heard/seen-count values for no-transfer
+  responses. They reject valid-looking wanted transient IDs outside the current
+  offer, including explicit `wanted_ids` for brand-new peers, before mutating
+  queue state or creating a new peer queue. Local peer sync offer ordering now
+  applies Python's prioritised destination weighting before sync-limit
+  selection, and peer sync persists Python-style cumulative acceptance-rate
+  cache values after multiple offer responses.
   Existing peers in local sync
   backoff now also postpone before the local existing-entry queue-fill path,
   but the active workspace does not yet match Python `LXMPeer` queueing,


### PR DESCRIPTION
## Summary
- reject explicit `wanted_ids` peer-sync offer responses when the peer has no existing offer/queue context
- prevent brand-new peers from being created and filled from stored propagation entries through an out-of-offer response
- update the roadmap and LXMF parity matrix with the new peer queue guard

## Verification
- RED: `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects_offer_response_without_existing_peer_queue -- --nocapture`
- `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects -- --nocapture`
- `cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p reticulum-rs-rpc --all-targets --all-features --no-deps -- -D warnings`
- `cargo test -p reticulum-rs-rpc --lib`