### PR TITLE
[codex] close C09 unknown handle conformance

### DIFF
--- a/crates/libs/test-support/src/sdk_conformance/mod.rs
+++ b/crates/libs/test-support/src/sdk_conformance/mod.rs
@@ -1184,6 +1184,28 @@ fn sdk_conformance_cancel_accepted_and_too_late_paths() {
     assert_eq!(too_late, CancelResult::TooLateToCancel);
 }
 
+#[tokio::test]
+async fn sdk_conformance_unknown_message_status_and_cancel() {
+    let harness = RpcHarness::new();
+    let client = harness.client();
+    client.start(base_start_request()).expect("start");
+
+    let unknown = MessageId("unknown-conformance-message".to_owned());
+    assert!(
+        client.status(unknown.clone()).expect("sync status").is_none(),
+        "unknown sync status must return no delivery snapshot"
+    );
+    assert!(
+        client.status_async(unknown.clone()).await.expect("async status").is_none(),
+        "unknown async status must return no delivery snapshot"
+    );
+    assert_eq!(
+        client.cancel(unknown).expect("cancel unknown message"),
+        CancelResult::NotFound,
+        "unknown cancel must return the typed equivalent of false"
+    );
+}
+
 #[test]
 fn sdk_conformance_configure_cas_conflict() {
     let harness = RpcHarness::new();

--- a/docs/async-conformance-matrix.md
+++ b/docs/async-conformance-matrix.md
@@ -1,6 +1,6 @@
 # Async Contract Conformance Matrix
 
-Last updated: 2026-02-20
+Last updated: 2026-06-09
 
 This matrix defines first-pass scenarios for validating the async client contract in `docs/lxmf-async-api.yaml` across adapters and interop paths.
 
@@ -34,7 +34,7 @@ Every scenario should run in all four lanes unless marked optional.
 | C06 | Ignore policy | Ignored destination yields terminal `failed` or `rejected` equivalent with normalized detail `ignored` | not-started | not-started | not-started | not-started |
 | C07 | Progress monotonicity | Progress events never decrease and never exceed `100` | not-started | not-started | not-started | not-started |
 | C08 | Event ordering | Per-handle event order is causal: progress before terminal | not-started | not-started | not-started | not-started |
-| C09 | Unknown handle lookup | `status(unknown)=null`, `cancel(unknown)=false` | not-started | not-started | not-started | not-started |
+| C09 | Unknown handle lookup | `status(unknown)=null`, `cancel(unknown)=false` (`CancelResult::NotFound` in the typed Rust API) | not-started | not-started | not-started | done |
 | C10 | Adapter deferred path | Backend transport failure maps to normalized deferred/failed status without panic | not-started | optional | optional | not-started |
 
 ## Extension scenarios


### PR DESCRIPTION
## Summary
- add L4 SDK conformance coverage for unknown message status through sync and async APIs
- verify unknown cancellation returns the typed `CancelResult::NotFound` equivalent of `false`
- promote async conformance matrix scenario C09 to done for L4

## Why
C09 is part of the required first-pass release gate, but the implemented behavior lacked public conformance evidence and the matrix remained stale.

## Validation
- `cargo run -p xtask -- sdk-conformance` (56 passed)
- `cargo test -p test-support sdk_conformance_unknown_message_status_and_cancel -- --nocapture`