### PR TITLE
Show peer propagation status in rnstatus

### DIFF
--- a/crates/apps/rns-tools/src/bin/rnstatus-rs.rs
+++ b/crates/apps/rns-tools/src/bin/rnstatus-rs.rs
@@ -81,6 +81,8 @@ fn write_human_status(output: &mut dyn Write, status: &Value) -> io::Result<()> 
             status.get("interfaces").and_then(Value::as_array).map_or(0, |rows| rows.len() as u64)
         })
     )?;
+    writeln!(output, "Peers: {}", status.get("peer_count").and_then(Value::as_u64).unwrap_or(0))?;
+    writeln!(output, "Propagation: {}", propagation_summary(status))?;
 
     let Some(interfaces) = status.get("interfaces").and_then(Value::as_array) else {
         return Ok(());
@@ -104,6 +106,28 @@ fn write_human_status(output: &mut dyn Write, status: &Value) -> io::Result<()> 
         writeln!(output, "{name:<24} {kind:<16} {enabled:<8} {endpoint:<22} {runtime}")?;
     }
     Ok(())
+}
+
+fn propagation_summary(status: &Value) -> String {
+    let Some(propagation) = status.get("propagation").and_then(Value::as_object) else {
+        return "unknown".to_string();
+    };
+    let enabled = propagation
+        .get("enabled")
+        .and_then(Value::as_bool)
+        .map(|value| if value { "enabled" } else { "disabled" })
+        .unwrap_or("unknown");
+    let selected_node = propagation
+        .get("selected_node")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("-");
+    let state = propagation
+        .get("state_name")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("-");
+    format!("{enabled}, selected_node={selected_node}, state={state}")
 }
 
 fn interface_endpoint(interface: &Value) -> String {
@@ -141,6 +165,12 @@ mod tests {
         let status = json!({
             "identity_hash": "abc",
             "running": true,
+            "peer_count": 2,
+            "propagation": {
+                "enabled": true,
+                "selected_node": "aabb",
+                "state_name": "completed"
+            },
             "interface_count": 1,
             "interfaces": [{
                 "name": "uplink",
@@ -163,6 +193,8 @@ mod tests {
         let output = String::from_utf8(output).expect("utf8");
         assert!(output.contains("uplink"));
         assert!(output.contains("tcp_server"));
+        assert!(output.contains("Peers: 2"));
+        assert!(output.contains("Propagation: enabled, selected_node=aabb, state=completed"));
         assert!(output.contains("failed (bind denied)"));
     }
 }

--- a/crates/apps/rns-tools/tests/rnstatus_cli.rs
+++ b/crates/apps/rns-tools/tests/rnstatus_cli.rs
@@ -24,6 +24,12 @@ fn rnstatus_fetches_daemon_status_and_renders_interface_runtime_state() {
             result: Some(json!({
                 "identity_hash": "0123456789abcdef0123456789abcdef",
                 "running": true,
+                "peer_count": 2,
+                "propagation": {
+                    "enabled": true,
+                    "selected_node": "aabbccddeeff00112233445566778899",
+                    "state_name": "completed"
+                },
                 "interface_count": 1,
                 "interfaces": [{
                     "name": "field-uplink",
@@ -78,6 +84,12 @@ fn rnstatus_fetches_daemon_status_and_renders_interface_runtime_state() {
             result: Some(json!({
                 "identity_hash": "0123456789abcdef0123456789abcdef",
                 "running": true,
+                "peer_count": 2,
+                "propagation": {
+                    "enabled": true,
+                    "selected_node": "aabbccddeeff00112233445566778899",
+                    "state_name": "completed"
+                },
                 "interface_count": 1,
                 "interfaces": [{
                     "name": "field-uplink",
@@ -111,6 +123,10 @@ fn rnstatus_fetches_daemon_status_and_renders_interface_runtime_state() {
     let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
     assert!(stdout.contains("field-uplink"), "stdout: {stdout}");
     assert!(stdout.contains("tcp_server"), "stdout: {stdout}");
+    assert!(stdout.contains("Peers: 2"), "stdout: {stdout}");
+    assert!(stdout.contains("Propagation: enabled"), "stdout: {stdout}");
+    assert!(stdout.contains("aabbccddeeff00112233445566778899"), "stdout: {stdout}");
+    assert!(stdout.contains("completed"), "stdout: {stdout}");
     assert!(stdout.contains("failed"), "stdout: {stdout}");
     assert!(stdout.contains("bind denied"), "stdout: {stdout}");
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -45,8 +45,8 @@ The project is best described by capability level:
   deterministic unsupported-family diagnostics instead of silently becoming
   inert unknown interface entries.
 - `rnstatus-rs` now provides a local daemon status utility over the existing
-  RPC status surface, including JSON output and human interface runtime
-  startup state.
+  RPC status surface, including JSON output plus human interface runtime,
+  peer-count, and selected propagation-node state.
 
 ### LXMF
 

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -33,7 +33,7 @@ Workspace paths are used for navigation. Published package names are
 | `RNS/Discovery.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | Announce/path discovery plus live AutoInterface discovery and peer runtime. | Public bootstrap/discovery breadth remains narrower than Python. |
 | `RNS/Resolver.py` | `crates/libs/rns-transport` | partial | Resolver helpers and cached lookup behavior exist. | Full resolver/discovery surface parity is not established. |
 | `RNS/Cryptography/*` | `crates/libs/rns-core` | done | Required Reticulum primitives used by identities, packets, links, and receipts. | No confirmed parity blocker. |
-| `RNS/Utilities/*` | `crates/apps/rns-tools` | partial | `rnx` is substantial; `rnsd` delegates to `reticulumd`; `rnstatus-rs` reports local daemon/interface status from RPC with JSON and human output. | Full equivalents for retired `rncp`, `rnid`, `rnir`, `rnodeconf`, `rnpath`, `rnpkg`, and `rnprobe` remain absent; `rnstatus-rs` is local status only. |
+| `RNS/Utilities/*` | `crates/apps/rns-tools` | partial | `rnx` is substantial; `rnsd` delegates to `reticulumd`; `rnstatus-rs` reports local daemon, interface, peer count, and selected propagation-node status from RPC with JSON and human output. | Full equivalents for retired `rncp`, `rnid`, `rnir`, `rnodeconf`, `rnpath`, `rnpkg`, and `rnprobe` remain absent; `rnstatus-rs` is local status only. |
 | `CRNS/*` | `crates/apps/rns-tools` | partial | Selected command workflows exist. | The Python command ecosystem is not reproduced. |
 
 ## Interface Detail


### PR DESCRIPTION
## Gap analysis
- Current peer/propagation protocol work is already split across several open PRs. The next most protocol-relevant local processed-ID candidate appears to be covered by an existing PR, so this patch avoids duplicating that state-machine work.
- A smaller daemon/tool parity gap remained: `daemon_status_ex` already exposes peer count and propagation selection state, but `rnstatus-rs` human output only showed identity, running state, and interfaces.
- This made peer/propagation operations harder to inspect from the Reticulum-style status tool even though the daemon already had the data.

## Update roadmap
- Keep landing non-overlapping peer/propagation slices while the larger queue/restart PRs are reconciled.
- Next protocol slices should stay focused on peer transfer/retry/restart lifecycle and router side effects once the overlapping processed-ID/download/haves PRs settle.
- Tooling can continue to expose existing daemon peer and propagation state without changing protocol behavior.

## Changes
- Adds peer count to `rnstatus-rs` human output.
- Adds propagation enabled/disabled, selected node, and state summary to `rnstatus-rs` human output.
- Extends the rnstatus CLI integration test and unit test to cover the new human output.
- Updates the Reticulum utility matrix and roadmap to document the improved daemon/tool visibility.

## Reference behavior note
- Reference inspection showed status tooling is intended as a broader operator view of node state, not only interface startup. This patch independently exposes already-available daemon peer and propagation fields without copying or vendoring reference code.

## Validation
- RED first: `cargo test -p rns-tools --test rnstatus_cli rnstatus_fetches_daemon_status_and_renders_interface_runtime_state` failed before implementation because human output omitted peer/propagation fields.
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p rns-tools --test rnstatus_cli rnstatus_fetches_daemon_status_and_renders_interface_runtime_state`
- `cargo test -p rns-tools human_status_includes_runtime_state --bin rnstatus-rs`
- `cargo clippy -p rns-tools --all-features --tests --no-deps -- -D warnings`
- Forbidden reference-name scan over touched files: no matches.

## Known local limitation
- `cargo run -p xtask -- architecture-checks` did not run locally because WSL failed before launching the boundary script: `execvpe(/bin/bash) failed: No such file or directory`.