### PR TITLE
Preserve peer heard state for no-transfer sync

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -623,6 +623,8 @@ impl RpcDaemon {
                 }
                 let existing_peer_type =
                     existing_peer.as_ref().and_then(|record| record.peer_type.clone());
+                let prior_peer_seen =
+                    existing_peer.as_ref().map(|record| (record.last_seen, record.seen_count));
                 let peer_type = if self.is_static_peer(peer_id) {
                     Some("static".to_string())
                 } else if existing_peer_type.as_deref() == Some("unpeered") {
@@ -897,6 +899,8 @@ impl RpcDaemon {
                     sync_transfer_rate,
                     tx_bytes,
                     alive,
+                    last_heard,
+                    seen_count,
                 ) = {
                     let mut guard = self.peers.lock().expect("peers mutex poisoned");
                     if let Some(existing) = guard.get_mut(&record.peer) {
@@ -922,6 +926,12 @@ impl RpcDaemon {
                             || existing.acceptance_rate > 0.0;
                         let was_alive = existing.alive;
                         existing.last_sync_attempt = timestamp;
+                        if propagation_no_transfer_offer_response {
+                            if let Some((last_seen, seen_count)) = prior_peer_seen {
+                                existing.last_seen = last_seen;
+                                existing.seen_count = seen_count;
+                            }
+                        }
                         existing.alive = if (propagation_no_work
                             && existing.sync_backoff == 0
                             && had_prior_peer_activity)
@@ -963,6 +973,8 @@ impl RpcDaemon {
                             existing.sync_transfer_rate,
                             existing.tx_bytes,
                             existing.alive,
+                            existing.last_seen,
+                            existing.seen_count,
                         )
                     } else {
                         (
@@ -973,6 +985,8 @@ impl RpcDaemon {
                             record.sync_transfer_rate,
                             record.tx_bytes,
                             record.alive,
+                            record.last_seen,
+                            record.seen_count,
                         )
                     }
                 };
@@ -1019,9 +1033,9 @@ impl RpcDaemon {
                         "timestamp": timestamp,
                         "name": &record.name,
                         "name_source": &record.name_source,
-                        "last_heard": record.last_seen,
+                        "last_heard": last_heard,
                         "first_seen": record.first_seen,
-                        "seen_count": record.seen_count,
+                        "seen_count": seen_count,
                         "state": 0,
                         "sync_strategy": 2,
                         "ler": 0,
@@ -1065,7 +1079,7 @@ impl RpcDaemon {
                         "name": record.name,
                         "name_source": record.name_source,
                         "first_seen": record.first_seen,
-                        "seen_count": record.seen_count,
+                        "seen_count": seen_count,
                         "synced": true,
                         "state": 0,
                         "sync_strategy": 2,
@@ -1076,7 +1090,7 @@ impl RpcDaemon {
                         "tx_bytes": tx_bytes,
                         "alive": alive,
                         "acceptance_rate": acceptance_rate,
-                        "last_heard": record.last_seen,
+                        "last_heard": last_heard,
                         "last_sync_attempt": last_sync_attempt,
                         "next_sync_attempt": next_sync_attempt,
                         "sync_backoff": sync_backoff,

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -6905,6 +6905,70 @@ fn peer_sync_updates_transfer_rate_from_transferred_bytes() {
 }
 
 #[test]
+fn peer_sync_no_transfer_preserves_last_heard_like_python() {
+    let (daemon, peer) = ready_propagation_peer_daemon(0x4d);
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.alive = false;
+        record.last_seen = 7;
+        record.seen_count = 3;
+        record.propagation_sync_limit = Some(1_000);
+    }
+
+    let entry = PropagationEntryRecord {
+        transient_id: "db".repeat(32),
+        destination: "18".repeat(16),
+        payload_hex: "25".repeat(40),
+        received_at: 1_700_000_619,
+        size_bytes: 40,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let result = daemon
+        .handle_rpc(rpc_request(
+            64,
+            "peer_sync",
+            json!({
+                "peer": peer.as_str(),
+                "wanted_ids": [],
+                "transfer_limit_kb": 1.0,
+            }),
+        ))
+        .expect("peer sync")
+        .result
+        .expect("peer sync result");
+
+    assert_eq!(result["propagation"]["handled"].as_u64(), Some(1));
+    assert_eq!(result["propagation"]["transferred"].as_u64(), Some(0));
+    let last_sync_attempt = result["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 7);
+    assert_eq!(result["last_heard"].as_i64(), Some(7));
+    assert_eq!(result["seen_count"].as_u64(), Some(3));
+    assert_eq!(result["alive"].as_bool(), Some(false));
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 65, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(peer.as_str()))
+        .expect("peer row");
+    assert_eq!(row["last_heard"].as_i64(), Some(7));
+    assert_eq!(row["seen_count"].as_u64(), Some(3));
+    assert_eq!(row["alive"].as_bool(), Some(false));
+}
+
+#[test]
 fn peer_sync_preserves_transfer_rate_when_no_offers_remain_like_python() {
     let (daemon, peer) = ready_propagation_peer_daemon(0x4c);
     {

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -173,6 +173,10 @@ gap, even though deeper propagation-router parity remains open.
   `wanted_ids: true` transfers every offered message, while `wanted_ids: false`
   and `wanted_ids: []` mark the whole offer handled without resource transfer,
   preserving the no-transfer liveness and transfer-rate behavior.
+- Local peer sync no-transfer offer responses now also preserve the previous
+  `last_heard` and `seen_count` values, matching Python's path where
+  `resource_concluded()` is not reached and no completed peer transfer is
+  recorded.
 - Local peer sync now also keeps Python's full-offer policy gates for
   `wanted_ids: true`: a boolean wants-all response waits for stamp-policy and
   peering-key readiness like the original offer path instead of bypassing those

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -2,14 +2,14 @@
 
 Status: historical parity snapshot; check `docs/status/current-roadmap.md` for
 current repo-wide status before relying on this file for active execution order.
-As of 2026-06-05, the live Python-reference interop workflow is green for the
+As of 2026-06-06, the live Python-reference interop workflow is green for the
 current branch, but that checkpoint does not convert the partial peer, router,
 propagation, and stamper rows below into full parity. The Reticulum
 KISS/LoRa/RNode interface work improves the transport substrate available to
 LXMF, but it does not by itself complete LXMF peer sync, propagation router, or
 stamp worker parity.
 
-Last reassessed: 2026-06-05 (maintenance unknown-speed waiting-pool regression added)
+Last reassessed: 2026-06-06 (no-transfer peer-sync last-heard regression added)
 
 Status legend: `not-started` | `partial` | `done`
 
@@ -105,9 +105,10 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   offer responses now accept
   Python's boolean all/none and list-shaped response forms, keep full-offer
   stamp-policy and peering-key gates for boolean wants-all, request-limited,
-  selected-ID transfer, and no-transfer responses, and reject valid-looking
-  wanted transient IDs outside the current offer before mutating queue state or
-  creating a new peer queue.
+  selected-ID transfer, and no-transfer responses, preserve previous
+  last-heard/seen-count values for no-transfer responses, and reject
+  valid-looking wanted transient IDs outside the current offer before mutating
+  queue state or creating a new peer queue.
   Existing peers in local sync
   backoff now also postpone before the local existing-entry queue-fill path,
   but the active workspace does not yet match Python `LXMPeer` queueing,
@@ -166,6 +167,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_request_transfer_limit_keeps_full_offer_policy_gates_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_selected_wanted_ids_keep_full_offer_policy_gates_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_empty_wanted_ids_keep_full_offer_policy_gates_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib peer_sync_no_transfer_preserves_last_heard_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_during_backoff_does_not_queue_new_existing_entries_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_remote_fetch -- --nocapture`


### PR DESCRIPTION
## Summary
- preserve prior `last_heard` / `seen_count` for local peer-sync no-transfer offer responses
- keep Python LXMPeer behavior where `resource_concluded()` is not reached unless a peer resource transfer completes
- update the roadmap and LXMF parity matrix with the focused peer-sync evidence

## Verification
- RED: `cargo test -p reticulum-rs-rpc --lib peer_sync_no_transfer_preserves_last_heard_like_python -- --nocapture`
- `cargo test -p reticulum-rs-rpc --lib peer_sync_no_transfer_preserves_last_heard_like_python -- --nocapture`
- `cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p reticulum-rs-rpc --all-targets --all-features --no-deps -- -D warnings`
- `cargo test -p reticulum-rs-rpc --lib`