### PR TITLE
Wait for propagation download haves acks

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
@@ -406,7 +406,7 @@ fn response_to_result(response: rmpv::Value) -> Result<rmpv::Value, std::io::Err
     Ok(response)
 }
 
-fn response_code_error(response: &rmpv::Value) -> Option<std::io::Error> {
+pub(super) fn response_code_error(response: &rmpv::Value) -> Option<std::io::Error> {
     if let Some(code) = response.as_u64().or_else(|| response.as_i64().map(|value| value as u64)) {
         let (kind, message) = match code as u8 {
             0xF0 => (std::io::ErrorKind::PermissionDenied, "propagation node requires identity"),

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_download.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_download.rs
@@ -1,3 +1,4 @@
+use super::remote_control::response_code_error;
 use super::remote_control_link::{
     build_link_identify_payload, build_link_request_payload, open_refreshed_remote_link,
     resolve_remote_identity, send_link_context_packet, wait_for_link_request_response,
@@ -119,13 +120,25 @@ pub(super) async fn propagation_download_request(
                 rmpv::Value::Array(haves.into_iter().map(rmpv::Value::Binary).collect()),
             ]),
         )?;
-        let _ = send_link_context_packet(
+        let ack_request_id = send_link_context_packet(
             transport,
             &link,
             PacketContext::Request,
             ack_payload.as_slice(),
         )
-        .await?;
+        .await?
+        .ok_or_else(|| std::io::Error::other("missing propagation haves ack request id"))?;
+        let ack_response = wait_for_link_request_response(
+            &mut data_rx,
+            &mut resource_rx,
+            destination.desc.address_hash,
+            link_id,
+            ack_request_id,
+            timeout,
+        )
+        .await
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::TimedOut, err))?;
+        propagation_download_ack_response_result(&ack_response)?;
     }
 
     Ok((
@@ -159,6 +172,13 @@ fn propagation_download_summary_json(
         "rejected": rejected,
         "transferred_bytes": transferred_bytes,
     })
+}
+
+fn propagation_download_ack_response_result(response: &rmpv::Value) -> Result<(), std::io::Error> {
+    if let Some(error) = response_code_error(response) {
+        return Err(error);
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -314,6 +334,15 @@ mod tests {
             summary["transferred_bytes"].as_u64(),
             Some(payloads.iter().map(Vec::len).sum::<usize>() as u64)
         );
+    }
+
+    #[test]
+    fn propagation_download_ack_rejects_remote_error_code() {
+        let err = propagation_download_ack_response_result(&rmpv::Value::from(0xF6_u8))
+            .expect_err("throttled ack response should fail");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::WouldBlock);
+        assert!(err.to_string().contains("throttled"));
     }
 
     #[tokio::test]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -278,6 +278,9 @@ The project is best described by capability level:
 - Remote import batch byte accounting now uses the same deduplicated accepted
   IDs, so duplicate payloads in one fetch/download/sync response do not inflate
   transferred byte totals or source peer receive byte counters.
+- Link-based remote downloads now wait for the propagation node's `/get` haves
+  acknowledgement and surface peer/control errors, so failed remote cleanup does
+  not look like a completed replication drain.
 - Repeated remote fetch/download/sync imports now increment source peer
   incoming counts and receive bytes only for payload IDs not already marked
   received from that source, while still replaying known payloads into relay

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -308,6 +308,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote import batch byte accounting follows the same deduplicated accepted
   IDs, so duplicate payloads in one fetch/download/sync response do not inflate
   transferred byte totals or source peer receive byte counters.
+- Link-based remote downloads wait for the propagation node's `/get` haves
+  acknowledgement and propagate peer/control errors, so failed remote cleanup is
+  not reported as a completed replication drain.
 - Repeated remote fetch/download/sync imports increment source peer incoming
   counts and receive bytes only for payload IDs not already marked received
   from that source, while still replaying known payloads into relay queues when


### PR DESCRIPTION
## Summary
- make link-based propagation downloads wait for `/get` haves acknowledgement responses
- reuse the existing propagation control error-code mapping for ack failures
- update parity docs for the completed remote cleanup behavior

## Gap analysis
The peer/propagation matrix still calls out propagation router lifecycle gaps. The smallest high-impact gap found in this pass was that remote fetch already waits for haves cleanup, while link-based remote download sent the same cleanup request as fire-and-forget. A failed cleanup could leave the remote propagation node treating already downloaded payloads as still pending.

Reference behavior inspiration: propagation replication treats haves acknowledgements as part of the transfer cleanup handshake, not an optional side effect. This patch independently applies that behavior to the link download path.

## Roadmap
Next peer/propagation candidates:
- per-peer in-flight transfer lifecycle for resource success/failure/retry ownership
- persistent local delivered/processed transient caches for restart idempotence
- propagation-node retain-vs-drain side effects for fetched payloads

## Validation
- cargo test -p reticulumd propagation_download_ack_rejects_remote_error_code
- cargo test -p reticulumd policy_rejected_downloaded_payload_is_not_reported_as_duplicate_have
- cargo test -p reticulumd propagation_download
- cargo clippy -p reticulumd --all-targets --all-features --no-deps -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- touched-file attribution scan: no prohibited reference strings

## Boundary notes
- `cargo run -p xtask -- architecture-checks` could not run locally because WSL cannot launch `/bin/bash` in this environment.