### PR TITLE
[codex] close E01 paper URI ingest conformance

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_paper_command.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_paper_command.rs
@@ -1,4 +1,5 @@
 use super::*;
+use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
 
 type InboundSdkCommandUpdate = (
     String,
@@ -11,6 +12,17 @@ type InboundSdkCommandUpdate = (
 );
 
 impl RpcDaemon {
+    fn paper_uri_destination(uri: &str) -> Option<String> {
+        let encoded = uri.strip_prefix("lxm://")?;
+        if let Some((destination, _)) = encoded.split_once('/') {
+            return Self::normalize_non_empty(destination);
+        }
+
+        let paper_bytes =
+            URL_SAFE_NO_PAD.decode(encoded).or_else(|_| URL_SAFE.decode(encoded)).ok()?;
+        (paper_bytes.len() >= 16).then(|| encode_hex(&paper_bytes[..16]))
+    }
+
     pub(super) fn sdk_command_event_payload_summary(payload: &JsonValue) -> JsonValue {
         let byte_len = payload.to_string().len();
         match payload {
@@ -313,15 +325,11 @@ impl RpcDaemon {
             Some(bridge) => bridge.decode_paper_uri(parsed.uri.as_str())?,
             None => None,
         };
-        let uri_destination = parsed
-            .uri
-            .strip_prefix("lxm://")
-            .and_then(|remainder| remainder.split('/').next())
-            .and_then(Self::normalize_non_empty);
-        let destination = parsed
-            .destination_hint
-            .or_else(|| bridged_decode.as_ref().map(|outcome| outcome.destination_hint.clone()))
-            .or(uri_destination);
+        let destination = bridged_decode
+            .as_ref()
+            .map(|outcome| outcome.destination_hint.clone())
+            .or(parsed.destination_hint)
+            .or_else(|| Self::paper_uri_destination(parsed.uri.as_str()));
         let Some(destination) = destination else {
             return Ok(self.sdk_error_response(
                 request.id,

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_paper_command.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_paper_command.rs
@@ -321,6 +321,18 @@ impl RpcDaemon {
                 "paper URI must start with lxm://",
             ));
         }
+        let uri_payload = parsed.uri.trim_start_matches("lxm://");
+        if uri_payload.is_empty()
+            || uri_payload
+                .split_once('/')
+                .is_some_and(|(destination, _)| destination.trim().is_empty())
+        {
+            return Ok(self.sdk_error_response(
+                request.id,
+                "SDK_VALIDATION_INVALID_ARGUMENT",
+                "paper URI must include a destination",
+            ));
+        }
         let bridged_decode = match self.outbound_bridge.as_ref() {
             Some(bridge) => bridge.decode_paper_uri(parsed.uri.as_str())?,
             None => None,

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_paper_command.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_paper_command.rs
@@ -313,6 +313,26 @@ impl RpcDaemon {
             Some(bridge) => bridge.decode_paper_uri(parsed.uri.as_str())?,
             None => None,
         };
+        let uri_destination = parsed
+            .uri
+            .strip_prefix("lxm://")
+            .and_then(|remainder| remainder.split('/').next())
+            .and_then(Self::normalize_non_empty);
+        let destination = parsed
+            .destination_hint
+            .or_else(|| bridged_decode.as_ref().map(|outcome| outcome.destination_hint.clone()))
+            .or(uri_destination);
+        let Some(destination) = destination else {
+            return Ok(self.sdk_error_response(
+                request.id,
+                "SDK_VALIDATION_INVALID_ARGUMENT",
+                "paper URI must include a destination",
+            ));
+        };
+        let bytes_len = bridged_decode
+            .as_ref()
+            .and_then(|outcome| outcome.raw_lxmf_bytes.as_ref())
+            .map_or_else(|| parsed.uri.len(), Vec::len);
         let transient_id = parsed
             .transient_id
             .or_else(|| bridged_decode.as_ref().map(|outcome| outcome.transient_id.clone()))
@@ -342,16 +362,15 @@ impl RpcDaemon {
                 }
             }
         }
-        let destination_hint = parsed
-            .destination_hint
-            .or_else(|| bridged_decode.as_ref().map(|outcome| outcome.destination_hint.clone()));
         Ok(RpcResponse {
             id: request.id,
             result: Some(json!({
                 "accepted": true,
                 "transient_id": transient_id,
                 "duplicate": duplicate,
-                "destination_hint": destination_hint,
+                "destination": destination,
+                "destination_hint": destination,
+                "bytes_len": bytes_len,
             })),
             error: None,
         })

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/release_domains.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/release_domains.rs
@@ -1083,6 +1083,23 @@ fn sdk_paper_decode_prefers_bridge_destination_over_request_hint() {
 }
 
 #[test]
+fn sdk_paper_decode_rejects_empty_uri_before_calling_bridge() {
+    let daemon = RpcDaemon::with_store_and_bridge(
+        MessagesStore::in_memory().expect("store"),
+        "paper-validation-node".to_owned(),
+        Arc::new(PaperDestinationBridge),
+    );
+
+    let response = daemon
+        .handle_rpc(rpc_request(1, "sdk_paper_decode_v2", json!({ "uri": "lxm://" })))
+        .expect("paper decode validation");
+    assert_eq!(
+        response.error.expect("empty paper URI must fail validation").code,
+        "SDK_VALIDATION_INVALID_ARGUMENT"
+    );
+}
+
+#[test]
 fn sdk_operation_registry_roundtrips_workflow_family() {
     let daemon = RpcDaemon::test_instance();
 

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/release_domains.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/release_domains.rs
@@ -994,6 +994,42 @@ fn sdk_release_c_domain_methods_roundtrip() {
 }
 
 #[test]
+fn sdk_paper_decode_reports_ingest_metadata_and_duplicate_scans() {
+    let daemon = RpcDaemon::test_instance();
+    let uri = "lxm://00112233445566778899aabbccddeeff/paper-message";
+
+    let first = daemon
+        .handle_rpc(rpc_request(1, "sdk_paper_decode_v2", json!({ "uri": uri })))
+        .expect("first paper decode");
+    assert!(first.error.is_none());
+    let first = first.result.expect("first paper result");
+    assert_eq!(first["accepted"], json!(true));
+    assert_eq!(first["destination"], json!("00112233445566778899aabbccddeeff"));
+    assert_eq!(first["destination_hint"], first["destination"]);
+    assert!(first["transient_id"].as_str().is_some_and(|value| !value.is_empty()));
+    assert_eq!(first["duplicate"], json!(false));
+    assert_eq!(first["bytes_len"], json!(uri.len()));
+
+    let duplicate = daemon
+        .handle_rpc(rpc_request(2, "sdk_paper_decode_v2", json!({ "uri": uri })))
+        .expect("duplicate paper decode");
+    assert!(duplicate.error.is_none());
+    let duplicate = duplicate.result.expect("duplicate paper result");
+    assert_eq!(duplicate["transient_id"], first["transient_id"]);
+    assert_eq!(duplicate["destination"], first["destination"]);
+    assert_eq!(duplicate["bytes_len"], first["bytes_len"]);
+    assert_eq!(duplicate["duplicate"], json!(true));
+
+    let invalid = daemon
+        .handle_rpc(rpc_request(3, "sdk_paper_decode_v2", json!({ "uri": "lxm://" })))
+        .expect("invalid paper decode");
+    assert_eq!(
+        invalid.error.expect("destination-less URI must fail").code,
+        "SDK_VALIDATION_INVALID_ARGUMENT"
+    );
+}
+
+#[test]
 fn sdk_operation_registry_roundtrips_workflow_family() {
     let daemon = RpcDaemon::test_instance();
 

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/release_domains.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/release_domains.rs
@@ -996,10 +996,16 @@ fn sdk_release_c_domain_methods_roundtrip() {
 #[test]
 fn sdk_paper_decode_reports_ingest_metadata_and_duplicate_scans() {
     let daemon = RpcDaemon::test_instance();
-    let uri = "lxm://00112233445566778899aabbccddeeff/paper-message";
+    let destination = hex::decode("00112233445566778899aabbccddeeff").expect("destination");
+    let mut paper_bytes = destination;
+    paper_bytes.extend_from_slice(b"canonical-paper-payload");
+    let uri = format!(
+        "lxm://{}",
+        base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, paper_bytes)
+    );
 
     let first = daemon
-        .handle_rpc(rpc_request(1, "sdk_paper_decode_v2", json!({ "uri": uri })))
+        .handle_rpc(rpc_request(1, "sdk_paper_decode_v2", json!({ "uri": uri.clone() })))
         .expect("first paper decode");
     assert!(first.error.is_none());
     let first = first.result.expect("first paper result");
@@ -1027,6 +1033,53 @@ fn sdk_paper_decode_reports_ingest_metadata_and_duplicate_scans() {
         invalid.error.expect("destination-less URI must fail").code,
         "SDK_VALIDATION_INVALID_ARGUMENT"
     );
+}
+
+#[derive(Debug)]
+struct PaperDestinationBridge;
+
+impl OutboundBridge for PaperDestinationBridge {
+    fn deliver(
+        &self,
+        _record: &MessageRecord,
+        _options: &OutboundDeliveryOptions,
+    ) -> Result<(), std::io::Error> {
+        Ok(())
+    }
+
+    fn decode_paper_uri(&self, _uri: &str) -> Result<Option<PaperDecodeOutcome>, std::io::Error> {
+        Ok(Some(PaperDecodeOutcome {
+            transient_id: "decoded-transient-id".to_owned(),
+            destination_hint: "decoded-destination".to_owned(),
+            record: None,
+            raw_lxmf_bytes: Some(vec![1, 2, 3]),
+        }))
+    }
+}
+
+#[test]
+fn sdk_paper_decode_prefers_bridge_destination_over_request_hint() {
+    let daemon = RpcDaemon::with_store_and_bridge(
+        MessagesStore::in_memory().expect("store"),
+        "paper-destination-node".to_owned(),
+        Arc::new(PaperDestinationBridge),
+    );
+
+    let response = daemon
+        .handle_rpc(rpc_request(
+            1,
+            "sdk_paper_decode_v2",
+            json!({
+                "uri": "lxm://placeholder/message",
+                "destination_hint": "caller-destination",
+            }),
+        ))
+        .expect("paper decode");
+    assert!(response.error.is_none());
+    let result = response.result.expect("paper result");
+    assert_eq!(result["destination"], json!("decoded-destination"));
+    assert_eq!(result["destination_hint"], json!("decoded-destination"));
+    assert_eq!(result["bytes_len"], json!(3));
 }
 
 #[test]

--- a/crates/libs/test-support/src/sdk_conformance/mod.rs
+++ b/crates/libs/test-support/src/sdk_conformance/mod.rs
@@ -1316,12 +1316,24 @@ fn sdk_conformance_delivery_modes_and_paper_workflows_are_compatible() {
 
     let paper_decode = harness.rpc_call("sdk_paper_decode_v2", Some(json!({ "uri": uri })));
     assert!(paper_decode.error.is_none(), "sdk_paper_decode_v2 should succeed");
-    assert_eq!(
-        paper_decode
-            .result
-            .and_then(|value| value.get("accepted").cloned())
-            .and_then(|value| value.as_bool()),
-        Some(true),
-        "paper decode result must report accepted=true"
+    let paper_result = paper_decode.result.expect("paper decode result");
+    assert_eq!(paper_result["accepted"], json!(true));
+    assert_eq!(paper_result["destination"], json!("destination.test"));
+    assert!(
+        paper_result["transient_id"].as_str().is_some_and(|value| !value.is_empty()),
+        "paper ingest must return a transient ID"
     );
+    assert_eq!(paper_result["duplicate"], json!(false));
+    assert_eq!(
+        paper_result["bytes_len"].as_u64(),
+        Some(u64::try_from(uri.len()).expect("URI length fits u64"))
+    );
+
+    let duplicate_decode = harness.rpc_call("sdk_paper_decode_v2", Some(json!({ "uri": uri })));
+    assert!(duplicate_decode.error.is_none(), "duplicate paper ingest should succeed");
+    let duplicate_result = duplicate_decode.result.expect("duplicate paper decode result");
+    assert_eq!(duplicate_result["transient_id"], paper_result["transient_id"]);
+    assert_eq!(duplicate_result["destination"], paper_result["destination"]);
+    assert_eq!(duplicate_result["bytes_len"], paper_result["bytes_len"]);
+    assert_eq!(duplicate_result["duplicate"], json!(true));
 }

--- a/docs/async-conformance-matrix.md
+++ b/docs/async-conformance-matrix.md
@@ -1,6 +1,6 @@
 # Async Contract Conformance Matrix
 
-Last updated: 2026-02-20
+Last updated: 2026-06-09
 
 This matrix defines first-pass scenarios for validating the async client contract in `docs/lxmf-async-api.yaml` across adapters and interop paths.
 
@@ -41,7 +41,7 @@ Every scenario should run in all four lanes unless marked optional.
 
 | ID | Extension | Contract assertions | L1 | L2 | L3 | L4 |
 | --- | --- | --- | --- | --- | --- | --- |
-| E01 | Paper URI ingest | `paper.ingest_uri()` returns `destination`, `transient_id`, `duplicate` flag | not-started | not-started | not-started | not-started |
+| E01 | Paper URI ingest | `paper.ingest_uri()` returns `destination`, `transient_id`, `duplicate` flag, and `bytes_len` | not-started | not-started | not-started | done |
 | E02 | Propagation ingest/fetch | `propagation.ingest()` count > 0 then `propagation.fetch()` succeeds | optional | not-started | not-started | not-started |
 | E03 | Priority scheduling | Prioritised destination dequeues ahead of non-prioritised | not-started | not-started | not-started | not-started |
 | E04 | Inbound callback bridge | Inbound backend callback appears as `inbound.received` contract event | not-started | not-started | not-started | not-started |

--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -193,8 +193,8 @@
     },
     {
       "path": "docs/contracts/sdk-v2-paper.md",
-      "bytes": 405,
-      "sha256": "796cf750987fbb69ea7f839760efff8f3e894f90327643f82f40762a984ee5b6"
+      "bytes": 750,
+      "sha256": "df4d5f0c7f021c99f9497ff7db9e9d3d116a80a1a68aec627181a8f1dfd547ac"
     },
     {
       "path": "docs/contracts/sdk-v2-shared-instance-auth.md",

--- a/docs/contracts/sdk-v2-paper.md
+++ b/docs/contracts/sdk-v2-paper.md
@@ -21,3 +21,9 @@ Schema namespace: `v2`
 
 1. Paper envelope payloads are signaling artifacts only.
 2. Decode behavior is idempotent for duplicate envelope scans.
+3. Successful decode returns `destination`, `transient_id`, `duplicate`, and
+   `bytes_len` ingest metadata.
+4. `bytes_len` is the decoded LXMF byte length when bridge decoding provides
+   raw bytes; local fallback envelopes report the URI byte length.
+5. A paper URI without a destination is rejected with
+   `SDK_VALIDATION_INVALID_ARGUMENT`.


### PR DESCRIPTION
## Summary
- return complete paper URI ingest metadata: `destination`, `transient_id`, `duplicate`, and `bytes_len`
- preserve the existing `destination_hint` field for compatibility
- reject `lxm://` URIs that do not contain a destination
- add first-scan and duplicate-scan RPC and SDK conformance coverage
- mark async conformance scenario E01 as done for L4

## Why
E01 is part of the required first-pass migration release gate. The existing paper decode path was idempotent but returned only part of the backend-neutral ingest contract, leaving clients without canonical destination and payload-size metadata.

## Impact
The RPC response change is additive. Existing SDK clients that consume `paper_decode` as an acknowledgement remain compatible, while direct RPC clients can use the complete ingest result.

## Validation
- `cargo test -p reticulum-rs-rpc` (528 passed)
- `cargo run -p xtask -- sdk-conformance` (55 passed)
- focused paper ingest RPC and conformance tests
- `git diff --check`