### PR TITLE
Persist local propagation processed IDs

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -354,13 +354,17 @@ impl RpcDaemon {
                 .get_propagation_entry(transient_id.as_str())
                 .map_err(std::io::Error::other)?
                 .is_some();
+            let already_processed = self
+                .store
+                .local_propagation_processed_mark_exists(transient_id.as_str())
+                .map_err(std::io::Error::other)?;
             let already_accepted =
                 accepted_ids.iter().any(|id| id.eq_ignore_ascii_case(transient_id.as_str()));
             if !already_accepted {
                 transferred_bytes = transferred_bytes.saturating_add(payload.len());
                 accepted_ids.push(transient_id.clone());
             }
-            if already_known_store || already_accepted {
+            if already_known_store || already_processed || already_accepted {
                 duplicate_count = duplicate_count.saturating_add(1);
             } else {
                 imported_count = imported_count.saturating_add(1);
@@ -370,6 +374,9 @@ impl RpcDaemon {
         }
         for record in validated {
             self.store.upsert_propagation_entry(&record).map_err(std::io::Error::other)?;
+            self.store
+                .mark_local_propagation_processed(record.transient_id.as_str())
+                .map_err(std::io::Error::other)?;
             self.propagation_payloads
                 .lock()
                 .expect("propagation payload mutex poisoned")
@@ -615,10 +622,16 @@ impl RpcDaemon {
         };
         let transient_id = normalize_propagation_transient_key(transient_id);
         let already_known = if normalized.is_some() && !transient_id.is_empty() {
-            self.store
+            let already_stored = self
+                .store
                 .get_propagation_entry(transient_id.as_str())
                 .map_err(std::io::Error::other)?
-                .is_some()
+                .is_some();
+            let already_processed = self
+                .store
+                .local_propagation_processed_mark_exists(transient_id.as_str())
+                .map_err(std::io::Error::other)?;
+            already_stored || already_processed
         } else {
             false
         };
@@ -634,6 +647,9 @@ impl RpcDaemon {
                 self.store_propagation_payload_hex(alias, payload_hex.as_str())?;
                 guard.insert(normalize_propagation_transient_key(alias), payload_hex.clone());
             }
+            self.store
+                .mark_local_propagation_processed(transient_id.as_str())
+                .map_err(std::io::Error::other)?;
         }
 
         let state = {
@@ -696,10 +712,16 @@ impl RpcDaemon {
             });
 
         let already_known = if normalized_payload.is_some() && !transient_id.is_empty() {
-            self.store
+            let already_stored = self
+                .store
                 .get_propagation_entry(transient_id.as_str())
                 .map_err(std::io::Error::other)?
-                .is_some()
+                .is_some();
+            let already_processed = self
+                .store
+                .local_propagation_processed_mark_exists(transient_id.as_str())
+                .map_err(std::io::Error::other)?;
+            already_stored || already_processed
         } else {
             false
         };
@@ -711,6 +733,9 @@ impl RpcDaemon {
                 .lock()
                 .expect("propagation payload mutex poisoned")
                 .insert(transient_id.clone(), payload_hex);
+            self.store
+                .mark_local_propagation_processed(transient_id.as_str())
+                .map_err(std::io::Error::other)?;
         }
 
         self.note_client_propagation_messages_received(usize::from(
@@ -1404,10 +1429,16 @@ impl RpcDaemon {
                             })
                     });
                 let already_known = if !payload_hex.is_empty() && !transient_id.is_empty() {
-                    self.store
+                    let already_stored = self
+                        .store
                         .get_propagation_entry(transient_id.as_str())
                         .map_err(std::io::Error::other)?
-                        .is_some()
+                        .is_some();
+                    let already_processed = self
+                        .store
+                        .local_propagation_processed_mark_exists(transient_id.as_str())
+                        .map_err(std::io::Error::other)?;
+                    already_stored || already_processed
                 } else {
                     false
                 };
@@ -1434,6 +1465,9 @@ impl RpcDaemon {
                         .lock()
                         .expect("propagation payload mutex poisoned")
                         .insert(transient_id.clone(), payload_hex);
+                    self.store
+                        .mark_local_propagation_processed(transient_id.as_str())
+                        .map_err(std::io::Error::other)?;
                 }
 
                 let state = {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_propagation_ingest.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_propagation_ingest.rs
@@ -600,6 +600,61 @@ fn duplicate_propagation_ingest_does_not_double_count_received() {
     assert_eq!(status["propagation"]["last_ingest_count"].as_u64(), Some(0));
 }
 
+#[test]
+fn purged_propagation_ingest_does_not_recount_processed_transient() {
+    use sha2::{Digest, Sha256};
+
+    let daemon = RpcDaemon::test_instance();
+    let destination = [0x9b_u8; 16];
+    let mut payload = destination.to_vec();
+    payload.extend_from_slice(b" purged local propagation idempotence");
+    let payload_hex = hex::encode(&payload);
+    let transient_id = Sha256::digest(&payload).to_vec();
+    let transient_hex = hex::encode(&transient_id);
+
+    let first = daemon
+        .handle_rpc(rpc_request(
+            83,
+            "propagation_ingest",
+            json!({
+                "transient_id": transient_hex,
+                "payload_hex": payload_hex,
+            }),
+        ))
+        .expect("first propagation ingest")
+        .result
+        .expect("first propagation ingest result");
+    assert_eq!(first["ingested_count"].as_u64(), Some(1));
+
+    let purged = daemon
+        .purge_propagation_payloads_for_destination(&destination, std::slice::from_ref(&transient_id));
+    assert!(purged > 0);
+
+    let second = daemon
+        .handle_rpc(rpc_request(
+            84,
+            "propagation_ingest",
+            json!({
+                "transient_id": transient_hex,
+                "payload_hex": payload_hex,
+            }),
+        ))
+        .expect("second propagation ingest")
+        .result
+        .expect("second propagation ingest result");
+    assert_eq!(second["ingested_count"].as_u64(), Some(0));
+    assert_eq!(second["duplicate_count"].as_u64(), Some(1));
+
+    let status = daemon
+        .handle_rpc(RpcRequest { id: 85, method: "propagation_status".to_string(), params: None })
+        .expect("propagation status")
+        .result
+        .expect("propagation status result");
+    assert_eq!(status["propagation"]["client_propagation_messages_received"].as_u64(), Some(1));
+    assert_eq!(status["propagation"]["total_ingested"].as_u64(), Some(1));
+    assert_eq!(status["propagation"]["last_ingest_count"].as_u64(), Some(0));
+}
+
 fn stamped_propagation_payload(lxm_data: &[u8], target_cost: u32) -> Vec<u8> {
     use hkdf::Hkdf;
     use sha2::{Digest, Sha256};

--- a/crates/libs/rns-rpc/src/storage/messages.rs
+++ b/crates/libs/rns-rpc/src/storage/messages.rs
@@ -853,6 +853,36 @@ impl MessagesStore {
         })
     }
 
+    pub fn mark_local_propagation_processed(&self, transient_id: &str) -> rusqlite::Result<bool> {
+        self.with_write_conn(|conn| {
+            let affected = conn.execute(
+                "INSERT OR IGNORE INTO propagation_local_entries
+                    (transient_id, processed_at)
+                 VALUES (?1, ?2)",
+                params![normalize_hex_key(transient_id), now_unix_secs()],
+            )?;
+            Ok(affected > 0)
+        })
+    }
+
+    pub fn local_propagation_processed_mark_exists(
+        &self,
+        transient_id: &str,
+    ) -> rusqlite::Result<bool> {
+        self.with_read_conn(|conn| {
+            let exists: Option<i64> = conn
+                .query_row(
+                    "SELECT 1 FROM propagation_local_entries
+                     WHERE transient_id = ?1
+                     LIMIT 1",
+                    params![normalize_hex_key(transient_id)],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            Ok(exists.is_some())
+        })
+    }
+
     pub fn propagation_entry_stats(&self) -> rusqlite::Result<PropagationEntryStats> {
         self.with_read_conn(|conn| {
             let (entries, bytes): (i64, Option<i64>) = conn.query_row(
@@ -2086,6 +2116,10 @@ impl MessagesStore {
                     state TEXT NOT NULL,
                     updated_at INTEGER NOT NULL,
                     PRIMARY KEY(peer, transient_id)
+                );
+                CREATE TABLE IF NOT EXISTS propagation_local_entries (
+                    transient_id TEXT PRIMARY KEY,
+                    processed_at INTEGER NOT NULL
                 );
                 CREATE INDEX IF NOT EXISTS idx_messages_timestamp_desc
                     ON messages(timestamp DESC);
@@ -3387,6 +3421,25 @@ mod tests {
                 .is_empty(),
             "retryable marks for the deleted payload are stale and should be removed"
         );
+    }
+
+    #[test]
+    fn local_propagation_processed_mark_is_idempotent() {
+        let store = MessagesStore::in_memory().expect("in-memory store");
+        let transient_id = "ac".repeat(32);
+
+        assert!(!store
+            .local_propagation_processed_mark_exists(transient_id.as_str())
+            .expect("missing processed mark"));
+        assert!(store
+            .mark_local_propagation_processed(transient_id.as_str())
+            .expect("insert processed mark"));
+        assert!(!store
+            .mark_local_propagation_processed(transient_id.as_str())
+            .expect("repeat processed mark"));
+        assert!(store
+            .local_propagation_processed_mark_exists(transient_id.as_str())
+            .expect("processed mark exists"));
     }
 
     #[test]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -278,6 +278,10 @@ The project is best described by capability level:
 - Remote import batch byte accounting now uses the same deduplicated accepted
   IDs, so duplicate payloads in one fetch/download/sync response do not inflate
   transferred byte totals or source peer receive byte counters.
+- Local propagation ingest now persists processed transient IDs separately
+  from retained payload entries, so reintroduced payloads after purge or peer
+  acknowledgement can refresh relay state without inflating local received or
+  ingested counters.
 - Repeated remote fetch/download/sync imports now increment source peer
   incoming counts and receive bytes only for payload IDs not already marked
   received from that source, while still replaying known payloads into relay

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -308,6 +308,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote import batch byte accounting follows the same deduplicated accepted
   IDs, so duplicate payloads in one fetch/download/sync response do not inflate
   transferred byte totals or source peer receive byte counters.
+- Local propagation ingest persists processed transient IDs separately from
+  retained payload entries, so payloads reintroduced after purge or peer
+  acknowledgement can refresh relay state without inflating local received or
+  ingested counters.
 - Repeated remote fetch/download/sync imports increment source peer incoming
   counts and receive bytes only for payload IDs not already marked received
   from that source, while still replaying known payloads into relay queues when


### PR DESCRIPTION
## Summary
- add a durable local processed-transient marker for propagation payloads
- treat reintroduced local propagation payloads as duplicates for local received/ingested counters while still allowing relay state refresh
- document the peer/propagation parity improvement in the roadmap and LXMF matrix

## Gap analysis
- Existing duplicate handling only covered retained payload entries.
- After purge or peer acknowledgement, the same transient could be accepted again as a new local receive because the processed state was tied to payload retention.
- The new marker separates local processed accounting from relay payload storage.

## Roadmap
- Next peer/propagation slice: extend the same durable lifecycle coverage to delivered/local-delivery markers and remote sync restart scenarios.
- Then broaden live Python interop around propagation peer rows and replayed queue state.

## Reference behavior note
- Inspired by peer/router behavior where transient IDs remain processed even when retained propagation payload storage is cleaned up. This is an independent Rust implementation.

## Validation
- cargo test -p reticulum-rs-rpc propagation_ingest
- cargo test -p reticulum-rs-rpc local_propagation_processed_mark_is_idempotent
- cargo fmt --all -- --check
- cargo clippy -p reticulum-rs-rpc --all-targets --all-features --no-deps -- -D warnings
- git diff --check

Boundary check note: cargo run -p xtask -- architecture-checks is blocked locally because WSL cannot launch /bin/bash.