### PR TITLE
Throttle deferred propagation offers

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
@@ -230,12 +230,12 @@ pub(super) fn handle_offer_request(
         guard.insert(*link_id);
     }
 
+    daemon.throttle_propagation_peer_offer(remote_propagation_hash_hex.as_str());
     if wanted.len() == offered_ids.len()
         && !daemon.propagation_peer_admission_allowed(remote_propagation_hash_hex.as_str())
     {
         return ControlResponse::Rmpv(rmpv::Value::Array(Vec::new()));
     }
-    daemon.throttle_propagation_peer_offer(remote_propagation_hash_hex.as_str());
 
     if wanted.is_empty() {
         return ControlResponse::Bool(false);
@@ -1086,6 +1086,82 @@ mod tests {
             control.validated_peer_links.lock().expect("validated peer links").contains(&link_id),
             "valid wanted offer should still validate the peering link"
         );
+    }
+
+    #[test]
+    fn offer_request_capacity_limited_valid_offer_starts_throttle_like_python() {
+        let daemon = RpcDaemon::test_instance();
+        daemon
+            .handle_rpc(RpcRequest {
+                id: 10,
+                method: "propagation_enable".to_string(),
+                params: Some(json!({
+                    "enabled": true,
+                    "peering_cost": 1,
+                    "max_peers": 1,
+                })),
+            })
+            .expect("enable propagation");
+        daemon
+            .handle_rpc(RpcRequest {
+                id: 11,
+                method: "peer_sync".to_string(),
+                params: Some(json!({ "peer": "peer-capacity-existing" })),
+            })
+            .expect("fill peer capacity");
+
+        let local_identity_hash = [0x11; 16];
+        let remote_private =
+            rns_transport::identity::PrivateIdentity::new_from_rand(rand_core::OsRng);
+        let remote_identity = *remote_private.as_identity();
+        let offered = [0xBC; 32];
+        let mut peering_id = Vec::with_capacity(32);
+        peering_id.extend_from_slice(local_identity_hash.as_slice());
+        peering_id.extend_from_slice(remote_identity.address_hash.as_slice());
+        let peering_key = generate_peering_key(peering_id.as_slice(), 1).expect("peering key");
+        let control = PropagationControlContext {
+            enabled: true,
+            local_identity_hash,
+            propagation_destination_hash_hex: Some("propagation".to_string()),
+            control_destination_hash_hex: Some("control".to_string()),
+            delivery_destination: None,
+            allowed_control_identities: Vec::new(),
+            validated_peer_links: test_validated_peer_links(),
+        };
+
+        let offer_data = || {
+            Some(rmpv::Value::Array(vec![
+                rmpv::Value::Binary(peering_key.clone()),
+                rmpv::Value::Array(vec![rmpv::Value::Binary(offered.to_vec())]),
+            ]))
+        };
+        let first = handle_offer_request(
+            &daemon,
+            &control,
+            &test_link_id(),
+            &remote_identity,
+            offer_data(),
+            0xF1,
+            0xF3,
+            0xF4,
+            0xF6,
+        );
+        let second = handle_offer_request(
+            &daemon,
+            &control,
+            &test_link_id(),
+            &remote_identity,
+            offer_data(),
+            0xF1,
+            0xF3,
+            0xF4,
+            0xF6,
+        );
+
+        assert!(
+            matches!(first, ControlResponse::Rmpv(rmpv::Value::Array(values)) if values.is_empty())
+        );
+        assert!(matches!(second, ControlResponse::Code(0xF6)));
     }
 
     #[test]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -269,6 +269,10 @@ The project is best described by capability level:
 - Inbound propagation offers now deduplicate validated offered transient IDs
   before building wanted-ID responses or applying source-accounting marks, so a
   duplicate offer cannot request or account the same payload more than once.
+- Capacity-limited but valid inbound propagation offers now also start the
+  offer throttle after peering-key and transient-ID validation, so repeated
+  deferred-admission offers return the Python-style throttled response instead
+  of repeatedly probing peer capacity.
 - Remote fetch and download imports now mark inactive source peers as received
   before later activation, so a propagation node is not offered back payloads it
   previously supplied just because it was not yet an active peer record.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -299,6 +299,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Inbound propagation offers deduplicate validated offered transient IDs before
   building wanted-ID responses or applying source-accounting marks, so duplicate
   offers cannot request or account the same payload more than once.
+- Capacity-limited but valid inbound propagation offers also start the offer
+  throttle after peering-key and transient-ID validation, so repeated
+  deferred-admission offers return the Python-style throttled response instead
+  of repeatedly probing peer capacity.
 - Remote fetch and download imports mark inactive source peers as received
   before later activation, so source-accounting survives even when the
   propagation node was not yet an active peer record.


### PR DESCRIPTION
## Summary
- start the propagation offer throttle after valid peering-key and transient-ID validation even when peer admission is deferred by max peer capacity
- add a regression test proving repeated capacity-limited valid offers return the throttled response
- update propagation parity/status docs for the deferred-admission throttle behavior

## Tests
- cargo fmt --all -- --check
- cargo test -p reticulumd inbound_worker::control::propagation_commands::tests::offer_request --bin reticulumd
- cargo test -p reticulumd
- cargo clippy -p reticulumd --all-features --tests --no-deps -- -D warnings
- git diff --check

## Notes
- Local architecture boundary check could not run because xtask invokes `/bin/bash` through WSL, and this environment reports `execvpe(/bin/bash) failed: No such file or directory`.