### PR TITLE
[codex] Consolidate parity status docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,11 @@ just happen to live under `docs/`.
 
 These are the first places to update when behavior changes:
 
-- `docs/status/`: current repository-wide delivery and parity status
+- `docs/status/current-roadmap.md`: repository-level posture, blockers, and
+  execution order
+- `docs/status/reticulum-parity-matrix.md`: maintained Reticulum row-level
+  parity status
+- `docs/status/lxmf-parity-matrix.md`: maintained LXMF row-level parity status
 - `docs/contracts/`: public contracts, compatibility policy, support policy, API
   behavior, and protocol-facing guarantees
 - `docs/sdk/`: integration guidance for embedding `lxmf-sdk`
@@ -36,7 +40,7 @@ current behavior:
 
 - `docs/migrations/`: cutover notes and migration guidance
 - `docs/releases/`: release-specific notes
-- `docs/plans/`: planning documents and parity tracking
+- `docs/plans/`: historical planning and issue-tracking records
 - `docs/plans/framework-parity-roadmap.md`: retained parity roadmap context
 
 If one of these becomes obsolete and has no remaining references, it can be
@@ -44,7 +48,9 @@ deleted or folded into a newer source-of-truth doc.
 
 ## Directory Guide
 
-- `docs/status/current-roadmap.md`: current repo-wide delivery and parity status
+- `docs/status/current-roadmap.md`: current repo-wide posture and execution order
+- `docs/status/reticulum-parity-matrix.md`: current Reticulum parity rows
+- `docs/status/lxmf-parity-matrix.md`: current LXMF parity rows
 - `docs/sdk/README.md`: starting point for SDK integrators
 - `docs/lxmf-rs-api.md`: API surface and stability summary
 - `docs/lxmf-cli.md`: operator CLI quick reference

--- a/docs/plans/2026-03-17-lxmd-tcp-server-parity-plan.md
+++ b/docs/plans/2026-03-17-lxmd-tcp-server-parity-plan.md
@@ -7,7 +7,9 @@ Last updated: 2026-03-17
 This plan is an execution addendum to:
 
 - `docs/plans/2026-01-26-lxmf-reticulum-full-parity.md` (full LXMF + Reticulum parity track)
-- `docs/status/lxmf-parity-matrix.md` and `docs/status/reticulum-parity-matrix.md` (status source of truth)
+- `docs/status/current-roadmap.md` (current execution order)
+- `docs/status/lxmf-parity-matrix.md` and
+  `docs/status/reticulum-parity-matrix.md` (maintained row-level status)
 - `docs/contracts/compatibility-contract.md` and `docs/contracts/compatibility-matrix.md` (compatibility gates)
 
 Goal for this addendum: close the specific gap where Rust `lxmd` does not behave like Python `lxmd` when configured as a TCP server, then extend the work to broader daemon/runtime parity.

--- a/docs/plans/2026-03-19-python-compatibility-execution-board.md
+++ b/docs/plans/2026-03-19-python-compatibility-execution-board.md
@@ -2,6 +2,10 @@
 
 Date: 2026-03-19
 
+Status: historical execution record. Current execution order is maintained in
+`docs/status/current-roadmap.md`; current row status is maintained in the two
+`docs/status/*-parity-matrix.md` files.
+
 Goal:
 
 - make Rust nodes interoperable with Python Reticulum and LXMF nodes without

--- a/docs/plans/framework-parity-roadmap.md
+++ b/docs/plans/framework-parity-roadmap.md
@@ -1,135 +1,20 @@
 # Framework Parity Roadmap
 
-Status: historical planning note
+Status: archived planning summary
 
-This roadmap is retained as planning context for parity work. The release gate
-and current status tracking live in:
+This document previously grouped parity work into broad delivery waves. Those
+waves became inaccurate as implementation proceeded in parallel across
+Reticulum interfaces, resources, LXMF propagation, stamps, SDK work, and
+interop.
 
-- `docs/status/lxmf-parity-matrix.md`
-- `docs/status/reticulum-parity-matrix.md`
-- `docs/runbooks/release-readiness.md`
+Use the maintained status documents instead:
 
-This plan groups the currently known Reticulum and LXMF framework gaps into delivery waves. The intent is to finish behavior-level parity in the active workspace, not to expand RPC surface area without matching protocol/runtime behavior.
+- `docs/status/current-roadmap.md`: current posture, blockers, and execution
+  order
+- `docs/status/reticulum-parity-matrix.md`: Reticulum row-level status
+- `docs/status/lxmf-parity-matrix.md`: LXMF row-level status
+- `docs/runbooks/release-readiness.md`: publication evidence and gates
 
-Historical naming note: this roadmap predates the crates.io rename pass. Where
-it refers to `lxmf-core` and `rns-rpc`, the current published package names are
-`lxmf-wire` and `reticulum-rs-rpc`.
-
-## Wave 1: Correctness And Core LXMF Behavior
-
-Focus:
-
-- Preserve live daemon outbound delivery-mode handling and keep extending the
-  propagation-specific behavior behind it.
-- Replace simplified paper-command behavior with real `lxmf-wire` paper encode/decode flow.
-- Move stamp and ticket behavior out of legacy-style RPC placeholders into active-workspace implementations.
-- Tighten the parity docs and test suite around what is actually implemented.
-
-Deliverables:
-
-- `reticulumd` delivery bridge respects `direct`, `opportunistic`, `propagated`, and `paper`.
-- Active stamp generation/validation and ticket derivation APIs exist outside migration-only crates.
-- SDK paper encode/decode uses canonical wire helpers from `lxmf-wire`.
-- Tests fail if the daemon silently falls back to a different delivery mode than requested.
-
-Exit criteria:
-
-- Message mode selection is observable and tested end to end.
-- Paper workflow output is generated from real wire helpers.
-- Stamp/ticket parity items move from `partial`/`not-started` to `done` or narrow, explicit `partial`.
-
-## Wave 2: Router, Peer, And Propagation Parity
-
-Focus:
-
-- Close the gap between the Python `LXMRouter` and the Rust daemon/router stack.
-- Replace local placeholder propagation storage with real propagation-node behavior.
-- Implement real peer semantics instead of peer-record bookkeeping only.
-
-Deliverables:
-
-- Real outbound propagation-node selection and fetch/ingest workflow.
-- Peer sync, peer removal, and peering metadata tied to actual router behavior.
-- Router state transitions and side effects aligned with Python LXMF expectations.
-- Interop-focused tests that exercise Python-compatible propagation and peer scenarios.
-
-Exit criteria:
-
-- `LXMPeer.py` and `LXMRouter.py` can be marked `done` or have only narrow, documented residual gaps.
-- Propagation RPC methods are backed by real router behavior rather than a blob store.
-- Peer-related parity items stop depending on SDK event translation alone.
-
-## Wave 3: Reticulum Runtime And Interface Breadth
-
-Focus:
-
-- Close the gap between Rust `reticulumd` and Python `Reticulum` daemon/runtime behavior.
-- Expand supported interface families beyond the current subset.
-- Improve daemon config/runtime parity and startup semantics.
-
-Deliverables:
-
-- A clear split between supported interfaces now and targeted interface additions.
-- Implement or explicitly defer missing interface families: Auto, AX.25, Backbone, I2P, KISS, Local, Pipe, RNode, and Weave.
-- Better runtime parity for discovery/bootstrap and interface lifecycle management.
-- Tests and docs for daemon startup policy, interface validation, and runtime behavior.
-
-Exit criteria:
-
-- `RNS/Reticulum.py`, `RNS/Transport.py`, and `RNS/Interfaces/*` all move materially closer to `done`.
-- The daemon supports more than the current narrow subset of interface kinds.
-- Discovery/bootstrap behavior is no longer substantially narrower than the Python reference.
-
-## Wave 4: Utility And Operator Surface Parity
-
-Focus:
-
-- Implement retired Python-style utility binaries in `rns-tools` as real
-  utilities before adding them back to the release surface.
-- Bring the operator experience closer to Python Reticulum/LXMF tooling.
-
-Deliverables:
-
-- Real implementations for `rncp`, `rnid`, `rnir`, `rnodeconf`, `rnpath`,
-  `rnpkg`, `rnprobe`, and `rnstatus`; `rnsd` remains the active
-  `reticulumd` delegate.
-- Clear overlap boundaries between `reticulumd`, `lxmf-cli`, and `rns-tools`.
-- Operator docs that map Rust commands to Python command equivalents.
-
-Exit criteria:
-
-- `RNS/Utilities/*` is no longer marked `partial` because of stubs.
-- The utility suite is usable without falling back to Python tools.
-
-## Wave 5: Cross-Implementation Interop And Release Gate
-
-Focus:
-
-- Prove parity against the Python reference behavior, not only against Rust-local contracts.
-- Lock parity claims behind repeatable interop gates.
-
-Deliverables:
-
-- Live cross-implementation tests against local checkouts of `Reticulum` and `LXMF`.
-- Fixture and behavioral gates for paper transport, propagation, peer sync, utilities, and interfaces.
-- Updated parity matrices that only mark `done` when backed by active interop evidence.
-
-Exit criteria:
-
-- `interop.python_live_gate` stays `done` with pinned Reticulum/LXMF commits and
-  live ignored tests enabled in CI.
-- Parity documents are release-grade rather than aspirational.
-- Future regressions are caught by active interop tests instead of manual review.
-
-## Suggested Execution Order
-
-1. Wave 1
-2. Wave 2
-3. Wave 3
-4. Wave 4
-5. Wave 5
-
-Wave 1 landed its baseline delivery-mode handling, but propagation-specific
-router behavior still needs to come before broader parity claims. Wave 5 should
-stay last because it depends on the earlier waves being behaviorally meaningful
-enough to test against the Python reference.
+Historical implementation plans under `docs/plans/` remain useful for design
+rationale and issue provenance, but they do not define current priority or
+completion.

--- a/docs/runbooks/release-readiness.md
+++ b/docs/runbooks/release-readiness.md
@@ -6,11 +6,12 @@ active branch.
 
 ## 1. Parity truth
 
-- Repository-wide status is tracked first in `docs/status/current-roadmap.md`.
+- Repository-wide posture and execution order are tracked in
+  `docs/status/current-roadmap.md`.
 - `docs/status/lxmf-parity-matrix.md` and `docs/status/reticulum-parity-matrix.md`
-  are historical parity snapshots, not the primary release gate.
-- If a parity matrix disagrees with `docs/status/current-roadmap.md`, treat the
-  matrix as stale until it is refreshed in the same change.
+  are the maintained row-level parity records.
+- Changes to a project-level claim must update the roadmap and affected matrix
+  together.
 - Rust/Python live interop is enforced by `.github/workflows/python-interop.yml`
   on pull requests for the pinned Python Reticulum/LXMF references. Do not mark
   parity complete until non-ignored evidence exists for the specific matrix row.
@@ -71,10 +72,9 @@ The SDK reports the parity checkpoint as its crate version plus the pinned
 reference revisions from `.github/workflows/python-interop.yml`: Reticulum
 conformance `0319444b20e0815f26c6b9ceeba8fa44de037c9b`, Python Reticulum
 `15320e4d2cfabb143c1db20ca887e275fd521585`, and Python LXMF
-`727830cefda83d9c6e3982b48675425f3f988f9c`. The latest GitHub metadata checked
-on 2026-05-29 showed the newest `Python reference interop` run failing on
-`switch_to_tracing`, with the latest successful run on 2026-05-28 for
-`udp-multicast`; do not encode transient run IDs in runtime SDK responses.
+`727830cefda83d9c6e3982b48675425f3f988f9c`. Check GitHub Actions for current
+run status; do not copy transient run IDs or conclusions into runtime SDK
+responses or long-lived documentation.
 
 The commands below remain useful release checks, but they are not currently
 enforced by pull-request CI unless and until `.github/workflows/ci.yml` is

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1,428 +1,110 @@
 # Current Roadmap Status
 
-Last updated: 2026-06-06
+Last reassessed: 2026-06-07
 
-This document is the current source of truth for repository-wide delivery
-status. Update this file first when parity status, release confidence, or the
-active execution order changes.
+This file is the repository-level source of truth for parity posture, release
+confidence, and execution order. Detailed row-level status lives in:
 
-Related documents:
+- `docs/status/reticulum-parity-matrix.md`
+- `docs/status/lxmf-parity-matrix.md`
 
-- Execution board: `docs/plans/2026-03-19-python-compatibility-execution-board.md`
-- Numbered compatibility backlog: `docs/plans/2026-03-18-rust-python-compat-issue-list.md`
-- LXMF parity snapshot: `docs/status/lxmf-parity-matrix.md`
-- Reticulum parity snapshot: `docs/status/reticulum-parity-matrix.md`
+Historical plans and issue lists explain how work was approached; they do not
+override these status files.
 
-## Current Summary
+## Current Position
 
-- PR #215's `master` -> `main` integration branch is mergeable and clean, with
-  the GitHub CI rollup green at head `0c4588c`.
-- The `CI / unused-deps (pull_request)` failure was resolved by removing stale
-  `reticulum-rs-rpc` dependency declarations; the matching local check
-  `cargo +nightly udeps --workspace --all-targets` reports all dependencies in
-  use.
-- The repository is not blocked by broken builds. The main blockers are now
-  remaining Python parity gaps, not CI or merge conflicts.
+LXMF-rs is a usable Rust implementation of Reticulum and LXMF with strong core
+protocol coverage and repeatable interoperability against pinned Python
+references. It is not yet a complete drop-in replacement for every Python
+Reticulum/LXMF runtime, interface, router, and utility behavior.
 
-## What Is True Now
+The project is best described by capability level:
 
-### Landed Baseline
+| Capability | Status | Meaning |
+| --- | --- | --- |
+| Wire compatible | achieved | Core Reticulum packet/identity primitives and LXMF message encodings are implemented and tested. |
+| Direct-message interoperable | achieved | Selected bidirectional Rust/Python direct, link, channel, paper, and daemon paths are exercised in CI. |
+| Propagation interoperable | partial | Propagated delivery and substantial peer/node behavior exist, but the complete Python router and peer lifecycle is not yet reproduced. |
+| Operationally substitutable | partial | `reticulumd` is deployable and supports several production interfaces, but runtime, interface, and utility breadth remains narrower than Python. |
+| Full Python surface parity | not achieved | Remaining gaps are tracked in the two parity matrices. |
 
-The following compatibility foundation work is on `main` and should be treated
-as the current baseline:
+## Strong Areas
 
-- buffer writer parity (`#110`)
-- buffer callback parity (`#111`)
-- resource lifecycle truth and generic-resource handling (`#112`)
-- daemon receipt semantics for resource-backed sends (`#113`)
-- honor LXMF delivery modes in the `reticulumd` bridge (`#114`)
-- path tag lifetime parity (`#115`)
+### Reticulum
 
-This means older planning notes that say `reticulumd` ignores requested LXMF
-delivery modes are stale. Delivery-mode handling is no longer an open baseline
-gap, even though deeper propagation-router parity remains open.
+- Identity, destination, packet, cryptography, link, resource, and buffer
+  behavior are the strongest RNS areas.
+- Link establishment, proof validation, interface binding, watchdog timing,
+  teardown, receipts, and resource lifecycle have active regression coverage.
+- `reticulumd` supports TCP client/server, UDP, serial, KISS, AutoInterface,
+  LoRa/RNode, feature-gated RNode BLE, and feature-gated VR-N76 KISS-over-BLE.
+- AutoInterface has a live daemon runtime, including discovery, peer lifecycle,
+  peer-data sockets, transport ingress, outbound routing, and multicast proof
+  fallback.
 
-### Still Open
+### LXMF
 
-- Rust/Python live interop is now represented in `.github/workflows/python-interop.yml`
-  for pinned Reticulum/LXMF references. The high-signal local gates are
-  `python_channel_interop`, `python_paper_interop`, and `python_compat_matrix`.
-  `crates/apps/lxmf-cli/tests/python_lxmd_remote_relay.rs` is also included for
-  cross-implementation LXMD relay paths.
-- `reticulumd` now defaults to local Unix RPC, treats TCP as opt-in, rejects
-  unauthenticated remote TCP binds, handles graceful listener shutdown, and
-  documents service-manager deployment in
-  `docs/runbooks/reticulumd-operational-deployment.md`.
-- Propagation-router behavior is still partial relative to Python LXMF. Remote
-  propagation status, sync, download, fetch, and unpeer RPCs now trim remote
-  identifiers and reject blank remotes before bridge calls or local sync/peer
-  side effects. Remote sync also rejects blank peers before bridge lookup and
-  does not create local peer state when the remote-control bridge is
-  unavailable, while preserving existing-peer backoff postponement before
-  bridge lookup. Remote sync imports now record inbound runtime activity,
-  received-byte counters, and inbound message accounting for the synced source
-  peer, including duplicate payloads that had previously been transferred to
-  that peer. Remote fetch and download imports now treat an active remote
-  source peer as already received and queue the imported payload only for other
-  active peers, matching the source-peer handling already used by remote sync.
-  Those fetch/download source peers now also record inbound runtime activity
-  and received-byte counters.
-- Daemon receipt status and peer-activity bookkeeping now preserve Python's
-  distinction between transport `sent:*` states and final `delivered` receipts:
-  send/resource completion records sent-only peer tx bookkeeping, while actual
-  delivery receipts mark the outbound peer heard/delivered.
-- RPC message listing now accepts bounded `limit`/`cursor` parameters and uses
-  a stable `timestamp:id` cursor so same-second messages paginate without
-  skipping or repeating records. Message and announce list handlers now report
-  `next_cursor` only when a following page exists. The legacy message timestamp
-  remains integer seconds; Python payload precision is still exposed through
-  `_lxmf.timestamp_f64`.
-- Outbound resource retry exhaustion and advertisement dispatch failure now emit
-  explicit transport failure events, and tracked daemon LXMF resource sends are
-  marked failed instead of leaving stale resource tracking after timeout.
-- Explicit outbound resource cancellation is available through the transport
-  API: it removes sender state, emits an `OutboundCancelled` event, and sends a
-  `ResourceInitiatorCancel` packet over the link's bound interface.
-- `reticulumd` now uses that cancellation path for tracked direct and
-  propagated resource-backed sends when a message is cancelled after the
-  resource transfer has started.
-- Stamp, ticket, and propagation-stamp semantics are still partial, but inbound
-  delivery-stamp validation now honors Python's stamp-cost flexibility window
-  by accepting proof-of-work at `target_cost - flexibility`, and local
-  propagated-message stamp metadata now uses the propagation
-  `target_cost - stamp_cost_flexibility` acceptance floor.
-  Outbound progress queries now treat terminal normal or propagation stamp work
-  states as authoritative over stale `_lxmf.progress` metadata, and outbound
-  stamp-cost queries now suppress stale target-cost metadata after terminal
-  normal or propagation stamp work states.
-- Peer/router/runtime parity remains partial.
-- Peer sync now follows Python `LXMPeer` sender behavior for low-value stamped
-  propagation entries: those entries are not rejected before the offer path, so
-  they continue through the normal peering-key, stamp-policy, sync-limit, and
-  transfer-limit gates.
-- Propagation peer config refresh now follows Python's strict peering-timebase
-  ordering: equal-timebase announces are retained in the announce log but no
-  longer overwrite the active peer's propagation limits, costs, or peering
-  policy fields.
-- Propagation peer admission now mirrors Python's high-cost peering policy for
-  existing non-static peers: a newer announce above `remote_peering_cost_max`
-  breaks manual or auto peering and clears propagation queue marks, while stale
-  high-cost announces are ignored.
-- Propagation peer maintenance now has an explicit RPC path for Python
-  `sync_peers()`-style unreachable-peer culling: non-static peers unheard for
-  `LXMPeer.MAX_UNREACHABLE` are unpeered and have their propagation queue marks
-  cleared, while configured static peers are retained.
-- Propagation peer maintenance now also mirrors Python `rotate_peers()` for
-  low-acceptance non-static peers: when configured peer capacity needs
-  headroom, tested non-static peers below the acceptance-rate threshold can be
-  unpeered with queue cleanup while static and higher-acceptance peers remain
-  peered.
-- Propagation peer maintenance now starts one eligible waiting or retry-ready
-  peer sync through the existing local `peer_sync` path, so Python
-  `sync_peers()`-style maintenance mutates queue marks and transfer accounting
-  instead of only reporting cull/rotation status.
-- Propagation peer maintenance selection now also mirrors Python's waiting
-  peer candidate pool: the fastest two waiting peers remain candidates, and
-  zero-transfer-rate peers are added so unknown-speed peers are not starved by
-  previously measured peers.
-- Propagation peer maintenance waiting-pool selection now includes every
-  zero-transfer-rate waiting peer like Python, instead of capping unknown-speed
-  additions to the fastest-pool size and starving later unknown-speed peers.
-- Propagation peer maintenance retry selection now mirrors Python's
-  unresponsive-peer pool behavior as well: when no live waiting peer is
-  eligible, retry-ready unresponsive peers are selected from the whole due pool
-  instead of always retrying the first sorted peer.
-- Propagation peer maintenance also follows Python's sync-pool boundary for
-  retained static peers: static peers past `LXMPeer.MAX_UNREACHABLE` are kept
-  peered, but are not selected for waiting or retry-ready sync in that
-  maintenance pass.
-- Propagation offer handling now follows Python's invalid propagation-stamp
-  throttle: peer resource transfers containing invalid propagation stamps mark
-  that propagation peer throttled for Python's `PN_STAMP_THROTTLE` window, and
-  subsequent `/offer` requests from the peer return `ERROR_THROTTLED` until the
-  throttle expires.
-- Remote propagation sync now maps peer `ERROR_THROTTLED` responses to the
-  Python throttle path: the peer's next sync attempt is postponed by
-  `PN_STAMP_THROTTLE` while liveness, acceptance, and generic sync backoff are
-  preserved.
-- Remote propagation sync now also treats peer `ERROR_NO_ACCESS` as a peering
-  break like Python `LXMPeer.offer_response`: the denied peer is unpeered
-  locally and its propagation queue marks are cleared instead of being retained
-  as a generic failed sync peer.
-- Remote propagation sync now preserves peers on `ERROR_NO_IDENTITY` like
-  Python's identify-and-retry path: the sync attempt is recorded, but peer
-  liveness, acceptance, generic backoff, and immediate retry eligibility are
-  preserved for a follow-up request with identity credentials.
-- Remote propagation sync now maps peer `ERROR_INVALID_KEY` responses and
-  treats invalid peering-key offers as retryable peer-sync errors, preserving
-  the peer and propagation queue without applying generic failure backoff.
-- Remote propagation sync now treats peer `ERROR_INVALID_DATA` offer rejections
-  as retryable request failures as well, matching Python's failed offer-response
-  cleanup without penalizing peer liveness or sync backoff.
-- Remote propagation sync now maps peer `ERROR_TIMEOUT` responses and preserves
-  the peer without generic liveness failure/backoff, matching Python's
-  failed offer-response cleanup for explicit peer timeout replies.
-- Remote propagation sync now preserves peers on `ERROR_NOT_FOUND` offer
-  responses as explicit peer-response cleanup, without treating that reply as
-  a local peering break or generic liveness failure.
-- Remote propagation sync success now treats imported payload bytes as inbound
-  peer traffic only: it updates source-peer liveness/backoff and inbound
-  counters without inflating outbound `tx_bytes`, `sync_transfer_rate`, or
-  offer acceptance when no outbound LXMPeer transfer completed.
-- Local peer sync now accepts Python's boolean and list-shaped offer responses:
-  `wanted_ids: true` transfers every offered message, while `wanted_ids: false`
-  and `wanted_ids: []` mark the whole offer handled without resource transfer,
-  preserving the no-transfer liveness and transfer-rate behavior.
-- Local peer sync no-transfer offer responses now also preserve the previous
-  `last_heard` and `seen_count` values, matching Python's path where
-  `resource_concluded()` is not reached and no completed peer transfer is
-  recorded.
-- Local peer sync now also keeps Python's full-offer policy gates for
-  `wanted_ids: true`: a boolean wants-all response waits for stamp-policy and
-  peering-key readiness like the original offer path instead of bypassing those
-  gates as an explicit selected-ID response.
-- Local peer sync request-only transfer limits now also stay on Python's
-  full-offer policy path: `transfer_limit_kb` constrains offer construction
-  but does not by itself bypass stamp-policy or peering-key readiness.
-- Local peer sync selected-ID offer responses that request a transfer now also
-  stay on Python's full-offer policy path: non-empty list-shaped `wanted_ids`
-  wait for stamp-policy and peering-key readiness before mutating queue state or
-  transferring payloads.
-- Local peer sync no-transfer offer responses now also stay on Python's
-  full-offer policy path: `wanted_ids: false` and `wanted_ids: []` wait for
-  stamp-policy and peering-key readiness before marking offered queue entries
-  handled without resource transfer.
-- Empty local peer sync now follows Python's no-unhandled-messages path: a
-  clean peer with no pending propagation entries records the attempt but
-  preserves liveness and the previous sync transfer rate, and avoids synthetic
-  failure backoff, while existing failure backoff remains intact.
-- Postponed local peer sync now also preserves the previous sync transfer rate
-  instead of clearing transfer accounting before any offer/resource path runs.
-- Postponed local peer sync now honors existing peer backoff before the local
-  queue-fill path: a backed-off peer does not opportunistically gain new
-  unhandled propagation marks until the sync attempt is eligible to run.
-- Local peer sync now preserves the previous sync transfer rate when pending
-  offers are only skipped by sync limits or marked transfer-limited, matching
-  Python's resource-completion-only transfer-rate updates.
-- Local offer-response handling now applies Python's offer-construction gates
-  before interpreting `wanted_ids`: transfer-limited entries are filtered before
-  the peer response, while sync-limited entries that were never offered remain
-  queued for a later sync instead of being marked handled.
-- Local offer-response handling now rejects valid-looking `wanted_ids` that are
-  not part of the current peer offer before mutating queue state, avoiding the
-  false completion path where an out-of-offer request marked pending messages
-  handled or created a new peer queue from existing propagation entries.
-- Local peer sync now persists the peer acceptance-rate cache from cumulative
-  `outgoing/offered` counters, matching Python `LXMPeer.acceptance_rate`
-  instead of replacing the cache with only the latest offer-response ratio.
-- Local peer sync offer ordering now also applies Python's prioritised
-  destination weighting before sync-limit selection, so propagation entries for
-  prioritised destinations are offered ahead of lower raw-weight entries when
-  only one payload fits.
-- Inbound propagation peer-resource handling now tracks Python's validated
-  peering-link rule: a successful admitted `/offer` peering-key validation
-  marks the link as peer-validated, capacity-denied offers do not authorize the
-  link, and client or peer resource transfers with multiple propagation
-  messages are rejected unless they arrive on such a validated link. Validated
-  link state is cleared when the link closes.
-- Inbound peer propagation resources with mixed valid and invalid propagation
-  stamps now follow Python's transfer handling more closely: valid messages are
-  ingested before the transfer is rejected and the offending peer is throttled.
-- Inbound peer propagation resources from a known source peer now follow
-  Python's source-peer queueing rule: the source peer is marked received/handled
-  and records inbound bytes, while newly ingested propagation entries are queued
-  only for other active peers.
-- Inbound peer propagation resources that locally deliver a payload now credit
-  the propagation source peer's inbound counters and mark the source peer
-  received/handled instead of treating the transfer as a client propagation
-  receive.
-- Inbound peer propagation resources from identified but unpeered senders now
-  update the Python-style unpeered propagation counters instead of client
-  counters, while still queueing accepted payloads for active peers.
-- Multi-message propagation rejection is now restricted to unvalidated resource
-  transfers; direct propagation packets continue to accept multi-message
-  envelopes like Python's `propagation_packet` path.
-- Reticulum interface breadth is still narrower than the Python reference, but
-  KISS and LoRa/RNode are active implemented areas in the current branch. The
-  daemon and transport crates now cover serial KISS
-  framing/configuration, TCP/Wi-Fi KISS client startup, serial and TCP/Wi-Fi
-  LoRa/RNode startup, feature-gated native RNode BLE startup, and feature-gated
-  VR-N76 KISS-over-BLE startup. The active path includes Python-compatible KISS
-  single-port command-byte decoding with port-nibble stripping, preserved full
-  RNode command bytes, RNode startup probe frames, and short-term/long-term
-  airtime-limit commands.
-  Configured UDP multicast startup now uses the transport multicast path so
-  peer-routing is registered for point-to-point replies discovered through the
-  multicast interface.
-  Python `AutoInterface` configuration is now parsed with Reticulum defaults,
-  the Python-compatible discovery multicast address is derived in
-  `rns-transport`, and reusable peering-token/IPv6-descoping, peer lifecycle,
-  outbound multicast/reverse peering packet planning, authenticated discovery
-  packet handling, spawned peer data-target planning on `data_port`,
-  per-adopted-interface UDP listener binding targets, unicast/multicast
-  discovery listener binding targets with Windows bind behavior, startup-plan
-  aggregation for Python `final_init`, runtime gating for `final_init_done` and
-  `online`, carrier-change runtime flag aggregation, platform
-  interface-filter, link-local address selection, link-local replacement
-  planning for adopted interfaces, and local multicast echo
-  classification helpers match the Python discovery algorithm, including
-  Python's first-hash-bytes peering packet comparison.
-  Shared AutoInterface timing profiles now expose
-  Python's announce, peer job, reverse-peering, initial discovery wait,
-  multicast echo, duplicate suppression, and Android peering-timeout settings,
-  and reusable discovery/deduplication state can be constructed from that
-  profile. Pure peer-job plans now follow Python's maintenance order by
-  removing timed-out peers before reverse peering, emitting reverse-peering
-  packets only for still-live peers, and reporting interfaces without an
-  initial multicast echo. A state-changing peer-job execution helper also
-  removes stale peers, marks reverse-peering sends, and updates multicast
-  carrier timeout state for live scheduler integration. Runtime
-  `carrier_changed` aggregation now mirrors Python's flag for carrier
-  lost/recovered events and link-local replacement. Multicast
-  `peer_announce` scheduling now emits an immediate first packet per adopted
-  interface and repeats on Python's announce interval. Multicast echo timeout
-  and carrier-transition helpers now match Python's strict timeout boundary,
-  and inbound multi-interface duplicate suppression matches Python's
-  48-entry/0.75-second packet-hash window. Spawned peer inbound delivery
-  decisions now reject unknown peers, suppress duplicate packets without
-  refreshing peer state, and refresh known peers only on accepted packets.
-  The daemon now enumerates operational OS link-local IPv6 candidates with
-  `if-addrs`, applies the shared AutoInterface selector, and records the
-  resulting adopted-device discovery/data listener startup plan plus initial
-  multicast peer-announce send plan in `_runtime.auto`, including structured
-  host/port/scope targets and planned send counts. The initial peer-announce
-  bridge can resolve those targets through an injected interface-index lookup
-  or the native `if-addrs` interface-index resolver and send the peering
-  payloads through a supplied UDP socket. `_runtime.auto` records that native
-  scope IDs come from `if-addrs` interface indexes. `_runtime.auto`
-  now also reports planned unicast and multicast discovery socket bind targets,
-  and the daemon has staged unicast and multicast discovery socket bind helpers.
-  The multicast helper resolves link-scope group joins to interface indexes and
-  binds on the unspecified address before joining the derived group. Bound
-  discovery sockets now expose typed single-datagram receives with socket kind,
-  interface, source, and raw payload metadata, and those datagrams can now be
-  authenticated and classified into local echo, peer event, or invalid-token
-  rejection outcomes through the shared AutoInterface discovery state. A
-  cancellable daemon receive-loop primitive now owns bound discovery sockets,
-  updates shared discovery state, and reports accepted/rejected receive events;
-  `_runtime.auto` reports the planned discovery receive-loop count. The daemon
-  also reports planned peer data socket binds, binds those `data_port` sockets,
-  receives typed peer data datagrams, and classifies them through the shared
-  known-peer and duplicate-suppression state. Enabled
-  AutoInterface startup now binds native-scope discovery sockets, starts those
-  receive loops, sends initial multicast peer-announce packets, starts the
-  repeat multicast peer-announce scheduler, starts the peer-job scheduler,
-  starts peer data receive loops, injects accepted peer-data packets into the
-  normal transport ingress path through per-peer virtual interfaces, routes
-  direct/broadcast transport sends back out over peer UDP data sockets, records
-  `auto_discovery_runtime` counts, and reports complete AutoInterface runtime
-  status when startup succeeds.
-  RNode detect, firmware-version, platform, and MCU probe responses have typed
-  parsers and validation helpers in `rns-transport`, and active LoRa
-  streams record probe, reported radio configuration, and hardware error
-  responses when present. Reported bandwidth, spreading factor, and coding rate
-  now participate in startup validation and expose Python-compatible on-air
-  bitrate calculation, and runtime RX/TX,
-  RSSI, SNR, SNR-quality, airtime, channel-load, noise-floor, interference, PHY,
-  CSMA, battery, temperature, random-byte, and display-platform stats use
-  Python-compatible scaling, including Python's RNode battery state names and
-  initial telemetry defaults. Inbound RNode KISS data frames clear retained
-  per-packet RSSI/SNR telemetry like Python `process_incoming`. The interface
-  also tracks reported radio online state, exposes display-platform
-  framebuffer/display command frames including Python-compatible 8-byte
-  framebuffer-write line frames, retains Python-sized
-  framebuffer and display-read payloads, exposes Python's hard-reset command
-  frame, treats Python's online ESP32 reset response as fatal, and retains the last fatal RNode
-  command-response error for runtime visibility. A combined
-  startup-response validator now folds retained fatal command errors, hardware
-  identity, firmware, and reported radio-state validation into one result, and
-  active streams invoke it after the RNode startup-response deadline. Startup
-  validation failures and fatal command responses now tear down the active LoRa
-  KISS stream for reconnect while malformed command responses remain non-fatal,
-  and fresh streams clear stale RNode response state before collecting startup
-  replies. `command_timeout_ms` is now accepted for RNode startup-response
-  deadline tuning, and the protocol surface exposes Python's radio-state query
-  frame plus the remaining RNode management command constants used by the
-  reference interface. Active LoRa/RNode streams send Python-style radio-off
-  plus leave-host commands on daemon or interface teardown. TCP/Wi-Fi RNode
-  streams now send Python's idle activity detect probe after 3.5 seconds
-  without a successful write, RNode radio-lock command responses are recorded
-  with the reported radio state, and RNode config validation accepts Python's
-  full `7800..=1625000` Hz LoRa bandwidth range plus Python's frequency and
-  TX-power ranges at parse time. KISS startup now always emits
-  Python's `CMD_READY 0x01` setup command, and KISS READY flow-control startup mirrors
-  Python by allowing the first outbound packet after configuration
-  before locking on later writes, and missed READY frames unlock after Python's
-  five-second timeout. Inbound KISS escape decoding now mirrors Python's
-  lenient handling of unknown or trailing escape bytes, and oversized inbound
-  KISS payloads are capped to MTU instead of rejected. Stale partial inbound
-  KISS frames are discarded after the Python read timeout before later bytes
-  are decoded. KISS station-ID beacons now match Python's missing-callsign
-  empty payload behavior and 15-byte minimum payload padding while RNode station-ID beacons remain unpadded. Python
-  `KISSInterface` configs that omit `speed` now inherit Python's `9600` baud
-  default during alias normalization, and serial Python `RNodeInterface`
-  configs that omit an explicit baud rate inherit Python's `115200` baud
-  default while `ble://` RNode ports are accepted as native BLE RNode ports and
-  never opened as serial devices. Without the `rnode-ble` feature, daemon
-  startup records an explicit failed status for those ports. The transport
-  layer now exposes Python's generic
-  RNode BLE Nordic UART UUID profile, write-without-response defaults, raw KISS
-  notification decoding, startup writes, READY flow-control session state, stale
-  partial-notification timeout handling, outbound station-ID beacon writes, and
-  oversized-outbound rejection plus max-write-length chunking before backend
-  writes, non-READY command-response preservation plus exposed RNode monitor
-  state for startup/radio validation, own station-ID beacon suppression, and a feature-gated native
-  `btleplug` RNode BLE backend for scan, connect, Nordic UART characteristic
-  discovery, subscription, write, notification, cleanup, and identifier
-  matching behind a backend-neutral runtime contract. Feature-gated daemon
-  `RNodeInterface` `ble://` startup now builds that native backend, spawns the
-  interface manager task, forwards outbound packets as raw KISS writes, polls
-  BLE notifications into inbound packets, emits RNode station-ID beacons,
-  appends the same RNode detect/radio-configuration command frames as
-  serial/TCP startup, and writes radio-off plus leave-host frames during BLE
-  cleanup. BLE startup and fatal command-response validation now feeds the same
-  RNode protocol state used by serial/TCP startup, but higher-level RNode
-  management CLI/configuration operations over BLE remain incomplete. BLE
-  connect timeout and RNode
-  command-response timeout are kept distinct: native BLE connect defaults to
-  five seconds and uses `ble_connect_timeout_ms` overrides, while RNode startup
-  validation defaults to Python's 1500 ms command deadline and uses
-  `command_timeout_ms` overrides.
-  Python `RNodeInterface` aliases now require explicit frequency,
-  bandwidth, spreading-factor, and coding-rate radio parameters instead of
-  silently inheriting Rust-native LoRa region defaults. Daemon
-  bootstrap status still does not synchronously fail on RNode response
-  validation. A feature-gated
-  `vrn76_kiss_ble` daemon interface now covers the VR-N76 UUID profile,
-  write-with-response KISS frames, outbound Benshi TNC fragmentation by
-  configured BLE write length, indications, READY flow control, KISS
-  station-ID beacon config/emission with Python empty-payload padding, own-beacon suppression,
-  stale partial KISS frame timeout handling, and native BLE adapter startup.
-  OS Bluetooth adapter setup, permissions, pairing, and bonding are host responsibilities outside this repository;
-  hardware-backed lifecycle evidence must be captured on a prepared host.
-- Parser-only `rns-tools` utility placeholders have been retired from the
-  release surface. Utility parity remains incomplete until real equivalents for
-  the retired Python-style commands are implemented.
-- Migration-era legacy crates and router/runtime stubs have been removed from
-  the repository surface; active code must stay in the workspace crates listed
-  in `Cargo.toml`.
-- The module-size gate is green after splitting `lxmd` launch/config helpers,
-  `rnx` TCP/BLE/scenario helpers, RPC event/helper/status tests, LXMF wire tests,
-  SDK backend/client/app-control/node tests, and transport resource/interface/
-  path/tunnel helpers out of oversized modules.
+- Message wire/storage packing, signatures, propagation packing, paper
+  encoding, timestamp precision metadata, binary-field preservation, and
+  Python-compatible storage containers are implemented.
+- Delivery modes are honored by the daemon; the old claim that requested modes
+  are ignored is obsolete.
+- Direct and propagated resource sends support receipt-state separation,
+  timeout/failure propagation, and active resource cancellation.
+- Ticket validity, renewal, derivation, persistence, and inbound ticket reuse
+  are implemented.
+- Propagation peers have real queue, policy, maintenance, throttling, peering,
+  offer-response, source-accounting, and acceptance-rate behavior. These are
+  substantial implementations, not SDK-only placeholders.
+
+## Remaining Release Blockers
+
+These are blockers to a broad "Python replacement" claim, not blockers to using
+the implemented subset.
+
+1. **Propagation router lifecycle**
+   - Complete peer offer, transfer, retry, fetch, download, and synchronization
+     behavior across success, denial, timeout, identity, and restart paths.
+   - Close remaining `LXMRouter` side effects and persistent queue semantics.
+2. **Deferred stamp lifecycle**
+   - Add Python-style background work ownership, queueing, retry, cancellation,
+     and progress behavior for expensive normal and propagation stamps.
+3. **Interop breadth**
+   - Add bidirectional live Python cases for every claimed delivery mode and
+     newly completed peer/router row.
+   - Capture release evidence for Sideband, MeshChatX, and Columba before making
+     client-specific compatibility claims.
+4. **Reticulum behavioral breadth**
+   - Finish channel ordering, resolver/bootstrap, announce/path edge behavior,
+     and runtime mutation parity.
+5. **Operational breadth**
+   - Add prepared-host hardware evidence for BLE/RNode paths.
+   - Implement or explicitly defer missing Python interface families and
+     utility commands.
 
 ## Active Execution Order
 
-1. Keep architecture and boundary gates trustworthy.
-2. Keep the pinned Rust/Python interop workflow green and extend it when new
-   compatibility rows become supported.
-3. Align `README.md`, `docs/runbooks/release-readiness.md`, and GitHub CI with
-   the same definition of "green".
+1. Finish propagation peer/router state machines.
+2. Finish deferred stamp worker and retry lifecycle.
+3. Expand pinned Rust/Python interoperability gates with each completed row.
+4. Close RNS channel, discovery, resolver, and transport-policy gaps.
+5. Collect hardware, soak, and external-client release evidence.
+6. Expand interface and utility breadth after protocol behavior stabilizes.
 
-## Update Rules
+## Verification Baseline
 
-- Update this file in the same PR that changes project-wide status claims.
-- When a historical planning note disagrees with this file, treat the planning
-  note as stale until it is refreshed.
-- Do not mark parity items as complete here unless the behavior is implemented
-  in active workspace code and backed by non-ignored evidence.
+- Primary CI: `.github/workflows/ci.yml`
+- Pinned Python interop: `.github/workflows/python-interop.yml`
+- Reference revisions are declared in the interop workflow rather than copied
+  into status prose.
+- Current run status belongs in GitHub Actions, not in this maintained document.
+- A passing Python-reference workflow proves only the scenarios it executes.
+
+## Status Rules
+
+- `done` requires active implementation plus active automated evidence.
+- A local model, RPC projection, or SDK state machine alone does not establish
+  Python protocol/runtime parity.
+- A passing interop workflow does not promote unrelated matrix rows.
+- Update this file and the affected matrix in the same change.
+- Keep implementation history in Git and historical plans, not in this file.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -1,36 +1,33 @@
 # LXMF Parity Matrix
 
-Status: historical parity snapshot; check `docs/status/current-roadmap.md` for
-current repo-wide status before relying on this file for active execution order.
-As of 2026-06-06, the live Python-reference interop workflow is green for the
-current branch, but that checkpoint does not convert the partial peer, router,
-propagation, and stamper rows below into full parity. The Reticulum
-KISS/LoRa/RNode interface work improves the transport substrate available to
-LXMF, but it does not by itself complete LXMF peer sync, propagation router, or
-stamp worker parity.
+Last reassessed: 2026-06-07
 
-Last reassessed: 2026-06-06 (local-delivery source-peer queue mark regression added)
+This is the maintained row-level status for Python LXMF compatibility.
+Repository-level posture and execution order live in
+`docs/status/current-roadmap.md`.
 
-Status legend: `not-started` | `partial` | `done`
+Status legend:
 
-`done` means the active workspace implements the behavior directly. RPC-domain placeholders, SDK-only state machines, or migration-only crates under `crates/internal/` do not qualify as full parity.
+- `done`: implemented in the active workspace and backed by active tests.
+- `partial`: useful behavior exists, but identified Python behavior or evidence
+  remains missing.
+- `not-started`: no meaningful active implementation.
 
-Naming note: this matrix keeps workspace paths such as `crates/libs/lxmf-core`
-and `crates/libs/rns-rpc` for code-navigation clarity. The published package
-names are `lxmf-wire` and `reticulum-rs-rpc`.
+Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
+`lxmf-wire`; `crates/libs/rns-rpc` publishes as `reticulum-rs-rpc`.
 
-## Module Map
+## Module Matrix
 
-| Python Module | Rust Module | Status | Notes |
-| --- | --- | --- | --- |
-| `LXMF/LXMF.py` | `crates/libs/lxmf-core` | partial | Core message and wire-format behavior is present, but the full Python module surface is not fully mirrored. |
-| `LXMF/LXMessage.py` | `crates/libs/lxmf-core` | done | Active workspace supports LXMF message payloads, wire packing, storage packing, signatures, propagation packing, and paper packing. |
-| `LXMF/LXMPeer.py` | `crates/libs/lxmf-sdk` + `crates/libs/rns-rpc` | partial | Peer presence records and SDK event mapping exist, but real peer sync/acceptance/queue behavior is not yet equivalent to the Python reference. |
-| `LXMF/LXMRouter.py` | `crates/libs/rns-rpc` + `crates/apps/reticulumd` | partial | There is a working router/daemon path, but propagation-node behavior and some command/peer side effects are not full reference parity. |
-| `LXMF/Handlers.py` | `crates/apps/reticulumd` + `crates/libs/rns-rpc` | partial | Delivery callbacks and bridge flows exist, but propagation and router side effects are narrower than the Python implementation. |
-| `LXMF/LXStamper.py` | active workspace split across `crates/libs/lxmf-core`, `crates/libs/rns-rpc`, and `crates/apps/reticulumd` | partial | Stamp bytes can be carried in messages, outbound stamp/ticket work is active, cancellation-aware generation is used by delivery tasks, and ticket reuse/renewal semantics are implemented. Full Python deferred-stamp queue/progress parity is still incomplete. |
+| Python module | Rust surface | Status | Implemented baseline | Residual gap |
+| --- | --- | --- | --- | --- |
+| `LXMF/LXMF.py` | `crates/libs/lxmf-core` | partial | Constants, payload fields, message identity, inbound decoding, and wire helpers. | The complete convenience/module surface is not mirrored. |
+| `LXMF/LXMessage.py` | `crates/libs/lxmf-core` | done | Wire, storage, propagation, paper, signatures, message IDs, binary fidelity, and timestamp precision metadata. | No confirmed base-message blocker. |
+| `LXMF/LXMPeer.py` | `crates/libs/rns-rpc`, `crates/apps/reticulumd` | partial | Persistent peers, queue marks, offer selection, policy gates, peering keys, throttling, maintenance, source accounting, cumulative acceptance, and boolean/list offer responses. | Complete transfer/retry/restart lifecycle and broad live peer interop remain. |
+| `LXMF/LXMRouter.py` | `crates/libs/rns-rpc`, `crates/apps/reticulumd` | partial | Outbound modes, selected propagation nodes, direct/propagated resources, cancellation, fetch/download/sync RPCs, receipts, persistence, and status. | Full Python queue, retry, propagation-node, and command side effects remain. |
+| `LXMF/Handlers.py` | `crates/apps/reticulumd`, `crates/libs/rns-rpc` | partial | Delivery, announce, propagation app-data, receipt, and inbound bridge handling. | Some router-coupled side effects and negative/drop observability remain narrower. |
+| `LXMF/LXStamper.py` | `crates/libs/lxmf-core`, `crates/libs/rns-rpc`, `crates/apps/reticulumd` | partial | Validation, generation, ticket-derived stamps, cancellation-aware task work, and lifecycle metadata. | Python-style deferred worker queue, retry ownership, and continuous progress remain. |
 
-## Required Method-Level Checklist
+## Method Checklist
 
 - PARITY_ITEM id=message.pack_wire status=done
 - PARITY_ITEM id=message.unpack_wire status=done
@@ -65,171 +62,61 @@ names are `lxmf-wire` and `reticulum-rs-rpc`.
 - PARITY_ITEM id=handlers.router_side_effects status=partial
 - PARITY_ITEM id=interop.python_live_gate status=done
 
-## Confirmed Gaps
+## Capability Detail
 
-- Delivery-mode parity baseline is implemented in active `reticulumd` tests.
-  Treat deeper propagation-router behavior as the remaining open area instead
-  of the old "bridge ignores delivery mode" claim.
-- Daemon status and peer scoring now preserve Python's `sent` vs `delivered`
-  distinction for active send/resource completion and delivery-receipt paths.
-- Tracked outbound resource timeout now propagates as a failed daemon receipt
-  instead of silently dropping transport state.
-- Propagation-node parity is incomplete. The active RPC propagation flow is
-  mostly a local payload store and metadata layer, not full LXMF peer/node sync
-  behavior, but remote propagation status, sync, download, fetch, and unpeer
-  RPCs now reject blank remote identifiers before bridge calls or local
-  lifecycle side effects. Remote sync additionally rejects blank peers before
-  bridge lookup and avoids creating local peer records when no remote-control
-  bridge is available, while still allowing existing peers in backoff to
-  postpone without a bridge. Remote fetch and download imports now mark an
-  active source peer as received and avoid re-offering that peer its own
-  payload while still queueing other active peers, and they record source-peer
-  inbound runtime byte counters.
-- Peer parity is incomplete. Peer records, configured static peers, events,
-  runtime counters, acceptance-rate/backoff fields, Python-style message
-  accounting, per-peer propagation transfer/sync limits, propagation stamp
-  policy, Python-compatible low-value stamped peer-offer handling,
-  strict peering-timebase config refresh, Python-style unreachable-peer
-  maintenance culling, low-acceptance non-static peer rotation,
-  maintenance-driven waiting peer sync, Python-style maintenance candidate
-  pooling for all unknown-speed peers, retry-ready unresponsive-peer pool
-  selection, and unreachable static peer sync-pool skipping, high-cost
-  existing-peer peering breaks with queue cleanup,
-  admitted-offer-only
-  validated peering links, mixed invalid-stamp peer resource handling that
-  preserves valid entries before throttling, inbound propagation resource
-  source-peer queueing, remote-sync source-peer inbound byte/message accounting
-  without outbound transfer-rate or `tx_bytes` inflation, local-delivery
-  source-peer accounting and queue marks, unpeered identified-sender accounting, peering-key
-  validated peering links for multi-message client or peer propagation
-  resources while packet propagation keeps Python-style multi-message
-  acceptance, mixed invalid-stamp peer resource handling that preserves valid
-  entries before throttling, inbound propagation resource source-peer queueing,
-  remote-sync source-peer inbound byte/message accounting without outbound
-  transfer-rate or `tx_bytes` inflation, local-delivery source-peer accounting,
-  unpeered identified-sender accounting, peering-key
-  values, and explicit peering-key readiness status values are exposed. Local
-  offer responses now accept
-  Python's boolean all/none and list-shaped response forms, keep full-offer
-  stamp-policy and peering-key gates for boolean wants-all, request-limited,
-  selected-ID transfer, and no-transfer responses, preserve previous
-  last-heard/seen-count values for no-transfer responses, and reject
-  valid-looking wanted transient IDs outside the current offer before mutating
-  queue state or creating a new peer queue.
-  selected-ID transfer, and no-transfer responses, and reject valid-looking
-  wanted transient IDs outside the current offer before mutating queue state or
-  creating a new peer queue.
-  Local peer sync also persists Python-style cumulative acceptance-rate cache
-  values after multiple offer responses.
-  creating a new peer queue. Local peer sync offer ordering now applies
-  Python's prioritised destination weighting before sync-limit selection.
-  Existing peers in local sync
-  backoff now also postpone before the local existing-entry queue-fill path,
-  but the active workspace does not yet match Python `LXMPeer` queueing,
-  transfer, and peering behavior.
-- Paper-command baseline is implemented for bridge-backed `reticulumd`: SDK
-  paper encode/decode uses canonical `lxmf-wire` paper URI helpers and tests
-  reject the old placeholder `lxm://{destination}/{message_id}` path. Broader
-  router command side effects remain partial.
-- Stamps and tickets are still incomplete as a combined lifecycle area. The
-  active workspace carries stamp fields, normal and propagation stamp
-  generation have cancellation-aware delivery-task code paths, ticket
-  issue/reuse follows the Python renewal window, renewed inbound tickets keep
-  older unexpired tickets valid like Python, outbound ticket stamps are
-  generated, signed inbound tickets are remembered for replies, and
-  Python-style expired ticket cleanup is implemented. Python-style outbound
-  progress and stamp-cost queries exist over stored message state. Inbound
-  delivery-stamp validation and local propagated-message stamp metadata apply
-  the Python-compatible configured flexibility floors. The
-  remaining gap is the full Python deferred-stamp queue, live worker progress,
-  and retry lifecycle.
-- Outbound cancellation is stronger than a status-only marker: spawned
-  `reticulumd` delivery tasks now observe persisted `cancelled` state at
-  scheduling, payload, identity-wait, propagation, and link-send boundaries.
-  Tracked resource-backed sends now monitor persisted cancel state and abort
-  the active Reticulum resource with `ResourceInitiatorCancel` when the user
-  cancels after the resource has started. It remains partial because the full
-  Python router work queue and retry lifecycle are not yet mirrored.
-- Release B/C SDK domains are broader than Python LXMF, but many are app-domain state machines rather than wire/protocol parity.
+### Messages and interchange
 
-## Reassessment Summary
+- Python-compatible wire and storage containers are emitted and accepted.
+- Propagation and paper packing use canonical `lxmf-wire` helpers.
+- Signed messages, fields, attachment aliases, floating timestamps, and
+  non-UTF8 title/content bytes retain client-visible fidelity.
 
-- `lxmf-wire` is the strongest parity area and should be treated as mostly complete for base message encoding/decoding.
-- `reticulumd` and `reticulum-rs-rpc` expose a large SDK surface, but a meaningful share of that surface is currently local domain logic rather than Python LXMF parity.
-- Full LXMF parity should not be claimed until propagation-node behavior,
-  command/peer side effects, and remaining stamp worker lifecycle behavior are
-  brought into the active workspace.
+### Delivery and receipts
 
-Recent focused evidence:
+- Direct, opportunistic, propagated, and paper modes are distinct.
+- Transport completion remains `sent`; final delivery receipts produce
+  `delivered`.
+- Resource advertisement failure, retry exhaustion, timeout, and explicit
+  cancellation reach daemon message state.
 
-- `cargo test -p reticulum-rs-rpc --lib ticket_generate_renews_ticket_inside_renewal_window -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib ticket_renewal_keeps_old_unexpired_ticket_valid_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib ticket -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib ticket_generate_reuses_persisted_ticket_after_daemon_restart -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib outbound_lxm -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_remote_sync -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_remote_sync_missing_bridge_does_not_create_peer -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_remote_sync_updates_peer_runtime_state -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_remote_sync_creates_missing_peer_record -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_remote_sync_marks_source_handled_and_queues_other_peers -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_remote_sync_counts_source_incoming_after_prior_transfer_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects_unknown_wanted_ids_without_mutating_queue -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects_unknown_wanted_ids_without_creating_new_peer_queue -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib peer_sync_rejects_transfer_limited_wanted_ids_without_mutating_queue -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib peer_sync_boolean -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib peer_sync_boolean_wanted_ids_true_keeps_full_offer_policy_gates_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib peer_sync_request_transfer_limit_keeps_full_offer_policy_gates_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib peer_sync_selected_wanted_ids_keep_full_offer_policy_gates_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib peer_sync_empty_wanted_ids_keep_full_offer_policy_gates_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib peer_sync_persists_cumulative_acceptance_rate_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib peer_sync_no_transfer_preserves_last_heard_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib peer_sync_during_backoff_does_not_queue_new_existing_entries_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib peer_sync_prioritised_destinations_reduce_offer_weight_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_remote_fetch -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_remote_download -- --nocapture`
-- PR #215 GitHub CI rollup at `0c4588c`, including the pinned
-  Python-reference interop workflow and `CI / unused-deps (pull_request)`.
-- `cargo test -p reticulum-rs-rpc --lib propagation_acknowledge_sync_completion -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib list_peers_exposes_python_style_message_counters -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_enable_activates_static_peers_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib announce_received_parses_propagation_peer_name_from_python_metadata -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib new_peer_acceptance_rate_matches_python_zero_offer_default -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib list_peers_exposes_peering_key_value_when_cost_is_known -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib list_peers_exposes_peering_key_status_values -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib autopeered_announce_records_propagation_peer_state -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib low_value_stamped_entries -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib equal_timebase_announce_does_not_refresh_propagation_peer_state_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib high_cost_announce_breaks_existing_manual_peer_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_culls_unreachable_non_static_peers_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_autopeers_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_rotates_low_acceptance_non_static_peers_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_syncs_one_waiting_peer_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_candidate_pool_includes_unknown_speed_peers_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_candidate_pool_includes_all_unknown_speed_peers_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_unresponsive_pool_does_not_starve_later_peers_like_python -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation_peer_maintenance_does_not_sync_unreachable_static_peer_like_python -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_value -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd python_status_exposes_peer_peering_key_status -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd peer_sync_command_reports_peering_key_status -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd python_status_prefers_peer_propagation_stamp_policy -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd python_status_reports_elapsed_uptime_not_epoch_time -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd python_status_uses_configured_node_transfer_limits -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd python_status_uses_zero_acceptance_rate_before_offers -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd python_status_collapses_internal_peer_types_to_static_or_discovered -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd propagation_offer_ignores_control_allow_list_like_python -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd offer_request_does_not_mark_known_offers_received_like_python -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd offer_request_rejects_capacity_limited_peer_admission -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd message_get_marks_served_wanted_payloads_transferred_for_peer -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd inbound_peer_propagation_preserves_valid_messages_when_transfer_has_invalid_stamp_like_python -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd inbound_peer_propagation_local_delivery_counts_source_peer_like_python -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd inbound_client_packet_propagation_accepts_multi_message_like_python -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd inbound_client_resource_rejects_multi_message_without_validated_link_like_python -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd inbound_peer_propagation_ -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd offer_request -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd inbound_worker::control::tests -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd transport_bridge_regenerates_propagation_app_data_from_daemon_state -- --nocapture`
-- `cargo test -p reticulum-rs-rpc --lib propagation -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd inbound_propagation_accepts_stamp_within_flexibility_window -- --nocapture`
-- `cargo test -p reticulumd --bin reticulumd inbound_worker::tests -- --nocapture`
-- `cargo test -p reticulumd --test lxmf_bridge_tests stamp -- --nocapture`
+### Tickets and stamps
+
+- Ticket grace, renewal, derivation, persistence, and reply reuse are complete.
+- Inbound normal and propagation stamps honor configured flexibility.
+- Outbound normal and propagation work records generating, ready, failed, and
+  cancelled state.
+- The remaining gap is background queue/worker/retry behavior, not basic stamp
+  cryptography or ticket semantics.
+
+### Peers and propagation
+
+- Peer behavior includes static/discovered admission, peering cost/timebase,
+  queue accounting, sync/transfer limits, stamp policy, throttling, candidate
+  selection, unreachable culling, low-acceptance rotation, and prioritized
+  offers.
+- Offer responses support Python boolean and list forms, reject out-of-offer
+  IDs, preserve no-transfer liveness, and retain cumulative acceptance rates.
+- Inbound propagation distinguishes clients, validated peers, unpeered
+  identified senders, and local delivery; source peers are accounted and not
+  re-offered their own payloads.
+- These behaviors materially narrow the gap, but complete Python peer transfer,
+  restart recovery, and router queue lifecycle remain unproven.
+
+## Highest-Priority Gaps
+
+1. Complete peer transfer, retry, restart, and persistent queue lifecycle.
+2. Complete propagation-node fetch/download/sync and router side effects.
+3. Add deferred stamp queue ownership and retry semantics.
+4. Expand live bidirectional Python interop for propagation and peer rows.
+5. Validate external clients before making client-specific claims.
+
+## Evidence
+
+- `.github/workflows/python-interop.yml` runs pinned Python reference
+  conformance plus live channel, paper, compatibility-matrix, and LXMD
+  remote-relay tests.
+- Focused daemon/RPC tests cover delivery modes, propagation offers, peer
+  maintenance, queue policy, source accounting, stamps, tickets, receipts, and
+  cancellation.
+- `interop.python_live_gate` means the configured scenarios run successfully;
+  it does not imply every partial row is complete.

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -1,72 +1,75 @@
 # Reticulum Parity Matrix
 
-Status: historical parity snapshot; check `docs/status/current-roadmap.md` for
-current repo-wide status before relying on this file for active execution order.
+Last reassessed: 2026-06-07
 
-Last reassessed: 2026-06-02 (PR #215 GitHub CI rollup green at `0c4588c`; local `cargo +nightly udeps --workspace --all-targets`)
+This is the maintained row-level status for Python Reticulum compatibility.
+Repository-level posture and execution order live in
+`docs/status/current-roadmap.md`.
 
-Status legend: `not-started` | `partial` | `done`
+Status legend:
 
-`done` means behavior is present in the active workspace and backed by active code/tests, not only by planning docs or migration-only crates under `crates/internal/`.
+- `done`: implemented in the active workspace and backed by active tests.
+- `partial`: useful behavior exists, but identified Python behavior or evidence
+  remains missing.
+- `not-started`: no meaningful active implementation.
 
-Naming note: this matrix keeps workspace paths in the table for code-navigation
-clarity. The corresponding published crate names are `reticulum-rs-core`,
-`reticulum-rs-transport`, and `reticulum-rs-rpc`.
+Workspace paths are used for navigation. Published package names are
+`reticulum-rs-core`, `reticulum-rs-transport`, and `reticulum-rs-rpc`.
 
-As of 2026-06-02, KISS and LoRa/RNode are implemented interface areas in the
-active branch rather than absent placeholders. The remaining `partial` status
-for `RNS/Interfaces/*` is about reference breadth and operational completeness:
-Python still ships additional interface families and wider management/tooling
-behavior than this repository currently starts, validates, and documents.
+## Surface Matrix
 
-| Python Surface | Rust Surface | Status | Notes |
-| --- | --- | --- | --- |
-| `RNS/Reticulum.py` | `crates/libs/rns-transport` + `crates/apps/reticulumd` | partial | Usable daemon/runtime exists, but overall runtime/config/interface breadth is narrower than the Python reference. |
-| `RNS/Identity.py` | `crates/libs/rns-core` | done | Identity material, hashing, signing, and key conversion are implemented in the active workspace. |
-| `RNS/Destination.py` | `crates/libs/rns-core` + `crates/libs/rns-transport` | done | Destination hashing, announces, and destination descriptors are implemented and tested. |
-| `RNS/Packet.py` | `crates/libs/rns-core` + `crates/libs/rns-transport` | done | Packet framing, serialization, and header semantics are present in active crates. |
-| `RNS/Transport.py` | `crates/libs/rns-transport` + `crates/apps/reticulumd` | partial | Core path/announce/resource/link transport exists, but full reference behavior and runtime policy parity are incomplete. |
-| `RNS/Link.py` | `crates/libs/rns-transport` | done | Link establishment, adaptive keepalive/stale timing, Python-style activity timers, protocol `LinkClose`, and link-scoped cleanup are implemented and covered by active tests plus the live Rust/Python compatibility matrix. |
-| `RNS/Interfaces/*` | `crates/libs/rns-transport` + `crates/apps/reticulumd` | partial | Active support includes `tcp_client`, `tcp_server`, `udp`, `serial`, `ble_gatt`, serial `kiss`, TCP/Wi-Fi `kiss_tcp_client`, serial and TCP/Wi-Fi LoRa/RNode-style radio startup when a `lora` device is configured, Python-compatible `TCPClientInterface`, `TCPServerInterface`, `UDPInterface`, `SerialInterface`, `KISSInterface`, and `RNodeInterface` config aliases, Python `AutoInterface` config parsing/status defaults plus discovery multicast address, peering-token, outbound multicast/reverse peering packet planning, multicast peer-announce scheduling, discovery listener binding targets, per-adopted-interface UDP listener binding targets, daemon-side link-local OS interface enumeration/adoption and startup-plan reporting with structured host/port/scope initial peer-announce send metadata, `_runtime.auto` unicast/multicast discovery socket bind-target reporting, staged unicast and multicast discovery socket bind helpers with injected interface-index scope resolution, typed discovery datagram receive bridging from bound discovery sockets, a supplied-UDP-socket peer-announce send bridge with injected interface-index scope resolution, Python `final_init` startup-plan aggregation and runtime gating, spawned peer data-target and inbound-delivery planning on `data_port`, authenticated discovery packet handling with first-hash-bytes payload comparison, peer-lifecycle and peer-job execution helpers, Python-compatible timing profile with state constructors, platform interface-filter, link-local address selection and replacement planning, local multicast echo classification, multicast echo carrier-transition helpers, runtime `carrier_changed` flag aggregation, multi-interface inbound duplicate suppression helpers, live AutoInterface multicast socket/per-peer runtime with transport ingress injection and direct/broadcast peer UDP routing, configured UDP multicast startup with transport peer-routing, common Reticulum `outgoing` transmit suppression, common per-interface `bitrate`/`announce_cap` announce pacing, `TCPClientInterface` `fixed_mtu` carry-through into the plain TCP runtime, `TCPClientInterface` `kiss_framing = true` routing onto Rust `kiss_tcp_client`, Python-compatible single-port `KISSInterface` command-byte port-nibble stripping while RNode command decoding preserves full command bytes, Python-compatible RNode startup probe frames, KISS/RNode `id_callsign` and `id_interval` station-ID beacons including Python `KISSInterface` 15-byte beacon padding, VR-N76 KISS-over-BLE station-ID config/emission, outbound Benshi TNC fragmentation by configured BLE write length, own-beacon suppression, and stale partial KISS frame timeout handling, RNode `command_timeout_ms` startup-response deadline tuning, RNode radio-state query frame and management command constants, RNode radio-off plus leave-host teardown commands, TCP/Wi-Fi RNode idle activity detect probes, generic RNode BLE Nordic UART profile constants/defaults and raw-KISS runtime/session state in `rns-transport` including outbound station-ID beacon writes, oversized-outbound rejection, max-write-length BLE chunking before backend writes, command-response preservation plus exposed RNode monitor state for startup/radio validation, stale partial notification timeout, own-beacon suppression, feature-gated native RNode BLE scan/connect/subscribe/write/notification plumbing, and feature-gated daemon `RNodeInterface` `ble://` startup that spawns the native BLE KISS interface, emits RNode detect/radio-configuration startup frames, validates startup and fatal command responses, and sends radio-off plus leave-host shutdown frames, RNode `flow_control` default-off behavior with explicit READY flow-control enablement, status recording and validation helpers for RNode detect/firmware/platform/MCU probe responses, reported radio configuration responses, and radio-lock responses, connection-scoped RNode response-state reset, combined RNode startup-response validation with active-stream deadline enforcement, Python-compatible RNode reported-bitrate calculation, runtime radio stats including channel, PHY, CSMA, battery state names, initial telemetry defaults, inbound packet RSSI/SNR clearing, temperature, random-byte, framebuffer/display-read command frames and payloads, framebuffer-write 8-byte line frames, hard-reset command frames, and display-platform telemetry, reported radio online-state tracking, online ESP32 reset handling, fatal RNode command-error retention, fatal command-response stream teardown, hardware error classification, short-term/long-term airtime-limit commands, and feature-gated `vrn76_kiss_ble` startup for VR-N76 KISS-over-BLE devices. VR-N76 and RNode BLE hardware lifecycle evidence must be captured on a prepared host, but OS Bluetooth adapter setup, permissions, pairing, and bonding are outside this repository's responsibility. Still-missing or partial Python interface families include AX.25, Backbone, I2P, Local, Pipe, full RNode management, and Weave. |
-| `RNS/Cryptography/*` | `crates/libs/rns-core` | done | Active workspace implements the required crypto primitives used by Reticulum packets and identities. |
-| `RNS/Resource.py` | `crates/libs/rns-transport` | done | Resource sender/receiver/manager flow is implemented and covered by active tests. |
-| `RNS/Channel.py` | `crates/libs/rns-transport` | partial | Channel primitives exist, but this repo does not yet demonstrate full behavioral parity with the Python sequential delivery surface. |
-| `RNS/Buffer.py` | `crates/libs/rns-core` + `crates/libs/rns-transport` | done | Buffer and packet buffer handling are implemented in the active crates. |
-| `RNS/Discovery.py` | `crates/libs/rns-transport` + `crates/apps/reticulumd` | partial | Announce/path discovery exists, but full bootstrap and public-interface discovery parity is not complete. |
-| `RNS/Resolver.py` | `crates/libs/rns-transport` | partial | Resolver utilities exist, but parity with the Python resolver/discovery surface is incomplete. |
-| `RNS/Utilities/*` | `crates/apps/rns-tools` | partial | `rnx` is substantial and `rnsd` delegates to `reticulumd`; parser-only utility placeholders such as `rncp`, `rnid`, `rnir`, `rnodeconf`, `rnpath`, `rnpkg`, `rnprobe`, and `rnstatus` have been retired until real equivalents exist. |
-| `CRNS/*` | `crates/apps/rns-tools` | partial | The command surface is not yet equivalent to the Python utility/tooling ecosystem. |
+| Python surface | Rust surface | Status | Implemented baseline | Residual gap |
+| --- | --- | --- | --- | --- |
+| `RNS/Reticulum.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | Deployable daemon, configuration, persistence, RPC, graceful shutdown, and multiple live interfaces. | Python runtime/config mutation and interface breadth remain wider. |
+| `RNS/Identity.py` | `crates/libs/rns-core` | done | Identity material, hashing, signing, encryption, recall, and key conversion. | No confirmed parity blocker. |
+| `RNS/Destination.py` | `crates/libs/rns-core`, `crates/libs/rns-transport` | done | Destination hashing, descriptors, announces, proof validation, ratchets, and known-key stability checks. | No confirmed parity blocker. |
+| `RNS/Packet.py` | `crates/libs/rns-core`, `crates/libs/rns-transport` | done | Framing, serialization, contexts, proofs, receipts, and header semantics. | No confirmed parity blocker. |
+| `RNS/Transport.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | Path and announce handling, link routing, resources, receipts, interface-aware sending, pacing, and duplicate suppression. | Remaining announce/path edge policy and full runtime behavior require live parity evidence. |
+| `RNS/Link.py` | `crates/libs/rns-transport` | done | Establishment, proof validation, bound-interface enforcement, RTT-derived liveness, protocol close, and cleanup. | Continue live regression coverage; no confirmed blocker. |
+| `RNS/Resource.py` | `crates/libs/rns-transport` | done | Bounded receive allocation, advertisement validation, retries, adaptive fragment scheduling, timeout/failure events, cancellation, and cleanup. | Split/segmented resources remain intentionally unsupported and rejected. |
+| `RNS/Channel.py` | `crates/libs/rns-transport` | partial | Channel packet handling, retry scheduling, buffering, and live Rust/Python channel tests. | Full Python sequential-delivery and callback behavior is not yet demonstrated. |
+| `RNS/Buffer.py` | `crates/libs/rns-core`, `crates/libs/rns-transport` | done | Packet buffers, readers/writers, and callback baseline. | No confirmed parity blocker. |
+| `RNS/Interfaces/*` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | TCP client/server, UDP, serial, KISS, AutoInterface, LoRa/RNode, feature-gated RNode BLE, and VR-N76 KISS-over-BLE. | AX.25, Backbone, I2P, Local, Pipe, Weave, full RNode management, and prepared-host hardware evidence remain. |
+| `RNS/Discovery.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | Announce/path discovery plus live AutoInterface discovery and peer runtime. | Public bootstrap/discovery breadth remains narrower than Python. |
+| `RNS/Resolver.py` | `crates/libs/rns-transport` | partial | Resolver helpers and cached lookup behavior exist. | Full resolver/discovery surface parity is not established. |
+| `RNS/Cryptography/*` | `crates/libs/rns-core` | done | Required Reticulum primitives used by identities, packets, links, and receipts. | No confirmed parity blocker. |
+| `RNS/Utilities/*` | `crates/apps/rns-tools` | partial | `rnx` is substantial; `rnsd` delegates to `reticulumd`. | Real equivalents for retired `rncp`, `rnid`, `rnir`, `rnodeconf`, `rnpath`, `rnpkg`, `rnprobe`, and `rnstatus` are absent. |
+| `CRNS/*` | `crates/apps/rns-tools` | partial | Selected command workflows exist. | The Python command ecosystem is not reproduced. |
 
-## Confirmed Gaps
+## Interface Detail
 
-- Interface parity is incomplete, but KISS and LoRa/RNode should no longer be
-  described as unimplemented. Active support now covers serial KISS,
-  TCP/Wi-Fi KISS client startup, serial and TCP/Wi-Fi LoRa/RNode startup,
-  feature-gated RNode BLE startup, and feature-gated VR-N76 KISS-over-BLE
-  startup. Remaining gaps are the Python interface families not yet covered
-  here, host/hardware lifecycle evidence for BLE/RNode devices, and broader
-  operational management behavior.
-- AutoInterface live daemon runtime is implemented. The daemon binds discovery
-  and peer-data sockets with native scoped IPv6 resolution from `if-addrs`,
-  receives and authenticates discovery datagrams, classifies peer-data packets,
-  starts discovery/data receive loops plus multicast peer-announce and peer-job
-  schedulers, injects accepted peer-data packets into transport through
-  per-peer virtual interfaces, and routes direct/broadcast transport sends over
-  peer UDP data sockets. Hardware, OS interface availability, and platform
-  Bluetooth or network setup remain host responsibilities.
-- Utility parity is incomplete. Unsupported Python-style utility binaries are no
-  longer shipped as no-op placeholders; real Rust equivalents still need to be
-  implemented before claiming Python utility parity.
-- Stamp/ticket parity is incomplete, but inbound delivery-stamp validation now
-  applies the Python-compatible stamp-cost flexibility floor when enforcement is
-  active.
-- Runtime/config parity is incomplete. The Rust daemon has a narrower set of supported live mutations and startup semantics than the Python reference.
-- `lxmd` TCP server parity is partial. Python-style interface-driven `tcp_server` startup now works from config without Rust-only transport overrides, but broader launcher/runtime parity is still incomplete.
-- Discovery/bootstrap parity is incomplete. Core announce/path logic exists, but the higher-level interface/discovery story is still narrower than the Python implementation.
+Implemented interface families are active runtime code, not parser-only
+placeholders:
 
-## Reassessment Summary
+- TCP client and server, including fixed-MTU and KISS-framed client modes.
+- UDP unicast and multicast with peer routing and multicast proof fallback.
+- Serial and serial KISS.
+- AutoInterface discovery, authenticated peering, peer lifecycle, duplicate
+  suppression, multicast announcements, data sockets, and transport bridging.
+- Serial and TCP/Wi-Fi LoRa/RNode with startup probes, configuration
+  validation, telemetry, flow control, and teardown.
+- Feature-gated native RNode BLE and VR-N76 KISS-over-BLE.
 
-- Core protocol primitives are in substantially better shape than the surrounding runtime/tooling surface.
-- The active workspace is closest to parity in `reticulum-rs-core` and the lower-level parts of `reticulum-rs-transport`.
-- The largest Reticulum gaps are the remaining interface-family breadth,
-  operational daemon behavior, and utility/CLI parity.
+Python-style interface-driven `tcp_server` startup now works from config
+without Rust-only transport overrides.
+
+`RNS/Interfaces/*` remains `partial` because parity is measured against the
+whole Python family, not because the implemented interfaces are stubs.
+
+## Highest-Priority Gaps
+
+1. Prove complete channel ordering and callback behavior.
+2. Close remaining announce/path/discovery edge-policy differences.
+3. Complete resolver/bootstrap behavior.
+4. Capture prepared-host BLE/RNode lifecycle evidence.
+5. Decide and document support policy for missing interface families.
+6. Implement real utility equivalents only where product demand justifies them.
+
+## Evidence
+
+- Workspace unit and integration tests cover core, transport, daemon, serial,
+  BLE, LoRa, AutoInterface, link, and resource behavior.
+- `.github/workflows/python-interop.yml` runs pinned live Python channel and
+  LXMF compatibility scenarios.
+- Nightly mesh, soak, and embedded HIL workflows provide additional operational
+  evidence, but do not promote unsupported interface families to `done`.


### PR DESCRIPTION
## Summary

- Consolidates the parity roadmap and RNS/LXMF matrices into non-overlapping maintained status documents.
- Removes duplicated implementation diary content and stale CI snapshots from long-lived docs.
- Clarifies that historical plans are archival context, while `docs/status/current-roadmap.md` owns execution order and the two parity matrices own row-level status.
- Updates release-readiness and docs-map language to match the new status structure.

## Validation

- `cargo run -p xtask -- sdk-docs-check`
- `cargo test -p reticulumd --bin reticulumd reticulum_parity_matrix_mentions_config_driven_lxmd_tcp_server_startup -- --nocapture`
- `git diff --check`
- stale terminology scan for outdated matrix/source-of-truth language

## Notes

This PR is documentation-only and preserves all 32 machine-readable LXMF `PARITY_ITEM` rows.