### PR TITLE
[codex] Gate full CI behind label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,17 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches: [main]
   workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   quality:
@@ -79,6 +84,7 @@ jobs:
         run: cargo xtask ci --stage build-matrix
 
   interfaces-build-linux:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -96,6 +102,7 @@ jobs:
         run: cargo check -p reticulumd --all-targets
 
   interfaces-build-macos:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -109,6 +116,7 @@ jobs:
         run: cargo check -p reticulumd --all-targets
 
   interfaces-build-windows:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -122,6 +130,7 @@ jobs:
         run: cargo check -p reticulumd --all-targets
 
   interfaces-test-serial:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -139,6 +148,7 @@ jobs:
         run: cargo test -p reticulum-rs-transport serial::tests
 
   interfaces-test-ble-linux:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -156,6 +166,7 @@ jobs:
         run: "cargo test -p reticulumd --bin reticulumd interfaces::ble::"
 
   interfaces-test-ble-macos:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -169,6 +180,7 @@ jobs:
         run: "cargo test -p reticulumd --bin reticulumd interfaces::ble::"
 
   interfaces-test-ble-windows:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -182,6 +194,7 @@ jobs:
         run: "cargo test -p reticulumd --bin reticulumd interfaces::ble::"
 
   interfaces-test-lora:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -199,6 +212,7 @@ jobs:
         run: cargo test -p reticulumd --bin reticulumd lora_state::tests
 
   interfaces-test-mobile-contract:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -218,6 +232,7 @@ jobs:
           cargo test -p test-support --test mobile_ble_android_conformance --test mobile_ble_ios_conformance
 
   interfaces-boundary-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -235,6 +250,7 @@ jobs:
         run: bash tools/scripts/check-boundaries.sh
 
   interfaces-required:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     needs:
       - interfaces-build-linux
@@ -263,6 +279,7 @@ jobs:
         run: cargo xtask ci --stage interfaces-required
 
   embedded-node-build:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -280,6 +297,7 @@ jobs:
         run: cargo xtask ci --stage embedded-node-build
 
   embedded-node-contract:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -297,6 +315,7 @@ jobs:
         run: cargo xtask ci --stage embedded-node-contract
 
   embedded-node-failure-matrix:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -314,6 +333,7 @@ jobs:
         run: cargo xtask ci --stage embedded-node-failure-matrix
 
   embedded-node-hil:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -358,6 +378,7 @@ jobs:
         run: cargo xtask ci --stage test-nextest-unit
 
   test-integration:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -392,6 +413,7 @@ jobs:
         run: cargo xtask ci --stage doc
 
   sdk-docs-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -409,6 +431,7 @@ jobs:
         run: cargo xtask ci --stage sdk-docs-check
 
   sdk-cookbook-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -426,6 +449,7 @@ jobs:
         run: cargo xtask ci --stage sdk-cookbook-check
 
   sdk-ergonomics-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -443,6 +467,7 @@ jobs:
         run: cargo xtask ci --stage sdk-ergonomics-check
 
   lxmf-cli-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -460,6 +485,7 @@ jobs:
         run: cargo xtask ci --stage lxmf-cli-check
 
   reference-integration-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -477,6 +503,7 @@ jobs:
         run: cargo xtask ci --stage reference-integration-check
 
   dx-bootstrap-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -494,6 +521,7 @@ jobs:
         run: cargo xtask ci --stage dx-bootstrap-check
 
   sdk-incident-runbook-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -511,6 +539,7 @@ jobs:
         run: cargo xtask ci --stage sdk-incident-runbook-check
 
   sdk-drill-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -528,6 +557,7 @@ jobs:
         run: cargo xtask ci --stage sdk-drill-check
 
   sdk-soak-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -549,6 +579,7 @@ jobs:
           path: target/soak/soak-report.json
 
   security:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -569,6 +600,7 @@ jobs:
         run: cargo xtask ci --stage security
 
   crypto-agility-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -586,6 +618,7 @@ jobs:
         run: cargo xtask ci --stage crypto-agility-check
 
   key-management-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -603,6 +636,7 @@ jobs:
         run: cargo xtask ci --stage key-management-check
 
   supply-chain-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -627,6 +661,7 @@ jobs:
             target/supply-chain/provenance/artifact-provenance.sha256
 
   reproducible-build-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -648,6 +683,7 @@ jobs:
           path: target/supply-chain/reproducible/reproducible-build-report.txt
 
   unused-deps:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -670,6 +706,7 @@ jobs:
         run: cargo xtask ci --stage unused-deps
 
   api-surface-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     env:
       SDK_API_BREAK_TOOLCHAIN: nightly-2026-02-15
@@ -694,6 +731,7 @@ jobs:
         run: cargo xtask ci --stage api-surface-check
 
   sdk-schema-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -711,6 +749,7 @@ jobs:
         run: cargo xtask ci --stage sdk-schema-check
 
   interop-artifacts:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -728,6 +767,7 @@ jobs:
         run: cargo xtask ci --stage interop-artifacts
 
   schema-client-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -749,6 +789,7 @@ jobs:
           path: target/interop/schema-client-smoke-report.txt
 
   compat-kit-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -766,6 +807,7 @@ jobs:
         run: cargo xtask ci --stage compat-kit-check
 
   compliance-profile-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -783,6 +825,7 @@ jobs:
         run: cargo xtask ci --stage compliance-profile-check
 
   e2e-compatibility:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -800,6 +843,7 @@ jobs:
         run: cargo xtask ci --stage e2e-compatibility
 
   sdk-conformance:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -817,6 +861,7 @@ jobs:
         run: cargo xtask ci --stage sdk-conformance
 
   sdk-wrapper-parity:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -834,6 +879,7 @@ jobs:
         run: cargo test -p test-support sdk_wrapper_parity_release_gate
 
   kotlin-wrapper-conformance:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -856,6 +902,7 @@ jobs:
         run: gradle -p wrappers/kotlin-mobile test
 
   sdk-security-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -873,6 +920,7 @@ jobs:
         run: cargo xtask ci --stage sdk-security-check
 
   sdk-fuzz-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -890,6 +938,7 @@ jobs:
         run: cargo xtask ci --stage sdk-fuzz-check
 
   sdk-property-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -907,6 +956,7 @@ jobs:
         run: cargo xtask ci --stage sdk-property-check
 
   sdk-model-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -924,6 +974,7 @@ jobs:
         run: cargo xtask ci --stage sdk-model-check
 
   sdk-race-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -941,6 +992,7 @@ jobs:
         run: cargo xtask ci --stage sdk-race-check
 
   sdk-replay-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -958,6 +1010,7 @@ jobs:
         run: cargo xtask ci --stage sdk-replay-check
 
   sdk-metrics-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -975,6 +1028,7 @@ jobs:
         run: cargo xtask ci --stage sdk-metrics-check
 
   sdk-bench-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -998,6 +1052,7 @@ jobs:
             target/criterion/**/estimates.json
 
   sdk-perf-budget-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1021,6 +1076,7 @@ jobs:
             target/criterion/bench-summary.txt
 
   release-scorecard-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1044,6 +1100,7 @@ jobs:
             target/release-scorecard/release-scorecard.json
 
   canary-criteria-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1067,6 +1124,7 @@ jobs:
             target/release-readiness/canary-criteria-report.json
 
   sdk-memory-budget-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1084,6 +1142,7 @@ jobs:
         run: cargo xtask ci --stage sdk-memory-budget-check
 
   sdk-queue-pressure-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1101,6 +1160,7 @@ jobs:
         run: cargo xtask ci --stage sdk-queue-pressure-check
 
   sdk-matrix-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1118,6 +1178,7 @@ jobs:
         run: cargo xtask ci --stage sdk-matrix-check
 
   embedded-link-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1135,6 +1196,7 @@ jobs:
         run: cargo xtask ci --stage embedded-link-check
 
   embedded-core-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1152,6 +1214,7 @@ jobs:
         run: cargo xtask ci --stage embedded-core-check
 
   embedded-footprint-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1173,6 +1236,7 @@ jobs:
           path: target/embedded/footprint-report.txt
 
   sdk-profile-build:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1190,6 +1254,7 @@ jobs:
         run: cargo xtask ci --stage sdk-profile-build
 
   sdk-examples-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1207,6 +1272,7 @@ jobs:
         run: cargo xtask ci --stage sdk-examples-check
 
   sdk-api-break:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     env:
       SDK_API_BREAK_TOOLCHAIN: nightly-2026-02-15
@@ -1231,6 +1297,7 @@ jobs:
         run: cargo xtask ci --stage sdk-api-break
 
   sdk-migration-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1248,6 +1315,7 @@ jobs:
         run: cargo xtask ci --stage sdk-migration-check
 
   changelog-migration-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1269,6 +1337,7 @@ jobs:
           path: target/release-readiness/generated-migration-notes.md
 
   governance-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1286,6 +1355,7 @@ jobs:
         run: cargo xtask ci --stage governance-check
 
   support-policy-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1303,6 +1373,7 @@ jobs:
         run: cargo xtask ci --stage support-policy-check
 
   unsafe-audit-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1320,6 +1391,7 @@ jobs:
         run: cargo xtask ci --stage unsafe-audit-check
 
   extension-registry-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1337,6 +1409,7 @@ jobs:
         run: cargo xtask ci --stage extension-registry-check
 
   plugin-negotiation-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1354,6 +1427,7 @@ jobs:
         run: cargo xtask ci --stage plugin-negotiation-check
 
   certification-report-check:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1377,6 +1451,7 @@ jobs:
             target/release-readiness/certification-report.json
 
   forbidden-deps:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1394,6 +1469,7 @@ jobs:
         run: cargo xtask ci --stage forbidden-deps
 
   architecture-lint:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1411,6 +1487,7 @@ jobs:
         run: cargo xtask ci --stage architecture-lint
 
   architecture-checks:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1428,6 +1505,7 @@ jobs:
         run: cargo xtask ci --stage architecture-checks
 
   migration-checks:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-interop.yml
+++ b/.github/workflows/python-interop.yml
@@ -2,6 +2,7 @@ name: Python reference interop
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:
@@ -19,6 +20,7 @@ env:
 
 jobs:
   python-reference-interop:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     name: Validate PR against pinned Python reference
     runs-on: ubuntu-latest
     timeout-minutes: 45


### PR DESCRIPTION
## Summary
- keep only five critical CI jobs running on every PR: quality, correctness, build-matrix, test-nextest-unit, and contracts
- gate the remaining CI jobs behind the run-full-CI label or manual workflow dispatch
- add PR CI concurrency so stale PR runs are cancelled instead of piling up

## Validation
- parsed .github/workflows/ci.yml and .github/workflows/python-interop.yml with PyYAML
- verified ci.yml has 78 jobs total: 5 ungated and 73 gated