### PR TITLE
Use canonical propagation ids in remote acks

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
@@ -2,9 +2,10 @@ use super::remote_control_download::propagation_download_request;
 use super::*;
 use reticulum_daemon::lxmf_bridge::rmpv_to_json;
 use rns_rpc::RemoteControlBridge;
-use sha2::{Digest, Sha256};
 
-use super::remote_fetch::{rmpv_binary_array, LocalPropagationImportOutcome};
+use super::remote_fetch::{
+    propagation_payload_ack_transient_id, rmpv_binary_array, LocalPropagationImportOutcome,
+};
 use super::remote_request::remote_control_request;
 
 impl TransportBridge {
@@ -377,7 +378,9 @@ fn propagation_remote_fetch_ack_payload(
                 LocalPropagationImportOutcome::Imported | LocalPropagationImportOutcome::Duplicate
             )
         })
-        .map(|(payload, _outcome)| rmpv::Value::Binary(Sha256::digest(payload).to_vec()))
+        .map(|(payload, _outcome)| {
+            rmpv::Value::Binary(propagation_payload_ack_transient_id(payload))
+        })
         .collect();
     rmpv::Value::Array(vec![rmpv::Value::Nil, rmpv::Value::Array(haves)])
 }
@@ -427,6 +430,7 @@ fn response_code_error(response: &rmpv::Value) -> Option<std::io::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reticulum_daemon::lxmf_stamps::generate_propagation_stamp;
     use sha2::{Digest, Sha256};
 
     #[test]
@@ -469,7 +473,15 @@ mod tests {
     #[test]
     fn propagation_remote_fetch_ack_payload_reports_imported_and_duplicate_haves() {
         let imported_payload = b"imported remote fetch payload".to_vec();
-        let duplicate_payload = b"duplicate remote fetch payload".to_vec();
+        let duplicate_lxm_data = vec![0x51; 160];
+        let duplicate_transient_id = Sha256::digest(&duplicate_lxm_data);
+        let duplicate_stamp = generate_propagation_stamp(
+            duplicate_transient_id.as_slice().try_into().expect("transient id width"),
+            1,
+        )
+        .expect("propagation stamp");
+        let mut duplicate_payload = duplicate_lxm_data.clone();
+        duplicate_payload.extend_from_slice(duplicate_stamp.as_slice());
         let rejected_payload = b"rejected remote fetch payload".to_vec();
 
         let ack = propagation_remote_fetch_ack_payload(&[
@@ -487,6 +499,7 @@ mod tests {
         };
         assert_eq!(haves.len(), 2);
         assert_eq!(haves[0], rmpv::Value::Binary(Sha256::digest(imported_payload).to_vec()));
-        assert_eq!(haves[1], rmpv::Value::Binary(Sha256::digest(duplicate_payload).to_vec()));
+        assert_eq!(haves[1], rmpv::Value::Binary(duplicate_transient_id.to_vec()));
+        assert_ne!(haves[1], rmpv::Value::Binary(Sha256::digest(duplicate_payload).to_vec()));
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_download.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_download.rs
@@ -2,6 +2,7 @@ use super::remote_control_link::{
     build_link_identify_payload, build_link_request_payload, open_refreshed_remote_link,
     resolve_remote_identity, send_link_context_packet, wait_for_link_request_response,
 };
+use super::remote_fetch::propagation_payload_ack_transient_id;
 use super::*;
 use lxmf::inbound_decode::InboundPayloadMode;
 use reticulum_daemon::inbound_delivery::{
@@ -9,7 +10,6 @@ use reticulum_daemon::inbound_delivery::{
     inbound_record_allowed_by_delivery_policy,
 };
 use rns_transport::identity::DecryptIdentity;
-use sha2::{Digest, Sha256};
 use x25519_dalek::PublicKey;
 
 pub(super) async fn propagation_download_request(
@@ -97,15 +97,15 @@ pub(super) async fn propagation_download_request(
     let mut duplicates = 0usize;
     let mut rejected = 0usize;
     for payload in &payloads {
-        let transient_id = Sha256::digest(payload);
+        let transient_id = propagation_payload_ack_transient_id(payload);
         match accept_downloaded_propagation_payload(daemon, delivery_destination, payload).await? {
             DownloadAcceptOutcome::Stored => {
                 downloaded += 1;
-                haves.push(transient_id.to_vec());
+                haves.push(transient_id);
             }
             DownloadAcceptOutcome::Duplicate => {
                 duplicates += 1;
-                haves.push(transient_id.to_vec());
+                haves.push(transient_id);
             }
             DownloadAcceptOutcome::Rejected => rejected += 1,
         }

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_fetch.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_fetch.rs
@@ -4,7 +4,9 @@ use reticulum_daemon::inbound_delivery::{
     annotate_inbound_record_stamp_status, decode_inbound_payload, evaluate_inbound_stamp_policy,
     inbound_record_allowed_by_delivery_policy,
 };
+use reticulum_daemon::lxmf_stamps::{validate_propagation_stamp, PROPAGATION_STAMP_SIZE};
 use rns_transport::identity::DecryptIdentity;
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum LocalPropagationImportOutcome {
@@ -30,6 +32,14 @@ pub(super) fn rmpv_binary_array(value: &rmpv::Value) -> Result<Vec<Vec<u8>>, std
             )),
         })
         .collect()
+}
+
+pub(super) fn propagation_payload_ack_transient_id(transient_payload: &[u8]) -> Vec<u8> {
+    if validate_propagation_stamp(transient_payload, 1).is_some() {
+        let lxm_data_len = transient_payload.len().saturating_sub(PROPAGATION_STAMP_SIZE);
+        return Sha256::digest(&transient_payload[..lxm_data_len]).to_vec();
+    }
+    Sha256::digest(transient_payload).to_vec()
 }
 
 impl TransportBridge {
@@ -175,6 +185,7 @@ mod tests {
     use lxmf::WireMessage;
     use rand_core::OsRng;
     use reticulum_daemon::lxmf_bridge::build_wire_message_with_options;
+    use reticulum_daemon::lxmf_stamps::generate_propagation_stamp;
     use rns_transport::destination::DestinationName;
     use rns_transport::identity::PrivateIdentity;
     use rns_transport::identity_bridge::{to_core_identity, to_core_private_identity};
@@ -311,5 +322,32 @@ mod tests {
 
         assert_eq!(first, LocalPropagationImportOutcome::Imported);
         assert_eq!(second, LocalPropagationImportOutcome::Duplicate);
+    }
+
+    #[test]
+    fn ack_transient_id_uses_lxm_data_for_stamped_payloads() {
+        let lxm_data = vec![0x42; 160];
+        let transient_id = Sha256::digest(&lxm_data);
+        let stamp = generate_propagation_stamp(
+            transient_id.as_slice().try_into().expect("transient id width"),
+            1,
+        )
+        .expect("propagation stamp");
+        let mut transient_payload = lxm_data.clone();
+        transient_payload.extend_from_slice(stamp.as_slice());
+
+        let ack_id = propagation_payload_ack_transient_id(transient_payload.as_slice());
+
+        assert_eq!(ack_id, transient_id.to_vec());
+        assert_ne!(ack_id, Sha256::digest(transient_payload).to_vec());
+    }
+
+    #[test]
+    fn ack_transient_id_keeps_unstamped_payload_hash() {
+        let transient_payload = b"ack-unstamped-lxm-data".to_vec();
+
+        let ack_id = propagation_payload_ack_transient_id(transient_payload.as_slice());
+
+        assert_eq!(ack_id, Sha256::digest(transient_payload).to_vec());
     }
 }

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -278,6 +278,10 @@ The project is best described by capability level:
 - Remote import batch byte accounting now uses the same deduplicated accepted
   IDs, so duplicate payloads in one fetch/download/sync response do not inflate
   transferred byte totals or source peer receive byte counters.
+- Remote fetch/download acknowledgements now use canonical propagation
+  transient IDs for stamped payloads, so `/get` haves purge the peer's offered
+  queue entry instead of acknowledging the stamped payload bytes under a
+  different hash.
 - Repeated remote fetch/download/sync imports now increment source peer
   incoming counts and receive bytes only for payload IDs not already marked
   received from that source, while still replaying known payloads into relay

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -308,6 +308,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote import batch byte accounting follows the same deduplicated accepted
   IDs, so duplicate payloads in one fetch/download/sync response do not inflate
   transferred byte totals or source peer receive byte counters.
+- Remote fetch/download acknowledgements use canonical propagation transient
+  IDs for stamped payloads, so `/get` haves clear the peer's offered queue entry
+  instead of reporting the stamped payload bytes under a different hash.
 - Repeated remote fetch/download/sync imports increment source peer incoming
   counts and receive bytes only for payload IDs not already marked received
   from that source, while still replaying known payloads into relay queues when


### PR DESCRIPTION
## Summary
- derive remote fetch/download /get acknowledgement haves from canonical propagation transient IDs
- preserve the raw payload hash path for unstamped payloads
- update parity status docs for the remote fetch/download acknowledgement behavior

## Gap analysis
Remote fetch/download acknowledgement haves were built from the full payload bytes. For stamped propagation payloads, the canonical transient ID is derived from the LXMF data before the trailing propagation stamp, so peers could keep offered queue entries after an acknowledgement.

## Reference behavior notes
The reference propagation model derives transient IDs from the LXMF data and treats the propagation stamp as trailing proof-of-work, not part of the queue identifier. This patch independently reimplements that protocol decision for remote acknowledgement construction.

## Verification
- cargo test -p reticulumd ack_transient_id
- cargo test -p reticulumd propagation_remote_fetch_ack_payload_reports_imported_and_duplicate_haves
- cargo clippy -p reticulumd --all-targets --all-features --no-deps -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- reference-name scan over touched files: no matches

Boundary note: cargo run -p xtask -- architecture-checks is blocked locally because WSL cannot launch /bin/bash on this machine.