### PR TITLE
[codex] Fix AutoInterface link proof multicast fallback

### DIFF
--- a/crates/libs/rns-transport/src/iface/udp.rs
+++ b/crates/libs/rns-transport/src/iface/udp.rs
@@ -11,7 +11,7 @@ use crate::buffer::{InputBuffer, OutputBuffer};
 use crate::error::RnsError;
 use crate::hash::AddressHash;
 use crate::iface::{IfaceRole, IfaceSource, InterfaceManager, RxMessage, TxMessageType};
-use crate::packet::Packet;
+use crate::packet::{Packet, PacketContext, PacketType};
 use crate::serde::Serialize;
 
 use super::{Interface, InterfaceContext};
@@ -68,6 +68,10 @@ fn bind_udp(bind_addr: &str, forward_addr: Option<&str>) -> std::io::Result<UdpS
 
 // UDP trace logging stays on by default for packet-level network bring-up visibility.
 const PACKET_TRACE: bool = true;
+
+fn is_link_proof(packet: &Packet) -> bool {
+    packet.header.packet_type == PacketType::Proof && packet.context == PacketContext::LinkProof
+}
 
 /// Returns true if `addr` parses as a SocketAddr whose IP is multicast
 /// (IPv4 `224.0.0.0/4` or IPv6 `ff00::/8`).
@@ -328,9 +332,11 @@ impl UdpInterface {
                                     //   Broadcast → multicast forward_addr (unchanged).
                                     //   Direct(iface_hash):
                                     //     - if hash resolves in peer_routing → unicast to that peer
+                                    //     - else if hash == this iface's own address and this is
+                                    //       an encrypted link proof → multicast fallback
                                     //     - else if hash == this iface's own address → drop
-                                    //       (the tx-guard: Direct tx to a multicast iface is
-                                    //       nonsensical — every packet would flood the group)
+                                    //       (the tx-guard: ordinary Direct tx to a multicast
+                                    //       iface is nonsensical — every packet would flood the group)
                                     //     - else → drop (unknown virtual iface)
                                     let target = match message.tx_type {
                                         TxMessageType::Broadcast(_) => Some(forward_addr.clone()),
@@ -338,6 +344,14 @@ impl UdpInterface {
                                             if let Some(ref routing) = peer_routing {
                                                 if let Some(peer) = routing.lock().await.addr_for_hash(&addr) {
                                                     Some(peer.to_string())
+                                                } else if addr == iface_address && is_link_proof(&message.packet) {
+                                                    if PACKET_TRACE {
+                                                        log::trace!(
+                                                            "broadcasting Direct link proof fallback for multicast iface {}",
+                                                            iface_address,
+                                                        );
+                                                    }
+                                                    Some(forward_addr.clone())
                                                 } else if addr == iface_address {
                                                     if PACKET_TRACE {
                                                         log::trace!(

--- a/crates/libs/rns-transport/tests/multicast_tx_guard.rs
+++ b/crates/libs/rns-transport/tests/multicast_tx_guard.rs
@@ -3,11 +3,14 @@
 //! Two properties we want to guarantee end-to-end, against real UDP
 //! sockets (no mocks):
 //!
-//!   1. tx-guard — `TxMessageType::Direct` targeting the multicast
-//!      iface's own `AddressHash` never reaches the wire. Otherwise a
-//!      Link keepalive / Data packet routed "directly at the multicast
-//!      iface" would flood the whole group, which is the bug that
-//!      originally brought us here.
+//!   1. tx-guard — ordinary `TxMessageType::Direct` traffic targeting
+//!      the multicast iface's own `AddressHash` never reaches the wire.
+//!      Otherwise a Link keepalive / Data packet routed "directly at
+//!      the multicast iface" would flood the whole group, which is the
+//!      bug that originally brought us here. Encrypted link proofs are
+//!      the exception: when the peer-specific virtual unicast entry has
+//!      not arrived yet, they fall back to the multicast group so the
+//!      first link attempt can activate.
 //!
 //!   2. per-peer unicast routing — `TxMessageType::Direct` targeting a
 //!      *virtual* iface hash registered in the host multicast iface's
@@ -26,7 +29,7 @@ use std::time::Duration;
 
 use rns_transport::iface::udp::spawn_multicast_udp;
 use rns_transport::iface::{IfaceRole, InterfaceManager, TxMessage, TxMessageType};
-use rns_transport::packet::Packet;
+use rns_transport::packet::{Packet, PacketContext, PacketType};
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
@@ -57,6 +60,17 @@ fn pick_free_port() -> u16 {
     let port = probe.local_addr().expect("probe local_addr").port();
     drop(probe);
     port
+}
+
+fn link_proof_packet() -> Packet {
+    Packet {
+        header: rns_transport::packet::Header {
+            packet_type: PacketType::Proof,
+            ..Default::default()
+        },
+        context: PacketContext::LinkProof,
+        ..Default::default()
+    }
 }
 
 #[tokio::test]
@@ -117,6 +131,35 @@ async fn direct_tx_targeting_multicast_iface_is_dropped() {
         "multicast listener must NOT see the Direct tx targeting the multicast iface itself; \
          saw {:?}",
         result
+    );
+}
+
+#[tokio::test]
+async fn direct_link_proof_targeting_multicast_iface_falls_back_to_broadcast() {
+    let port = pick_free_port();
+    let group_addr = format!("{}:{}", MCAST_GROUP, port);
+    let bind_addr = format!("127.0.0.1:{}", port);
+    let listener = bind_listener(port, true);
+
+    let mut mgr = InterfaceManager::new(64);
+    let (iface_hash, _routing) =
+        spawn_multicast_udp(&mut mgr, bind_addr.clone(), Some(group_addr.clone()));
+    let mgr = Arc::new(Mutex::new(mgr));
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let mut rx_buf = [0u8; 2048];
+    let _ = timeout(Duration::from_millis(150), listener.recv_from(&mut rx_buf)).await;
+
+    mgr.lock()
+        .await
+        .send(TxMessage { tx_type: TxMessageType::Direct(iface_hash), packet: link_proof_packet() })
+        .await;
+
+    let result = timeout(Duration::from_millis(500), listener.recv_from(&mut rx_buf)).await;
+    assert!(
+        result.is_ok(),
+        "multicast listener expected to see Direct LinkProof fallback within 500ms"
     );
 }
 


### PR DESCRIPTION
## Summary
- allow encrypted link-proof packets addressed to a multicast AutoInterface hash to fall back to the multicast group when peer virtual unicast routing is not registered yet
- keep the existing guard that drops ordinary direct traffic targeting the multicast iface hash
- add a wire-level multicast regression test for the first-link-attempt race

Closes #232

## Validation
- `cargo test -p reticulum-rs-transport --test multicast_tx_guard direct_link_proof_targeting_multicast_iface_falls_back_to_broadcast -- --nocapture` (red before fix, green after fix)
- `cargo test -p reticulum-rs-transport --test multicast_tx_guard`
- `cargo fmt --all -- --check`
- `cargo clippy -p reticulum-rs-transport --all-targets -- -D warnings`
- `cargo test -p reticulum-rs-transport` (first run had one transient announce-limit failure while clippy was also building; isolated rerun passed, full rerun passed)
- `git diff --check`