### PR TITLE
[codex] Enable Android BLE native gates

### DIFF
--- a/crates/apps/reticulumd/Cargo.toml
+++ b/crates/apps/reticulumd/Cargo.toml
@@ -56,7 +56,7 @@ path = "src/bin/reticulumd/main.rs"
 name = "lxm-interchange"
 path = "src/bin/lxm-interchange.rs"
 
-[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
 btleplug = "0.11.8"
 futures = "0.3.31"
 uuid = "1.16.0"

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/android.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/android.rs
@@ -1,0 +1,13 @@
+use super::{native, BleRuntimeSettings};
+use reticulum_daemon::config::InterfaceConfig;
+use rns_transport::hash::AddressHash;
+use rns_transport::iface::InterfaceManager;
+use std::sync::Arc;
+
+pub(super) async fn spawn(
+    iface_manager: Arc<tokio::sync::Mutex<InterfaceManager>>,
+    iface: &InterfaceConfig,
+    settings: BleRuntimeSettings,
+) -> Result<AddressHash, String> {
+    native::spawn_with_backend("android", iface_manager, iface, settings).await
+}

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/mod.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/mod.rs
@@ -4,11 +4,13 @@ use rns_transport::iface::InterfaceManager;
 use std::sync::Arc;
 use std::time::Duration;
 
+#[cfg(target_os = "android")]
+mod android;
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "macos")]
 mod macos;
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 mod native;
 #[cfg(target_os = "windows")]
 mod windows;
@@ -123,6 +125,10 @@ pub(crate) async fn spawn(
 ) -> Result<AddressHash, String> {
     let settings = runtime_settings(iface)?;
 
+    #[cfg(target_os = "android")]
+    {
+        return android::spawn(iface_manager, iface, settings).await;
+    }
     #[cfg(target_os = "linux")]
     {
         return linux::spawn(iface_manager, iface, settings).await;

--- a/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
@@ -1571,6 +1571,34 @@ fn kiss_docs_document_bearers_and_vtn76_bluetooth() {
 }
 
 #[test]
+fn android_ble_native_target_gates_include_android() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..");
+    let reticulumd_manifest =
+        fs::read_to_string(repo_root.join("crates/apps/reticulumd/Cargo.toml"))
+            .expect("read reticulumd manifest");
+    let rns_tools_manifest = fs::read_to_string(repo_root.join("crates/apps/rns-tools/Cargo.toml"))
+        .expect("read rns-tools manifest");
+    let ble_mod = fs::read_to_string(
+        repo_root.join("crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/mod.rs"),
+    )
+    .expect("read reticulumd BLE module");
+    let rnx_ble = fs::read_to_string(repo_root.join("crates/apps/rns-tools/src/bin/rnx/ble.rs"))
+        .expect("read rns-tools BLE commands");
+
+    for (label, text) in [
+        ("reticulumd target dependencies", reticulumd_manifest.as_str()),
+        ("rns-tools target dependencies", rns_tools_manifest.as_str()),
+        ("reticulumd BLE dispatch", ble_mod.as_str()),
+        ("rns-tools BLE commands", rnx_ble.as_str()),
+    ] {
+        assert!(
+            text.contains("target_os = \"android\""),
+            "{label} should include android in native BLE target gates"
+        );
+    }
+}
+
+#[test]
 fn bootstrap_starts_udp_interface_from_config() {
     let temp = TempDir::new().expect("temp dir");
     let db_path = temp.path().join("reticulum.db");

--- a/crates/apps/rns-tools/Cargo.toml
+++ b/crates/apps/rns-tools/Cargo.toml
@@ -21,7 +21,7 @@ rns-embedded-core = { path = "../../libs/rns-embedded-core", version = "0.1.0" }
 rns-embedded-runtime = { path = "../../libs/rns-embedded-runtime", version = "0.1.0", features = ["std"] }
 rns_rpc = { package = "reticulum-rs-rpc", path = "../../libs/rns-rpc", version = "0.3.0" }
 
-[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
 btleplug = "0.11.8"
 futures = "0.3.31"
 uuid = "1.16.0"

--- a/crates/apps/rns-tools/src/bin/rnx.rs
+++ b/crates/apps/rns-tools/src/bin/rnx.rs
@@ -661,7 +661,7 @@ fn sha256_hex(bytes: &[u8]) -> String {
     out
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 fn hex_lower(bytes: &[u8]) -> String {
     let mut out = String::with_capacity(bytes.len() * 2);
     for byte in bytes {

--- a/crates/apps/rns-tools/src/bin/rnx/ble.rs
+++ b/crates/apps/rns-tools/src/bin/rnx/ble.rs
@@ -1,17 +1,32 @@
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 use btleplug::api::{Central, Manager as _, Peripheral as _, ScanFilter};
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 use btleplug::platform::{Manager, Peripheral};
 use std::io;
 use std::time::{Duration, Instant};
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 use crate::helpers::{
     ascii_lower, format_manufacturer_data, normalize_identifier, parse_gatt_uuid,
 };
 use crate::{hex_lower, NativePeerMode};
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(crate) fn run_camera_capture_upload(
     rpc: String,
     peripheral_id: String,
@@ -34,7 +49,12 @@ pub(crate) fn run_camera_capture_upload(
     )
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+)))]
 pub(crate) fn run_camera_capture_upload(
     _rpc: String,
     _peripheral_id: String,
@@ -45,10 +65,10 @@ pub(crate) fn run_camera_capture_upload(
     _chunk_size: usize,
     _timeout_secs: u64,
 ) -> io::Result<()> {
-    Err(io::Error::other("camera-capture-upload is only supported on linux/macos/windows"))
+    Err(io::Error::other("camera-capture-upload is only supported on android/linux/macos/windows"))
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(crate) fn run_ble_scan(
     timeout_secs: u64,
     limit: usize,
@@ -122,7 +142,7 @@ pub(crate) fn run_ble_scan(
     })
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(crate) fn run_ble_find_camera(
     scan_secs: u64,
     name_hint: String,
@@ -216,8 +236,7 @@ pub(crate) fn run_ble_find_camera(
     })
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(crate) fn run_ble_native_peer(
     scan_secs: u64,
     name_hint: String,
@@ -248,7 +267,12 @@ pub(crate) fn run_ble_native_peer(
     )
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+)))]
 pub(crate) fn run_ble_native_peer(
     _scan_secs: u64,
     _name_hint: String,
@@ -263,10 +287,10 @@ pub(crate) fn run_ble_native_peer(
     _source_hex: String,
     _timeout_secs: u64,
 ) -> io::Result<()> {
-    Err(io::Error::other("ble-native-peer is only supported on linux/macos/windows"))
+    Err(io::Error::other("ble-native-peer is only supported on android/linux/macos/windows"))
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(crate) fn run_ble_native_bridge(
     scan_secs: u64,
     name_hint: String,
@@ -299,7 +323,12 @@ pub(crate) fn run_ble_native_bridge(
     )
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+)))]
 pub(crate) fn run_ble_native_bridge(
     _scan_secs: u64,
     _name_hint: String,
@@ -315,9 +344,14 @@ pub(crate) fn run_ble_native_bridge(
     _timeout_secs: u64,
     _content_type: String,
 ) -> io::Result<()> {
-    Err(io::Error::other("ble-native-bridge is only supported on linux/macos/windows"))
+    Err(io::Error::other("ble-native-bridge is only supported on android/linux/macos/windows"))
 }
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+)))]
 pub(crate) fn run_ble_find_camera(
     _scan_secs: u64,
     _name_hint: String,
@@ -325,15 +359,20 @@ pub(crate) fn run_ble_find_camera(
     _write_char_uuid: String,
     _notify_char_uuid: String,
 ) -> io::Result<()> {
-    Err(io::Error::other("ble-find-camera is only supported on linux/macos/windows"))
+    Err(io::Error::other("ble-find-camera is only supported on android/linux/macos/windows"))
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+)))]
 pub(crate) fn run_ble_scan(
     _timeout_secs: u64,
     _limit: usize,
     _service_uuid: Option<String>,
     _manufacturer_prefix: Option<String>,
 ) -> io::Result<()> {
-    Err(io::Error::other("ble-scan is only supported on linux/macos/windows"))
+    Err(io::Error::other("ble-scan is only supported on android/linux/macos/windows"))
 }

--- a/crates/apps/rns-tools/src/bin/rnx/ble_camera.rs
+++ b/crates/apps/rns-tools/src/bin/rnx/ble_camera.rs
@@ -1,21 +1,41 @@
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 use btleplug::api::{Central, CharPropFlags, Manager as _, Peripheral as _, ScanFilter, WriteType};
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 use btleplug::platform::Manager;
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 use futures::StreamExt;
 
 use std::io;
 use std::time::{Duration, Instant};
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "windows"))]
 use crate::helpers::find_camera_peripheral_by_profile;
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 use crate::helpers::{find_peripheral, parse_gatt_uuid};
 use crate::upload_attachment_via_rpc;
 use rns_rpc::e2e_harness::timestamp_millis;
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(crate) fn run_camera_capture_upload(
     rpc: String,
     peripheral_id: String,
@@ -52,7 +72,12 @@ fn camera_capture_upload_success_line(bytes: usize, attachment_id: &str) -> Stri
     format!("CAMERA_CAPTURE_UPLOAD ok: bytes={bytes} attachment_id={attachment_id}")
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+)))]
 pub(crate) fn run_camera_capture_upload(
     _rpc: String,
     _peripheral_id: String,
@@ -63,10 +88,10 @@ pub(crate) fn run_camera_capture_upload(
     _chunk_size: usize,
     _timeout_secs: u64,
 ) -> io::Result<()> {
-    Err(io::Error::other("camera-capture-upload is only supported on linux/macos/windows"))
+    Err(io::Error::other("camera-capture-upload is only supported on android/linux/macos/windows"))
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 fn capture_camera_over_ble(
     peripheral_id: &str,
     service_uuid: &str,

--- a/crates/apps/rns-tools/src/bin/rnx/ble_helpers.rs
+++ b/crates/apps/rns-tools/src/bin/rnx/ble_helpers.rs
@@ -1,8 +1,23 @@
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 use btleplug::api::{Central, Peripheral as _};
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 use btleplug::platform::Peripheral;
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 use uuid::Uuid;
 
 use std::io;
@@ -10,7 +25,7 @@ use std::time::{Duration, Instant};
 
 use crate::hex_lower;
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(super) fn format_manufacturer_data(data: &std::collections::HashMap<u16, Vec<u8>>) -> String {
     let mut entries: Vec<String> = data
         .iter()
@@ -22,7 +37,7 @@ pub(super) fn format_manufacturer_data(data: &std::collections::HashMap<u16, Vec
     format!("[{}]", entries.join(","))
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 fn ascii_safe(bytes: &[u8]) -> String {
     bytes
         .iter()
@@ -30,12 +45,12 @@ fn ascii_safe(bytes: &[u8]) -> String {
         .collect()
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(super) fn ascii_lower(bytes: &[u8]) -> String {
     ascii_safe(bytes).to_lowercase()
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(super) async fn find_peripheral(
     adapter: &btleplug::platform::Adapter,
     peripheral_id: &str,
@@ -57,7 +72,7 @@ pub(super) async fn find_peripheral(
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "windows"))]
 pub(super) async fn find_camera_peripheral_by_profile(
     adapter: &btleplug::platform::Adapter,
     peripheral_hint: &str,
@@ -116,7 +131,7 @@ pub(super) async fn find_camera_peripheral_by_profile(
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 async fn peripheral_matches(
     peripheral: &Peripheral,
     configured_id: &str,
@@ -144,14 +159,14 @@ async fn peripheral_matches(
     Ok(false)
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 fn identifiers_match(configured: &str, discovered: &str) -> bool {
     let configured = normalize_identifier(configured);
     let discovered = normalize_identifier(discovered);
     configured == discovered || discovered.contains(&configured) || configured.contains(&discovered)
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(super) fn normalize_identifier(value: &str) -> String {
     value
         .trim()
@@ -161,7 +176,7 @@ pub(super) fn normalize_identifier(value: &str) -> String {
         .collect()
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(super) fn parse_gatt_uuid(value: &str) -> io::Result<Uuid> {
     let normalized = value.trim();
     if normalized.len() == 4 && normalized.chars().all(|ch| ch.is_ascii_hexdigit()) {

--- a/crates/apps/rns-tools/src/bin/rnx/ble_native.rs
+++ b/crates/apps/rns-tools/src/bin/rnx/ble_native.rs
@@ -1,8 +1,23 @@
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 use btleplug::api::{Central, CharPropFlags, Manager as _, Peripheral as _, ScanFilter, WriteType};
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 use btleplug::platform::{Manager, Peripheral};
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 use futures::StreamExt;
 
 use std::io;
@@ -22,7 +37,7 @@ use rns_embedded_runtime::{
 
 use super::helpers::{find_peripheral, parse_gatt_uuid};
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(crate) fn run_ble_native_peer(
     scan_secs: u64,
     name_hint: String,
@@ -188,7 +203,7 @@ pub(crate) fn run_ble_native_peer(
     })
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(crate) fn run_ble_native_bridge(
     scan_secs: u64,
     name_hint: String,

--- a/docs/runbooks/reticulumd-ble-interface.md
+++ b/docs/runbooks/reticulumd-ble-interface.md
@@ -7,7 +7,7 @@ This runbook documents configuration, startup semantics, and recovery for `ble_g
 ## Scope
 
 - Interface kind: `ble_gatt`
-- Backends: Linux, macOS, Windows
+- Backends: Android, Linux, macOS, Windows
 - Startup lifecycle: daemon bootstrap only
 - Runtime mutation policy: `set_interfaces`/`reload_config` with `ble_gatt` changes require restart
 
@@ -51,6 +51,11 @@ interfaces = [
 6. Startup emits a deterministic configuration line with adapter/peripheral/service/characteristic IDs plus lifecycle attempt/transition counts.
 7. Invalid runtime bounds are rejected before backend startup.
 
+Android builds use the same native `btleplug` backend path as the desktop
+targets. The embedding Android app must package and initialize the `btleplug`
+Java/JNI support before adapter enumeration; otherwise BLE startup fails at
+runtime before any silent fallback path is used.
+
 Startup policy controls:
 
 - Default mode is best-effort (daemon continues in degraded mode when some interfaces fail).
@@ -60,6 +65,7 @@ Startup policy controls:
 
 Expected startup log examples:
 
+- `ble_gatt configured (android backend) ...`
 - `ble_gatt configured (linux backend) ...`
 - `ble_gatt configured (macos backend) ...`
 - `ble_gatt configured (windows backend) ...`
@@ -90,6 +96,7 @@ Runtime status visibility:
 cargo test -p reticulumd --test config
 cargo test -p reticulumd --bin reticulumd runtime_settings
 cargo check -p reticulumd --all-targets
+cargo check -p reticulumd --target aarch64-linux-android --features rnode-ble
 ```
 
 ## Rollback


### PR DESCRIPTION
﻿## Summary
- Includes Android in the native BLE target gates for `reticulumd` and `rns-tools` so Android no longer falls through to unsupported-target paths.
- Adds an Android `reticulumd` BLE backend wrapper that routes `ble_gatt` startup through the existing native `btleplug` implementation.
- Documents the Android `btleplug` Java/JNI packaging and initialization requirement in the BLE runbook.

## Root Cause
Android had mobile BLE contract fixtures, but the native BLE dependency and module cfg gates only listed Linux, macOS, and Windows. That let Android builds omit the native BLE path instead of failing or starting through an explicit Android backend.

Closes #246

## Test Plan
- `cargo test -p lxmf-sdk --test mobile_ble_contract`
- `cargo test -p test-support --test mobile_ble_android_conformance`
- `cargo test -p reticulumd --bin reticulumd ble_lifecycle`
- `cargo test -p reticulumd --bin reticulumd bootstrap_best_effort_marks_ble_validation_failure_as_failed`
- `cargo check -p reticulumd --target aarch64-linux-android --features rnode-ble`
- `cargo check -p rns-tools --target aarch64-linux-android`
- `cargo test -p reticulumd --bin reticulumd android_ble_native_target_gates_include_android`
- `cargo fmt --all -- --check`
- `git diff --check`
- `rg -n 'target_os = "linux", target_os = "macos", target_os = "windows"' crates/apps/reticulumd crates/apps/rns-tools`
