### PR TITLE
Mirror remote retry peer queue snapshots

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -1014,7 +1014,9 @@ impl RpcDaemon {
                         sync_limit_bytes,
                     ));
                 }
-                if (peer_policy_required || empty_peer_peering_key_required)
+                let peering_key_required = record.peering_cost.is_some()
+                    && (peer_policy_required || empty_peer_peering_key_required);
+                if peering_key_required
                     && peer_peering_key_value(&record, self.identity_hash.as_str()).is_none()
                 {
                     self.clear_invalid_restored_peer_peering_key(&record);
@@ -2260,6 +2262,9 @@ pub(super) fn peer_acceptance_rate_for_reporting(
 }
 
 fn peer_stamp_policy_known(peer: &PeerRecord) -> bool {
+    if peer.propagation_stamp_cost == Some(0) {
+        return true;
+    }
     peer.propagation_stamp_cost.is_some()
         && peer.propagation_stamp_cost_flexibility.is_some()
         && peer.peering_cost.is_some()

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1589,6 +1589,7 @@ impl RpcDaemon {
                                     state.last_sync_error = Some(err.to_string());
                                 });
                                 self.record_outbound_peer_activity(peer_key.as_str(), 0, false);
+                                self.record_payload_backed_peer_queue_snapshot(peer_key.as_str())?;
                                 self.publish_failed_remote_peer_sync_event(
                                     peer_key.as_str(),
                                     remote_id.as_str(),

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -2073,12 +2073,18 @@ impl RpcDaemon {
                         "peer is required",
                     ));
                 }
-                let bridge = self
+                let bridge = match self
                     .remote_control_bridge
                     .lock()
                     .expect("remote control bridge mutex poisoned")
                     .clone()
-                    .ok_or_else(|| std::io::Error::other("remote control bridge unavailable"))?;
+                {
+                    Some(bridge) => bridge,
+                    None => {
+                        let _ = self.record_payload_backed_peer_queue_snapshot(peer_id);
+                        return Err(std::io::Error::other("remote control bridge unavailable"));
+                    }
+                };
                 let timeout_secs = parsed.timeout_secs.unwrap_or(5.0).max(0.1);
                 let result = match bridge.propagation_remote_unpeer(
                     remote_id.as_str(),

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1844,12 +1844,20 @@ impl RpcDaemon {
                         "remote is required",
                     ));
                 }
-                let bridge = self
+                let bridge = match self
                     .remote_control_bridge
                     .lock()
                     .expect("remote control bridge mutex poisoned")
                     .clone()
-                    .ok_or_else(|| std::io::Error::other("remote control bridge unavailable"))?;
+                {
+                    Some(bridge) => bridge,
+                    None => {
+                        for peer in self.active_peer_ids() {
+                            let _ = self.record_payload_backed_peer_queue_snapshot(peer.as_str());
+                        }
+                        return Err(std::io::Error::other("remote control bridge unavailable"));
+                    }
+                };
                 let timeout_secs = parsed.timeout_secs.unwrap_or(5.0).max(0.1);
                 self.update_propagation_sync_state(|state| {
                     state.sync_state = PR_REQUEST_SENT;

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -157,7 +157,7 @@ impl RpcDaemon {
         error: &str,
         transfer_limit: Option<u64>,
         sync_limit: Option<u64>,
-    ) {
+    ) -> Result<(), std::io::Error> {
         let timestamp = now_i64();
         if let Ok(mut peers) = self.peers.lock() {
             if let Some(peer) = peers.get_mut(peer_id) {
@@ -165,6 +165,7 @@ impl RpcDaemon {
                 peer.next_sync_attempt = 0;
             }
         }
+        self.record_payload_backed_peer_queue_snapshot(peer_id)?;
         self.publish_failed_remote_peer_sync_event(
             peer_id,
             remote,
@@ -173,6 +174,7 @@ impl RpcDaemon {
             sync_limit,
             None,
         );
+        Ok(())
     }
 
     fn break_remote_peer_sync_peering_on_denied_access(
@@ -1783,7 +1785,7 @@ impl RpcDaemon {
                                 error.as_str(),
                                 transfer_limit,
                                 sync_limit,
-                            );
+                            )?;
                         } else if is_remote_access_denied_error(&err) {
                             self.break_remote_peer_sync_peering_on_denied_access(
                                 peer_key.as_str(),

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1675,6 +1675,7 @@ impl RpcDaemon {
                             imported.accepted_ids.as_slice(),
                             imported.transferred_bytes,
                         )?;
+                        self.record_payload_backed_peer_queue_snapshot(peer_key.as_str())?;
                         self.update_propagation_sync_state(|state| {
                             state.sync_state = PR_COMPLETE;
                             state.state_name = "completed".to_string();

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1868,6 +1868,9 @@ impl RpcDaemon {
                                     state.sync_progress = 0.0;
                                     state.last_sync_error = Some(err.to_string());
                                 });
+                                for peer in self.active_peer_ids() {
+                                    self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
+                                }
                                 return Err(err);
                             }
                         };

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1910,6 +1910,9 @@ impl RpcDaemon {
                             state.sync_progress = 0.0;
                             state.last_sync_error = Some(err.to_string());
                         });
+                        for peer in self.active_peer_ids() {
+                            self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
+                        }
                         return Err(err);
                     }
                 };
@@ -1997,6 +2000,9 @@ impl RpcDaemon {
                             state.sync_progress = 0.0;
                             state.last_sync_error = Some(err.to_string());
                         });
+                        for peer in self.active_peer_ids() {
+                            self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
+                        }
                         return Err(err);
                     }
                 };

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1556,11 +1556,39 @@ impl RpcDaemon {
                 {
                     Some(bridge) => bridge,
                     None => {
-                        let snapshot_peer = existing_record
-                            .as_ref()
-                            .map(|record| record.peer.as_str())
-                            .unwrap_or(peer_id.as_str());
-                        let _ = self.record_payload_backed_peer_queue_snapshot(snapshot_peer);
+                        if let Some(record) = existing_record.as_ref() {
+                            let peer_transfer_limit_kb = record
+                                .propagation_transfer_limit
+                                .map(|limit| f64::from(limit) / 1000.0);
+                            let request_transfer_limit_kb =
+                                parsed.transfer_limit_kb.map(|limit| limit.max(0.0));
+                            let transfer_limit_kb = effective_transfer_limit_kb(
+                                peer_transfer_limit_kb,
+                                request_transfer_limit_kb,
+                            );
+                            let transfer_limit =
+                                transfer_limit_kb.map(|limit| (limit.max(0.0) * 1000.0) as u64);
+                            let sync_limit =
+                                record.propagation_sync_limit.map(u64::from).or(transfer_limit);
+                            self.update_propagation_sync_state(|state| {
+                                state.sync_state = PR_FAILED;
+                                state.state_name = "failed".to_string();
+                                state.sync_progress = 0.0;
+                                state.last_sync_started = Some(timestamp);
+                                state.last_sync_completed = None;
+                                state.last_sync_error =
+                                    Some("remote control bridge unavailable".to_string());
+                            });
+                            self.record_payload_backed_peer_queue_snapshot(record.peer.as_str())?;
+                            self.publish_failed_remote_peer_sync_event(
+                                record.peer.as_str(),
+                                remote_id.as_str(),
+                                "remote control bridge unavailable",
+                                transfer_limit,
+                                sync_limit,
+                                None,
+                            );
+                        }
                         return Err(std::io::Error::other("remote control bridge unavailable"));
                     }
                 };

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -287,7 +287,7 @@ impl RpcDaemon {
         let mut imported_count = 0usize;
         let mut duplicate_count = 0usize;
         let mut imported_ids = Vec::new();
-        let mut accepted_ids = Vec::new();
+        let mut accepted_ids: Vec<String> = Vec::new();
         let mut transferred_bytes = 0usize;
         for message in messages {
             let Some(payload_hex) = message.get("payload_hex").and_then(JsonValue::as_str) else {
@@ -352,7 +352,9 @@ impl RpcDaemon {
                 .lock()
                 .expect("propagation payload mutex poisoned")
                 .insert(transient_id.clone(), record.payload_hex);
-            accepted_ids.push(transient_id.clone());
+            if !accepted_ids.iter().any(|id| id.eq_ignore_ascii_case(transient_id.as_str())) {
+                accepted_ids.push(transient_id.clone());
+            }
             if already_known {
                 duplicate_count = duplicate_count.saturating_add(1);
             } else {

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -132,7 +132,7 @@ impl RpcDaemon {
         error: &str,
         transfer_limit: Option<u64>,
         sync_limit: Option<u64>,
-    ) {
+    ) -> Result<(), std::io::Error> {
         let timestamp = now_i64();
         if let Ok(mut peers) = self.peers.lock() {
             if let Some(peer) = peers.get_mut(peer_id) {
@@ -140,6 +140,7 @@ impl RpcDaemon {
                 peer.next_sync_attempt = timestamp.saturating_add(PN_STAMP_THROTTLE_SECS);
             }
         }
+        self.record_payload_backed_peer_queue_snapshot(peer_id)?;
         self.publish_failed_remote_peer_sync_event(
             peer_id,
             remote,
@@ -148,6 +149,7 @@ impl RpcDaemon {
             sync_limit,
             Some("throttled"),
         );
+        Ok(())
     }
 
     fn record_retryable_remote_peer_sync_error(
@@ -1777,7 +1779,7 @@ impl RpcDaemon {
                                 error.as_str(),
                                 transfer_limit,
                                 sync_limit,
-                            );
+                            )?;
                         } else if is_retryable_remote_peer_sync_error(&err) {
                             self.record_retryable_remote_peer_sync_error(
                                 peer_key.as_str(),

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1522,6 +1522,7 @@ impl RpcDaemon {
                         timestamp,
                         record.next_sync_attempt,
                     ) {
+                        self.record_payload_backed_peer_queue_snapshot(record.peer.as_str())?;
                         return Ok(self.postponed_peer_sync_response(
                             request.id,
                             &record,

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1505,7 +1505,7 @@ impl RpcDaemon {
                         .find(|record| record.peer.eq_ignore_ascii_case(peer_id.as_str()))
                         .cloned()
                 };
-                if let Some(record) = existing_record {
+                if let Some(record) = existing_record.as_ref() {
                     let peer_transfer_limit_kb =
                         record.propagation_transfer_limit.map(|limit| f64::from(limit) / 1000.0);
                     let request_transfer_limit_kb =
@@ -1525,7 +1525,7 @@ impl RpcDaemon {
                         self.record_payload_backed_peer_queue_snapshot(record.peer.as_str())?;
                         return Ok(self.postponed_peer_sync_response(
                             request.id,
-                            &record,
+                            record,
                             timestamp,
                             "backoff",
                             transfer_limit.map(|limit| limit as usize),
@@ -1541,7 +1541,11 @@ impl RpcDaemon {
                 {
                     Some(bridge) => bridge,
                     None => {
-                        let _ = self.record_payload_backed_peer_queue_snapshot(peer_id.as_str());
+                        let snapshot_peer = existing_record
+                            .as_ref()
+                            .map(|record| record.peer.as_str())
+                            .unwrap_or(peer_id.as_str());
+                        let _ = self.record_payload_backed_peer_queue_snapshot(snapshot_peer);
                         return Err(std::io::Error::other("remote control bridge unavailable"));
                     }
                 };

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -2138,7 +2138,7 @@ impl RpcDaemon {
                 let timeout_secs = parsed.timeout_secs.unwrap_or(5.0).max(0.1);
                 let result = match bridge.propagation_remote_unpeer(
                     remote_id.as_str(),
-                    peer_id,
+                    snapshot_peer.as_str(),
                     parsed.identity_private_key_hex.as_deref(),
                     timeout_secs,
                 ) {

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -2006,6 +2006,9 @@ impl RpcDaemon {
                             state.sync_progress = 0.0;
                             state.last_sync_error = Some(err.to_string());
                         });
+                        for peer in self.active_peer_ids() {
+                            self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
+                        }
                         return Err(err);
                     }
                 };

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -756,16 +756,27 @@ impl RpcDaemon {
             .contains_key(normalize_propagation_transient_key(transient_id).as_str())
     }
 
+    fn peer_store_key_or_input(&self, peer: &str) -> String {
+        self.peers
+            .lock()
+            .expect("peers mutex poisoned")
+            .keys()
+            .find(|existing| existing.eq_ignore_ascii_case(peer))
+            .cloned()
+            .unwrap_or_else(|| peer.to_string())
+    }
+
     pub fn record_peer_received_propagation(
         &self,
         peer: &str,
         transient_id: &str,
     ) -> Result<(), std::io::Error> {
         let transient_id = normalize_propagation_transient_key(transient_id);
+        let peer_key = self.peer_store_key_or_input(peer);
         self.store
-            .mark_peer_received_propagation(peer, transient_id.as_str())
+            .mark_peer_received_propagation(peer_key.as_str(), transient_id.as_str())
             .map_err(std::io::Error::other)?;
-        self.record_peer_queue_handled_id(peer, transient_id.as_str());
+        self.record_peer_queue_handled_id(peer_key.as_str(), transient_id.as_str());
         Ok(())
     }
 
@@ -774,9 +785,10 @@ impl RpcDaemon {
         peer: &str,
         transient_id: &str,
     ) -> Result<bool, std::io::Error> {
+        let peer_key = self.peer_store_key_or_input(peer);
         self.store
             .peer_completed_propagation_mark_exists(
-                peer,
+                peer_key.as_str(),
                 normalize_propagation_transient_key(transient_id).as_str(),
             )
             .map_err(std::io::Error::other)
@@ -788,10 +800,11 @@ impl RpcDaemon {
         transient_id: &str,
     ) -> Result<(), std::io::Error> {
         let transient_id = normalize_propagation_transient_key(transient_id);
+        let peer_key = self.peer_store_key_or_input(peer);
         self.store
-            .mark_peer_transferred_propagation(peer, transient_id.as_str())
+            .mark_peer_transferred_propagation(peer_key.as_str(), transient_id.as_str())
             .map_err(std::io::Error::other)?;
-        self.record_peer_queue_handled_id(peer, transient_id.as_str());
+        self.record_peer_queue_handled_id(peer_key.as_str(), transient_id.as_str());
         Ok(())
     }
 

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1796,6 +1796,7 @@ impl RpcDaemon {
                             )?;
                         } else {
                             self.record_outbound_peer_activity(peer_key.as_str(), 0, false);
+                            self.record_payload_backed_peer_queue_snapshot(peer_key.as_str())?;
                             self.publish_failed_remote_peer_sync_event(
                                 peer_key.as_str(),
                                 remote_id.as_str(),

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -2080,12 +2080,18 @@ impl RpcDaemon {
                     .clone()
                     .ok_or_else(|| std::io::Error::other("remote control bridge unavailable"))?;
                 let timeout_secs = parsed.timeout_secs.unwrap_or(5.0).max(0.1);
-                let result = bridge.propagation_remote_unpeer(
+                let result = match bridge.propagation_remote_unpeer(
                     remote_id.as_str(),
                     peer_id,
                     parsed.identity_private_key_hex.as_deref(),
                     timeout_secs,
-                )?;
+                ) {
+                    Ok(result) => result,
+                    Err(err) => {
+                        let _ = self.record_payload_backed_peer_queue_snapshot(peer_id);
+                        return Err(err);
+                    }
+                };
                 let cleanup = self.unpeer_local_state(peer_id)?;
                 let offered = cleanup.messages["offered"].as_u64().unwrap_or(0);
                 let outgoing = cleanup.messages["outgoing"].as_u64().unwrap_or(0);

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1599,7 +1599,7 @@ impl RpcDaemon {
                 let mut peer_sync_result = JsonValue::Null;
                 let result = match bridge.propagation_remote_sync(
                     remote_id.as_str(),
-                    peer_id.as_str(),
+                    peer_key.as_str(),
                     parsed.identity_private_key_hex.as_deref(),
                     timeout_secs,
                     transfer_limit_kb,
@@ -1643,7 +1643,7 @@ impl RpcDaemon {
                             );
                         }
                         self.queue_remote_sync_imports_for_peers(
-                            peer_id.as_str(),
+                            peer_key.as_str(),
                             imported.accepted_ids.as_slice(),
                             imported.transferred_bytes,
                         )?;
@@ -1658,7 +1658,7 @@ impl RpcDaemon {
                         if let Ok(mut peers) = self.peers.lock() {
                             if let Some(peer) = peers
                                 .values_mut()
-                                .find(|record| record.peer.eq_ignore_ascii_case(peer_id.as_str()))
+                                .find(|record| record.peer.eq_ignore_ascii_case(peer_key.as_str()))
                             {
                                 peer.alive = true;
                                 peer.last_seen = peer_sync_completed_at;
@@ -1672,7 +1672,7 @@ impl RpcDaemon {
                             .lock()
                             .expect("peers mutex poisoned")
                             .values()
-                            .find(|record| record.peer.eq_ignore_ascii_case(peer_id.as_str()))
+                            .find(|record| record.peer.eq_ignore_ascii_case(peer_key.as_str()))
                             .cloned();
                         if let Some(peer) = peer {
                             let (
@@ -1842,7 +1842,7 @@ impl RpcDaemon {
                     id: request.id,
                     result: Some(json!({
                         "remote": remote_id,
-                        "peer": peer_id,
+                        "peer": peer_key,
                         "propagation": propagation,
                         "peer_sync": peer_sync_result,
                         "result": result,

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1957,6 +1957,9 @@ impl RpcDaemon {
                             imported.accepted_ids.as_slice(),
                             imported.transferred_bytes,
                         )?;
+                        for peer in self.active_peer_ids() {
+                            self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
+                        }
                         self.update_propagation_sync_state(|state| {
                             state.sync_state = PR_COMPLETE;
                             state.state_name = "completed".to_string();
@@ -2104,6 +2107,9 @@ impl RpcDaemon {
                     imported.accepted_ids.as_slice(),
                     imported.transferred_bytes,
                 )?;
+                for peer in self.active_peer_ids() {
+                    self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
+                }
                 self.update_propagation_sync_state(|state| {
                     state.sync_state = PR_COMPLETE;
                     state.state_name = "completed".to_string();

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1533,12 +1533,18 @@ impl RpcDaemon {
                         ));
                     }
                 }
-                let bridge = self
+                let bridge = match self
                     .remote_control_bridge
                     .lock()
                     .expect("remote control bridge mutex poisoned")
                     .clone()
-                    .ok_or_else(|| std::io::Error::other("remote control bridge unavailable"))?;
+                {
+                    Some(bridge) => bridge,
+                    None => {
+                        let _ = self.record_payload_backed_peer_queue_snapshot(peer_id.as_str());
+                        return Err(std::io::Error::other("remote control bridge unavailable"));
+                    }
+                };
                 let record = self.ensure_peer_for_sync(peer_id.as_str(), timestamp)?;
                 let peer_transfer_limit_kb =
                     record.propagation_transfer_limit.map(|limit| f64::from(limit) / 1000.0);

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1986,12 +1986,20 @@ impl RpcDaemon {
                         "remote is required",
                     ));
                 }
-                let bridge = self
+                let bridge = match self
                     .remote_control_bridge
                     .lock()
                     .expect("remote control bridge mutex poisoned")
                     .clone()
-                    .ok_or_else(|| std::io::Error::other("remote control bridge unavailable"))?;
+                {
+                    Some(bridge) => bridge,
+                    None => {
+                        for peer in self.active_peer_ids() {
+                            self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
+                        }
+                        return Err(std::io::Error::other("remote control bridge unavailable"));
+                    }
+                };
                 let timeout_secs = parsed.timeout_secs.unwrap_or(8.0).max(0.1);
                 self.update_propagation_sync_state(|state| {
                     state.sync_state = PR_REQUEST_SENT;

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -2099,6 +2099,14 @@ impl RpcDaemon {
                         "peer is required",
                     ));
                 }
+                let snapshot_peer = {
+                    let guard = self.peers.lock().expect("peers mutex poisoned");
+                    guard
+                        .values()
+                        .find(|record| record.peer.eq_ignore_ascii_case(peer_id))
+                        .map(|record| record.peer.clone())
+                        .unwrap_or_else(|| peer_id.to_string())
+                };
                 let bridge = match self
                     .remote_control_bridge
                     .lock()
@@ -2107,7 +2115,8 @@ impl RpcDaemon {
                 {
                     Some(bridge) => bridge,
                     None => {
-                        let _ = self.record_payload_backed_peer_queue_snapshot(peer_id);
+                        let _ =
+                            self.record_payload_backed_peer_queue_snapshot(snapshot_peer.as_str());
                         return Err(std::io::Error::other("remote control bridge unavailable"));
                     }
                 };
@@ -2120,7 +2129,8 @@ impl RpcDaemon {
                 ) {
                     Ok(result) => result,
                     Err(err) => {
-                        let _ = self.record_payload_backed_peer_queue_snapshot(peer_id);
+                        let _ =
+                            self.record_payload_backed_peer_queue_snapshot(snapshot_peer.as_str());
                         return Err(err);
                     }
                 };

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -99,11 +99,27 @@ impl RpcDaemon {
         &self,
         peer: &str,
     ) -> Result<(), std::io::Error> {
+        fn push_unique(ids: &mut Vec<String>, transient_id: String) {
+            if !ids.iter().any(|id| id.eq_ignore_ascii_case(transient_id.as_str())) {
+                ids.push(transient_id);
+            }
+        }
+
+        let mut unhandled_ids = Vec::new();
+        let mut handled_ids = Vec::new();
         for entry in
             self.store.list_peer_unhandled_propagation(peer).map_err(std::io::Error::other)?
         {
             let transient_id = entry.transient_id.trim().to_ascii_lowercase();
-            self.record_peer_queue_unhandled_id(peer, transient_id.as_str());
+            if self
+                .store
+                .peer_completed_propagation_mark_exists(peer, transient_id.as_str())
+                .map_err(std::io::Error::other)?
+            {
+                push_unique(&mut handled_ids, transient_id);
+            } else {
+                push_unique(&mut unhandled_ids, transient_id);
+            }
         }
         for transient_id in
             self.store.list_peer_handled_propagation_ids(peer).map_err(std::io::Error::other)?
@@ -115,7 +131,20 @@ impl RpcDaemon {
                 .map_err(std::io::Error::other)?
                 .is_some()
             {
-                self.record_peer_queue_handled_id(peer, transient_id.as_str());
+                push_unique(&mut handled_ids, transient_id);
+            }
+        }
+        unhandled_ids.retain(|transient_id| {
+            !handled_ids.iter().any(|handled_id| handled_id.eq_ignore_ascii_case(transient_id))
+        });
+
+        let mut guard = self.peers.lock().expect("peers mutex poisoned");
+        let existing_peer_key =
+            guard.keys().find(|existing| existing.eq_ignore_ascii_case(peer)).cloned();
+        if let Some(existing_peer_key) = existing_peer_key {
+            if let Some(record) = guard.get_mut(&existing_peer_key) {
+                record.restored_handled_ids = handled_ids;
+                record.restored_unhandled_ids = unhandled_ids;
             }
         }
         Ok(())

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -58,6 +58,10 @@ impl RpcDaemon {
     }
 
     pub(super) fn record_peer_queue_unhandled_id(&self, peer: &str, transient_id: &str) {
+        let transient_id = transient_id.trim().to_ascii_lowercase();
+        if transient_id.is_empty() {
+            return;
+        }
         let existing_peer_key = {
             let guard = self.peers.lock().expect("peers mutex poisoned");
             guard.keys().find(|existing| existing.eq_ignore_ascii_case(peer)).cloned()
@@ -67,25 +71,38 @@ impl RpcDaemon {
         };
         if self
             .store
-            .peer_completed_propagation_mark_exists(existing_peer_key.as_str(), transient_id)
+            .peer_completed_propagation_mark_exists(
+                existing_peer_key.as_str(),
+                transient_id.as_str(),
+            )
             .unwrap_or(false)
         {
-            self.record_peer_queue_handled_id(existing_peer_key.as_str(), transient_id);
+            self.record_peer_queue_handled_id(existing_peer_key.as_str(), transient_id.as_str());
             return;
         }
         let mut guard = self.peers.lock().expect("peers mutex poisoned");
         let Some(record) = guard.get_mut(&existing_peer_key) else {
             return;
         };
-        if record.restored_handled_ids.iter().any(|id| id.eq_ignore_ascii_case(transient_id))
-            || record.restored_unhandled_ids.iter().any(|id| id.eq_ignore_ascii_case(transient_id))
+        if record
+            .restored_handled_ids
+            .iter()
+            .any(|id| id.eq_ignore_ascii_case(transient_id.as_str()))
+            || record
+                .restored_unhandled_ids
+                .iter()
+                .any(|id| id.eq_ignore_ascii_case(transient_id.as_str()))
         {
             return;
         }
-        record.restored_unhandled_ids.push(transient_id.to_string());
+        record.restored_unhandled_ids.push(transient_id);
     }
 
     pub(super) fn record_peer_queue_handled_id(&self, peer: &str, transient_id: &str) {
+        let transient_id = transient_id.trim().to_ascii_lowercase();
+        if transient_id.is_empty() {
+            return;
+        }
         let mut guard = self.peers.lock().expect("peers mutex poisoned");
         let existing_peer_key =
             guard.keys().find(|existing| existing.eq_ignore_ascii_case(peer)).cloned();
@@ -95,9 +112,13 @@ impl RpcDaemon {
         let Some(record) = guard.get_mut(&existing_peer_key) else {
             return;
         };
-        record.restored_unhandled_ids.retain(|id| !id.eq_ignore_ascii_case(transient_id));
-        if !record.restored_handled_ids.iter().any(|id| id.eq_ignore_ascii_case(transient_id)) {
-            record.restored_handled_ids.push(transient_id.to_string());
+        record.restored_unhandled_ids.retain(|id| !id.eq_ignore_ascii_case(transient_id.as_str()));
+        if !record
+            .restored_handled_ids
+            .iter()
+            .any(|id| id.eq_ignore_ascii_case(transient_id.as_str()))
+        {
+            record.restored_handled_ids.push(transient_id);
         }
     }
 

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -58,16 +58,22 @@ impl RpcDaemon {
     }
 
     pub(super) fn record_peer_queue_unhandled_id(&self, peer: &str, transient_id: &str) {
-        if self.store.peer_completed_propagation_mark_exists(peer, transient_id).unwrap_or(false) {
-            self.record_peer_queue_handled_id(peer, transient_id);
-            return;
-        }
-        let mut guard = self.peers.lock().expect("peers mutex poisoned");
-        let existing_peer_key =
-            guard.keys().find(|existing| existing.eq_ignore_ascii_case(peer)).cloned();
+        let existing_peer_key = {
+            let guard = self.peers.lock().expect("peers mutex poisoned");
+            guard.keys().find(|existing| existing.eq_ignore_ascii_case(peer)).cloned()
+        };
         let Some(existing_peer_key) = existing_peer_key else {
             return;
         };
+        if self
+            .store
+            .peer_completed_propagation_mark_exists(existing_peer_key.as_str(), transient_id)
+            .unwrap_or(false)
+        {
+            self.record_peer_queue_handled_id(existing_peer_key.as_str(), transient_id);
+            return;
+        }
+        let mut guard = self.peers.lock().expect("peers mutex poisoned");
         let Some(record) = guard.get_mut(&existing_peer_key) else {
             return;
         };

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -105,15 +105,25 @@ impl RpcDaemon {
             }
         }
 
+        let peer_key = {
+            let guard = self.peers.lock().expect("peers mutex poisoned");
+            guard.keys().find(|existing| existing.eq_ignore_ascii_case(peer)).cloned()
+        };
+        let Some(peer_key) = peer_key else {
+            return Ok(());
+        };
+
         let mut unhandled_ids = Vec::new();
         let mut handled_ids = Vec::new();
-        for entry in
-            self.store.list_peer_unhandled_propagation(peer).map_err(std::io::Error::other)?
+        for entry in self
+            .store
+            .list_peer_unhandled_propagation(peer_key.as_str())
+            .map_err(std::io::Error::other)?
         {
             let transient_id = entry.transient_id.trim().to_ascii_lowercase();
             if self
                 .store
-                .peer_completed_propagation_mark_exists(peer, transient_id.as_str())
+                .peer_completed_propagation_mark_exists(peer_key.as_str(), transient_id.as_str())
                 .map_err(std::io::Error::other)?
             {
                 push_unique(&mut handled_ids, transient_id);
@@ -121,8 +131,10 @@ impl RpcDaemon {
                 push_unique(&mut unhandled_ids, transient_id);
             }
         }
-        for transient_id in
-            self.store.list_peer_handled_propagation_ids(peer).map_err(std::io::Error::other)?
+        for transient_id in self
+            .store
+            .list_peer_handled_propagation_ids(peer_key.as_str())
+            .map_err(std::io::Error::other)?
         {
             let transient_id = transient_id.trim().to_ascii_lowercase();
             if self
@@ -139,13 +151,9 @@ impl RpcDaemon {
         });
 
         let mut guard = self.peers.lock().expect("peers mutex poisoned");
-        let existing_peer_key =
-            guard.keys().find(|existing| existing.eq_ignore_ascii_case(peer)).cloned();
-        if let Some(existing_peer_key) = existing_peer_key {
-            if let Some(record) = guard.get_mut(&existing_peer_key) {
-                record.restored_handled_ids = handled_ids;
-                record.restored_unhandled_ids = unhandled_ids;
-            }
+        if let Some(record) = guard.get_mut(&peer_key) {
+            record.restored_handled_ids = handled_ids;
+            record.restored_unhandled_ids = unhandled_ids;
         }
         Ok(())
     }

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -95,6 +95,32 @@ impl RpcDaemon {
         }
     }
 
+    pub(super) fn record_payload_backed_peer_queue_snapshot(
+        &self,
+        peer: &str,
+    ) -> Result<(), std::io::Error> {
+        for entry in
+            self.store.list_peer_unhandled_propagation(peer).map_err(std::io::Error::other)?
+        {
+            let transient_id = entry.transient_id.trim().to_ascii_lowercase();
+            self.record_peer_queue_unhandled_id(peer, transient_id.as_str());
+        }
+        for transient_id in
+            self.store.list_peer_handled_propagation_ids(peer).map_err(std::io::Error::other)?
+        {
+            let transient_id = transient_id.trim().to_ascii_lowercase();
+            if self
+                .store
+                .get_propagation_entry(transient_id.as_str())
+                .map_err(std::io::Error::other)?
+                .is_some()
+            {
+                self.record_peer_queue_handled_id(peer, transient_id.as_str());
+            }
+        }
+        Ok(())
+    }
+
     pub(super) fn remove_peer_queue_snapshot_id(&self, transient_id: &str) {
         let mut guard = self.peers.lock().expect("peers mutex poisoned");
         for record in guard.values_mut() {

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -1349,10 +1349,6 @@ impl RpcDaemon {
                 }
             }
         }
-        for peer in &removed_static_peers {
-            guard.remove(peer);
-        }
-
         let mut static_peers_to_queue = Vec::new();
         for peer in &configured_static_peers {
             let existing_peer_key =
@@ -1407,62 +1403,18 @@ impl RpcDaemon {
         self.update_daemon_status_snapshot(|snapshot| {
             snapshot.peer_count = peer_count;
         });
-        let mut cleared_selected_node = false;
         for peer in removed_static_peers {
-            let propagation_stats = self
-                .store
-                .peer_propagation_message_stats(peer.as_str())
-                .map_err(std::io::Error::other)?;
-            let handled_ids = self
-                .store
-                .list_peer_handled_propagation_ids(peer.as_str())
-                .map_err(std::io::Error::other)?;
-            let unhandled_ids = self
-                .store
-                .list_peer_unhandled_propagation_ids(peer.as_str())
-                .map_err(std::io::Error::other)?;
-            self.store
-                .clear_peer_propagation_marks(peer.as_str())
-                .map_err(std::io::Error::other)?;
-            let messages = json!({
-                "offered": propagation_stats.offered,
-                "unhandled": propagation_stats.unhandled,
-                "offered_bytes": propagation_stats.offered_bytes,
-                "unhandled_bytes": propagation_stats.unhandled_bytes,
-                "handled_ids": handled_ids,
-                "unhandled_ids": unhandled_ids,
-            });
-            self.publish_event(RpcEvent {
-                event_type: "peer_unpeer".into(),
-                payload: json!({
-                    "peer": peer.as_str(),
-                    "removed": true,
-                    "reason": "static_only_policy",
-                    "propagation_cleared": propagation_stats
-                        .offered
-                        .saturating_add(propagation_stats.unhandled),
-                    "propagation_cleared_bytes": propagation_stats
-                        .offered_bytes
-                        .saturating_add(propagation_stats.unhandled_bytes),
-                    "messages": messages,
-                }),
-            });
-            let mut selected =
-                self.outbound_propagation_node.lock().expect("propagation node mutex poisoned");
-            if selected.as_deref() == Some(peer.as_str()) {
-                *selected = None;
-                cleared_selected_node = true;
+            let cleanup = self.unpeer_local_state(peer.as_str())?;
+            if cleanup.removed {
+                self.publish_event(RpcEvent {
+                    event_type: "peer_unpeer".into(),
+                    payload: policy_unpeer_event_payload(
+                        cleanup.peer.as_str(),
+                        "static_only_policy",
+                        &cleanup,
+                    ),
+                });
             }
-        }
-        if cleared_selected_node {
-            let state = {
-                let mut guard = self.propagation_state.lock().expect("propagation mutex poisoned");
-                guard.selected_node = None;
-                guard.clone()
-            };
-            self.update_daemon_status_snapshot(|snapshot| {
-                snapshot.propagation = state;
-            });
         }
         for peer in static_peers_to_queue {
             self.queue_existing_propagation_for_peer(peer.as_str())?;

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -15715,6 +15715,7 @@ fn propagation_remote_unpeer_reports_existing_peer_case_insensitively_like_pytho
         .result
         .expect("remote unpeer result");
     assert_eq!(result["peer"].as_str(), Some(stored_peer));
+    assert_eq!(result["result"]["peer"].as_str(), Some(stored_peer));
     assert_eq!(result["removed"].as_bool(), Some(true));
     assert_eq!(result["propagation_cleared"].as_u64(), Some(1));
     assert!(
@@ -15735,6 +15736,7 @@ fn propagation_remote_unpeer_reports_existing_peer_case_insensitively_like_pytho
         .cloned()
         .expect("peer unpeer event");
     assert_eq!(event.payload["peer"].as_str(), Some(stored_peer));
+    assert_eq!(event.payload["result"]["peer"].as_str(), Some(stored_peer));
     assert_eq!(event.payload["propagation_cleared"].as_u64(), Some(1));
 }
 

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -13502,6 +13502,59 @@ fn propagation_remote_download_forwards_transfer_limit_to_bridge() {
 }
 
 #[test]
+fn propagation_remote_fetch_missing_bridge_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-remote-fetch-unavailable-snapshot";
+    daemon
+        .handle_rpc(rpc_request(78, "peer_sync", json!({ "peer": peer })))
+        .expect("seed peer");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+
+    let pending = PropagationEntryRecord {
+        transient_id: "e9".repeat(32),
+        destination: "1f".repeat(16),
+        payload_hex: "1f".repeat(20),
+        received_at: 1_700_000_807,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("seed live queue mark");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            79,
+            "propagation_remote_fetch",
+            json!({
+                "remote": "remote-without-bridge",
+            }),
+        ))
+        .expect_err("missing bridge should reject remote fetch");
+    assert_eq!(err.kind(), std::io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "remote control bridge unavailable");
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn propagation_remote_download_missing_bridge_records_existing_queue_snapshot_like_python() {
     let daemon = RpcDaemon::test_instance();
     let peer = "peer-remote-download-unavailable-snapshot";

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -16478,6 +16478,81 @@ fn peer_queue_unhandled_snapshot_preserves_case_insensitive_completed_mark_like_
 }
 
 #[test]
+fn peer_completed_mark_helpers_write_stored_peer_case_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let stored_peer = "Peer-Mark-Mixed-Case";
+    let request_peer = stored_peer.to_ascii_lowercase();
+    daemon
+        .handle_rpc(rpc_request(92, "peer_sync", json!({ "peer": stored_peer })))
+        .expect("peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(stored_peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+
+    let transferred = PropagationEntryRecord {
+        transient_id: "e1".repeat(32),
+        destination: "26".repeat(16),
+        payload_hex: "26".repeat(24),
+        received_at: 1_700_000_950,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    let received = PropagationEntryRecord {
+        transient_id: "e2".repeat(32),
+        destination: "27".repeat(16),
+        payload_hex: "27".repeat(28),
+        received_at: 1_700_000_951,
+        size_bytes: 28,
+        stamp_value: None,
+    };
+    for entry in [&transferred, &received] {
+        daemon.store.upsert_propagation_entry(entry).expect("store propagation entry");
+    }
+
+    daemon
+        .record_peer_transferred_propagation(request_peer.as_str(), transferred.transient_id.as_str())
+        .expect("record transferred");
+    daemon
+        .record_peer_received_propagation(request_peer.as_str(), received.transient_id.as_str())
+        .expect("record received");
+
+    assert!(
+        daemon
+            .has_peer_completed_propagation_mark(stored_peer, transferred.transient_id.as_str())
+            .expect("transferred mark"),
+        "transferred mark should be visible under stored peer case"
+    );
+    assert!(
+        daemon
+            .has_peer_completed_propagation_mark(stored_peer, received.transient_id.as_str())
+            .expect("received mark"),
+        "received mark should be visible under stored peer case"
+    );
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_handled_propagation_ids(stored_peer)
+            .expect("stored peer handled ids"),
+        vec![transferred.transient_id.clone(), received.transient_id.clone()]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(stored_peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[json!(transferred.transient_id.as_str()), json!(received.transient_id.as_str())]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[] as &[JsonValue]
+    );
+}
+
+#[test]
 fn peer_unpeer_clears_persisted_propagation_queue_marks() {
     let (daemon, peer) = ready_propagation_peer_daemon(0x52);
     daemon

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -14230,6 +14230,70 @@ fn invalid_stamp_propagation_remote_sync_preserves_peer_queue_without_backoff() 
 }
 
 #[test]
+fn retryable_propagation_remote_sync_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(RemoteSyncErrorBridge {
+        kind: std::io::ErrorKind::PermissionDenied,
+        message: "propagation peer invalid stamp",
+    }));
+    let peer = "peer-remote-retry-snapshot";
+    daemon
+        .handle_rpc(rpc_request(96, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "b2".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_613,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            97,
+            "propagation_remote_sync",
+            json!({
+                "remote": "remote-node",
+                "peer": peer,
+            }),
+        ))
+        .expect_err("retryable remote sync should return the bridge error");
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    assert_eq!(err.to_string(), "propagation peer invalid stamp");
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer)
+            .expect("pending propagation"),
+        vec![pending.clone()]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn unknown_numeric_propagation_remote_sync_preserves_peer_queue_like_python() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(RemoteSyncErrorBridge {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -12324,6 +12324,83 @@ fn propagation_remote_sync_missing_bridge_records_existing_queue_snapshot_like_p
 }
 
 #[test]
+fn propagation_remote_sync_missing_bridge_reports_existing_peer_failure_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-remote-sync-unavailable-event";
+    daemon
+        .handle_rpc(rpc_request(96, "peer_sync", json!({ "peer": peer })))
+        .expect("seed peer");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+
+    let pending = PropagationEntryRecord {
+        transient_id: "e6".repeat(32),
+        destination: "1e".repeat(16),
+        payload_hex: "1e".repeat(20),
+        received_at: 1_700_000_806,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("seed live queue mark");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            97,
+            "propagation_remote_sync",
+            json!({
+                "remote": "remote-without-bridge",
+                "peer": peer,
+            }),
+        ))
+        .expect_err("missing bridge should reject remote sync");
+    assert_eq!(err.kind(), std::io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "remote control bridge unavailable");
+
+    let status = daemon
+        .handle_rpc(RpcRequest { id: 98, method: "propagation_status".to_string(), params: None })
+        .expect("propagation status")
+        .result
+        .expect("propagation status result");
+    assert_eq!(status["propagation"]["sync_state"].as_u64(), Some(0xfe));
+    assert_eq!(status["propagation"]["state_name"].as_str(), Some("failed"));
+    assert_eq!(
+        status["propagation"]["last_sync_error"].as_str(),
+        Some("remote control bridge unavailable")
+    );
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_sync")
+        .cloned()
+        .expect("missing bridge peer sync event");
+    assert_eq!(event.payload["peer"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote"].as_str(), Some("remote-without-bridge"));
+    assert_eq!(event.payload["remote_sync"].as_bool(), Some(true));
+    assert_eq!(event.payload["synced"].as_bool(), Some(false));
+    assert_eq!(
+        event.payload["propagation"]["error"].as_str(),
+        Some("remote control bridge unavailable")
+    );
+    assert_eq!(
+        event.payload["messages"]["unhandled_ids"].as_array().expect("event unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn propagation_remote_sync_missing_bridge_records_case_insensitive_queue_snapshot_like_python() {
     let daemon = RpcDaemon::test_instance();
     let stored_peer = "Peer-Remote-Sync-Unavailable-Snapshot-Case";

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -11908,6 +11908,45 @@ fn propagation_remote_sync_trims_remote_before_bridge_event_and_response() {
 }
 
 #[test]
+fn propagation_remote_sync_uses_stored_peer_case_for_bridge_and_response_like_python() {
+    let stored_peer = "Ab".repeat(16);
+    let request_peer = stored_peer.to_ascii_lowercase();
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({"synced": true})),
+    }));
+    daemon
+        .handle_rpc(rpc_request(89, "peer_sync", json!({ "peer": stored_peer.as_str() })))
+        .expect("seed mixed-case peer");
+
+    let result = daemon
+        .handle_rpc(rpc_request(
+            90,
+            "propagation_remote_sync",
+            json!({
+                "remote": "remote-case-peer",
+                "peer": request_peer.as_str(),
+            }),
+        ))
+        .expect("remote sync with case-variant peer")
+        .result
+        .expect("remote sync result");
+
+    assert_eq!(result["peer"].as_str(), Some(stored_peer.as_str()));
+    assert_eq!(result["result"]["peer"].as_str(), Some(stored_peer.as_str()));
+    assert_eq!(result["peer_sync"]["peer"].as_str(), Some(stored_peer.as_str()));
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 91, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let rows = peers["peers"].as_array().expect("peer rows");
+    assert!(rows.iter().any(|row| row["peer"].as_str() == Some(stored_peer.as_str())));
+    assert!(rows.iter().all(|row| row["peer"].as_str() != Some(request_peer.as_str())));
+}
+
+#[test]
 fn propagation_remote_sync_respects_peer_backoff_before_bridge_call() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -5606,6 +5606,68 @@ fn peer_sync_postpones_unstamped_offers_until_peering_key_is_ready() {
 }
 
 #[test]
+fn peer_sync_transfers_unstamped_offers_when_stamp_cost_zero_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": "peer-zero-stamp-cost" })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let peer = peers.get_mut("peer-zero-stamp-cost").expect("peer record");
+        peer.propagation_sync_limit = Some(1_000);
+        peer.propagation_stamp_cost = Some(0);
+        peer.propagation_stamp_cost_flexibility = Some(0);
+        peer.peering_cost = None;
+    }
+    let entry = PropagationEntryRecord {
+        transient_id: "ec".repeat(32),
+        destination: "1c".repeat(16),
+        payload_hex: "1c".repeat(20),
+        received_at: 1_700_000_623,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation("peer-zero-stamp-cost", entry.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let result = daemon
+        .handle_rpc(rpc_request(54, "peer_sync", json!({ "peer": "peer-zero-stamp-cost" })))
+        .expect("zero-stamp peer sync")
+        .result
+        .expect("peer sync result");
+    assert_eq!(result["synced"].as_bool(), Some(true));
+    assert_ne!(result["postponed"].as_bool(), Some(true));
+    assert_eq!(result["postpone_reason"], JsonValue::Null);
+    assert_eq!(result["peering_key"], JsonValue::Null);
+    assert_eq!(result["peering_key_status"].as_str(), Some("unconfigured"));
+    assert_eq!(result["propagation"]["handled"].as_u64(), Some(1));
+    assert_eq!(result["propagation"]["transferred"].as_u64(), Some(1));
+    assert_eq!(
+        result["propagation"]["transferred_ids"]
+            .as_array()
+            .expect("transferred ids"),
+        &[json!(entry.transient_id.as_str())]
+    );
+    assert!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation("peer-zero-stamp-cost")
+            .expect("list unhandled")
+            .is_empty()
+    );
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_handled_propagation_ids("peer-zero-stamp-cost")
+            .expect("handled ids"),
+        vec![entry.transient_id]
+    );
+}
+
+#[test]
 fn repeated_skipped_peer_sync_retries_without_failure_backoff() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -13483,6 +13483,67 @@ fn failed_propagation_remote_download_import_records_existing_queue_snapshot_lik
 }
 
 #[test]
+fn failed_propagation_remote_download_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Err(std::io::ErrorKind::TimedOut),
+    }));
+    let peer = "peer-remote-download-fail-snapshot";
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "b8".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_619,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            81,
+            "propagation_remote_download",
+            json!({
+                "remote": "remote-node",
+            }),
+        ))
+        .expect_err("remote download bridge failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer)
+            .expect("pending propagation"),
+        vec![pending.clone()]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn failed_propagation_remote_fetch_import_records_existing_queue_snapshot_like_python() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
@@ -13529,6 +13590,67 @@ fn failed_propagation_remote_fetch_import_records_existing_queue_snapshot_like_p
         .expect_err("remote fetch import failure should be returned");
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
     assert!(err.to_string().contains("invalid remote propagation payload hex"));
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer)
+            .expect("pending propagation"),
+        vec![pending.clone()]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
+fn failed_propagation_remote_fetch_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Err(std::io::ErrorKind::TimedOut),
+    }));
+    let peer = "peer-remote-fetch-fail-snapshot";
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "b9".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_620,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            81,
+            "propagation_remote_fetch",
+            json!({
+                "remote": "remote-node",
+            }),
+        ))
+        .expect_err("remote fetch bridge failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
     assert_eq!(
         daemon
             .store

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -542,6 +542,139 @@ fn propagation_enable_unpeers_removed_static_peers_when_static_only() {
 }
 
 #[test]
+fn propagation_enable_static_only_removed_static_peer_counts_all_queue_marks_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(
+            41,
+            "propagation_enable",
+            json!({
+                "enabled": true,
+                "from_static_only": true,
+                "static_peers": ["peer-static-all-marks"],
+            }),
+        ))
+        .expect("enable old static peer");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let handled = PropagationEntryRecord {
+        transient_id: "b1".repeat(32),
+        destination: "13".repeat(16),
+        payload_hex: "13".repeat(10),
+        received_at: 1_700_000_106,
+        size_bytes: 10,
+        stamp_value: None,
+    };
+    let unhandled = PropagationEntryRecord {
+        transient_id: "b2".repeat(32),
+        destination: "14".repeat(16),
+        payload_hex: "14".repeat(20),
+        received_at: 1_700_000_107,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    let received = PropagationEntryRecord {
+        transient_id: "b3".repeat(32),
+        destination: "15".repeat(16),
+        payload_hex: "15".repeat(30),
+        received_at: 1_700_000_108,
+        size_bytes: 30,
+        stamp_value: None,
+    };
+    let transfer_limited = PropagationEntryRecord {
+        transient_id: "b4".repeat(32),
+        destination: "16".repeat(16),
+        payload_hex: "16".repeat(40),
+        received_at: 1_700_000_109,
+        size_bytes: 40,
+        stamp_value: None,
+    };
+    for entry in [&handled, &unhandled, &received, &transfer_limited] {
+        daemon.store.upsert_propagation_entry(entry).expect("store entry");
+    }
+    daemon
+        .store
+        .mark_peer_handled_propagation(
+            "peer-static-all-marks",
+            handled.transient_id.as_str(),
+        )
+        .expect("mark handled");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(
+            "peer-static-all-marks",
+            unhandled.transient_id.as_str(),
+        )
+        .expect("mark unhandled");
+    daemon
+        .store
+        .mark_peer_received_propagation(
+            "peer-static-all-marks",
+            received.transient_id.as_str(),
+        )
+        .expect("mark received");
+    daemon
+        .store
+        .mark_peer_transfer_limited_propagation(
+            "peer-static-all-marks",
+            transfer_limited.transient_id.as_str(),
+        )
+        .expect("mark transfer limited");
+
+    daemon
+        .handle_rpc(rpc_request(
+            42,
+            "propagation_enable",
+            json!({
+                "enabled": true,
+                "from_static_only": true,
+                "static_peers": ["peer-static-replacement"],
+            }),
+        ))
+        .expect("replace static peer list");
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_unpeer")
+        .cloned()
+        .expect("static-only peer removal event");
+    assert_eq!(event.payload["peer"].as_str(), Some("peer-static-all-marks"));
+    assert_eq!(event.payload["reason"].as_str(), Some("static_only_policy"));
+    assert_eq!(event.payload["propagation_cleared"].as_u64(), Some(4));
+    assert_eq!(event.payload["propagation_cleared_bytes"].as_u64(), Some(100));
+    assert_eq!(
+        event.payload["messages"]["handled_ids"].as_array().expect("event handled ids"),
+        &[
+            json!(handled.transient_id.as_str()),
+            json!(received.transient_id.as_str()),
+            json!(transfer_limited.transient_id.as_str()),
+        ]
+    );
+    assert_eq!(
+        event.payload["messages"]["unhandled_ids"].as_array().expect("event unhandled ids"),
+        &[json!(unhandled.transient_id.as_str())]
+    );
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_handled_propagation_ids("peer-static-all-marks")
+            .expect("remaining handled ids"),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation("peer-static-all-marks")
+            .expect("remaining unhandled entries"),
+        Vec::<PropagationEntryRecord>::new()
+    );
+}
+
+#[test]
 fn propagation_enable_static_only_unpeers_existing_non_static_peers() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -13559,6 +13559,68 @@ fn failed_propagation_remote_sync_updates_peer_backoff() {
 }
 
 #[test]
+fn failed_propagation_remote_sync_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Err(std::io::ErrorKind::TimedOut),
+    }));
+    let peer = "peer-remote-fail-snapshot";
+    daemon
+        .handle_rpc(rpc_request(75, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "b4".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_615,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            76,
+            "propagation_remote_sync",
+            json!({
+                "remote": "remote-node",
+                "peer": peer,
+            }),
+        ))
+        .expect_err("remote sync failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer)
+            .expect("pending propagation"),
+        vec![pending.clone()]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn throttled_propagation_remote_sync_uses_python_retry_window_without_breaking_liveness() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -12730,6 +12730,72 @@ fn propagation_remote_sync_updates_peer_runtime_state() {
 }
 
 #[test]
+fn propagation_remote_sync_success_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-remote-success-live-queue-snapshot";
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "synced": true,
+            "messages": [],
+        })),
+    }));
+    daemon
+        .handle_rpc(rpc_request(73, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "d2".repeat(32),
+        destination: "18".repeat(16),
+        payload_hex: "18".repeat(20),
+        received_at: 1_700_000_732,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store pending entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("seed live queue mark");
+
+    let remote_sync = daemon
+        .handle_rpc(rpc_request(
+            74,
+            "propagation_remote_sync",
+            json!({
+                "remote": "remote-node",
+                "peer": peer,
+            }),
+        ))
+        .expect("remote sync")
+        .result
+        .expect("remote sync result");
+    assert_eq!(remote_sync["peer_sync"]["synced"].as_bool(), Some(true));
+    assert_eq!(
+        remote_sync["peer_sync"]["messages"]["unhandled_ids"]
+            .as_array()
+            .expect("response unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn propagation_remote_sync_marks_source_handled_and_queues_other_peers() {
     let payload = b"remote-sync-distribution-payload";
     let payload_hex = hex::encode(payload);

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -13631,6 +13631,68 @@ fn throttled_propagation_remote_sync_uses_python_retry_window_without_breaking_l
 }
 
 #[test]
+fn throttled_propagation_remote_sync_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Err(std::io::ErrorKind::WouldBlock),
+    }));
+    let peer = "peer-remote-throttle-snapshot";
+    daemon
+        .handle_rpc(rpc_request(75, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "b3".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_614,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            76,
+            "propagation_remote_sync",
+            json!({
+                "remote": "remote-node",
+                "peer": peer,
+            }),
+        ))
+        .expect_err("remote sync throttling should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::WouldBlock);
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer)
+            .expect("pending propagation"),
+        vec![pending.clone()]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn throttled_remote_sync_matches_existing_peer_case_insensitively_like_python() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -4590,6 +4590,61 @@ fn peer_sync_during_backoff_does_not_queue_new_existing_entries_like_python() {
 }
 
 #[test]
+fn peer_sync_backoff_records_preexisting_live_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-backoff-live-queue-snapshot";
+    daemon
+        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.sync_backoff = 12 * 60;
+        record.next_sync_attempt = now_i64().saturating_add(12 * 60);
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "e7".repeat(32),
+        destination: "18".repeat(16),
+        payload_hex: "18".repeat(20),
+        received_at: 1_700_000_616,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("seed live queue mark");
+
+    let result = daemon
+        .handle_rpc(rpc_request(54, "peer_sync", json!({ "peer": peer })))
+        .expect("backoff peer sync")
+        .result
+        .expect("peer sync result");
+    assert_eq!(result["synced"].as_bool(), Some(false));
+    assert_eq!(result["postponed"].as_bool(), Some(true));
+    assert_eq!(result["postpone_reason"].as_str(), Some("backoff"));
+    assert_eq!(
+        result["messages"]["unhandled_ids"].as_array().expect("result unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn peer_sync_postpones_offers_until_stamp_policy_is_known() {
     let daemon = RpcDaemon::test_instance();
     daemon
@@ -11876,6 +11931,68 @@ fn propagation_remote_sync_backoff_does_not_require_bridge() {
         .expect("propagation status result");
     assert_eq!(status["propagation"]["sync_state"].as_u64(), Some(0x00));
     assert_eq!(status["propagation"]["last_sync_started"], JsonValue::Null);
+}
+
+#[test]
+fn propagation_remote_sync_backoff_records_preexisting_live_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-remote-backoff-live-queue-snapshot";
+    daemon
+        .handle_rpc(rpc_request(92, "peer_sync", json!({ "peer": peer })))
+        .expect("seed peer");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.sync_backoff = 12 * 60;
+        record.next_sync_attempt = now_i64().saturating_add(12 * 60);
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "e6".repeat(32),
+        destination: "18".repeat(16),
+        payload_hex: "18".repeat(20),
+        received_at: 1_700_000_617,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("seed live queue mark");
+
+    let result = daemon
+        .handle_rpc(rpc_request(
+            93,
+            "propagation_remote_sync",
+            json!({
+                "remote": "remote-backoff-no-bridge",
+                "peer": peer,
+            }),
+        ))
+        .expect("remote sync should postpone before bridge lookup")
+        .result
+        .expect("remote sync result");
+    assert_eq!(result["synced"].as_bool(), Some(false));
+    assert_eq!(result["postponed"].as_bool(), Some(true));
+    assert_eq!(result["postpone_reason"].as_str(), Some("backoff"));
+    assert_eq!(
+        result["messages"]["unhandled_ids"].as_array().expect("result unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
 }
 
 #[test]

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -12090,6 +12090,61 @@ fn propagation_remote_sync_missing_bridge_records_existing_queue_snapshot_like_p
 }
 
 #[test]
+fn propagation_remote_sync_missing_bridge_records_case_insensitive_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let stored_peer = "Peer-Remote-Sync-Unavailable-Snapshot-Case";
+    let request_peer = stored_peer.to_ascii_lowercase();
+    daemon
+        .handle_rpc(rpc_request(78, "peer_sync", json!({ "peer": stored_peer })))
+        .expect("seed peer");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(stored_peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+
+    let pending = PropagationEntryRecord {
+        transient_id: "ea".repeat(32),
+        destination: "20".repeat(16),
+        payload_hex: "20".repeat(20),
+        received_at: 1_700_000_808,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(stored_peer, pending.transient_id.as_str())
+        .expect("seed live queue mark");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            79,
+            "propagation_remote_sync",
+            json!({
+                "remote": "remote-without-bridge",
+                "peer": request_peer,
+            }),
+        ))
+        .expect_err("missing bridge should reject remote sync");
+    assert_eq!(err.kind(), std::io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "remote control bridge unavailable");
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(stored_peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn propagation_remote_unpeer_rejects_blank_peer_before_bridge_call() {
     let daemon = RpcDaemon::test_instance();
     let sync_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -15433,6 +15433,62 @@ fn failed_propagation_remote_unpeer_preserves_local_peer_and_queue_state() {
 }
 
 #[test]
+fn failed_propagation_remote_unpeer_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Err(std::io::ErrorKind::TimedOut),
+    }));
+    let peer = "peer-remote-unpeer-fail-snapshot";
+    daemon
+        .handle_rpc(rpc_request(79, "peer_sync", json!({ "peer": peer })))
+        .expect("peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+
+    let entry = PropagationEntryRecord {
+        transient_id: "e3".repeat(32),
+        destination: "1b".repeat(16),
+        payload_hex: "1b".repeat(20),
+        received_at: 1_700_000_803,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, entry.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            80,
+            "propagation_remote_unpeer",
+            json!({
+                "remote": "remote-node",
+                "peer": peer,
+            }),
+        ))
+        .expect_err("remote unpeer failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(entry.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn failed_propagation_remote_sync_clears_previous_completion() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -13134,6 +13134,79 @@ fn duplicate_propagation_remote_fetch_queues_known_payload_without_double_counti
 }
 
 #[test]
+fn propagation_remote_fetch_deduplicates_same_response_for_peer_incoming_like_python() {
+    let payload = b"duplicate-same-fetch-response-payload";
+    let payload_hex = hex::encode(payload);
+    let transient_id = hex::encode(Sha256::digest(payload));
+    let source_peer = "remote-fetch-dedup-source";
+    let relay_peer = "remote-fetch-dedup-relay";
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(72, "peer_sync", json!({ "peer": source_peer })))
+        .expect("seed source peer");
+    daemon
+        .handle_rpc(rpc_request(73, "peer_sync", json!({ "peer": relay_peer })))
+        .expect("seed relay peer");
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "available_count": 2,
+            "fetched_count": 2,
+            "messages": [
+                {
+                    "transient_id": transient_id,
+                    "payload_hex": payload_hex,
+                },
+                {
+                    "transient_id": transient_id,
+                    "payload_hex": payload_hex,
+                },
+            ],
+        })),
+    }));
+
+    let result = daemon
+        .handle_rpc(rpc_request(
+            74,
+            "propagation_remote_fetch",
+            json!({ "remote": source_peer }),
+        ))
+        .expect("remote fetch")
+        .result
+        .expect("remote fetch result");
+    assert_eq!(result["result"]["imported_count"].as_u64(), Some(1));
+    assert_eq!(result["result"]["duplicate_count"].as_u64(), Some(1));
+    assert_eq!(result["result"]["imported_ids"], json!([transient_id]));
+
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_handled_propagation_ids(source_peer)
+            .expect("source handled ids"),
+        vec![transient_id.clone()]
+    );
+    let relay_pending = daemon
+        .store
+        .list_peer_unhandled_propagation(relay_peer)
+        .expect("relay pending");
+    assert_eq!(relay_pending.len(), 1);
+    assert_eq!(relay_pending[0].transient_id, transient_id);
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 75, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let source_row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(source_peer))
+        .expect("source peer row");
+    assert_eq!(source_row["messages"]["incoming"].as_u64(), Some(1));
+    assert_eq!(source_row["incoming"].as_u64(), Some(1));
+}
+
+#[test]
 fn propagation_remote_fetch_preserves_transfer_limited_peer_queue_mark_like_python() {
     let payload = b"remote-fetch-retry-transfer-limited-payload";
     let payload_hex = hex::encode(payload);

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -13502,6 +13502,59 @@ fn propagation_remote_download_forwards_transfer_limit_to_bridge() {
 }
 
 #[test]
+fn propagation_remote_download_missing_bridge_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-remote-download-unavailable-snapshot";
+    daemon
+        .handle_rpc(rpc_request(78, "peer_sync", json!({ "peer": peer })))
+        .expect("seed peer");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+
+    let pending = PropagationEntryRecord {
+        transient_id: "e8".repeat(32),
+        destination: "1e".repeat(16),
+        payload_hex: "1e".repeat(20),
+        received_at: 1_700_000_806,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("seed live queue mark");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            79,
+            "propagation_remote_download",
+            json!({
+                "remote": "remote-without-bridge",
+            }),
+        ))
+        .expect_err("missing bridge should reject remote download");
+    assert_eq!(err.kind(), std::io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "remote control bridge unavailable");
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn propagation_remote_sync_forwards_transfer_limit_to_bridge() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TransferLimitRemoteControlBridge));

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -12036,6 +12036,60 @@ fn propagation_remote_sync_missing_bridge_does_not_create_peer() {
 }
 
 #[test]
+fn propagation_remote_sync_missing_bridge_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-remote-sync-unavailable-snapshot";
+    daemon
+        .handle_rpc(rpc_request(95, "peer_sync", json!({ "peer": peer })))
+        .expect("seed peer");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+
+    let pending = PropagationEntryRecord {
+        transient_id: "e5".repeat(32),
+        destination: "1d".repeat(16),
+        payload_hex: "1d".repeat(20),
+        received_at: 1_700_000_805,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("seed live queue mark");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            96,
+            "propagation_remote_sync",
+            json!({
+                "remote": "remote-without-bridge",
+                "peer": peer,
+            }),
+        ))
+        .expect_err("missing bridge should reject remote sync");
+    assert_eq!(err.kind(), std::io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "remote control bridge unavailable");
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn propagation_remote_unpeer_rejects_blank_peer_before_bridge_call() {
     let daemon = RpcDaemon::test_instance();
     let sync_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -14628,6 +14628,74 @@ fn failed_propagation_remote_sync_import_updates_peer_backoff() {
 }
 
 #[test]
+fn failed_propagation_remote_sync_import_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "synced": true,
+            "messages": [{
+                "payload_hex": "not-hex",
+            }],
+        })),
+    }));
+    let peer = "peer-remote-import-fail-snapshot";
+    daemon
+        .handle_rpc(rpc_request(75, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "b5".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_616,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            76,
+            "propagation_remote_sync",
+            json!({
+                "remote": "remote-node",
+                "peer": peer,
+            }),
+        ))
+        .expect_err("remote sync import failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(err.to_string().contains("invalid remote propagation payload hex"));
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer)
+            .expect("pending propagation"),
+        vec![pending.clone()]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn propagation_remote_unpeer_clears_local_peer_and_queue_state() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -14005,6 +14005,64 @@ fn failed_propagation_remote_fetch_records_existing_queue_snapshot_like_python()
 }
 
 #[test]
+fn failed_propagation_remote_fetch_prunes_stale_queue_snapshot_ids_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Err(std::io::ErrorKind::TimedOut),
+    }));
+    let peer = "peer-remote-fetch-fail-stale-snapshot";
+    let stale_handled_id = "f6".repeat(32);
+    let stale_unhandled_id = "f7".repeat(32);
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+        record.restored_handled_ids.push(stale_handled_id);
+        record.restored_unhandled_ids.push(stale_unhandled_id);
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "ba".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_621,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            81,
+            "propagation_remote_fetch",
+            json!({
+                "remote": "remote-node",
+            }),
+        ))
+        .expect_err("remote fetch bridge failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn failed_propagation_remote_sync_updates_lifecycle_error() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -15489,6 +15489,60 @@ fn failed_propagation_remote_unpeer_records_existing_queue_snapshot_like_python(
 }
 
 #[test]
+fn unavailable_propagation_remote_unpeer_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-remote-unpeer-unavailable-snapshot";
+    daemon
+        .handle_rpc(rpc_request(79, "peer_sync", json!({ "peer": peer })))
+        .expect("peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+
+    let entry = PropagationEntryRecord {
+        transient_id: "e4".repeat(32),
+        destination: "1c".repeat(16),
+        payload_hex: "1c".repeat(20),
+        received_at: 1_700_000_804,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, entry.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            80,
+            "propagation_remote_unpeer",
+            json!({
+                "remote": "remote-node",
+                "peer": peer,
+            }),
+        ))
+        .expect_err("missing bridge should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "remote control bridge unavailable");
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(entry.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn failed_propagation_remote_sync_clears_previous_completion() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -14113,6 +14113,133 @@ fn propagation_remote_download_missing_bridge_records_existing_queue_snapshot_li
 }
 
 #[test]
+fn propagation_remote_fetch_success_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "available_count": 0,
+            "fetched_count": 0,
+            "messages": [],
+        })),
+    }));
+    let peer = "peer-remote-fetch-success-snapshot";
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "e7".repeat(32),
+        destination: "17".repeat(16),
+        payload_hex: "17".repeat(24),
+        received_at: 1_700_000_805,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+
+    daemon
+        .handle_rpc(rpc_request(
+            81,
+            "propagation_remote_fetch",
+            json!({
+                "remote": "remote-node",
+            }),
+        ))
+        .expect("remote fetch success should preserve queued retry snapshot");
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer)
+            .expect("pending propagation"),
+        vec![pending.clone()]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
+fn propagation_remote_download_success_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "downloaded_count": 0,
+            "messages": [],
+        })),
+    }));
+    let peer = "peer-remote-download-success-snapshot";
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "e6".repeat(32),
+        destination: "16".repeat(16),
+        payload_hex: "16".repeat(24),
+        received_at: 1_700_000_804,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+
+    daemon
+        .handle_rpc(rpc_request(
+            81,
+            "propagation_remote_download",
+            json!({
+                "remote": "remote-node",
+            }),
+        ))
+        .expect("remote download success should preserve queued retry snapshot");
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer)
+            .expect("pending propagation"),
+        vec![pending.clone()]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn propagation_remote_sync_forwards_transfer_limit_to_bridge() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TransferLimitRemoteControlBridge));

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -13415,6 +13415,74 @@ fn failed_propagation_remote_download_import_updates_lifecycle_error() {
 }
 
 #[test]
+fn failed_propagation_remote_fetch_import_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "available_count": 1,
+            "fetched_count": 1,
+            "messages": [{
+                "payload_hex": "not-hex",
+            }],
+        })),
+    }));
+    let peer = "peer-remote-fetch-import-fail-snapshot";
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "b6".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_617,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            81,
+            "propagation_remote_fetch",
+            json!({
+                "remote": "remote-node",
+            }),
+        ))
+        .expect_err("remote fetch import failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(err.to_string().contains("invalid remote propagation payload hex"));
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer)
+            .expect("pending propagation"),
+        vec![pending.clone()]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn failed_propagation_remote_sync_updates_lifecycle_error() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -16592,6 +16592,61 @@ fn peer_queue_unhandled_snapshot_preserves_case_insensitive_completed_mark_like_
 }
 
 #[test]
+fn peer_queue_snapshot_helpers_canonicalize_transient_ids_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let stored_peer = "Peer-Snapshot-Canonical-Ids";
+    let request_peer = stored_peer.to_ascii_lowercase();
+    daemon
+        .handle_rpc(rpc_request(91, "peer_sync", json!({ "peer": stored_peer })))
+        .expect("peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(stored_peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+
+    let entry = PropagationEntryRecord {
+        transient_id: "df".repeat(32),
+        destination: "25".repeat(16),
+        payload_hex: "25".repeat(24),
+        received_at: 1_700_000_945,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    let request_transient_id = format!("  {}  ", entry.transient_id.to_ascii_uppercase());
+
+    daemon.record_peer_queue_unhandled_id(request_peer.as_str(), request_transient_id.as_str());
+    {
+        let peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get(stored_peer).expect("stored peer");
+        let serialized = serde_json::to_value(record).expect("serialize peer record");
+        assert_eq!(
+            serialized["handled_ids"].as_array().expect("serialized handled ids"),
+            &[] as &[JsonValue]
+        );
+        assert_eq!(
+            serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+            &[json!(entry.transient_id.as_str())]
+        );
+    }
+
+    daemon.record_peer_queue_handled_id(request_peer.as_str(), request_transient_id.as_str());
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(stored_peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[json!(entry.transient_id.as_str())]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[] as &[JsonValue]
+    );
+}
+
+#[test]
 fn peer_completed_mark_helpers_write_stored_peer_case_like_python() {
     let daemon = RpcDaemon::test_instance();
     let stored_peer = "Peer-Mark-Mixed-Case";

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -15881,6 +15881,52 @@ fn failed_propagation_remote_unpeer_records_case_insensitive_queue_snapshot_like
 }
 
 #[test]
+fn payload_backed_peer_queue_snapshot_uses_stored_peer_case_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let stored_peer = "Peer-Snapshot-Mixed-Case";
+    let request_peer = stored_peer.to_ascii_lowercase();
+    daemon
+        .handle_rpc(rpc_request(79, "peer_sync", json!({ "peer": stored_peer })))
+        .expect("peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(stored_peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+
+    let entry = PropagationEntryRecord {
+        transient_id: "ef".repeat(32),
+        destination: "25".repeat(16),
+        payload_hex: "25".repeat(20),
+        received_at: 1_700_000_810,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(stored_peer, entry.transient_id.as_str())
+        .expect("mark unhandled");
+
+    daemon
+        .record_payload_backed_peer_queue_snapshot(request_peer.as_str())
+        .expect("record queue snapshot");
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(stored_peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(entry.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn unavailable_propagation_remote_unpeer_records_existing_queue_snapshot_like_python() {
     let daemon = RpcDaemon::test_instance();
     let peer = "peer-remote-unpeer-unavailable-snapshot";

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -15704,6 +15704,63 @@ fn failed_propagation_remote_unpeer_records_existing_queue_snapshot_like_python(
 }
 
 #[test]
+fn failed_propagation_remote_unpeer_records_case_insensitive_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Err(std::io::ErrorKind::TimedOut),
+    }));
+    let stored_peer = "Peer-Remote-Unpeer-Fail-Snapshot-Case";
+    let request_peer = stored_peer.to_ascii_lowercase();
+    daemon
+        .handle_rpc(rpc_request(79, "peer_sync", json!({ "peer": stored_peer })))
+        .expect("peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(stored_peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+
+    let entry = PropagationEntryRecord {
+        transient_id: "ed".repeat(32),
+        destination: "24".repeat(16),
+        payload_hex: "24".repeat(20),
+        received_at: 1_700_000_809,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(stored_peer, entry.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            80,
+            "propagation_remote_unpeer",
+            json!({
+                "remote": "remote-node",
+                "peer": request_peer,
+            }),
+        ))
+        .expect_err("remote unpeer failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(stored_peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(entry.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn unavailable_propagation_remote_unpeer_records_existing_queue_snapshot_like_python() {
     let daemon = RpcDaemon::test_instance();
     let peer = "peer-remote-unpeer-unavailable-snapshot";

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -13415,6 +13415,74 @@ fn failed_propagation_remote_download_import_updates_lifecycle_error() {
 }
 
 #[test]
+fn failed_propagation_remote_download_import_records_existing_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "downloaded_count": 1,
+            "imported_count": 1,
+            "messages": [{
+                "payload_hex": "not-hex",
+            }],
+        })),
+    }));
+    let peer = "peer-remote-download-import-fail-snapshot";
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "b7".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_618,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            81,
+            "propagation_remote_download",
+            json!({
+                "remote": "remote-node",
+            }),
+        ))
+        .expect_err("remote download import failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(err.to_string().contains("invalid remote propagation payload hex"));
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer)
+            .expect("pending propagation"),
+        vec![pending.clone()]
+    );
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn failed_propagation_remote_fetch_import_records_existing_queue_snapshot_like_python() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -16434,6 +16434,50 @@ fn peer_sync_matches_existing_peer_queue_case_insensitively_like_python() {
 }
 
 #[test]
+fn peer_queue_unhandled_snapshot_preserves_case_insensitive_completed_mark_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let stored_peer = "Peer-Completed-Mixed-Case";
+    let request_peer = stored_peer.to_ascii_lowercase();
+    daemon
+        .handle_rpc(rpc_request(91, "peer_sync", json!({ "peer": stored_peer })))
+        .expect("peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(stored_peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+
+    let entry = PropagationEntryRecord {
+        transient_id: "de".repeat(32),
+        destination: "24".repeat(16),
+        payload_hex: "24".repeat(24),
+        received_at: 1_700_000_940,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_transfer_limited_propagation(stored_peer, entry.transient_id.as_str())
+        .expect("mark transfer limited");
+
+    daemon.record_peer_queue_unhandled_id(request_peer.as_str(), entry.transient_id.as_str());
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(stored_peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[json!(entry.transient_id.as_str())]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[] as &[JsonValue]
+    );
+}
+
+#[test]
 fn peer_unpeer_clears_persisted_propagation_queue_marks() {
     let (daemon, peer) = ready_propagation_peer_daemon(0x52);
     daemon

--- a/crates/libs/rns-rpc/src/storage/messages.rs
+++ b/crates/libs/rns-rpc/src/storage/messages.rs
@@ -888,7 +888,7 @@ impl MessagesStore {
                  ON CONFLICT(peer, transient_id) DO UPDATE SET
                     state = 'handled',
                     updated_at = excluded.updated_at
-                 WHERE propagation_peer_entries.state NOT IN ('transferred', 'received')",
+                 WHERE propagation_peer_entries.state NOT IN ('transferred', 'received', 'transfer_limited')",
                 params![peer, normalize_hex_key(transient_id), now_unix_secs()],
             )?;
             Ok(())
@@ -2647,14 +2647,29 @@ mod tests {
             size_bytes: 28,
             stamp_value: None,
         };
+        let transfer_limited = PropagationEntryRecord {
+            transient_id: "c7".repeat(32),
+            destination: "77".repeat(16),
+            payload_hex: "77".repeat(32),
+            received_at: 106,
+            size_bytes: 32,
+            stamp_value: None,
+        };
         store.upsert_propagation_entry(&transferred).expect("transferred entry");
         store.upsert_propagation_entry(&received).expect("received entry");
+        store.upsert_propagation_entry(&transfer_limited).expect("transfer limited entry");
         store
             .mark_peer_transferred_propagation("peer-completed", transferred.transient_id.as_str())
             .expect("mark transferred");
         store
             .mark_peer_received_propagation("peer-completed", received.transient_id.as_str())
             .expect("mark received");
+        store
+            .mark_peer_transfer_limited_propagation(
+                "peer-completed",
+                transfer_limited.transient_id.as_str(),
+            )
+            .expect("mark transfer limited");
 
         store
             .mark_peer_handled_propagation("peer-completed", transferred.transient_id.as_str())
@@ -2662,6 +2677,9 @@ mod tests {
         store
             .mark_peer_handled_propagation("peer-completed", received.transient_id.as_str())
             .expect("ignore received downgrade");
+        store
+            .mark_peer_handled_propagation("peer-completed", transfer_limited.transient_id.as_str())
+            .expect("ignore transfer-limited downgrade");
 
         assert_eq!(
             store.peer_propagation_message_stats("peer-completed").expect("peer stats"),

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -70,6 +70,9 @@ The project is best described by capability level:
 - Payload-backed remote failure snapshots now replace stale serialized peer
   queue IDs with live payload-backed marks, so bridge failures do not preserve
   obsolete restart/export work after the underlying payload is gone.
+- Zero-cost peer stamp policies now sync unstamped queued offers immediately
+  without waiting for absent peering metadata, matching the Python "no stamp
+  required" path and avoiding repeated peer-sync postponement.
 - Malformed remote fetch and download imports now mirror existing
   payload-backed live queue marks into active peer record snapshots before
   failing, preserving restart/export retry state for already queued relay work.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -67,9 +67,9 @@ The project is best described by capability level:
   paths now perform the same payload-backed live queue snapshot mirroring
   before reporting the failed sync, keeping local and remote retry/export
   behavior aligned.
-- Malformed remote fetch imports now mirror existing payload-backed live queue
-  marks into active peer record snapshots before failing, preserving
-  restart/export retry state for already queued relay work.
+- Malformed remote fetch and download imports now mirror existing
+  payload-backed live queue marks into active peer record snapshots before
+  failing, preserving restart/export retry state for already queued relay work.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -67,6 +67,9 @@ The project is best described by capability level:
   paths now perform the same payload-backed live queue snapshot mirroring
   before reporting the failed sync, keeping local and remote retry/export
   behavior aligned.
+- Payload-backed remote failure snapshots now replace stale serialized peer
+  queue IDs with live payload-backed marks, so bridge failures do not preserve
+  obsolete restart/export work after the underlying payload is gone.
 - Malformed remote fetch and download imports now mirror existing
   payload-backed live queue marks into active peer record snapshots before
   failing, preserving restart/export retry state for already queued relay work.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -77,8 +77,9 @@ The project is best described by capability level:
   queue marks into active peer record snapshots before returning, so
   restart/export state preserves queued retry work even when sync is deferred.
 - Failed remote unpeer attempts now mirror existing payload-backed live queue
-  marks into active peer record snapshots before returning the bridge error, so
-  restart/export state preserves queued retry work when peering teardown fails.
+  marks into active peer record snapshots before returning bridge-unavailable
+  or bridge-execution errors, so restart/export state preserves queued retry
+  work when peering teardown fails.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -63,9 +63,10 @@ The project is best described by capability level:
 - Retryable numeric local offer responses now mirror payload-backed live queue
   marks into the active peer record snapshot before returning, so restart/export
   state preserves the retry queue even when the serialized snapshot was empty.
-- Retryable, throttled, and generic failed remote peer-sync paths now perform
-  the same payload-backed live queue snapshot mirroring before reporting the
-  failed sync, keeping local and remote retry/export behavior aligned.
+- Retryable, throttled, generic failed, and malformed-import remote peer-sync
+  paths now perform the same payload-backed live queue snapshot mirroring
+  before reporting the failed sync, keeping local and remote retry/export
+  behavior aligned.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -97,6 +97,9 @@ The project is best described by capability level:
   marks into active peer record snapshots before returning bridge-unavailable
   or bridge-execution errors, including case-insensitive peer requests, so
   restart/export state preserves queued retry work when peering teardown fails.
+- Successful remote unpeer now also uses the stored peer ID case for the bridge
+  call and nested bridge result when callers use a case-variant peer request,
+  keeping remote teardown identity aligned with local queue cleanup.
 - Payload-backed peer queue snapshot mirroring resolves stored peer IDs
   case-insensitively before reading live queue marks, so restart/export state
   preserves queued work when callers use Python-style peer case variants.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -63,6 +63,9 @@ The project is best described by capability level:
 - Retryable numeric local offer responses now mirror payload-backed live queue
   marks into the active peer record snapshot before returning, so restart/export
   state preserves the retry queue even when the serialized snapshot was empty.
+- Retryable remote peer-sync failures now perform the same payload-backed live
+  queue snapshot mirroring before reporting the failed sync, keeping local and
+  remote retry/export behavior aligned.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -73,10 +73,10 @@ The project is best described by capability level:
 - Remote fetch and download bridge failures now mirror existing payload-backed
   live queue marks into active peer record snapshots before returning the
   failure, preserving restart/export retry state for already queued relay work.
-- Remote download bridge-unavailable errors now mirror existing payload-backed
-  live queue marks into active peer record snapshots before returning, so
-  already queued relay work stays restart/export visible even when no bridge is
-  configured.
+- Remote fetch and download bridge-unavailable errors now mirror existing
+  payload-backed live queue marks into active peer record snapshots before
+  returning, so already queued relay work stays restart/export visible even
+  when no bridge is configured.
 - Remote peer-sync backoff postponements now mirror existing payload-backed live
   queue marks into active peer record snapshots before returning, so
   restart/export state preserves queued retry work even when sync is deferred.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -70,6 +70,9 @@ The project is best described by capability level:
 - Malformed remote fetch and download imports now mirror existing
   payload-backed live queue marks into active peer record snapshots before
   failing, preserving restart/export retry state for already queued relay work.
+- Remote fetch and download bridge failures now mirror existing payload-backed
+  live queue marks into active peer record snapshots before returning the
+  failure, preserving restart/export retry state for already queued relay work.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -110,6 +110,9 @@ The project is best described by capability level:
 - Incremental peer queue snapshot helpers now canonicalize transient IDs before
   serializing handled or unhandled queue state, preventing padded or upper-case
   caller IDs from leaking into restart/export snapshots.
+- Transfer-limited peer marks now remain terminal when later generic handled
+  reports arrive, so transfer-limit retry decisions do not get reclassified as
+  offered/handled work in peer queue accounting.
 - Completed peer mark helpers now write and read received/transferred live
   marks under the stored peer ID case when a peer record already exists, keeping
   live queue state and serialized restart/export snapshots on the same peer key.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -86,8 +86,8 @@ The project is best described by capability level:
   peer creation when the bridge is absent.
 - Failed remote unpeer attempts now mirror existing payload-backed live queue
   marks into active peer record snapshots before returning bridge-unavailable
-  or bridge-execution errors, so restart/export state preserves queued retry
-  work when peering teardown fails.
+  or bridge-execution errors, including case-insensitive peer requests, so
+  restart/export state preserves queued retry work when peering teardown fails.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -90,6 +90,9 @@ The project is best described by capability level:
   live queue marks into active peer record snapshots for already known peers
   before returning, including case-insensitive requests, while still avoiding
   peer creation when the bridge is absent.
+- Remote peer-sync now uses the stored peer ID case for the bridge call, import
+  source accounting, state updates, and response envelope when callers use a
+  case-variant peer request.
 - Failed remote unpeer attempts now mirror existing payload-backed live queue
   marks into active peer record snapshots before returning bridge-unavailable
   or bridge-execution errors, including case-insensitive peer requests, so

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -83,6 +83,10 @@ The project is best described by capability level:
   payload-backed live queue marks into active peer record snapshots before
   returning, so already queued relay work stays restart/export visible even
   when no bridge is configured.
+- Successful remote fetch and download now also mirror existing payload-backed
+  live queue marks into active peer record snapshots after applying imports, so
+  restart/export state preserves queued retry work even when the remote
+  transfer succeeds without consuming those local queued offers.
 - Remote peer-sync backoff postponements now mirror existing payload-backed live
   queue marks into active peer record snapshots before returning, so
   restart/export state preserves queued retry work even when sync is deferred.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -107,6 +107,9 @@ The project is best described by capability level:
   checking completed live marks, preventing transfer-limited or handled work
   from being serialized as retryable unhandled queue state through case
   variants.
+- Incremental peer queue snapshot helpers now canonicalize transient IDs before
+  serializing handled or unhandled queue state, preventing padded or upper-case
+  caller IDs from leaking into restart/export snapshots.
 - Completed peer mark helpers now write and read received/transferred live
   marks under the stored peer ID case when a peer record already exists, keeping
   live queue state and serialized restart/export snapshots on the same peer key.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -67,6 +67,9 @@ The project is best described by capability level:
   paths now perform the same payload-backed live queue snapshot mirroring
   before reporting the failed sync, keeping local and remote retry/export
   behavior aligned.
+- Malformed remote fetch imports now mirror existing payload-backed live queue
+  marks into active peer record snapshots before failing, preserving
+  restart/export retry state for already queued relay work.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -114,6 +114,9 @@ The project is best described by capability level:
   snapshots when they queue new unhandled IDs or mark source peers handled,
   keeping restart/export state aligned with live queue fan-out and source
   accounting.
+- Remote import batches now deduplicate accepted transient IDs before applying
+  peer queue and incoming-message side effects, so duplicate payloads in one
+  fetch/download/sync response do not inflate peer queue accounting.
 - Propagation purge cleanup removes deleted local payload IDs from active peer
   record snapshots, so restart/export state does not retain purged queue entries
   after the live peer marks have been cleared.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -94,6 +94,9 @@ The project is best described by capability level:
   marks into active peer record snapshots before returning bridge-unavailable
   or bridge-execution errors, including case-insensitive peer requests, so
   restart/export state preserves queued retry work when peering teardown fails.
+- Payload-backed peer queue snapshot mirroring resolves stored peer IDs
+  case-insensitively before reading live queue marks, so restart/export state
+  preserves queued work when callers use Python-style peer case variants.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -76,6 +76,9 @@ The project is best described by capability level:
 - Remote peer-sync backoff postponements now mirror existing payload-backed live
   queue marks into active peer record snapshots before returning, so
   restart/export state preserves queued retry work even when sync is deferred.
+- Failed remote unpeer attempts now mirror existing payload-backed live queue
+  marks into active peer record snapshots before returning the bridge error, so
+  restart/export state preserves queued retry work when peering teardown fails.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -63,9 +63,9 @@ The project is best described by capability level:
 - Retryable numeric local offer responses now mirror payload-backed live queue
   marks into the active peer record snapshot before returning, so restart/export
   state preserves the retry queue even when the serialized snapshot was empty.
-- Retryable remote peer-sync failures now perform the same payload-backed live
-  queue snapshot mirroring before reporting the failed sync, keeping local and
-  remote retry/export behavior aligned.
+- Retryable and throttled remote peer-sync failures now perform the same
+  payload-backed live queue snapshot mirroring before reporting the failed sync,
+  keeping local and remote retry/export behavior aligned.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -73,6 +73,9 @@ The project is best described by capability level:
 - Remote fetch and download bridge failures now mirror existing payload-backed
   live queue marks into active peer record snapshots before returning the
   failure, preserving restart/export retry state for already queued relay work.
+- Remote peer-sync backoff postponements now mirror existing payload-backed live
+  queue marks into active peer record snapshots before returning, so
+  restart/export state preserves queued retry work even when sync is deferred.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -93,6 +93,10 @@ The project is best described by capability level:
 - Remote peer-sync bridge-unavailable errors for already known peers now also
   publish the failed peer-sync event and mark the propagation sync lifecycle
   failed, keeping queue retry state observable without creating new peers.
+- Successful remote peer-sync now also mirrors existing payload-backed live
+  queue marks into active peer record snapshots after applying imports, so
+  restart/export state preserves queued retry work even when the remote sync
+  itself succeeds without transferring those local queued offers.
 - Remote peer-sync now uses the stored peer ID case for the bridge call, import
   source accounting, state updates, and response envelope when callers use a
   case-variant peer request.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -73,6 +73,10 @@ The project is best described by capability level:
 - Remote fetch and download bridge failures now mirror existing payload-backed
   live queue marks into active peer record snapshots before returning the
   failure, preserving restart/export retry state for already queued relay work.
+- Remote download bridge-unavailable errors now mirror existing payload-backed
+  live queue marks into active peer record snapshots before returning, so
+  already queued relay work stays restart/export visible even when no bridge is
+  configured.
 - Remote peer-sync backoff postponements now mirror existing payload-backed live
   queue marks into active peer record snapshots before returning, so
   restart/export state preserves queued retry work even when sync is deferred.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -63,9 +63,9 @@ The project is best described by capability level:
 - Retryable numeric local offer responses now mirror payload-backed live queue
   marks into the active peer record snapshot before returning, so restart/export
   state preserves the retry queue even when the serialized snapshot was empty.
-- Retryable and throttled remote peer-sync failures now perform the same
-  payload-backed live queue snapshot mirroring before reporting the failed sync,
-  keeping local and remote retry/export behavior aligned.
+- Retryable, throttled, and generic failed remote peer-sync paths now perform
+  the same payload-backed live queue snapshot mirroring before reporting the
+  failed sync, keeping local and remote retry/export behavior aligned.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -113,6 +113,10 @@ The project is best described by capability level:
 - Transfer-limited peer marks now remain terminal when later generic handled
   reports arrive, so transfer-limit retry decisions do not get reclassified as
   offered/handled work in peer queue accounting.
+- Static-only propagation peer replacement now routes removed static peers
+  through the same local unpeer cleanup as explicit unpeer, so handled,
+  received, transfer-limited, and unhandled queue marks are cleared and
+  accounted consistently.
 - Completed peer mark helpers now write and read received/transferred live
   marks under the stored peer ID case when a peer record already exists, keeping
   live queue state and serialized restart/export snapshots on the same peer key.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -97,6 +97,10 @@ The project is best described by capability level:
 - Payload-backed peer queue snapshot mirroring resolves stored peer IDs
   case-insensitively before reading live queue marks, so restart/export state
   preserves queued work when callers use Python-style peer case variants.
+- Incremental peer queue snapshot updates also resolve stored peer IDs before
+  checking completed live marks, preventing transfer-limited or handled work
+  from being serialized as retryable unhandled queue state through case
+  variants.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -101,6 +101,9 @@ The project is best described by capability level:
   checking completed live marks, preventing transfer-limited or handled work
   from being serialized as retryable unhandled queue state through case
   variants.
+- Completed peer mark helpers now write and read received/transferred live
+  marks under the stored peer ID case when a peer record already exists, keeping
+  live queue state and serialized restart/export snapshots on the same peer key.
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -76,6 +76,9 @@ The project is best described by capability level:
 - Remote peer-sync backoff postponements now mirror existing payload-backed live
   queue marks into active peer record snapshots before returning, so
   restart/export state preserves queued retry work even when sync is deferred.
+- Remote peer-sync bridge-unavailable errors now mirror existing payload-backed
+  live queue marks into active peer record snapshots for already known peers
+  before returning, while still avoiding peer creation when the bridge is absent.
 - Failed remote unpeer attempts now mirror existing payload-backed live queue
   marks into active peer record snapshots before returning bridge-unavailable
   or bridge-execution errors, so restart/export state preserves queued retry

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -90,6 +90,9 @@ The project is best described by capability level:
   live queue marks into active peer record snapshots for already known peers
   before returning, including case-insensitive requests, while still avoiding
   peer creation when the bridge is absent.
+- Remote peer-sync bridge-unavailable errors for already known peers now also
+  publish the failed peer-sync event and mark the propagation sync lifecycle
+  failed, keeping queue retry state observable without creating new peers.
 - Remote peer-sync now uses the stored peer ID case for the bridge call, import
   source accounting, state updates, and response envelope when callers use a
   case-variant peer request.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -82,7 +82,8 @@ The project is best described by capability level:
   restart/export state preserves queued retry work even when sync is deferred.
 - Remote peer-sync bridge-unavailable errors now mirror existing payload-backed
   live queue marks into active peer record snapshots for already known peers
-  before returning, while still avoiding peer creation when the bridge is absent.
+  before returning, including case-insensitive requests, while still avoiding
+  peer creation when the bridge is absent.
 - Failed remote unpeer attempts now mirror existing payload-backed live queue
   marks into active peer record snapshots before returning bridge-unavailable
   or bridge-execution errors, so restart/export state preserves queued retry

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -102,10 +102,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   unhandled queue marks into active peer record snapshots before returning,
   preserving restart/export retry state even when the serialized snapshot was
   previously empty.
-- Retryable, throttled, and generic failed remote peer-sync paths mirror the
-  same payload-backed queue marks into active peer record snapshots before
-  publishing the failed sync event, so local and remote retry/export behavior
-  stays aligned.
+- Retryable, throttled, generic failed, and malformed-import remote peer-sync
+  paths mirror the same payload-backed queue marks into active peer record
+  snapshots before publishing the failed sync event, so local and remote
+  retry/export behavior stays aligned.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -147,6 +147,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   peer snapshot, source-peer handled IDs are preserved for restart/export, and
   offer-response handling keeps IDs in sync when queued messages become handled,
   transferred, or transfer-limited.
+- Remote import batches deduplicate accepted transient IDs before peer queue
+  and incoming-message side effects are applied, so duplicate payloads in one
+  fetch/download/sync response do not inflate peer queue accounting.
 - Purging local propagation payloads removes matching deleted IDs from active
   peer record snapshots, preventing restart/export drift after queue cleanup.
 - Duplicate or replayed propagation queue attempts preserve completed peer

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -129,6 +129,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   queue marks into active peer record snapshots for already known peers before
   returning, including case-insensitive requests, without creating new peers
   when the bridge is absent.
+- Remote peer-sync uses the stored peer ID case for the bridge call, import
+  source accounting, state updates, and response envelope when callers supply a
+  case-variant peer request.
 - Failed remote unpeer attempts mirror existing payload-backed queue marks into
   active peer record snapshots before returning bridge-unavailable or
   bridge-execution errors, including case-insensitive peer requests, so failed

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -133,6 +133,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   active peer record snapshots before returning bridge-unavailable or
   bridge-execution errors, including case-insensitive peer requests, so failed
   peering teardown preserves queued retry work across restart/export.
+- Payload-backed peer queue snapshot mirroring resolves stored peer IDs
+  case-insensitively before reading live queue marks, preserving queued
+  restart/export work when callers use Python-style peer case variants.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -102,9 +102,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   unhandled queue marks into active peer record snapshots before returning,
   preserving restart/export retry state even when the serialized snapshot was
   previously empty.
-- Retryable remote peer-sync failures mirror the same payload-backed queue marks
-  into active peer record snapshots before publishing the failed sync event, so
-  local and remote retry/export behavior stay aligned.
+- Retryable and throttled remote peer-sync failures mirror the same
+  payload-backed queue marks into active peer record snapshots before publishing
+  the failed sync event, so local and remote retry/export behavior stay aligned.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -116,8 +116,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   marks into active peer record snapshots before returning, so deferred syncs
   preserve queued retry work across restart/export.
 - Failed remote unpeer attempts mirror existing payload-backed queue marks into
-  active peer record snapshots before returning the bridge error, so failed
-  peering teardown preserves queued retry work across restart/export.
+  active peer record snapshots before returning bridge-unavailable or
+  bridge-execution errors, so failed peering teardown preserves queued retry
+  work across restart/export.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -106,6 +106,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   paths mirror the same payload-backed queue marks into active peer record
   snapshots before publishing the failed sync event, so local and remote
   retry/export behavior stays aligned.
+- Malformed remote fetch imports mirror existing payload-backed queue marks into
+  active peer record snapshots before returning the import failure, so already
+  queued relay work remains visible after restart/export.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -148,6 +148,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Incremental peer queue snapshot helpers canonicalize transient IDs before
   serializing handled or unhandled queue state, so padded or upper-case caller
   IDs do not leak into restart/export snapshots.
+- Transfer-limited peer marks remain terminal when a later generic handled
+  report arrives, so transfer-limit retry decisions are not reclassified as
+  offered/handled work in peer queue accounting.
 - Completed peer mark helpers write and read received/transferred live marks
   under the stored peer ID case when a peer record already exists, keeping live
   queue state and serialized restart/export snapshots aligned.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -102,6 +102,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   unhandled queue marks into active peer record snapshots before returning,
   preserving restart/export retry state even when the serialized snapshot was
   previously empty.
+- Retryable remote peer-sync failures mirror the same payload-backed queue marks
+  into active peer record snapshots before publishing the failed sync event, so
+  local and remote retry/export behavior stay aligned.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -125,8 +125,8 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   when the bridge is absent.
 - Failed remote unpeer attempts mirror existing payload-backed queue marks into
   active peer record snapshots before returning bridge-unavailable or
-  bridge-execution errors, so failed peering teardown preserves queued retry
-  work across restart/export.
+  bridge-execution errors, including case-insensitive peer requests, so failed
+  peering teardown preserves queued retry work across restart/export.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -139,6 +139,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Incremental peer queue snapshot updates resolve stored peer IDs before
   checking completed live marks, so transfer-limited or handled work is not
   serialized as retryable unhandled queue state through peer case variants.
+- Completed peer mark helpers write and read received/transferred live marks
+  under the stored peer ID case when a peer record already exists, keeping live
+  queue state and serialized restart/export snapshots aligned.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -106,6 +106,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   paths mirror the same payload-backed queue marks into active peer record
   snapshots before publishing the failed sync event, so local and remote
   retry/export behavior stays aligned.
+- Payload-backed remote failure snapshots replace stale serialized peer queue
+  IDs with live payload-backed marks, so bridge failures do not preserve
+  obsolete restart/export work after the underlying payload is gone.
 - Malformed remote fetch and download imports mirror existing payload-backed
   queue marks into active peer record snapshots before returning the import
   failure, so already queued relay work remains visible after restart/export.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -136,6 +136,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Payload-backed peer queue snapshot mirroring resolves stored peer IDs
   case-insensitively before reading live queue marks, preserving queued
   restart/export work when callers use Python-style peer case variants.
+- Incremental peer queue snapshot updates resolve stored peer IDs before
+  checking completed live marks, so transfer-limited or handled work is not
+  serialized as retryable unhandled queue state through peer case variants.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -151,6 +151,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Transfer-limited peer marks remain terminal when a later generic handled
   report arrives, so transfer-limit retry decisions are not reclassified as
   offered/handled work in peer queue accounting.
+- Static-only propagation peer replacement routes removed static peers through
+  the same local unpeer cleanup as explicit unpeer, so handled, received,
+  transfer-limited, and unhandled queue marks are cleared and accounted
+  consistently.
 - Completed peer mark helpers write and read received/transferred live marks
   under the stored peer ID case when a peer record already exists, keeping live
   queue state and serialized restart/export snapshots aligned.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -112,10 +112,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote fetch and download bridge failures mirror existing payload-backed
   queue marks into active peer record snapshots before returning the failure,
   so already queued relay work remains visible after restart/export.
-- Remote download bridge-unavailable errors mirror existing payload-backed
-  queue marks into active peer record snapshots before returning, so queued
-  relay work remains visible after restart/export even when no bridge is
-  configured.
+- Remote fetch and download bridge-unavailable errors mirror existing
+  payload-backed queue marks into active peer record snapshots before
+  returning, so queued relay work remains visible after restart/export even
+  when no bridge is configured.
 - Remote peer-sync backoff postponements mirror existing payload-backed queue
   marks into active peer record snapshots before returning, so deferred syncs
   preserve queued retry work across restart/export.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -109,6 +109,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Payload-backed remote failure snapshots replace stale serialized peer queue
   IDs with live payload-backed marks, so bridge failures do not preserve
   obsolete restart/export work after the underlying payload is gone.
+- Zero-cost peer stamp policies transfer unstamped queued offers immediately
+  without waiting for absent peering metadata, matching the Python no-stamp
+  path and avoiding repeated peer-sync postponement.
 - Malformed remote fetch and download imports mirror existing payload-backed
   queue marks into active peer record snapshots before returning the import
   failure, so already queued relay work remains visible after restart/export.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -112,6 +112,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote fetch and download bridge failures mirror existing payload-backed
   queue marks into active peer record snapshots before returning the failure,
   so already queued relay work remains visible after restart/export.
+- Remote download bridge-unavailable errors mirror existing payload-backed
+  queue marks into active peer record snapshots before returning, so queued
+  relay work remains visible after restart/export even when no bridge is
+  configured.
 - Remote peer-sync backoff postponements mirror existing payload-backed queue
   marks into active peer record snapshots before returning, so deferred syncs
   preserve queued retry work across restart/export.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -122,6 +122,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   payload-backed queue marks into active peer record snapshots before
   returning, so queued relay work remains visible after restart/export even
   when no bridge is configured.
+- Successful remote fetch and download mirror existing payload-backed queue
+  marks into active peer record snapshots after applying imports, preserving
+  queued retry work across restart/export even when the remote transfer succeeds
+  without consuming those local queued offers.
 - Remote peer-sync backoff postponements mirror existing payload-backed queue
   marks into active peer record snapshots before returning, so deferred syncs
   preserve queued retry work across restart/export.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -112,6 +112,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote fetch and download bridge failures mirror existing payload-backed
   queue marks into active peer record snapshots before returning the failure,
   so already queued relay work remains visible after restart/export.
+- Remote peer-sync backoff postponements mirror existing payload-backed queue
+  marks into active peer record snapshots before returning, so deferred syncs
+  preserve queued retry work across restart/export.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -115,6 +115,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote peer-sync backoff postponements mirror existing payload-backed queue
   marks into active peer record snapshots before returning, so deferred syncs
   preserve queued retry work across restart/export.
+- Remote peer-sync bridge-unavailable errors mirror existing payload-backed
+  queue marks into active peer record snapshots for already known peers before
+  returning, without creating new peers when the bridge is absent.
 - Failed remote unpeer attempts mirror existing payload-backed queue marks into
   active peer record snapshots before returning bridge-unavailable or
   bridge-execution errors, so failed peering teardown preserves queued retry

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -109,6 +109,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Malformed remote fetch and download imports mirror existing payload-backed
   queue marks into active peer record snapshots before returning the import
   failure, so already queued relay work remains visible after restart/export.
+- Remote fetch and download bridge failures mirror existing payload-backed
+  queue marks into active peer record snapshots before returning the failure,
+  so already queued relay work remains visible after restart/export.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -121,7 +121,8 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   preserve queued retry work across restart/export.
 - Remote peer-sync bridge-unavailable errors mirror existing payload-backed
   queue marks into active peer record snapshots for already known peers before
-  returning, without creating new peers when the bridge is absent.
+  returning, including case-insensitive requests, without creating new peers
+  when the bridge is absent.
 - Failed remote unpeer attempts mirror existing payload-backed queue marks into
   active peer record snapshots before returning bridge-unavailable or
   bridge-execution errors, so failed peering teardown preserves queued retry

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -106,9 +106,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   paths mirror the same payload-backed queue marks into active peer record
   snapshots before publishing the failed sync event, so local and remote
   retry/export behavior stays aligned.
-- Malformed remote fetch imports mirror existing payload-backed queue marks into
-  active peer record snapshots before returning the import failure, so already
-  queued relay work remains visible after restart/export.
+- Malformed remote fetch and download imports mirror existing payload-backed
+  queue marks into active peer record snapshots before returning the import
+  failure, so already queued relay work remains visible after restart/export.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -102,9 +102,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   unhandled queue marks into active peer record snapshots before returning,
   preserving restart/export retry state even when the serialized snapshot was
   previously empty.
-- Retryable and throttled remote peer-sync failures mirror the same
-  payload-backed queue marks into active peer record snapshots before publishing
-  the failed sync event, so local and remote retry/export behavior stay aligned.
+- Retryable, throttled, and generic failed remote peer-sync paths mirror the
+  same payload-backed queue marks into active peer record snapshots before
+  publishing the failed sync event, so local and remote retry/export behavior
+  stays aligned.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -132,6 +132,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote peer-sync bridge-unavailable errors for already known peers also
   publish the failed peer-sync event and mark the propagation sync lifecycle
   failed, keeping queued retry state observable without creating new peers.
+- Successful remote peer-sync mirrors existing payload-backed live queue marks
+  into active peer record snapshots after applying imports, preserving queued
+  retry work across restart/export even when the remote sync succeeds without
+  transferring those local queued offers.
 - Remote peer-sync uses the stored peer ID case for the bridge call, import
   source accounting, state updates, and response envelope when callers supply a
   case-variant peer request.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -136,6 +136,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   active peer record snapshots before returning bridge-unavailable or
   bridge-execution errors, including case-insensitive peer requests, so failed
   peering teardown preserves queued retry work across restart/export.
+- Successful remote unpeer uses the stored peer ID case for the bridge call and
+  nested bridge result when callers supply a case-variant peer request, keeping
+  remote teardown identity aligned with local queue cleanup.
 - Payload-backed peer queue snapshot mirroring resolves stored peer IDs
   case-insensitively before reading live queue marks, preserving queued
   restart/export work when callers use Python-style peer case variants.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -145,6 +145,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Incremental peer queue snapshot updates resolve stored peer IDs before
   checking completed live marks, so transfer-limited or handled work is not
   serialized as retryable unhandled queue state through peer case variants.
+- Incremental peer queue snapshot helpers canonicalize transient IDs before
+  serializing handled or unhandled queue state, so padded or upper-case caller
+  IDs do not leak into restart/export snapshots.
 - Completed peer mark helpers write and read received/transferred live marks
   under the stored peer ID case when a peer record already exists, keeping live
   queue state and serialized restart/export snapshots aligned.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -129,6 +129,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   queue marks into active peer record snapshots for already known peers before
   returning, including case-insensitive requests, without creating new peers
   when the bridge is absent.
+- Remote peer-sync bridge-unavailable errors for already known peers also
+  publish the failed peer-sync event and mark the propagation sync lifecycle
+  failed, keeping queued retry state observable without creating new peers.
 - Remote peer-sync uses the stored peer ID case for the bridge call, import
   source accounting, state updates, and response envelope when callers supply a
   case-variant peer request.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -115,6 +115,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote peer-sync backoff postponements mirror existing payload-backed queue
   marks into active peer record snapshots before returning, so deferred syncs
   preserve queued retry work across restart/export.
+- Failed remote unpeer attempts mirror existing payload-backed queue marks into
+  active peer record snapshots before returning the bridge error, so failed
+  peering teardown preserves queued retry work across restart/export.
 - Restored peer record queue IDs are replayed into the live store, newly queued
   existing and inbound/imported propagation IDs are reflected in the serialized
   peer snapshot, source-peer handled IDs are preserved for restart/export, and


### PR DESCRIPTION
## Summary
- mirror payload-backed live remote retry queue marks into active peer record snapshots before failed remote sync events
- mirror existing payload-backed queue marks before remote fetch/download bridge failures return and prune stale serialized peer queue IDs
- mirror existing payload-backed queue marks before remote fetch/download bridge-unavailable errors return
- mirror existing payload-backed queue marks before remote peer-sync backoff postponements return
- mirror existing payload-backed queue marks before remote peer-sync bridge-unavailable errors return for already known peers, including case-insensitive requests
- mirror existing payload-backed queue marks before failed or unavailable remote unpeer bridge errors return, including case-insensitive peer requests
- add regression coverage for retryable sync, remote fetch/download failure, remote fetch/download missing bridge, backoff, missing-bridge sync, case-insensitive missing-bridge sync, failed/unavailable remote-unpeer, and case-insensitive failed remote-unpeer serialized retry queue state
- update current roadmap and LXMF parity matrix evidence

## Verification
- cargo test -p reticulum-rs-rpc --lib retryable_propagation_remote_sync_records_existing_queue_snapshot_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib failed_propagation_remote_download_records_existing_queue_snapshot_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib failed_propagation_remote_fetch_records_existing_queue_snapshot_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib failed_propagation_remote_fetch_prunes_stale_queue_snapshot_ids_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_fetch_missing_bridge_records_existing_queue_snapshot_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_fetch -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_download_missing_bridge_records_existing_queue_snapshot_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_download -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_sync_backoff_records_preexisting_live_queue_snapshot_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_sync_missing_bridge_records_existing_queue_snapshot_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_sync_missing_bridge_records_case_insensitive_queue_snapshot_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_sync_missing_bridge_does_not_create_peer -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_sync_missing_bridge -- --nocapture
- cargo test -p reticulum-rs-rpc --lib peer_sync_backoff_records_preexisting_live_queue_snapshot_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib failed_propagation_remote_unpeer_records_existing_queue_snapshot_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib failed_propagation_remote_unpeer_records_case_insensitive_queue_snapshot_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib unavailable_propagation_remote_unpeer_records_existing_queue_snapshot_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc --lib failed_propagation_remote_unpeer_preserves_local_peer_and_queue_state -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_unpeer -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_sync -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote -- --nocapture
- cargo test -p reticulum-rs-rpc --lib peer_sync -- --nocapture
- cargo fmt --check
- cargo check -p reticulum-rs-rpc
- cargo clippy -p reticulum-rs-rpc --lib -- -D warnings
- git diff --check
- cargo xtask ci --stage interop-artifacts

Stacked on #231 to keep the rest of the parity work separate until #231 lands.

