### PR TITLE
Preserve cumulative peer acceptance rate

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -941,9 +941,11 @@ impl RpcDaemon {
                                 existing.offered.saturating_add(propagation_offered as u64);
                             existing.outgoing =
                                 existing.outgoing.saturating_add(propagation_transferred as u64);
-                            existing.acceptance_rate = (propagation_transferred as f64
-                                / propagation_offered as f64)
-                                .clamp(0.0, 1.0);
+                            existing.acceptance_rate = if existing.offered == 0 {
+                                0.0
+                            } else {
+                                (existing.outgoing as f64 / existing.offered as f64).clamp(0.0, 1.0)
+                            };
                         }
                         if propagation_completed {
                             existing.sync_backoff = 0;

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -5886,6 +5886,76 @@ fn peer_sync_result_reports_cumulative_acceptance_rate_like_python() {
 }
 
 #[test]
+fn peer_sync_persists_cumulative_acceptance_rate_like_python() {
+    let (daemon, peer) = ready_propagation_peer_daemon(0x44);
+    let first = PropagationEntryRecord {
+        transient_id: "44".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_611,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&first).expect("store first entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer.as_str(), first.transient_id.as_str())
+        .expect("mark first unhandled");
+    daemon
+        .handle_rpc(rpc_request(
+            57,
+            "peer_sync",
+            json!({ "peer": peer.as_str(), "transfer_limit_kb": 1 }),
+        ))
+        .expect("initial peer sync");
+
+    let wanted = PropagationEntryRecord {
+        transient_id: "45".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "13".repeat(24),
+        received_at: 1_700_000_612,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    let already_known = PropagationEntryRecord {
+        transient_id: "46".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "14".repeat(24),
+        received_at: 1_700_000_613,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    for entry in [&wanted, &already_known] {
+        daemon.store.upsert_propagation_entry(entry).expect("store propagation entry");
+        daemon
+            .store
+            .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
+            .expect("mark unhandled");
+    }
+
+    daemon
+        .handle_rpc(rpc_request(
+            58,
+            "peer_sync",
+            json!({
+                "peer": peer.as_str(),
+                "wanted_ids": [wanted.transient_id.as_str()],
+            }),
+        ))
+        .expect("second peer sync");
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer.as_str()).expect("peer record");
+    assert_eq!(record.offered, 3);
+    assert_eq!(record.outgoing, 2);
+    assert!(
+        (record.acceptance_rate - (2.0 / 3.0)).abs() < f64::EPSILON,
+        "stored acceptance rate should remain cumulative, got {}",
+        record.acceptance_rate
+    );
+}
+
+#[test]
 fn peer_sync_persists_counters_after_propagation_entries_are_purged_like_python() {
     let (daemon, peer) = ready_propagation_peer_daemon(0xb4);
     let wanted = PropagationEntryRecord {

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -208,6 +208,9 @@ gap, even though deeper propagation-router parity remains open.
   not part of the current peer offer before mutating queue state, avoiding the
   false completion path where an out-of-offer request marked pending messages
   handled or created a new peer queue from existing propagation entries.
+- Local peer sync now persists the peer acceptance-rate cache from cumulative
+  `outgoing/offered` counters, matching Python `LXMPeer.acceptance_rate`
+  instead of replacing the cache with only the latest offer-response ratio.
 - Inbound propagation peer-resource handling now tracks Python's validated
   peering-link rule: a successful admitted `/offer` peering-key validation
   marks the link as peer-validated, capacity-denied offers do not authorize the

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -108,6 +108,8 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
   selected-ID transfer, and no-transfer responses, and reject valid-looking
   wanted transient IDs outside the current offer before mutating queue state or
   creating a new peer queue.
+  Local peer sync also persists Python-style cumulative acceptance-rate cache
+  values after multiple offer responses.
   Existing peers in local sync
   backoff now also postpone before the local existing-entry queue-fill path,
   but the active workspace does not yet match Python `LXMPeer` queueing,
@@ -166,6 +168,7 @@ Recent focused evidence:
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_request_transfer_limit_keeps_full_offer_policy_gates_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_selected_wanted_ids_keep_full_offer_policy_gates_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_empty_wanted_ids_keep_full_offer_policy_gates_like_python -- --nocapture`
+- `cargo test -p reticulum-rs-rpc --lib peer_sync_persists_cumulative_acceptance_rate_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync_during_backoff_does_not_queue_new_existing_entries_like_python -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture`
 - `cargo test -p reticulum-rs-rpc --lib propagation_remote_fetch -- --nocapture`


### PR DESCRIPTION
## Summary
- persist local peer sync acceptance_rate from cumulative outgoing/offered counters
- add a regression that fails when the peer record cache keeps only the latest offer-response ratio
- update the LXMF parity roadmap/matrix evidence for the focused peer-sync increment

## Verification
- cargo test -p reticulum-rs-rpc --lib peer_sync_persists_cumulative_acceptance_rate_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture
- cargo fmt --check
- cargo test -p reticulum-rs-rpc --lib -- --nocapture