### PR TITLE
Add Python propagation node relay interop gate

### DIFF
--- a/crates/apps/lxmf-cli/tests/python_lxmd_remote_relay.rs
+++ b/crates/apps/lxmf-cli/tests/python_lxmd_remote_relay.rs
@@ -211,6 +211,131 @@ fn rust_to_python_lxmd_relay_remote_path_e2e() {
 
 #[test]
 #[ignore = "requires local Python Reticulum/LXMF repos and daemon runtime"]
+fn rust_selects_python_lxmd_propagation_node_e2e() {
+    let lxmd_bin = resolve_test_binary("lxmd", option_env!("CARGO_BIN_EXE_lxmd"));
+    let reticulumd_bin = resolve_test_binary("reticulumd", option_env!("CARGO_BIN_EXE_reticulumd"));
+    let workspace_root =
+        Path::new(env!("CARGO_MANIFEST_DIR")).ancestors().nth(3).expect("workspace root");
+
+    let python_bin = env::var("LXMF_PYTHON_BIN").unwrap_or_else(|_| "python3".to_string());
+    let reticulum_repo = env::var("RETICULUM_PY_REPO").unwrap_or_else(|_| {
+        workspace_root.parent().expect("workspace parent").join("reticulum").display().to_string()
+    });
+    let lxmf_repo = env::var("LXMF_PY_REPO").unwrap_or_else(|_| {
+        workspace_root.parent().expect("workspace parent").join("lxmf").display().to_string()
+    });
+
+    assert!(Path::new(&reticulum_repo).exists(), "reticulum repo not found: {reticulum_repo}");
+    assert!(Path::new(&lxmf_repo).exists(), "lxmf repo not found: {lxmf_repo}");
+
+    let temp = tempfile::tempdir().expect("tempdir");
+
+    let upstream_server_port = ReservedPort::reserve();
+    let upstream_server_port_num = upstream_server_port.port();
+    let sender_rpc = ReservedPort::reserve();
+    let sender_transport = ReservedPort::reserve();
+
+    let python_lxmd_dir = temp.path().join("python-propagation-lxmd");
+    let python_rns_dir = temp.path().join("python-propagation-rns");
+    let sender_dir = temp.path().join("rust-sender");
+
+    write_python_lxmd_propagation_config(&python_lxmd_dir, "Python Propagation");
+    write_python_rns_config(&python_rns_dir, upstream_server_port_num);
+    write_rust_config(
+        &sender_dir,
+        &rust_node_config(
+            "rust-sender",
+            sender_rpc.port(),
+            Some(sender_transport.port()),
+            &[tcp_client_interface("sender-uplink", upstream_server_port_num)],
+        ),
+    );
+
+    let mut python_node = Some(spawn_python_lxmd_relay(
+        &python_bin,
+        &reticulum_repo,
+        &lxmf_repo,
+        &python_lxmd_dir,
+        &python_rns_dir,
+        &mut [upstream_server_port],
+    ));
+    let mut sender = None;
+
+    let outcome: Result<(), String> = (|| {
+        wait_for_python_port(
+            upstream_server_port_num,
+            python_node.as_mut().expect("python propagation child"),
+            "python-propagation-node",
+        )?;
+
+        sender = Some(spawn_lxmd(
+            &lxmd_bin,
+            &reticulumd_bin,
+            sender_rpc.port(),
+            &sender_dir,
+            &mut [sender_rpc, sender_transport],
+        ));
+        wait_for_ready(
+            sender.as_ref().expect("sender child").rpc_port(),
+            sender.as_mut().expect("sender child"),
+            "rust-sender",
+        )?;
+
+        let python_propagation_hash =
+            python_destination_hash(&python_bin, &reticulum_repo, &python_lxmd_dir, "propagation")?;
+        let sender_rpc = sender.as_ref().expect("sender child").rpc_port();
+
+        let selected = rpc_call(
+            sender_rpc,
+            "set_outbound_propagation_node",
+            Some(json!({ "peer": python_propagation_hash })),
+        )?;
+        if selected["peer"].as_str() != Some(python_propagation_hash.as_str()) {
+            return Err(format!("selected propagation node mismatch: {selected}"));
+        }
+
+        let listed = rpc_call(sender_rpc, "list_propagation_nodes", None)?;
+        let listed_selected = listed["nodes"].as_array().is_some_and(|nodes| {
+            nodes.iter().any(|node| {
+                node["peer"].as_str() == Some(python_propagation_hash.as_str())
+                    && node["selected"].as_bool() == Some(true)
+            })
+        });
+        if !listed_selected {
+            return Err(format!(
+                "selected Python propagation node not visible in list_propagation_nodes: {listed}"
+            ));
+        }
+
+        Ok(())
+    })();
+
+    let sender_rpc = sender.as_ref().map_or(0, SpawnedNode::rpc_port);
+
+    let failure_details = if let Err(err) = &outcome {
+        Some(format!(
+            "{err}\n\n{}\n\n{}",
+            collect_python_diagnostics("python-propagation-node", python_node.as_mut()),
+            collect_node_diagnostics("rust-sender", sender_rpc, sender.as_mut()),
+        ))
+    } else {
+        None
+    };
+
+    if let Some(node) = sender.as_mut() {
+        terminate_child(&mut node.child);
+    }
+    if let Some(node) = python_node.as_mut() {
+        terminate_child(&mut node.child);
+    }
+
+    if let Some(details) = failure_details {
+        panic!("python lxmd propagation node selection failed:\n{details}");
+    }
+}
+
+#[test]
+#[ignore = "requires local Python Reticulum/LXMF repos and daemon runtime"]
 fn python_to_rust_lxmd_relay_remote_path_e2e() {
     let lxmd_bin = resolve_test_binary("lxmd", option_env!("CARGO_BIN_EXE_lxmd"));
     let reticulumd_bin = resolve_test_binary("reticulumd", option_env!("CARGO_BIN_EXE_reticulumd"));

--- a/crates/apps/lxmf-cli/tests/support/python_lxmd_remote_relay.rs
+++ b/crates/apps/lxmf-cli/tests/support/python_lxmd_remote_relay.rs
@@ -175,11 +175,34 @@ pub fn write_rust_config(dir: &Path, config: &str) {
 }
 
 pub fn write_python_lxmd_config(dir: &Path, display_name: &str) {
+    write_python_lxmd_config_with_propagation(dir, display_name, false);
+}
+
+pub fn write_python_lxmd_propagation_config(dir: &Path, display_name: &str) {
+    write_python_lxmd_config_with_propagation(dir, display_name, true);
+}
+
+fn write_python_lxmd_config_with_propagation(
+    dir: &Path,
+    display_name: &str,
+    propagation_enabled: bool,
+) {
     fs::create_dir_all(dir).expect("create python lxmd dir");
+    if !propagation_enabled {
+        fs::write(
+            dir.join("config"),
+            format!(
+                "[propagation]\nenable_node = no\nannounce_at_start = no\nautopeer = no\nauth_required = no\n\n[lxmf]\ndisplay_name = {display_name}\nannounce_at_start = no\ndelivery_transfer_max_accepted_size = 1000\n\n[logging]\nloglevel = 7\n"
+            ),
+        )
+        .expect("write python lxmd config");
+        return;
+    }
+
     fs::write(
         dir.join("config"),
         format!(
-            "[propagation]\nenable_node = no\nannounce_at_start = no\nautopeer = no\nauth_required = no\n\n[lxmf]\ndisplay_name = {display_name}\nannounce_at_start = no\ndelivery_transfer_max_accepted_size = 1000\n\n[logging]\nloglevel = 7\n"
+            "[propagation]\nenable_node = yes\nannounce_at_start = yes\nannounce_interval = 1\nautopeer = yes\nautopeer_maxdepth = 6\nauth_required = no\npropagation_stamp_cost_target = 0\npropagation_stamp_cost_flexibility = 0\n\n[lxmf]\ndisplay_name = {display_name}\nannounce_at_start = no\ndelivery_transfer_max_accepted_size = 1000\n\n[logging]\nloglevel = 7\n"
         ),
     )
     .expect("write python lxmd config");
@@ -579,6 +602,77 @@ pub fn python_control_call(
             .to_string());
     }
     Ok(value.get("result").cloned().unwrap_or(Value::Null))
+}
+
+pub fn python_destination_hash(
+    python_bin: &str,
+    reticulum_repo: &str,
+    lxmd_dir: &Path,
+    destination_aspect: &str,
+) -> Result<String, String> {
+    let identity_path = lxmd_dir.join("identity");
+    let python_path =
+        std::env::join_paths([Path::new(reticulum_repo)]).map_err(|err| err.to_string())?;
+    let script = r#"
+import os
+import sys
+import tempfile
+
+import RNS
+
+identity_path, destination_aspect = sys.argv[1:3]
+cfg = tempfile.mkdtemp(prefix="rns-hash-")
+with open(os.path.join(cfg, "config"), "w", encoding="utf-8") as handle:
+    handle.write(
+        "[reticulum]\n"
+        "share_instance = no\n"
+        "enable_transport = no\n"
+        "discover_interfaces = false\n"
+        "autoconnect_discovered_interfaces = 0\n"
+    )
+
+RNS.Reticulum(configdir=cfg, loglevel=0)
+identity = RNS.Identity.from_file(identity_path)
+if identity is None:
+    raise SystemExit(f"failed to load identity from {identity_path}")
+
+destination = RNS.Destination(
+    identity,
+    RNS.Destination.IN,
+    RNS.Destination.SINGLE,
+    "lxmf",
+    destination_aspect,
+)
+print(RNS.hexrep(destination.hash, delimit=False).lower())
+"#;
+    let output = Command::new(python_bin)
+        .arg("-c")
+        .arg(script)
+        .arg(&identity_path)
+        .arg(destination_aspect)
+        .env("PYTHONPATH", python_path)
+        .output()
+        .map_err(|err| err.to_string())?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        return Err(format!(
+            "failed to derive Python destination hash from {}: {}{}{}",
+            identity_path.display(),
+            stderr,
+            if stderr.is_empty() || stdout.is_empty() { "" } else { "\n" },
+            stdout,
+        ));
+    }
+    let hash = String::from_utf8(output.stdout).map_err(|err| err.to_string())?.trim().to_string();
+    if hash.is_empty() {
+        return Err(format!(
+            "empty Python destination hash for {} aspect {}",
+            identity_path.display(),
+            destination_aspect
+        ));
+    }
+    Ok(hash)
 }
 
 fn rpc_snapshot(rpc_port: u16, method: &str, params: Option<Value>) -> String {

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -380,6 +380,10 @@ The project is best described by capability level:
   after peering-key and transient-ID validation, so repeated replication offers
   from the same peer take the throttled response path even when the peer changes
   the offered transient-ID set.
+- The live Rust/Python remote-relay interop gate now covers selecting a Python
+  `lxmd` propagation destination as the Rust outbound propagation node, so
+  mixed propagation-node discovery and selection stay under pinned reference
+  coverage.
 
 ## Remaining Release Blockers
 

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -249,6 +249,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Outbound propagated delivery resolves selected propagation-node
   `propagation_stamp_cost` case-insensitively, so Python-style hash casing does
   not fall back to the default propagation stamp cost.
+- The live Rust/Python remote-relay interop gate now selects a Python `lxmd`
+  propagation destination as the Rust outbound propagation node, covering mixed
+  propagation-node discovery and selection before broader store-and-forward
+  claims are made.
 - Duplicate inbound peer propagation payloads still fan out to active relay
   peers while keeping the source peer handled, so a known local payload does
   not bypass relay queue creation.


### PR DESCRIPTION
## Summary
- add an ignored live Rust/Python remote-relay interop case that enables a Python lxmd propagation node and selects its propagation destination from Rust
- add small harness helpers for propagation-enabled Python lxmd config and Python destination-hash derivation
- update parity/status docs to record the new propagation-node discovery/selection coverage

## Gap analysis
- The existing remote relay gate covered direct remote-path delivery in both directions, but did not prove mixed propagation-node discovery or outbound propagation-node selection.
- The parity matrix still identifies broad peer/router live interop as a residual gap; this narrows that gap without claiming full store-and-forward completion.
- This avoids overlap with the open remote-download/haves and inbound-offer throttle PRs because it changes only interop coverage and harness setup.

## Roadmap
- Next: extend the same harness from selection to propagated store-and-forward delivery through the selected node.
- Then: add bidirectional peer-sync/fetch/download live cases as each narrow peer/router behavior is completed.
- Keep Python interop gates aligned with status rows so docs only promote behavior with executable evidence.

## Reference behavior note
- Inspired by the reference model where propagation nodes expose a separate LXMF propagation destination derived from node identity, and clients select that destination before propagated delivery.
- Reimplemented independently in the local test harness; no reference code was copied or vendored.

## Validation
- `cargo test -p lxmf-cli --test python_lxmd_remote_relay rust_selects_python_lxmd_propagation_node_e2e -- --ignored --nocapture`
- `cargo fmt --all -- --check`
- `cargo test -p lxmf-cli --test python_lxmd_remote_relay --no-run`
- `cargo clippy -p lxmf-cli --all-features --tests --no-deps -- -D warnings`
- `git diff --check`
- forbidden attribution string scan over touched files

## Known local limitation
- `cargo run -p xtask -- architecture-checks` is blocked in this Windows environment because WSL cannot launch `/bin/bash` (`execvpe(/bin/bash) failed: No such file or directory`).