### PR TITLE
Close peer replication parity gaps

### DIFF
--- a/crates/apps/lxmf-cli/src/bin/lxmd.rs
+++ b/crates/apps/lxmf-cli/src/bin/lxmd.rs
@@ -637,6 +637,32 @@ enable_node = yes
     }
 
     #[test]
+    fn python_config_keeps_lxmf_peer_and_propagation_node_announce_intervals_separate() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_dir = temp.path().join("lxmd");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        let config_path = config_dir.join("config");
+        fs::write(
+            &config_path,
+            r#"
+[lxmf]
+announce_interval = 3
+
+[propagation]
+announce_interval = 2
+"#,
+        )
+        .expect("write config");
+
+        let args =
+            super::Args::parse_from(["lxmd", "--config", config_path.to_str().expect("utf8 path")]);
+        let effective = load_effective_args(&args).expect("effective args");
+
+        assert_eq!(effective.python_compat.peer_announce_interval_min, Some(3));
+        assert_eq!(effective.python_compat.node_announce_interval_min, Some(2));
+    }
+
+    #[test]
     fn python_config_sections_are_parsed() {
         let sections = parse_python_lxmd_config(
             r#"

--- a/crates/apps/lxmf-cli/src/bin/lxmd/config_python.rs
+++ b/crates/apps/lxmf-cli/src/bin/lxmd/config_python.rs
@@ -39,6 +39,8 @@ pub(crate) fn apply_python_config_file(
             .get("announce_at_start")
             .and_then(|value| parse_python_bool(value))
             .unwrap_or(false);
+        effective.python_compat.peer_announce_interval_min =
+            lxmf.get("announce_interval").and_then(|value| value.parse::<u64>().ok());
     }
 
     if let Some(propagation) = sections.get("propagation") {
@@ -101,8 +103,11 @@ pub(crate) fn apply_python_config_file(
             .unwrap_or(false);
         effective.python_compat.node_announce_interval_min =
             propagation.get("announce_interval").and_then(|value| value.parse::<u64>().ok());
-        effective.python_compat.peer_announce_interval_min =
-            propagation.get("peer_announce_interval").and_then(|value| value.parse::<u64>().ok());
+        if effective.python_compat.peer_announce_interval_min.is_none() {
+            effective.python_compat.peer_announce_interval_min = propagation
+                .get("peer_announce_interval")
+                .and_then(|value| value.parse::<u64>().ok());
+        }
     }
 
     effective.python_compat.allowed_identities =

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_propagation.rs
@@ -14,7 +14,9 @@ impl DeliveryTask {
             .and_then(|value| value.as_array())
             .and_then(|rows| {
                 rows.iter().find(|row| {
-                    row.get("peer").and_then(|value| value.as_str()) == Some(propagation_node_hex)
+                    row.get("peer")
+                        .and_then(|value| value.as_str())
+                        .is_some_and(|peer| peer.eq_ignore_ascii_case(propagation_node_hex))
                 })
             })
             .and_then(|row| row.get("propagation_stamp_cost"))

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests.rs
@@ -3,6 +3,45 @@ use rand_core::OsRng;
 use rns_rpc::{MessageRecord, MessagesStore};
 use rns_transport::transport::TransportConfig;
 
+fn delivery_task_for_propagation_cost_lookup(daemon: Arc<RpcDaemon>) -> DeliveryTask {
+    let signer = PrivateIdentity::new_from_name("propagation-cost-lookup-task");
+    let transport_identity = rns_transport::identity_bridge::to_transport_private_identity(&signer);
+    let transport = Arc::new(Transport::new(TransportConfig::new(
+        "propagation-cost-lookup-task",
+        &transport_identity,
+        true,
+    )));
+    let (receipt_tx, _receipt_rx) = tokio::sync::mpsc::channel(16);
+    let destination = [0u8; 16];
+    DeliveryTask {
+        daemon,
+        transport,
+        peer_crypto: Arc::new(Mutex::new(HashMap::new())),
+        outbound_propagation_identities: Arc::new(Mutex::new(HashMap::new())),
+        receipt_map: Arc::new(Mutex::new(HashMap::new())),
+        outbound_resource_map: Arc::new(Mutex::new(HashMap::new())),
+        outbound_propagation_link: Arc::new(tokio::sync::Mutex::new(None)),
+        receipt_tx,
+        message_id: "propagation-cost-lookup-message".to_string(),
+        source_hash: [1u8; 16],
+        destination,
+        destination_hash: AddressHash::new(destination),
+        destination_hex: hex::encode(destination),
+        title: String::new(),
+        content: String::new(),
+        fields: None,
+        signer,
+        stamp_cost: None,
+        outbound_ticket: None,
+        include_ticket: None,
+        peer_identity: None,
+        propagation_node_identity: None,
+        requested_method: RequestedDeliveryMethod::Propagated,
+        try_propagation_on_fail: false,
+        propagation_node_hex: None,
+    }
+}
+
 #[test]
 fn cancelled_status_detection_is_case_and_space_tolerant() {
     assert!(DeliveryTask::is_cancelled_status(Some("cancelled")));
@@ -518,4 +557,48 @@ async fn record_propagation_payload_metadata_persists_packed_bytes() {
     );
     assert_eq!(message["fields"]["_lxmf"]["propagation_packed_size"], json!(26));
     assert_eq!(message["fields"]["_lxmf"]["propagation_stamp_value"], json!(17));
+}
+
+#[tokio::test]
+async fn propagation_target_cost_matches_selected_node_case_insensitively() {
+    let daemon = Arc::new(RpcDaemon::test_instance());
+    daemon
+        .handle_rpc(RpcRequest {
+            id: 701,
+            method: "propagation_enable".to_string(),
+            params: Some(json!({
+                "enabled": true,
+                "autopeer": true,
+            })),
+        })
+        .expect("enable propagation");
+    let peer = "aabbccddeeff00112233445566778899";
+    let app_data = rmp_serde::to_vec_named(&rmpv::Value::Array(vec![
+        rmpv::Value::Boolean(false),
+        rmpv::Value::from(1_700_000_021i64),
+        rmpv::Value::Boolean(true),
+        rmpv::Value::from(333),
+        rmpv::Value::from(999),
+        rmpv::Value::Array(vec![rmpv::Value::from(23), rmpv::Value::from(2), rmpv::Value::from(5)]),
+        rmpv::Value::Map(Vec::new()),
+    ]))
+    .expect("encode propagation app data");
+    let announce = daemon
+        .handle_rpc(RpcRequest {
+            id: 702,
+            method: "announce_received".to_string(),
+            params: Some(json!({
+                "peer": peer,
+                "timestamp": 1_700_000_021i64,
+                "app_data_hex": hex::encode(app_data),
+                "aspect": "lxmf.propagation",
+                "hops": 1,
+            })),
+        })
+        .expect("announce received");
+    assert!(announce.error.is_none(), "unexpected announce error: {announce:?}");
+
+    let task = delivery_task_for_propagation_cost_lookup(daemon);
+
+    assert_eq!(task.propagation_target_cost(&peer.to_ascii_uppercase()), Some(23));
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_peer.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_peer.rs
@@ -82,7 +82,11 @@ fn peer_exists(daemon: &RpcDaemon, peer_hex: &str) -> bool {
         .and_then(|value| value.get("peers").cloned())
         .and_then(|value| value.as_array().cloned())
         .map(|rows| {
-            rows.iter().any(|row| row.get("peer").and_then(Value::as_str) == Some(peer_hex))
+            rows.iter().any(|row| {
+                row.get("peer")
+                    .and_then(Value::as_str)
+                    .is_some_and(|peer| peer.eq_ignore_ascii_case(peer_hex))
+            })
         })
         .unwrap_or(false)
 }
@@ -368,6 +372,53 @@ mod tests {
     }
 
     #[test]
+    fn peer_sync_command_accepts_case_variant_existing_peer_like_python() {
+        let peer_bytes = [0xCA; 16];
+        let stored_peer = hex::encode(peer_bytes).to_ascii_uppercase();
+        let daemon = RpcDaemon::with_store(
+            MessagesStore::in_memory().expect("store"),
+            hex::encode([2u8; 16]),
+        );
+        daemon
+            .accept_announce_with_metadata(
+                stored_peer.clone(),
+                1_700_000_612,
+                None,
+                None,
+                None,
+                Some(vec!["propagation".to_string()]),
+                None,
+                None,
+                None,
+                Some(1),
+                Some(Some(1)),
+                Some(Some(1)),
+                None,
+                Some(1),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("accept mixed-case propagation peer announce");
+
+        let response = handle_peer_command(
+            &daemon,
+            control_path_hash("/pn/peer/sync"),
+            Some(rmpv::Value::Binary(peer_bytes.to_vec())),
+            ERROR_INVALID_DATA,
+            ERROR_NOT_FOUND,
+        )
+        .expect("peer sync command response");
+
+        let ControlResponse::Value(result) = response else {
+            panic!("expected peer sync result value");
+        };
+        assert_eq!(result["peer"].as_str(), Some(stored_peer.as_str()));
+        assert_ne!(result["error"].as_str(), Some("not_found"));
+    }
+
+    #[test]
     fn peer_unpeer_command_returns_daemon_cleanup_result() {
         let daemon = RpcDaemon::test_instance();
         let peer_bytes = [0xB6; 16];
@@ -412,5 +463,36 @@ mod tests {
             .result
             .expect("peers result");
         assert_eq!(peers["peers"].as_array().map(Vec::len), Some(0));
+    }
+
+    #[test]
+    fn peer_unpeer_command_accepts_case_variant_existing_peer_like_python() {
+        let daemon = RpcDaemon::test_instance();
+        let peer_bytes = [0xB7; 16];
+        let stored_peer = hex::encode(peer_bytes).to_ascii_uppercase();
+        daemon
+            .handle_rpc(RpcRequest {
+                id: 1,
+                method: "propagation_enable".to_string(),
+                params: Some(json!({
+                    "enabled": true,
+                    "static_peers": [stored_peer],
+                })),
+            })
+            .expect("enable propagation");
+
+        let response = handle_peer_command(
+            &daemon,
+            control_path_hash("/pn/peer/unpeer"),
+            Some(rmpv::Value::Binary(peer_bytes.to_vec())),
+            ERROR_INVALID_DATA,
+            ERROR_NOT_FOUND,
+        );
+
+        let Some(ControlResponse::Value(result)) = response else {
+            panic!("expected peer unpeer result value");
+        };
+        assert_eq!(result["peer"].as_str(), Some(stored_peer.as_str()));
+        assert_eq!(result["removed"].as_bool(), Some(true));
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_peer.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_peer.rs
@@ -22,6 +22,9 @@ pub(super) fn handle_peer_command(
         return Some(ControlResponse::Code(error_not_found));
     }
     let mut params = json!({ "peer": peer_hex });
+    if sync_command {
+        params["force_sync"] = json!(true);
+    }
     if let Some(transfer_limit_kb) = transfer_limit_kb {
         params["transfer_limit_kb"] = json!(transfer_limit_kb);
     }
@@ -252,6 +255,68 @@ mod tests {
         assert_eq!(result["propagation"]["transferred"].as_u64(), Some(1));
         assert_eq!(result["propagation"]["transferred_ids"], json!([transient_id]));
         assert_eq!(result["propagation"]["messages"].as_array().map(Vec::len), Some(1));
+    }
+
+    #[test]
+    fn peer_sync_command_bypasses_existing_backoff_like_python() {
+        let peer_bytes = [0xC6; 16];
+        let peer_hex = hex::encode(peer_bytes);
+        let payload_hex = format!("{}{}", "23".repeat(16), "46".repeat(24));
+        let daemon = RpcDaemon::test_instance_with_identity(hex::encode([2u8; 16]));
+        daemon
+            .handle_rpc(RpcRequest {
+                id: 1,
+                method: "propagation_enable".to_string(),
+                params: Some(json!({
+                    "enabled": true,
+                    "static_peers": [peer_hex],
+                })),
+            })
+            .expect("enable propagation");
+        assert_eq!(make_ready_propagation_peer(&daemon, 0xC6), peer_hex);
+        let ingest = daemon
+            .handle_rpc(RpcRequest {
+                id: 2,
+                method: "propagation_ingest".to_string(),
+                params: Some(json!({ "payload_hex": payload_hex })),
+            })
+            .expect("ingest propagation")
+            .result
+            .expect("ingest result");
+        let transient_id = ingest["transient_id"].as_str().expect("transient id");
+        daemon.record_outbound_peer_activity(peer_hex.as_str(), 64, false);
+        let peers = daemon
+            .handle_rpc(RpcRequest { id: 3, method: "list_peers".to_string(), params: None })
+            .expect("list peers")
+            .result
+            .expect("peers result");
+        let row = peers["peers"]
+            .as_array()
+            .expect("peer rows")
+            .iter()
+            .find(|row| row["peer"].as_str() == Some(peer_hex.as_str()))
+            .expect("peer row");
+        assert!(row["sync_backoff"].as_u64().expect("sync backoff") > 0);
+        assert!(row["next_sync_attempt"].as_i64().expect("next sync attempt") > 0);
+
+        let response = handle_peer_command(
+            &daemon,
+            control_path_hash("/pn/peer/sync"),
+            Some(rmpv::Value::Binary(peer_bytes.to_vec())),
+            ERROR_INVALID_DATA,
+            ERROR_NOT_FOUND,
+        )
+        .expect("peer sync command response");
+
+        let ControlResponse::Value(result) = response else {
+            panic!("expected peer sync result value");
+        };
+        assert_eq!(result["peer"].as_str(), Some(peer_hex.as_str()));
+        assert_eq!(result["synced"].as_bool(), Some(true));
+        assert_ne!(result["postpone_reason"].as_str(), Some("backoff"));
+        assert_eq!(result["propagation"]["transferred_ids"], json!([transient_id]));
+        assert_eq!(result["sync_backoff"].as_u64(), Some(0));
+        assert_eq!(result["next_sync_attempt"].as_i64(), Some(0));
     }
 
     #[test]

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
@@ -74,8 +74,11 @@ pub(super) fn handle_message_get_request(
         }
     }
 
+    if entries.first().is_some_and(rmpv::Value::is_nil) {
+        return ControlResponse::Bool(true);
+    }
+
     let wants = match entries.first() {
-        Some(value) if value.is_nil() => Vec::new(),
         Some(rmpv::Value::Array(values)) => binary_id_list(values),
         _ => return ControlResponse::Code(error_invalid_data),
     };
@@ -1062,7 +1065,9 @@ mod tests {
             0xF6,
         );
 
-        assert!(matches!(response, ControlResponse::Bool(true)));
+        assert!(
+            matches!(response, ControlResponse::Rmpv(rmpv::Value::Array(values)) if values.is_empty())
+        );
         let peers = daemon
             .handle_rpc(RpcRequest { id: 12, method: "list_peers".to_string(), params: None })
             .expect("list peers")
@@ -1422,9 +1427,7 @@ mod tests {
             0xF4,
         );
 
-        assert!(
-            matches!(response, ControlResponse::Rmpv(rmpv::Value::Array(values)) if values.is_empty())
-        );
+        assert!(matches!(response, ControlResponse::Bool(true)));
         assert!(!daemon.has_propagation_payload(have_hex.as_str()));
         assert!(
             daemon
@@ -1467,6 +1470,86 @@ mod tests {
             row["messages"]["unhandled_ids"],
             json!([]),
             "reingested haves should not be queued back to the declaring peer"
+        );
+    }
+
+    #[test]
+    fn message_get_haves_preserve_other_peer_completed_marks_across_purge_and_reingest() {
+        let daemon = RpcDaemon::test_instance();
+        let remote_private =
+            rns_transport::identity::PrivateIdentity::new_from_rand(rand_core::OsRng);
+        let remote_identity = *remote_private.as_identity();
+        let remote_delivery_hash = delivery_destination_hash_for_identity(&remote_identity);
+        let remote_propagation_hash =
+            hex::encode(propagation_destination_hash_for_identity(&remote_identity));
+        let other_peer = "ab".repeat(16);
+        let have = [0x37; 32];
+        let have_hex = hex::encode(have);
+        let mut have_payload = remote_delivery_hash.to_vec();
+        have_payload.extend_from_slice(b" haves should preserve other peer accounting");
+        daemon.record_propagation_offer_peer(other_peer.as_str()).expect("activate other peer");
+        daemon
+            .ingest_propagation_payload_bytes_with_aliases(
+                have_payload.as_slice(),
+                have_hex.as_str(),
+                &[],
+            )
+            .expect("store have payload");
+        daemon
+            .record_peer_transferred_propagation(other_peer.as_str(), have_hex.as_str())
+            .expect("mark other peer transferred");
+
+        let response = handle_message_get_request(
+            &daemon,
+            &remote_identity,
+            Some(rmpv::Value::Array(vec![
+                rmpv::Value::Nil,
+                rmpv::Value::Array(vec![rmpv::Value::Binary(have.to_vec())]),
+            ])),
+            0xF1,
+            0xF4,
+        );
+
+        assert!(matches!(response, ControlResponse::Bool(true)));
+        assert!(!daemon.has_propagation_payload(have_hex.as_str()));
+        assert!(
+            daemon
+                .has_peer_completed_propagation_mark(other_peer.as_str(), have_hex.as_str())
+                .expect("other peer completed mark"),
+            "purging one peer's haves must not erase another peer's completed mark"
+        );
+        assert!(
+            daemon
+                .has_peer_completed_propagation_mark(
+                    remote_propagation_hash.as_str(),
+                    have_hex.as_str(),
+                )
+                .expect("requesting peer completed mark"),
+            "requesting peer should still be marked completed after purge"
+        );
+
+        daemon
+            .ingest_propagation_payload_bytes_with_aliases(
+                have_payload.as_slice(),
+                have_hex.as_str(),
+                &[],
+            )
+            .expect("reingest have payload");
+        let peers = daemon
+            .handle_rpc(RpcRequest { id: 16, method: "list_peers".to_string(), params: None })
+            .expect("list peers")
+            .result
+            .expect("list peers result");
+        let row = peers["peers"]
+            .as_array()
+            .expect("peer rows")
+            .iter()
+            .find(|row| row["peer"].as_str() == Some(other_peer.as_str()))
+            .expect("other peer row");
+        assert_eq!(
+            row["messages"]["unhandled_ids"],
+            json!([]),
+            "reingested payload must not be requeued to a peer that already completed it"
         );
     }
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
@@ -45,18 +45,33 @@ pub(super) fn handle_message_get_request(
         _ => return ControlResponse::Code(error_invalid_data),
     };
     if !haves.is_empty() {
-        let haves_match_local_payload = daemon
+        let matched_haves = daemon
             .list_propagation_payloads_for_destination(&remote_delivery_hash)
             .into_iter()
-            .any(|(transient_id, _size)| {
-                haves.iter().any(|have| have.as_slice() == transient_id.as_slice())
-            });
-        if haves_match_local_payload
+            .filter_map(|(transient_id, _size)| {
+                haves
+                    .iter()
+                    .any(|have| have.as_slice() == transient_id.as_slice())
+                    .then(|| hex::encode(transient_id))
+            })
+            .collect::<Vec<_>>();
+        if !matched_haves.is_empty()
             && daemon.record_propagation_offer_peer(remote_propagation_hash.as_str()).is_err()
         {
             return ControlResponse::Code(error_no_access);
         }
         daemon.purge_propagation_payloads_for_destination(&remote_delivery_hash, &haves);
+        for transient_id in matched_haves {
+            if daemon
+                .record_peer_received_propagation(
+                    remote_propagation_hash.as_str(),
+                    transient_id.as_str(),
+                )
+                .is_err()
+            {
+                return ControlResponse::Code(error_no_access);
+            }
+        }
     }
 
     let wants = match entries.first() {
@@ -1373,6 +1388,86 @@ mod tests {
         assert_eq!(messages, vec![rmpv::Value::Binary(wanted_payload)]);
         assert!(!daemon.has_propagation_payload(hex::encode(have).as_str()));
         assert!(daemon.has_propagation_payload(hex::encode(ignored).as_str()));
+    }
+
+    #[test]
+    fn message_get_haves_mark_requesting_peer_received_across_purge_and_reingest() {
+        let daemon = RpcDaemon::test_instance();
+        let remote_private =
+            rns_transport::identity::PrivateIdentity::new_from_rand(rand_core::OsRng);
+        let remote_identity = *remote_private.as_identity();
+        let remote_delivery_hash = delivery_destination_hash_for_identity(&remote_identity);
+        let remote_propagation_hash =
+            hex::encode(propagation_destination_hash_for_identity(&remote_identity));
+        let have = [0x36; 32];
+        let have_hex = hex::encode(have);
+        let mut have_payload = remote_delivery_hash.to_vec();
+        have_payload.extend_from_slice(b" already have propagation accounting lxm");
+        daemon
+            .ingest_propagation_payload_bytes_with_aliases(
+                have_payload.as_slice(),
+                have_hex.as_str(),
+                &[],
+            )
+            .expect("store have payload");
+
+        let response = handle_message_get_request(
+            &daemon,
+            &remote_identity,
+            Some(rmpv::Value::Array(vec![
+                rmpv::Value::Nil,
+                rmpv::Value::Array(vec![rmpv::Value::Binary(have.to_vec())]),
+            ])),
+            0xF1,
+            0xF4,
+        );
+
+        assert!(
+            matches!(response, ControlResponse::Rmpv(rmpv::Value::Array(values)) if values.is_empty())
+        );
+        assert!(!daemon.has_propagation_payload(have_hex.as_str()));
+        assert!(
+            daemon
+                .has_peer_completed_propagation_mark(
+                    remote_propagation_hash.as_str(),
+                    have_hex.as_str(),
+                )
+                .expect("completed propagation mark lookup"),
+            "message-get haves should be remembered as peer-received after local purge"
+        );
+
+        daemon
+            .ingest_propagation_payload_bytes_with_aliases(
+                have_payload.as_slice(),
+                have_hex.as_str(),
+                &[],
+            )
+            .expect("reingest have payload");
+        assert!(
+            daemon
+                .has_peer_completed_propagation_mark(
+                    remote_propagation_hash.as_str(),
+                    have_hex.as_str(),
+                )
+                .expect("completed propagation mark after reingest"),
+            "reingesting a purged payload must not forget that the peer already has it"
+        );
+        let peers = daemon
+            .handle_rpc(RpcRequest { id: 15, method: "list_peers".to_string(), params: None })
+            .expect("list peers")
+            .result
+            .expect("list peers result");
+        let row = peers["peers"]
+            .as_array()
+            .expect("peer rows")
+            .iter()
+            .find(|row| row["peer"].as_str() == Some(remote_propagation_hash.as_str()))
+            .expect("peer row");
+        assert_eq!(
+            row["messages"]["unhandled_ids"],
+            json!([]),
+            "reingested haves should not be queued back to the declaring peer"
+        );
     }
 
     #[test]

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
@@ -210,7 +210,6 @@ pub(super) fn handle_offer_request(
     if daemon.propagation_peer_offer_is_throttled(remote_propagation_hash_hex.as_str()) {
         return ControlResponse::Code(error_throttled);
     }
-    daemon.throttle_propagation_peer_offer(remote_propagation_hash_hex.as_str());
 
     let mut wanted = Vec::new();
     for bytes in &offered_ids {
@@ -227,16 +226,20 @@ pub(super) fn handle_offer_request(
             return ControlResponse::Code(error_no_access);
         }
     }
-    if wanted.is_empty() {
-        if let Ok(mut guard) = control.validated_peer_links.lock() {
-            guard.insert(*link_id);
-        }
-        return ControlResponse::Bool(false);
-    }
     if let Ok(mut guard) = control.validated_peer_links.lock() {
         guard.insert(*link_id);
     }
 
+    if wanted.len() == offered_ids.len()
+        && !daemon.propagation_peer_admission_allowed(remote_propagation_hash_hex.as_str())
+    {
+        return ControlResponse::Rmpv(rmpv::Value::Array(Vec::new()));
+    }
+    daemon.throttle_propagation_peer_offer(remote_propagation_hash_hex.as_str());
+
+    if wanted.is_empty() {
+        return ControlResponse::Bool(false);
+    }
     if wanted.len() == offered_ids.len() {
         ControlResponse::Bool(true)
     } else {

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
@@ -207,12 +207,10 @@ pub(super) fn handle_offer_request(
             offered_ids.push(bytes.clone());
         }
     }
-    if daemon
-        .propagation_peer_offer_is_throttled(remote_propagation_hash_hex.as_str(), &offered_ids)
-    {
+    if daemon.propagation_peer_offer_is_throttled(remote_propagation_hash_hex.as_str()) {
         return ControlResponse::Code(error_throttled);
     }
-    daemon.throttle_propagation_peer_offer(remote_propagation_hash_hex.as_str(), &offered_ids);
+    daemon.throttle_propagation_peer_offer(remote_propagation_hash_hex.as_str());
 
     let mut wanted = Vec::new();
     for bytes in &offered_ids {
@@ -724,7 +722,7 @@ mod tests {
 
         assert!(matches!(first, ControlResponse::Bool(true)));
         assert!(matches!(second, ControlResponse::Code(0xF6)));
-        assert!(matches!(different_offer, ControlResponse::Bool(true)));
+        assert!(matches!(different_offer, ControlResponse::Code(0xF6)));
     }
 
     #[test]

--- a/crates/apps/reticulumd/src/config.rs
+++ b/crates/apps/reticulumd/src/config.rs
@@ -462,6 +462,9 @@ impl InterfaceConfig {
             "ble_gatt" => self.validate_ble(index),
             "vrn76_kiss_ble" => self.validate_vrn76_kiss_ble(index),
             "lora" => self.validate_lora(index, original_kind),
+            _ if is_known_unsupported_python_interface(original_kind) => Err(format!(
+                "interfaces[{index}].type {original_kind} is a known unsupported Reticulum interface family"
+            )),
             _ => Ok(()),
         }
     }
@@ -1597,6 +1600,17 @@ fn normalize_interface_kind(value: &str) -> String {
         "Vrn76KissBluetoothInterface" | "Vrn76KissBleInterface" => "vrn76_kiss_ble".to_string(),
         value => value.to_string(),
     }
+}
+
+fn is_known_unsupported_python_interface(value: &str) -> bool {
+    matches!(
+        value,
+        "PipeInterface"
+            | "LocalInterface"
+            | "I2PInterface"
+            | "WeaveInterface"
+            | "BackboneInterface"
+    )
 }
 
 fn is_tcp_lora_port(value: &str) -> bool {

--- a/crates/apps/reticulumd/tests/config.rs
+++ b/crates/apps/reticulumd/tests/config.rs
@@ -1002,6 +1002,31 @@ interfaces = [
 }
 
 #[test]
+fn rejects_known_unsupported_python_interface_families_with_specific_error() {
+    for kind in
+        ["PipeInterface", "LocalInterface", "I2PInterface", "WeaveInterface", "BackboneInterface"]
+    {
+        let input = format!(
+            r#"
+interfaces = [
+  {{ type = "{kind}", enabled = true, name = "unsupported" }}
+]
+"#
+        );
+        let err = match DaemonConfig::from_toml(&input) {
+            Ok(_) => panic!("{kind} should be rejected as known unsupported"),
+            Err(err) => err,
+        };
+        let message = err.to_string();
+        assert!(
+            message.contains("known unsupported Reticulum interface family"),
+            "unexpected parse error for {kind}: {message}"
+        );
+        assert!(message.contains(kind), "error should name {kind}: {message}");
+    }
+}
+
+#[test]
 fn allows_disabled_new_interface_without_required_fields() {
     let input = r#"
 interfaces = [

--- a/crates/apps/rns-tools/src/bin/rnstatus-rs.rs
+++ b/crates/apps/rns-tools/src/bin/rnstatus-rs.rs
@@ -1,0 +1,168 @@
+use std::io::{self, Read, Write};
+use std::net::{Shutdown, TcpStream};
+
+use clap::Parser;
+use rns_rpc::e2e_harness::{build_http_post, build_rpc_frame, parse_http_response_body};
+use serde_json::Value;
+
+#[derive(Debug, Parser)]
+#[command(name = "rnstatus-rs")]
+struct Cli {
+    #[arg(long, default_value = "127.0.0.1:4243")]
+    rpc: String,
+
+    #[arg(long)]
+    json: bool,
+}
+
+fn main() -> std::process::ExitCode {
+    let cli = Cli::parse();
+    match run(&cli, &mut io::stdout()) {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("rnstatus-rs: {error}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(cli: &Cli, output: &mut dyn Write) -> io::Result<()> {
+    let response = rpc_call(&cli.rpc, 1, "daemon_status_ex")?;
+    let status = ensure_rpc_ok(response, "daemon_status_ex")?
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing daemon status"))?;
+    if cli.json {
+        writeln!(output, "{}", serde_json::to_string_pretty(&status)?)?;
+    } else {
+        write_human_status(output, &status)?;
+    }
+    Ok(())
+}
+
+fn rpc_call(rpc: &str, id: u64, method: &str) -> io::Result<rns_rpc::RpcResponse> {
+    let frame = build_rpc_frame(id, method, None)?;
+    let request = build_http_post("/rpc", rpc, &frame);
+    let mut stream = TcpStream::connect(rpc)?;
+    stream.write_all(&request)?;
+    stream.shutdown(Shutdown::Write)?;
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response)?;
+    let body = parse_http_response_body(&response)?;
+    rns_rpc::rpc::codec::decode_frame(&body)
+}
+
+fn ensure_rpc_ok(
+    response: rns_rpc::RpcResponse,
+    context: &str,
+) -> io::Result<Option<serde_json::Value>> {
+    if let Some(error) = response.error {
+        return Err(io::Error::other(format!(
+            "{} failed: {} ({})",
+            context, error.message, error.code
+        )));
+    }
+    Ok(response.result)
+}
+
+fn write_human_status(output: &mut dyn Write, status: &Value) -> io::Result<()> {
+    writeln!(
+        output,
+        "Identity: {}",
+        status.get("identity_hash").and_then(Value::as_str).unwrap_or("unknown")
+    )?;
+    writeln!(
+        output,
+        "Running: {}",
+        status.get("running").and_then(Value::as_bool).unwrap_or(false)
+    )?;
+    writeln!(
+        output,
+        "Interfaces: {}",
+        status.get("interface_count").and_then(Value::as_u64).unwrap_or_else(|| {
+            status.get("interfaces").and_then(Value::as_array).map_or(0, |rows| rows.len() as u64)
+        })
+    )?;
+
+    let Some(interfaces) = status.get("interfaces").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    if interfaces.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(output)?;
+    writeln!(output, "{:<24} {:<16} {:<8} {:<22} Runtime", "Name", "Type", "Enabled", "Endpoint")?;
+    for interface in interfaces {
+        let name = interface.get("name").and_then(Value::as_str).unwrap_or("-");
+        let kind = interface.get("type").and_then(Value::as_str).unwrap_or("-");
+        let enabled = interface
+            .get("enabled")
+            .and_then(Value::as_bool)
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let endpoint = interface_endpoint(interface);
+        let runtime = interface_runtime(interface);
+        writeln!(output, "{name:<24} {kind:<16} {enabled:<8} {endpoint:<22} {runtime}")?;
+    }
+    Ok(())
+}
+
+fn interface_endpoint(interface: &Value) -> String {
+    match (
+        interface.get("host").and_then(Value::as_str),
+        interface.get("port").and_then(Value::as_u64),
+    ) {
+        (Some(host), Some(port)) => format!("{host}:{port}"),
+        (Some(host), None) => host.to_string(),
+        (None, Some(port)) => port.to_string(),
+        (None, None) => "-".to_string(),
+    }
+}
+
+fn interface_runtime(interface: &Value) -> String {
+    let runtime = interface
+        .get("settings")
+        .and_then(|settings| settings.get("_runtime"))
+        .unwrap_or(&Value::Null);
+    let status = runtime.get("startup_status").and_then(Value::as_str).unwrap_or("-");
+    let error = runtime.get("startup_error").and_then(Value::as_str);
+    match error {
+        Some(error) if !error.is_empty() => format!("{status} ({error})"),
+        _ => status.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn human_status_includes_runtime_state() {
+        let status = json!({
+            "identity_hash": "abc",
+            "running": true,
+            "interface_count": 1,
+            "interfaces": [{
+                "name": "uplink",
+                "type": "tcp_server",
+                "enabled": true,
+                "host": "127.0.0.1",
+                "port": 4242,
+                "settings": {
+                    "_runtime": {
+                        "startup_status": "failed",
+                        "startup_error": "bind denied"
+                    }
+                }
+            }]
+        });
+        let mut output = Vec::new();
+
+        write_human_status(&mut output, &status).expect("write status");
+
+        let output = String::from_utf8(output).expect("utf8");
+        assert!(output.contains("uplink"));
+        assert!(output.contains("tcp_server"));
+        assert!(output.contains("failed (bind denied)"));
+    }
+}

--- a/crates/apps/rns-tools/tests/rnstatus_cli.rs
+++ b/crates/apps/rns-tools/tests/rnstatus_cli.rs
@@ -1,0 +1,132 @@
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpListener};
+use std::process::Command;
+use std::thread;
+
+use rns_rpc::rpc::codec;
+use rns_rpc::RpcResponse;
+use serde_json::json;
+
+#[test]
+fn rnstatus_fetches_daemon_status_and_renders_interface_runtime_state() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock rpc");
+    let rpc = listener.local_addr().expect("mock rpc addr").to_string();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept rpc request");
+        let mut request = Vec::new();
+        stream.read_to_end(&mut request).expect("read rpc request");
+        let body = http_body(&request);
+        let rpc_request = codec::decode_frame::<rns_rpc::RpcRequest>(body).expect("decode request");
+        assert_eq!(rpc_request.method, "daemon_status_ex");
+
+        let response = RpcResponse {
+            id: rpc_request.id,
+            result: Some(json!({
+                "identity_hash": "0123456789abcdef0123456789abcdef",
+                "running": true,
+                "interface_count": 1,
+                "interfaces": [{
+                    "name": "field-uplink",
+                    "type": "tcp_server",
+                    "enabled": true,
+                    "host": "0.0.0.0",
+                    "port": 4242,
+                    "settings": {
+                        "_runtime": {
+                            "startup_status": "failed",
+                            "startup_error": "bind denied"
+                        }
+                    }
+                }]
+            })),
+            error: None,
+        };
+        let body = codec::encode_frame(&response).expect("encode response");
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/msgpack\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).expect("write response headers");
+        stream.write_all(&body).expect("write response body");
+        stream.shutdown(Shutdown::Write).expect("shutdown response");
+    });
+
+    let output = Command::new(rnstatus_bin())
+        .arg("--rpc")
+        .arg(rpc)
+        .arg("--json")
+        .output()
+        .expect("run rnstatus-rs");
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("json output");
+    assert_eq!(value["identity_hash"], "0123456789abcdef0123456789abcdef");
+    assert_eq!(value["interfaces"][0]["settings"]["_runtime"]["startup_status"], "failed");
+
+    server.join().expect("mock rpc server");
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock rpc");
+    let rpc = listener.local_addr().expect("mock rpc addr").to_string();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept rpc request");
+        let mut request = Vec::new();
+        stream.read_to_end(&mut request).expect("read rpc request");
+        let body = http_body(&request);
+        let rpc_request = codec::decode_frame::<rns_rpc::RpcRequest>(body).expect("decode request");
+        let response = RpcResponse {
+            id: rpc_request.id,
+            result: Some(json!({
+                "identity_hash": "0123456789abcdef0123456789abcdef",
+                "running": true,
+                "interface_count": 1,
+                "interfaces": [{
+                    "name": "field-uplink",
+                    "type": "tcp_server",
+                    "enabled": true,
+                    "host": "0.0.0.0",
+                    "port": 4242,
+                    "settings": {
+                        "_runtime": {
+                            "startup_status": "failed",
+                            "startup_error": "bind denied"
+                        }
+                    }
+                }]
+            })),
+            error: None,
+        };
+        let body = codec::encode_frame(&response).expect("encode response");
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/msgpack\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).expect("write response headers");
+        stream.write_all(&body).expect("write response body");
+        stream.shutdown(Shutdown::Write).expect("shutdown response");
+    });
+
+    let output =
+        Command::new(rnstatus_bin()).arg("--rpc").arg(rpc).output().expect("run rnstatus-rs");
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    assert!(stdout.contains("field-uplink"), "stdout: {stdout}");
+    assert!(stdout.contains("tcp_server"), "stdout: {stdout}");
+    assert!(stdout.contains("failed"), "stdout: {stdout}");
+    assert!(stdout.contains("bind denied"), "stdout: {stdout}");
+
+    server.join().expect("mock rpc server");
+}
+
+fn rnstatus_bin() -> String {
+    env!("CARGO_BIN_EXE_rnstatus-rs").to_string()
+}
+
+fn http_body(request: &[u8]) -> &[u8] {
+    let marker = b"\r\n\r\n";
+    let start = request
+        .windows(marker.len())
+        .position(|window| window == marker)
+        .map(|index| index + marker.len())
+        .expect("request headers");
+    &request[start..]
+}

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -828,6 +828,7 @@ impl RpcDaemon {
                     let sync_limit_bytes =
                         record.propagation_sync_limit.map(|limit| limit as usize);
                     if !parsed.maintenance_claimed
+                        && !parsed.force_sync
                         && record.peer_type.as_deref() != Some("unpeered")
                         && peer_sync_backoff_active(timestamp, record.next_sync_attempt)
                     {
@@ -876,6 +877,7 @@ impl RpcDaemon {
                     };
                 let sync_limit_bytes = record.propagation_sync_limit.map(|limit| limit as usize);
                 if !parsed.maintenance_claimed
+                    && !parsed.force_sync
                     && peer_sync_backoff_active(timestamp, record.next_sync_attempt)
                 {
                     return Ok(self.postponed_peer_sync_response(

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -2233,6 +2233,17 @@ impl RpcDaemon {
                 snapshot.propagation = state;
             });
         }
+        let static_peer_state = {
+            let mut guard = self.propagation_state.lock().expect("propagation mutex poisoned");
+            let before = guard.static_peers.len();
+            guard.static_peers.retain(|peer| !peer.eq_ignore_ascii_case(peer_key.as_str()));
+            (guard.static_peers.len() != before).then(|| guard.clone())
+        };
+        if let Some(state) = static_peer_state {
+            self.update_daemon_status_snapshot(|snapshot| {
+                snapshot.propagation = state;
+            });
+        }
         Ok(LocalUnpeerCleanup {
             peer: peer_key,
             removed,

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -827,7 +827,8 @@ impl RpcDaemon {
                         };
                     let sync_limit_bytes =
                         record.propagation_sync_limit.map(|limit| limit as usize);
-                    if record.peer_type.as_deref() != Some("unpeered")
+                    if !parsed.maintenance_claimed
+                        && record.peer_type.as_deref() != Some("unpeered")
                         && peer_sync_backoff_active(timestamp, record.next_sync_attempt)
                     {
                         return Ok(self.postponed_peer_sync_response(
@@ -874,7 +875,9 @@ impl RpcDaemon {
                         (None, None) => None,
                     };
                 let sync_limit_bytes = record.propagation_sync_limit.map(|limit| limit as usize);
-                if peer_sync_backoff_active(timestamp, record.next_sync_attempt) {
+                if !parsed.maintenance_claimed
+                    && peer_sync_backoff_active(timestamp, record.next_sync_attempt)
+                {
                     return Ok(self.postponed_peer_sync_response(
                         request.id,
                         &record,

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -302,6 +302,7 @@ impl RpcDaemon {
         let mut imported_ids = Vec::new();
         let mut accepted_ids: Vec<String> = Vec::new();
         let mut transferred_bytes = 0usize;
+        let mut validated = Vec::new();
         for message in messages {
             let Some((payload, payload_hex)) = remote_propagation_message_payload(message)? else {
                 continue;
@@ -348,26 +349,31 @@ impl RpcDaemon {
                 size_bytes: payload.len() as u64,
                 stamp_value,
             };
-            let already_known = self
+            let already_known_store = self
                 .store
                 .get_propagation_entry(transient_id.as_str())
                 .map_err(std::io::Error::other)?
                 .is_some();
+            let already_accepted =
+                accepted_ids.iter().any(|id| id.eq_ignore_ascii_case(transient_id.as_str()));
+            if !already_accepted {
+                transferred_bytes = transferred_bytes.saturating_add(payload.len());
+                accepted_ids.push(transient_id.clone());
+            }
+            if already_known_store || already_accepted {
+                duplicate_count = duplicate_count.saturating_add(1);
+            } else {
+                imported_count = imported_count.saturating_add(1);
+                imported_ids.push(transient_id.clone());
+            }
+            validated.push(record);
+        }
+        for record in validated {
             self.store.upsert_propagation_entry(&record).map_err(std::io::Error::other)?;
             self.propagation_payloads
                 .lock()
                 .expect("propagation payload mutex poisoned")
-                .insert(transient_id.clone(), record.payload_hex);
-            if !accepted_ids.iter().any(|id| id.eq_ignore_ascii_case(transient_id.as_str())) {
-                transferred_bytes = transferred_bytes.saturating_add(payload.len());
-                accepted_ids.push(transient_id.clone());
-            }
-            if already_known {
-                duplicate_count = duplicate_count.saturating_add(1);
-            } else {
-                imported_count = imported_count.saturating_add(1);
-                imported_ids.push(transient_id);
-            }
+                .insert(record.transient_id, record.payload_hex);
         }
         if !messages.is_empty() {
             self.note_client_propagation_messages_received(imported_count);
@@ -1227,7 +1233,7 @@ impl RpcDaemon {
                     self.handle_rpc(RpcRequest {
                         id: request.id,
                         method: "peer_sync".to_string(),
-                        params: Some(json!({ "peer": peer })),
+                        params: Some(json!({ "peer": peer, "maintenance_claimed": true })),
                     })?
                     .result
                     .unwrap_or(JsonValue::Null)
@@ -1841,7 +1847,9 @@ impl RpcDaemon {
                             imported.accepted_ids.as_slice(),
                             imported.transferred_bytes,
                         )?;
-                        self.record_payload_backed_peer_queue_snapshot(peer_key.as_str())?;
+                        for active_peer in self.active_peer_ids() {
+                            self.record_payload_backed_peer_queue_snapshot(active_peer.as_str())?;
+                        }
                         self.update_propagation_sync_state(|state| {
                             state.sync_state = PR_COMPLETE;
                             state.state_name = "completed".to_string();

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -569,8 +569,8 @@ impl RpcDaemon {
             .insert(peer, now_i64().saturating_add(PN_STAMP_THROTTLE_SECS));
     }
 
-    pub fn throttle_propagation_peer_offer(&self, peer: &str, offered_ids: &[Vec<u8>]) {
-        if let Some(key) = propagation_offer_throttle_key(peer, offered_ids) {
+    pub fn throttle_propagation_peer_offer(&self, peer: &str) {
+        if let Some(key) = propagation_offer_throttle_key(peer) {
             self.throttle_propagation_peer_key(key.as_str());
         }
     }
@@ -595,8 +595,8 @@ impl RpcDaemon {
         }
     }
 
-    pub fn propagation_peer_offer_is_throttled(&self, peer: &str, offered_ids: &[Vec<u8>]) -> bool {
-        propagation_offer_throttle_key(peer, offered_ids)
+    pub fn propagation_peer_offer_is_throttled(&self, peer: &str) -> bool {
+        propagation_offer_throttle_key(peer)
             .is_some_and(|key| self.propagation_peer_is_throttled(key.as_str()))
     }
 
@@ -2654,18 +2654,12 @@ pub(super) fn propagation_payload_hash_input(
     Ok(lxm_data)
 }
 
-fn propagation_offer_throttle_key(peer: &str, offered_ids: &[Vec<u8>]) -> Option<String> {
+fn propagation_offer_throttle_key(peer: &str) -> Option<String> {
     let peer = peer.trim().to_ascii_lowercase();
     if peer.is_empty() {
         return None;
     }
-    let mut offered_ids = offered_ids.to_vec();
-    offered_ids.sort();
-    let mut hasher = Sha256::new();
-    for offered_id in offered_ids {
-        hasher.update(offered_id);
-    }
-    Some(format!("offer:{peer}:{}", hex::encode(hasher.finalize())))
+    Some(format!("offer:{peer}"))
 }
 
 pub(super) fn split_propagation_stamp(transient_data: &[u8]) -> Option<(&[u8], &[u8])> {

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -1793,15 +1793,33 @@ impl RpcDaemon {
                     .cloned(),
             );
             let selected_index = timestamp.rem_euclid(peer_pool.len() as i64) as usize;
-            return Ok(peer_pool.into_iter().nth(selected_index).map(|record| record.peer));
+            let selected = peer_pool.into_iter().nth(selected_index).map(|record| record.peer);
+            self.claim_peer_for_maintenance_sync(selected.as_deref(), timestamp);
+            return Ok(selected);
         }
 
         if !unresponsive.is_empty() {
             unresponsive.sort_by(|left, right| left.peer.cmp(&right.peer));
             let selected_index = timestamp.rem_euclid(unresponsive.len() as i64) as usize;
-            return Ok(unresponsive.into_iter().nth(selected_index).map(|record| record.peer));
+            let selected = unresponsive.into_iter().nth(selected_index).map(|record| record.peer);
+            self.claim_peer_for_maintenance_sync(selected.as_deref(), timestamp);
+            return Ok(selected);
         }
         Ok(None)
+    }
+
+    fn claim_peer_for_maintenance_sync(&self, peer: Option<&str>, timestamp: i64) {
+        let Some(peer) = peer else {
+            return;
+        };
+        let mut peers = self.peers.lock().expect("peers mutex poisoned");
+        let Some(record) = peers.values_mut().find(|record| record.peer.eq_ignore_ascii_case(peer))
+        else {
+            return;
+        };
+        record.last_sync_attempt = timestamp;
+        record.sync_backoff = record.sync_backoff.saturating_add(LXMF_PEER_SYNC_BACKOFF_STEP_SECS);
+        record.next_sync_attempt = timestamp.saturating_add(i64::from(record.sync_backoff));
     }
 
     pub(super) fn ensure_peer_admission_allowed(

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -157,6 +157,13 @@ impl RpcDaemon {
         let Some(peer_key) = peer_key else {
             return Ok(());
         };
+        let record = {
+            let guard = self.peers.lock().expect("peers mutex poisoned");
+            guard.get(&peer_key).cloned()
+        };
+        if let Some(record) = record {
+            self.restore_peer_record_queue_marks(&record)?;
+        }
 
         let mut unhandled_ids = Vec::new();
         let mut handled_ids = Vec::new();

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -542,6 +542,17 @@ impl RpcDaemon {
         self.propagation_state.lock().expect("propagation mutex poisoned").clone()
     }
 
+    pub fn propagation_peer_admission_allowed(&self, peer: &str) -> bool {
+        let guard = self.peers.lock().expect("peers mutex poisoned");
+        if guard.values().any(|record| {
+            record.peer.eq_ignore_ascii_case(peer)
+                && record.peer_type.as_deref() != Some("unpeered")
+        }) {
+            return true;
+        }
+        self.ensure_peer_admission_allowed(peer, Self::active_peer_count_from_guard(&guard)).is_ok()
+    }
+
     pub fn valid_issued_tickets_for(&self, destination: &str) -> Vec<Vec<u8>> {
         let now = now_i64();
         self.prune_expired_tickets(now);

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -18419,6 +18419,49 @@ fn list_peers_static_type_tracks_current_static_peer_config() {
 }
 
 #[test]
+fn peer_unpeer_removes_configured_static_peer_membership_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(
+            78,
+            "propagation_enable",
+            json!({
+                "enabled": true,
+                "static_peers": ["peer-static-unpeer"],
+            }),
+        ))
+        .expect("enable static peer");
+    daemon
+        .handle_rpc(rpc_request(79, "peer_sync", json!({ "peer": "peer-static-unpeer" })))
+        .expect("sync static peer");
+
+    let unpeered = daemon
+        .handle_rpc(rpc_request(80, "peer_unpeer", json!({ "peer": "peer-static-unpeer" })))
+        .expect("unpeer static peer");
+    assert!(unpeered.error.is_none());
+
+    let status = daemon
+        .handle_rpc(RpcRequest { id: 81, method: "propagation_status".to_string(), params: None })
+        .expect("propagation status")
+        .result
+        .expect("propagation status result");
+    assert_eq!(
+        status["propagation"]["static_peers"].as_array().expect("static peers"),
+        &[] as &[JsonValue]
+    );
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 82, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    assert!(
+        peers["peers"].as_array().expect("peer rows").is_empty(),
+        "explicit unpeer should not be undone by static-peer activation"
+    );
+}
+
+#[test]
 fn unpeered_peers_do_not_consume_max_peer_capacity() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -3948,6 +3948,45 @@ fn propagation_peer_maintenance_syncs_one_waiting_peer_like_python() {
 }
 
 #[test]
+fn propagation_peer_maintenance_selection_claims_peer_before_sync_like_python() {
+    let (daemon, peer) = ready_propagation_peer_daemon(0x64);
+    let entry = PropagationEntryRecord {
+        transient_id: "e2".repeat(32),
+        destination: "20".repeat(16),
+        payload_hex: "2c".repeat(32),
+        received_at: 1_700_000_629,
+        size_bytes: 32,
+        stamp_value: Some(12),
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
+        .expect("mark unhandled");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.alive = true;
+        record.last_seen = 1_700_000_629;
+        record.last_sync_attempt = 1_700_000_600;
+        record.next_sync_attempt = 0;
+        record.sync_backoff = 0;
+        record.sync_transfer_rate = 1024.0;
+    }
+
+    let selected = daemon
+        .select_peer_for_maintenance_sync(1_700_000_629)
+        .expect("select maintenance sync peer");
+
+    assert_eq!(selected.as_deref(), Some(peer.as_str()));
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer.as_str()).expect("peer record");
+    assert_eq!(record.last_sync_attempt, 1_700_000_629);
+    assert_eq!(record.sync_backoff, 12 * 60);
+    assert_eq!(record.next_sync_attempt, 1_700_000_629 + 12 * 60);
+}
+
+#[test]
 fn propagation_peer_maintenance_replays_restored_unhandled_queue_like_python() {
     let (daemon, peer) = ready_propagation_peer_daemon(0x63);
     let entry = PropagationEntryRecord {
@@ -13914,6 +13953,29 @@ fn propagation_remote_sync_marks_source_handled_and_queues_other_peers() {
     daemon
         .handle_rpc(rpc_request(75, "peer_sync", json!({ "peer": relay_peer })))
         .expect("seed relay peer");
+    let pending_payload = b"remote-sync-preexisting-relay-pending";
+    let pending_transient_id = hex::encode(Sha256::digest(pending_payload));
+    daemon
+        .store
+        .upsert_propagation_entry(&PropagationEntryRecord {
+            transient_id: pending_transient_id.clone(),
+            destination: "41".repeat(16),
+            payload_hex: hex::encode(pending_payload),
+            received_at: 1_700_000_745,
+            size_bytes: pending_payload.len() as u64,
+            stamp_value: None,
+        })
+        .expect("store preexisting relay pending payload");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(relay_peer.as_str(), pending_transient_id.as_str())
+        .expect("seed preexisting relay live queue mark");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(relay_peer.as_str()).expect("relay peer record");
+        record.restored_unhandled_ids.clear();
+        record.restored_handled_ids.clear();
+    }
 
     let remote_sync = daemon
         .handle_rpc(rpc_request(
@@ -13967,8 +14029,21 @@ fn propagation_remote_sync_marks_source_handled_and_queues_other_peers() {
         .store
         .list_peer_unhandled_propagation(relay_peer.as_str())
         .expect("relay unhandled");
-    assert_eq!(relay_unhandled.len(), 1);
-    assert_eq!(relay_unhandled[0].transient_id, transient_id);
+    assert_eq!(relay_unhandled.len(), 2);
+    assert!(relay_unhandled
+        .iter()
+        .any(|entry| entry.transient_id == pending_transient_id));
+    assert!(relay_unhandled.iter().any(|entry| entry.transient_id == transient_id));
+    let peer_records = daemon.peers.lock().expect("peers mutex poisoned");
+    let relay_record = peer_records
+        .get(relay_peer.as_str())
+        .expect("relay peer record after remote sync");
+    let serialized = serde_json::to_value(relay_record).expect("serialize relay peer");
+    let restored_unhandled = serialized["unhandled_ids"]
+        .as_array()
+        .expect("serialized relay unhandled ids");
+    assert!(restored_unhandled.contains(&json!(pending_transient_id.as_str())));
+    assert!(restored_unhandled.contains(&json!(transient_id.as_str())));
 }
 
 #[test]
@@ -15084,6 +15159,72 @@ fn propagation_remote_fetch_rejects_mismatched_transient_id() {
             .get_propagation_entry("aa".repeat(32).as_str())
             .expect("load bogus transient id")
             .is_none()
+    );
+}
+
+#[test]
+fn propagation_remote_fetch_rejects_mixed_batch_without_partial_import_side_effects() {
+    let valid_payload = b"remote-fetch-valid-before-invalid";
+    let valid_payload_hex = hex::encode(valid_payload);
+    let valid_transient_id = hex::encode(Sha256::digest(valid_payload));
+    let invalid_payload_hex = hex::encode(b"remote-fetch-invalid-after-valid");
+    let relay_peer = "peer-fetch-atomic-relay";
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(77, "peer_sync", json!({ "peer": relay_peer })))
+        .expect("seed relay peer");
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "available_count": 2,
+            "fetched_count": 2,
+            "imported_count": 2,
+            "messages": [
+                {
+                    "transient_id": valid_transient_id,
+                    "payload_hex": valid_payload_hex,
+                },
+                {
+                    "transient_id": "aa".repeat(32),
+                    "payload_hex": invalid_payload_hex,
+                }
+            ],
+        })),
+    }));
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            78,
+            "propagation_remote_fetch",
+            json!({
+                "remote": "remote-node",
+            }),
+        ))
+        .expect_err("mixed remote import batch should reject atomically");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(err.to_string().contains("transient_id does not match propagation payload"));
+    assert!(
+        daemon
+            .store
+            .get_propagation_entry(valid_transient_id.as_str())
+            .expect("load valid transient id")
+            .is_none(),
+        "valid payload preceding an invalid payload must not be persisted"
+    );
+    assert!(
+        !daemon
+            .propagation_payloads
+            .lock()
+            .expect("propagation payload mutex poisoned")
+            .contains_key(valid_transient_id.as_str()),
+        "valid payload preceding an invalid payload must not be cached in memory"
+    );
+    assert!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(relay_peer)
+            .expect("relay pending")
+            .is_empty(),
+        "rejected mixed batch must not queue relay work"
     );
 }
 

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -17024,6 +17024,19 @@ fn timeout_propagation_remote_sync_preserves_peer_without_backoff() {
         peer.next_sync_attempt = 0;
         peer.acceptance_rate = 0.5;
     }
+    let pending = PropagationEntryRecord {
+        transient_id: "fa".repeat(32),
+        destination: "1f".repeat(16),
+        payload_hex: "1f".repeat(24),
+        received_at: 1_700_001_010,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation("peer-timeout", pending.transient_id.as_str())
+        .expect("mark timeout peer unhandled");
     daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
 
     let err = daemon
@@ -17055,6 +17068,16 @@ fn timeout_propagation_remote_sync_preserves_peer_without_backoff() {
     assert_eq!(row["next_sync_attempt"].as_i64(), Some(0));
     assert_eq!(row["acceptance_rate"].as_f64(), Some(0.5));
     assert!(row["last_sync_attempt"].as_i64().expect("last sync attempt") > 0);
+    assert_eq!(row["messages"]["unhandled_ids"], json!([pending.transient_id.as_str()]));
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get("peer-timeout").expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+    drop(peers);
 
     let events = daemon.event_queue.lock().expect("event_queue mutex poisoned");
     assert!(

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -13505,6 +13505,67 @@ fn propagation_remote_sync_missing_bridge_records_existing_queue_snapshot_like_p
 }
 
 #[test]
+fn propagation_remote_sync_missing_bridge_replays_restored_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-remote-sync-unavailable-restored-snapshot";
+    daemon
+        .handle_rpc(rpc_request(95, "peer_sync", json!({ "peer": peer })))
+        .expect("seed peer");
+
+    let pending = PropagationEntryRecord {
+        transient_id: "e7".repeat(32),
+        destination: "1f".repeat(16),
+        payload_hex: "1f".repeat(20),
+        received_at: 1_700_000_807,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    let handled = PropagationEntryRecord {
+        transient_id: "e8".repeat(32),
+        destination: "20".repeat(16),
+        payload_hex: "20".repeat(20),
+        received_at: 1_700_000_808,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store pending entry");
+    daemon.store.upsert_propagation_entry(&handled).expect("store handled entry");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+        record.restored_handled_ids.push(handled.transient_id.clone());
+        record.restored_unhandled_ids.push(pending.transient_id.clone());
+    }
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            96,
+            "propagation_remote_sync",
+            json!({
+                "remote": "remote-without-bridge",
+                "peer": peer,
+            }),
+        ))
+        .expect_err("missing bridge should reject remote sync");
+    assert_eq!(err.kind(), std::io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "remote control bridge unavailable");
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[json!(handled.transient_id.as_str())]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn propagation_remote_sync_missing_bridge_reports_existing_peer_failure_like_python() {
     let daemon = RpcDaemon::test_instance();
     let peer = "peer-remote-sync-unavailable-event";
@@ -17243,6 +17304,70 @@ fn retryable_propagation_remote_sync_records_existing_queue_snapshot_like_python
     assert_eq!(
         serialized["handled_ids"].as_array().expect("serialized handled ids"),
         &[] as &[JsonValue]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
+fn retryable_propagation_remote_sync_replays_restored_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(RemoteSyncErrorBridge {
+        kind: std::io::ErrorKind::PermissionDenied,
+        message: "propagation peer invalid stamp",
+    }));
+    let peer = "peer-remote-retry-restored-snapshot";
+    daemon
+        .handle_rpc(rpc_request(96, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    let pending = PropagationEntryRecord {
+        transient_id: "b5".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_616,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    let handled = PropagationEntryRecord {
+        transient_id: "b6".repeat(32),
+        destination: "13".repeat(16),
+        payload_hex: "13".repeat(24),
+        received_at: 1_700_000_617,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store pending entry");
+    daemon.store.upsert_propagation_entry(&handled).expect("store handled entry");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+        record.restored_handled_ids.push(handled.transient_id.clone());
+        record.restored_unhandled_ids.push(pending.transient_id.clone());
+    }
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            97,
+            "propagation_remote_sync",
+            json!({
+                "remote": "remote-node",
+                "peer": peer,
+            }),
+        ))
+        .expect_err("retryable remote sync should return the bridge error");
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    assert_eq!(err.to_string(), "propagation peer invalid stamp");
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[json!(handled.transient_id.as_str())]
     );
     assert_eq!(
         serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -17975,6 +17975,72 @@ fn failed_propagation_remote_unpeer_records_existing_queue_snapshot_like_python(
 }
 
 #[test]
+fn failed_propagation_remote_unpeer_replays_restored_queue_snapshot_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Err(std::io::ErrorKind::TimedOut),
+    }));
+    let peer = "peer-remote-unpeer-fail-restored-snapshot";
+    daemon
+        .handle_rpc(rpc_request(79, "peer_sync", json!({ "peer": peer })))
+        .expect("peer sync");
+
+    let entry = PropagationEntryRecord {
+        transient_id: "e5".repeat(32),
+        destination: "1d".repeat(16),
+        payload_hex: "1d".repeat(20),
+        received_at: 1_700_000_805,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    let handled_entry = PropagationEntryRecord {
+        transient_id: "e6".repeat(32),
+        destination: "1e".repeat(16),
+        payload_hex: "1e".repeat(20),
+        received_at: 1_700_000_806,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .upsert_propagation_entry(&handled_entry)
+        .expect("store handled propagation entry");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+        record.restored_handled_ids.push(handled_entry.transient_id.clone());
+        record.restored_unhandled_ids.push(entry.transient_id.clone());
+    }
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            80,
+            "propagation_remote_unpeer",
+            json!({
+                "remote": "remote-node",
+                "peer": peer,
+            }),
+        ))
+        .expect_err("remote unpeer failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["handled_ids"].as_array().expect("serialized handled ids"),
+        &[json!(handled_entry.transient_id.as_str())]
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(entry.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn failed_propagation_remote_unpeer_records_case_insensitive_queue_snapshot_like_python() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -5247,6 +5247,53 @@ fn peer_sync_during_backoff_postpones_skipped_offers() {
 }
 
 #[test]
+fn forced_peer_sync_bypasses_existing_backoff_like_manual_control() {
+    let (daemon, peer) = ready_propagation_peer_daemon(0x48);
+    let entry = PropagationEntryRecord {
+        transient_id: "ef".repeat(32),
+        destination: "18".repeat(16),
+        payload_hex: "18".repeat(20),
+        received_at: 1_700_000_614,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer.as_str(), entry.transient_id.as_str())
+        .expect("mark unhandled");
+    daemon.record_outbound_peer_activity(peer.as_str(), 64, false);
+
+    let postponed = daemon
+        .handle_rpc(rpc_request(54, "peer_sync", json!({ "peer": peer.as_str() })))
+        .expect("default peer sync")
+        .result
+        .expect("default peer sync result");
+    assert_eq!(postponed["synced"].as_bool(), Some(false));
+    assert_eq!(postponed["postpone_reason"].as_str(), Some("backoff"));
+
+    let result = daemon
+        .handle_rpc(rpc_request(
+            55,
+            "peer_sync",
+            json!({
+                "peer": peer.as_str(),
+                "force_sync": true,
+            }),
+        ))
+        .expect("forced peer sync")
+        .result
+        .expect("forced peer sync result");
+
+    assert_eq!(result["synced"].as_bool(), Some(true));
+    assert_ne!(result["postpone_reason"].as_str(), Some("backoff"));
+    assert_eq!(result["propagation"]["transferred"].as_u64(), Some(1));
+    assert_eq!(result["propagation"]["transferred_ids"], json!([entry.transient_id]));
+    assert_eq!(result["sync_backoff"].as_u64(), Some(0));
+    assert_eq!(result["next_sync_attempt"].as_i64(), Some(0));
+}
+
+#[test]
 fn peer_sync_during_backoff_does_not_queue_new_existing_entries_like_python() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/crates/libs/rns-rpc/src/rpc/params/core.rs
+++ b/crates/libs/rns-rpc/src/rpc/params/core.rs
@@ -72,6 +72,8 @@ struct PeerOpParams {
     transfer_limit_kb: Option<f64>,
     #[serde(default)]
     wanted_ids: Option<JsonValue>,
+    #[serde(default)]
+    maintenance_claimed: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/libs/rns-rpc/src/rpc/params/core.rs
+++ b/crates/libs/rns-rpc/src/rpc/params/core.rs
@@ -74,6 +74,8 @@ struct PeerOpParams {
     wanted_ids: Option<JsonValue>,
     #[serde(default)]
     maintenance_claimed: bool,
+    #[serde(default)]
+    force_sync: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/libs/rns-rpc/src/storage/messages.rs
+++ b/crates/libs/rns-rpc/src/storage/messages.rs
@@ -1457,7 +1457,8 @@ impl MessagesStore {
                 if affected > 0 {
                     tx.execute(
                         "DELETE FROM propagation_peer_entries
-                         WHERE transient_id = ?1",
+                         WHERE transient_id = ?1
+                           AND state = 'unhandled'",
                         params![transient_id],
                     )?;
                     purged = purged.saturating_add(affected);
@@ -3343,7 +3344,7 @@ mod tests {
     }
 
     #[test]
-    fn purge_propagation_entries_removes_peer_marks_for_deleted_entries() {
+    fn purge_propagation_entries_removes_unhandled_marks_but_preserves_completed_state() {
         let store = MessagesStore::in_memory().expect("in-memory store");
         let entry = PropagationEntryRecord {
             transient_id: "af".repeat(32),
@@ -3357,6 +3358,9 @@ mod tests {
         store
             .mark_peer_handled_propagation("peer-cleanup", entry.transient_id.as_str())
             .expect("mark handled");
+        store
+            .mark_peer_unhandled_propagation("peer-retry", entry.transient_id.as_str())
+            .expect("mark unhandled");
 
         let purged = store
             .purge_propagation_entries_for_destination(
@@ -3370,6 +3374,19 @@ mod tests {
             .list_peer_handled_propagation_ids("peer-cleanup")
             .expect("handled ids")
             .is_empty());
+        assert!(
+            store
+                .peer_completed_propagation_mark_exists("peer-cleanup", entry.transient_id.as_str())
+                .expect("completed mark"),
+            "completed peer accounting survives payload purge for future reingest"
+        );
+        assert!(
+            store
+                .list_peer_unhandled_propagation_ids("peer-retry")
+                .expect("unhandled ids")
+                .is_empty(),
+            "retryable marks for the deleted payload are stale and should be removed"
+        );
     }
 
     #[test]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -235,6 +235,11 @@ The project is best described by capability level:
   haves as received/completed work for the requesting propagation peer after
   purge, so reintroduced payloads are not queued back to peers that already
   declared them.
+- Inbound propagation message-get purge-only requests now return the
+  Python-style boolean success response after haves are applied, and payload
+  purge cleanup preserves completed peer accounting for other peers while
+  removing stale unhandled marks, so reintroduced payloads are not offered back
+  to peers that already completed them.
 - Inbound propagation message-get requests now mark wanted payloads skipped by
   the peer's transfer budget as transfer-limited completed work after peer
   admission, so oversized fetch attempts do not remain retryable queue entries.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -140,6 +140,10 @@ The project is best described by capability level:
 - Successful remote unpeer now also uses the stored peer ID case for the bridge
   call and nested bridge result when callers use a case-variant peer request,
   keeping remote teardown identity aligned with local queue cleanup.
+- Inbound reticulumd `/pn/peer/sync` and `/pn/peer/unpeer` control commands now
+  resolve stored peer IDs case-insensitively before dispatching to daemon RPCs,
+  so binary peer-control requests do not report not-found for restored or
+  configured peers whose status rows preserve a different hex presentation.
 - Payload-backed peer queue snapshot mirroring resolves stored peer IDs
   case-insensitively before reading live queue marks, so restart/export state
   preserves queued work when callers use Python-style peer case variants.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -87,6 +87,10 @@ The project is best described by capability level:
   invoking sync by recording the sync attempt and next backoff window, while
   allowing the internal maintenance-triggered sync to consume that claim, so
   concurrent scheduler passes cannot double-select the same peer.
+- Manual `/pn/peer/sync` control requests now force an immediate peer sync
+  through ordinary backoff windows, while scheduled maintenance and remote
+  syncs still respect retry postponement, matching the operator-triggered
+  retry path.
 - Remote fetch/download/sync imports now validate the full returned propagation
   payload batch before mutating the local store or in-memory payload cache, so a
   mixed valid/invalid remote response fails without leaving partial relay state.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -370,8 +370,8 @@ The project is best described by capability level:
   admission does not queue those source payloads back to the sender.
 - Valid inbound propagation offers now start the peer offer throttle window
   after peering-key and transient-ID validation, so repeated replication offers
-  from the same peer take the throttled response path instead of immediately
-  reprocessing the same offer.
+  from the same peer take the throttled response path even when the peer changes
+  the offered transient-ID set.
 
 ## Remaining Release Blockers
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -41,6 +41,12 @@ The project is best described by capability level:
 - AutoInterface has a live daemon runtime, including discovery, peer lifecycle,
   peer-data sockets, transport ingress, outbound routing, and multicast proof
   fallback.
+- Known but unsupported Python interface families now fail config parsing with
+  deterministic unsupported-family diagnostics instead of silently becoming
+  inert unknown interface entries.
+- `rnstatus-rs` now provides a local daemon status utility over the existing
+  RPC status surface, including JSON output and human interface runtime
+  startup state.
 
 ### LXMF
 
@@ -77,6 +83,13 @@ The project is best described by capability level:
   advertised integer or fractional kilobytes into the byte limits used by
   peer-sync queue selection, so valid queued payloads are not misclassified as
   transfer-limited.
+- Propagation peer maintenance selection now claims the chosen peer before
+  invoking sync by recording the sync attempt and next backoff window, while
+  allowing the internal maintenance-triggered sync to consume that claim, so
+  concurrent scheduler passes cannot double-select the same peer.
+- Remote fetch/download/sync imports now validate the full returned propagation
+  payload batch before mutating the local store or in-memory payload cache, so a
+  mixed valid/invalid remote response fails without leaving partial relay state.
 - Malformed remote fetch and download imports now mirror existing
   payload-backed live queue marks into active peer record snapshots before
   failing, preserving restart/export retry state for already queued relay work.
@@ -106,6 +119,10 @@ The project is best described by capability level:
   queue marks into active peer record snapshots after applying imports, so
   restart/export state preserves queued retry work even when the remote sync
   itself succeeds without transferring those local queued offers.
+- Successful remote peer-sync imports now also refresh payload-backed queue
+  snapshots for all active peers affected by imported payloads, so relay peers
+  preserve complete restart/export-visible unhandled queues instead of only the
+  newly imported IDs.
 - Remote peer-sync now uses the stored peer ID case for the bridge call, import
   source accounting, state updates, and response envelope when callers use a
   case-variant peer request.
@@ -179,6 +196,12 @@ The project is best described by capability level:
 - Live propagation announces now retain Python PN metadata on active peer
   records, so announce-derived peer metadata survives into later peering and
   queue restart/export snapshots.
+- Python-style `lxmd` `[lxmf] announce_interval` now drives peer/delivery
+  announce cadence separately from `[propagation] announce_interval`, which
+  remains the propagation-node announce cadence.
+- Outbound propagated delivery now resolves selected propagation-node
+  `propagation_stamp_cost` case-insensitively, so Python-style hash casing does
+  not fall back to the default propagation stamp cost.
 - Peer sync queue creation also records newly queued existing propagation IDs in
   the peer record snapshot, so postponed syncs can restart/export with the same
   unhandled queue visible in live status.
@@ -208,6 +231,10 @@ The project is best described by capability level:
 - Inbound propagation message-get `haves` handling now applies peer admission
   before purging matching local payloads, so rejected peers cannot delete queued
   transfers they are not allowed to acknowledge.
+- Inbound propagation message-get `haves` handling now also records matched
+  haves as received/completed work for the requesting propagation peer after
+  purge, so reintroduced payloads are not queued back to peers that already
+  declared them.
 - Inbound propagation message-get requests now mark wanted payloads skipped by
   the peer's transfer budget as transfer-limited completed work after peer
   admission, so oversized fetch attempts do not remain retryable queue entries.
@@ -332,6 +359,10 @@ The project is best described by capability level:
 - Inbound propagation offers now mark already-known offered payload IDs as
   received from the offering peer after peering-key validation, so later peer
   admission does not queue those source payloads back to the sender.
+- Valid inbound propagation offers now start the peer offer throttle window
+  after peering-key and transient-ID validation, so repeated replication offers
+  from the same peer take the throttled response path instead of immediately
+  reprocessing the same offer.
 
 ## Remaining Release Blockers
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -131,11 +131,11 @@ The project is best described by capability level:
   source accounting, state updates, and response envelope when callers use a
   case-variant peer request.
 - Failed remote unpeer attempts now mirror existing payload-backed live queue
-  marks into active peer record snapshots before returning bridge-unavailable
-  or bridge-execution errors, including case-insensitive peer requests, so
-  restart/export state preserves queued retry work when peering teardown fails;
-  these failed attempts also mark the propagation lifecycle failed instead of
-  leaving stale idle/completed state.
+  marks and restored peer-record queue IDs into active peer record snapshots
+  before returning bridge-unavailable or bridge-execution errors, including
+  case-insensitive peer requests, so restart/export state preserves queued retry
+  work when peering teardown fails; these failed attempts also mark the
+  propagation lifecycle failed instead of leaving stale idle/completed state.
 - Successful remote unpeer now also uses the stored peer ID case for the bridge
   call and nested bridge result when callers use a case-variant peer request,
   keeping remote teardown identity aligned with local queue cleanup.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -69,10 +69,10 @@ The project is best described by capability level:
 - Retryable numeric local offer responses now mirror payload-backed live queue
   marks into the active peer record snapshot before returning, so restart/export
   state preserves the retry queue even when the serialized snapshot was empty.
-- Retryable, throttled, generic failed, and malformed-import remote peer-sync
-  paths now perform the same payload-backed live queue snapshot mirroring
-  before reporting the failed sync, keeping local and remote retry/export
-  behavior aligned.
+- Retryable, throttled, generic failed, malformed-import, and
+  bridge-unavailable remote peer-sync paths now perform the same payload-backed
+  live and restored queue snapshot mirroring before reporting the failed sync,
+  keeping local and remote retry/export behavior aligned.
 - Payload-backed remote failure snapshots now replace stale serialized peer
   queue IDs with live payload-backed marks, so bridge failures do not preserve
   obsolete restart/export work after the underlying payload is gone.
@@ -113,9 +113,10 @@ The project is best described by capability level:
   queue marks into active peer record snapshots before returning, so
   restart/export state preserves queued retry work even when sync is deferred.
 - Remote peer-sync bridge-unavailable errors now mirror existing payload-backed
-  live queue marks into active peer record snapshots for already known peers
-  before returning, including case-insensitive requests, while still avoiding
-  peer creation when the bridge is absent.
+  live marks and restored peer-record queue IDs into active peer record
+  snapshots for already known peers before returning, including
+  case-insensitive requests, while still avoiding peer creation when the bridge
+  is absent.
 - Remote peer-sync bridge-unavailable errors for already known peers now also
   publish the failed peer-sync event and mark the propagation sync lifecycle
   failed, keeping queue retry state observable without creating new peers.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -310,6 +310,9 @@ The project is best described by capability level:
 - Peer unpeer cleanup now clears case-variant propagation marks as one peer,
   so completed marks merged during activation cannot survive teardown and
   reappear as handled work when that peer is later reactivated.
+- Peer unpeer cleanup now also removes the peer from configured static
+  propagation membership, so an explicit unpeer cannot be undone by the next
+  static-peer activation pass.
 - Peer unpeer cleanup accounting now also reads case-variant live queue marks
   as one effective peer before clearing them, so the response and event report
   the same handled/unhandled IDs and byte totals that teardown actually

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -102,10 +102,11 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   unhandled queue marks into active peer record snapshots before returning,
   preserving restart/export retry state even when the serialized snapshot was
   previously empty.
-- Retryable, throttled, generic failed, and malformed-import remote peer-sync
-  paths mirror the same payload-backed queue marks into active peer record
-  snapshots before publishing the failed sync event, so local and remote
-  retry/export behavior stays aligned.
+- Retryable, throttled, generic failed, malformed-import, and
+  bridge-unavailable remote peer-sync paths mirror the same payload-backed live
+  and restored queue marks into active peer record snapshots before publishing
+  the failed sync event, so local and remote retry/export behavior stays
+  aligned.
 - Payload-backed remote failure snapshots replace stale serialized peer queue
   IDs with live payload-backed marks, so bridge failures do not preserve
   obsolete restart/export work after the underlying payload is gone.
@@ -145,9 +146,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   marks into active peer record snapshots before returning, so deferred syncs
   preserve queued retry work across restart/export.
 - Remote peer-sync bridge-unavailable errors mirror existing payload-backed
-  queue marks into active peer record snapshots for already known peers before
-  returning, including case-insensitive requests, without creating new peers
-  when the bridge is absent.
+  live marks and restored peer-record queue IDs into active peer record
+  snapshots for already known peers before returning, including
+  case-insensitive requests, without creating new peers when the bridge is
+  absent.
 - Remote peer-sync bridge-unavailable errors for already known peers also
   publish the failed peer-sync event and mark the propagation sync lifecycle
   failed, keeping queued retry state observable without creating new peers.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -265,6 +265,11 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   received/completed work for the requesting propagation peer after purge, so
   reintroduced payloads are not queued back to peers that already declared
   them.
+- Inbound propagation message-get purge-only requests return the Python-style
+  boolean success response after haves are applied, and payload purge cleanup
+  preserves completed peer accounting for other peers while removing stale
+  unhandled marks, so reintroduced payloads are not offered back to peers that
+  already completed them.
 - Inbound propagation message-get requests mark wanted payloads skipped by the
   peer's transfer budget as transfer-limited completed work after peer
   admission, so oversized fetch attempts do not remain retryable queue entries.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -120,6 +120,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   sync by recording the sync attempt and next backoff window, while allowing the
   internal maintenance-triggered sync to consume that claim, so concurrent
   scheduler passes cannot double-select the same peer.
+- Manual `/pn/peer/sync` control requests force an immediate peer sync through
+  ordinary backoff windows, while scheduled maintenance and remote syncs still
+  respect retry postponement, matching the operator-triggered retry path.
 - Remote fetch/download/sync imports validate the full returned propagation
   payload batch before mutating the local store or in-memory payload cache, so
   mixed valid/invalid remote responses fail without leaving partial relay state.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -177,6 +177,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Successful remote unpeer uses the stored peer ID case for the bridge call and
   nested bridge result when callers supply a case-variant peer request, keeping
   remote teardown identity aligned with local queue cleanup.
+- Inbound reticulumd `/pn/peer/sync` and `/pn/peer/unpeer` control commands
+  resolve stored peer IDs case-insensitively before dispatching to daemon RPCs,
+  so binary peer-control requests do not report not-found for restored or
+  configured peers whose status rows preserve a different hex presentation.
 - Payload-backed peer queue snapshot mirroring resolves stored peer IDs
   case-insensitively before reading live queue marks, preserving queued
   restart/export work when callers use Python-style peer case variants.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -393,8 +393,8 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   admission from offering the sender its own known payloads.
 - Valid inbound propagation offers start the peer offer throttle window after
   peering-key and transient-ID validation, so repeated replication offers from
-  the same peer return the throttled response instead of reprocessing
-  immediately.
+  the same peer return the throttled response even when the peer changes the
+  offered transient-ID set.
 - Inbound propagation distinguishes clients, validated peers, unpeered
   identified senders, and local delivery; source peers are accounted and not
   re-offered their own payloads.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -116,6 +116,13 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   advertised integer or fractional kilobytes into the byte limits used by
   peer-sync queue selection, so valid queued payloads are not misclassified as
   transfer-limited.
+- Propagation peer maintenance selection claims the chosen peer before invoking
+  sync by recording the sync attempt and next backoff window, while allowing the
+  internal maintenance-triggered sync to consume that claim, so concurrent
+  scheduler passes cannot double-select the same peer.
+- Remote fetch/download/sync imports validate the full returned propagation
+  payload batch before mutating the local store or in-memory payload cache, so
+  mixed valid/invalid remote responses fail without leaving partial relay state.
 - Malformed remote fetch and download imports mirror existing payload-backed
   queue marks into active peer record snapshots before returning the import
   failure, so already queued relay work remains visible after restart/export.
@@ -145,6 +152,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   into active peer record snapshots after applying imports, preserving queued
   retry work across restart/export even when the remote sync succeeds without
   transferring those local queued offers.
+- Successful remote peer-sync imports refresh payload-backed queue snapshots
+  for all active peers affected by imported payloads, so relay peers preserve
+  complete restart/export-visible unhandled queues rather than only newly
+  imported IDs.
 - Remote peer-sync imports transferred propagation payloads from both daemon
   `payload_hex` fields and MessagePack binary payload arrays, so bridge results
   converted through `rmpv_to_json` enqueue the same relay work without treating
@@ -223,6 +234,12 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Live propagation announces retain Python PN metadata on active peer records,
   so announce-derived peer metadata survives into later peering and queue
   restart/export snapshots.
+- Python-style `lxmd` `[lxmf] announce_interval` drives peer/delivery announce
+  cadence separately from `[propagation] announce_interval`, which remains the
+  propagation-node announce cadence.
+- Outbound propagated delivery resolves selected propagation-node
+  `propagation_stamp_cost` case-insensitively, so Python-style hash casing does
+  not fall back to the default propagation stamp cost.
 - Duplicate inbound peer propagation payloads still fan out to active relay
   peers while keeping the source peer handled, so a known local payload does
   not bypass relay queue creation.
@@ -244,6 +261,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Inbound propagation message-get `haves` handling applies peer admission
   before purging matching local payloads, so rejected peers cannot delete queued
   transfers they are not allowed to acknowledge.
+- Inbound propagation message-get `haves` handling records matched haves as
+  received/completed work for the requesting propagation peer after purge, so
+  reintroduced payloads are not queued back to peers that already declared
+  them.
 - Inbound propagation message-get requests mark wanted payloads skipped by the
   peer's transfer budget as transfer-limited completed work after peer
   admission, so oversized fetch attempts do not remain retryable queue entries.
@@ -362,6 +383,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Inbound propagation offers mark already-known offered payload IDs as received
   for the offering peer after peering-key validation, preventing later peer
   admission from offering the sender its own known payloads.
+- Valid inbound propagation offers start the peer offer throttle window after
+  peering-key and transient-ID validation, so repeated replication offers from
+  the same peer return the throttled response instead of reprocessing
+  immediately.
 - Inbound propagation distinguishes clients, validated peers, unpeered
   identified senders, and local delivery; source peers are accounted and not
   re-offered their own payloads.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -335,6 +335,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Peer unpeer cleanup clears case-variant propagation marks as one peer, so
   completed marks merged during activation cannot survive teardown and reappear
   as handled work when that peer is later reactivated.
+- Peer unpeer cleanup also removes the peer from configured static propagation
+  membership, so an explicit unpeer cannot be undone by the next static-peer
+  activation pass.
 - Peer unpeer cleanup accounting reads case-variant live queue marks as one
   effective peer before clearing them, so the response and event report the
   handled/unhandled IDs and byte totals that teardown actually removes.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -166,12 +166,12 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote peer-sync uses the stored peer ID case for the bridge call, import
   source accounting, state updates, and response envelope when callers supply a
   case-variant peer request.
-- Failed remote unpeer attempts mirror existing payload-backed queue marks into
-  active peer record snapshots before returning bridge-unavailable or
-  bridge-execution errors, including case-insensitive peer requests, so failed
-  peering teardown preserves queued retry work across restart/export and marks
-  the propagation lifecycle failed instead of leaving stale idle/completed
-  state.
+- Failed remote unpeer attempts mirror existing payload-backed queue marks and
+  restored peer-record queue IDs into active peer record snapshots before
+  returning bridge-unavailable or bridge-execution errors, including
+  case-insensitive peer requests, so failed peering teardown preserves queued
+  retry work across restart/export and marks the propagation lifecycle failed
+  instead of leaving stale idle/completed state.
 - Successful remote unpeer uses the stored peer ID case for the bridge call and
   nested bridge result when callers supply a case-variant peer request, keeping
   remote teardown identity aligned with local queue cleanup.

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -33,7 +33,7 @@ Workspace paths are used for navigation. Published package names are
 | `RNS/Discovery.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | Announce/path discovery plus live AutoInterface discovery and peer runtime. | Public bootstrap/discovery breadth remains narrower than Python. |
 | `RNS/Resolver.py` | `crates/libs/rns-transport` | partial | Resolver helpers and cached lookup behavior exist. | Full resolver/discovery surface parity is not established. |
 | `RNS/Cryptography/*` | `crates/libs/rns-core` | done | Required Reticulum primitives used by identities, packets, links, and receipts. | No confirmed parity blocker. |
-| `RNS/Utilities/*` | `crates/apps/rns-tools` | partial | `rnx` is substantial; `rnsd` delegates to `reticulumd`. | Real equivalents for retired `rncp`, `rnid`, `rnir`, `rnodeconf`, `rnpath`, `rnpkg`, `rnprobe`, and `rnstatus` are absent. |
+| `RNS/Utilities/*` | `crates/apps/rns-tools` | partial | `rnx` is substantial; `rnsd` delegates to `reticulumd`; `rnstatus-rs` reports local daemon/interface status from RPC with JSON and human output. | Full equivalents for retired `rncp`, `rnid`, `rnir`, `rnodeconf`, `rnpath`, `rnpkg`, and `rnprobe` remain absent; `rnstatus-rs` is local status only. |
 | `CRNS/*` | `crates/apps/rns-tools` | partial | Selected command workflows exist. | The Python command ecosystem is not reproduced. |
 
 ## Interface Detail
@@ -55,6 +55,11 @@ without Rust-only transport overrides.
 
 `RNS/Interfaces/*` remains `partial` because parity is measured against the
 whole Python family, not because the implemented interfaces are stubs.
+
+Known but unsupported Python interface families such as `PipeInterface`,
+`LocalInterface`, `I2PInterface`, `WeaveInterface`, and `BackboneInterface`
+now fail config parsing with deterministic unsupported-family diagnostics
+instead of silently loading as inert unknown interface entries.
 
 ## Highest-Priority Gaps
 


### PR DESCRIPTION
## Summary
- preserve completed peer queue marks when propagation payload purges run
- force manual peer sync requests through existing backoff gates
- throttle inbound propagation offers by peer, even when offered transient IDs change
- update parity/status docs for the peer replication behavior now covered

## Verification
- cargo test -p reticulumd offer_request_repeated_valid_offer_is_throttled_like_python
- cargo test -p reticulum-rs-rpc propagation_peer_offer
- cargo test -p reticulum-rs-rpc forced_peer_sync_bypasses_existing_backoff_like_manual_control
- cargo test -p reticulum-rs-rpc peer_sync_during_backoff_
- cargo test -p reticulum-rs-rpc propagation_remote_sync_respects_peer_backoff_before_bridge_call
- cargo test -p reticulum-rs-rpc propagation_remote_sync_backoff_does_not_require_bridge
- cargo clippy -p reticulum-rs-rpc -p reticulumd --all-targets --all-features --no-deps -- -D warnings
- cargo fmt --all -- --check
- git diff --check

## Notes
- cargo run -p xtask -- architecture-checks is blocked locally because WSL cannot launch /bin/bash in this Windows environment: execvpe(/bin/bash) failed.