### PR TITLE
Wait for propagation download haves ack

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
@@ -399,7 +399,7 @@ fn response_to_json(response: &rmpv::Value) -> Result<JsonValue, std::io::Error>
     }
 }
 
-fn response_to_result(response: rmpv::Value) -> Result<rmpv::Value, std::io::Error> {
+pub(super) fn response_to_result(response: rmpv::Value) -> Result<rmpv::Value, std::io::Error> {
     if let Some(error) = response_code_error(&response) {
         return Err(error);
     }

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_download.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_download.rs
@@ -119,13 +119,25 @@ pub(super) async fn propagation_download_request(
                 rmpv::Value::Array(haves.into_iter().map(rmpv::Value::Binary).collect()),
             ]),
         )?;
-        let _ = send_link_context_packet(
+        let ack_request_id = send_link_context_packet(
             transport,
             &link,
             PacketContext::Request,
             ack_payload.as_slice(),
         )
-        .await?;
+        .await?
+        .ok_or_else(|| std::io::Error::other("missing propagation haves request id"))?;
+        let ack_response = wait_for_link_request_response(
+            &mut data_rx,
+            &mut resource_rx,
+            destination.desc.address_hash,
+            link_id,
+            ack_request_id,
+            timeout,
+        )
+        .await
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::TimedOut, err))?;
+        propagation_download_ack_response_result(&ack_response)?;
     }
 
     Ok((
@@ -138,6 +150,11 @@ pub(super) async fn propagation_download_request(
         ),
         remote_identity,
     ))
+}
+
+fn propagation_download_ack_response_result(response: &rmpv::Value) -> Result<(), std::io::Error> {
+    super::remote_control::response_to_result(response.clone())?;
+    Ok(())
 }
 
 fn propagation_download_summary_json(
@@ -383,5 +400,14 @@ mod tests {
             DownloadAcceptOutcome::Rejected,
             "policy-rejected downloads are not local haves and must not be acked"
         );
+    }
+
+    #[test]
+    fn propagation_download_ack_rejects_remote_error_code() {
+        let err = propagation_download_ack_response_result(&rmpv::Value::from(0xF4_u64))
+            .expect_err("remote ack rejection must fail the download");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("rejected"));
     }
 }

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -244,6 +244,10 @@ The project is best described by capability level:
   haves as received/completed work for the requesting propagation peer after
   purge, so reintroduced payloads are not queued back to peers that already
   declared them.
+- Link-based remote propagation downloads now wait for the final haves
+  acknowledgement response after imported or duplicate payloads are reported,
+  so node-side rejection or timeout is surfaced instead of reporting a
+  completed download before remote cleanup is confirmed.
 - Inbound propagation message-get purge-only requests now return the
   Python-style boolean success response after haves are applied, and payload
   purge cleanup preserves completed peer accounting for other peers while

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -274,6 +274,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   received/completed work for the requesting propagation peer after purge, so
   reintroduced payloads are not queued back to peers that already declared
   them.
+- Link-based remote propagation downloads wait for the final haves
+  acknowledgement response after imported or duplicate payloads are reported,
+  so node-side rejection or timeout is surfaced instead of reporting a
+  completed download before remote cleanup is confirmed.
 - Inbound propagation message-get purge-only requests return the Python-style
   boolean success response after haves are applied, and payload purge cleanup
   preserves completed peer accounting for other peers while removing stale


### PR DESCRIPTION
## Summary
- wait for the final link-based propagation download haves acknowledgement response
- reuse the existing propagation-control response-code mapping so node-side rejection/timeout fails the download instead of being ignored
- document the peer/propagation parity improvement in the roadmap and LXMF matrix

## Gap analysis
- Link-based remote download already waited for list and get responses, but the final haves acknowledgement was sent fire-and-forget.
- That could report a completed download even when the propagation node rejected, lost, or timed out the cleanup acknowledgement.
- Waiting for the ack response better matches the peer/router state-machine boundary used by propagation-control flows.

## Roadmap
- Next peer/propagation slice: pre-classify listed remote IDs into local haves versus wants before transfer, so duplicates can be acknowledged without downloading them again.
- Separate follow-up: add live Python remote status/control interop coverage for propagation-node paths.

## Reference behavior note
- Inspired by propagation client flows that complete only after the remote haves/purge response is received. This is an independent Rust implementation.

## Validation
- cargo test -p reticulumd propagation_download
- cargo test -p reticulumd propagation_remote_download
- cargo test -p reticulumd policy_rejected_downloaded_payload_is_not_reported_as_duplicate_have
- cargo fmt --all -- --check
- cargo clippy -p reticulumd --all-targets --all-features --no-deps -- -D warnings
- git diff --check

Boundary check note: cargo run -p xtask -- architecture-checks is blocked locally because WSL cannot launch /bin/bash.