### PR TITLE
Fallback oversized opportunistic delivery to link

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task.rs
@@ -309,10 +309,7 @@ impl DeliveryTask {
                 "opportunistic",
                 "payload too large",
             );
-            let _ = self.receipt_tx.try_send(ReceiptEvent {
-                message_id: self.message_id,
-                status: "failed: opportunistic payload too large".to_string(),
-            });
+            self.run_opportunistic_link_fallback(payload, identity, "payload too large").await;
             return;
         }
 
@@ -361,10 +358,7 @@ impl DeliveryTask {
                 "opportunistic",
                 "ciphertext too large",
             );
-            let _ = self.receipt_tx.try_send(ReceiptEvent {
-                message_id: self.message_id,
-                status: "failed: opportunistic ciphertext too large".to_string(),
-            });
+            self.run_opportunistic_link_fallback(payload, identity, "ciphertext too large").await;
             return;
         }
         packet.data = encrypted_data;
@@ -394,6 +388,53 @@ impl DeliveryTask {
             message_id: self.message_id,
             status: send_outcome_status("opportunistic", outcome),
         });
+    }
+
+    async fn run_opportunistic_link_fallback(
+        self,
+        payload: Vec<u8>,
+        identity: Identity,
+        reason: &str,
+    ) {
+        if self.abort_if_cancelled("opportunistic-link") {
+            return;
+        }
+        log_delivery_trace(
+            &self.message_id,
+            &self.destination_hex,
+            "opportunistic",
+            &format!("{reason}; falling back to link delivery"),
+        );
+        let destination_desc = DestinationDesc {
+            identity,
+            address_hash: self.destination_hash,
+            name: DestinationName::new("lxmf", "delivery"),
+        };
+        if let Err(err) = self
+            .send_via_link_mode(
+                "opportunistic-link",
+                self.destination_hex.as_str(),
+                destination_desc,
+                &payload,
+                LinkModeStatuses {
+                    packet: "sent: opportunistic link",
+                    resource: "sending: link resource",
+                    resource_sent: OUTBOUND_RESOURCE_SENT_STATUS,
+                },
+            )
+            .await
+        {
+            log_delivery_trace(
+                &self.message_id,
+                &self.destination_hex,
+                "opportunistic-link",
+                &format!("fallback failed err={err}"),
+            );
+            let _ = self.receipt_tx.try_send(ReceiptEvent {
+                message_id: self.message_id,
+                status: format!("failed: {err}"),
+            });
+        }
     }
 
     async fn resolve_destination_identity(&self) -> Option<Identity> {

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests.rs
@@ -321,6 +321,130 @@ async fn resource_cancel_monitor_aborts_resource_after_late_cancel() {
 }
 
 #[tokio::test]
+async fn oversized_opportunistic_delivery_falls_back_to_link_delivery() {
+    let message_id = "oversized-opportunistic-fallback";
+    let store = MessagesStore::in_memory().expect("store");
+    store
+        .insert_message(&MessageRecord {
+            id: message_id.to_string(),
+            source: "source".to_string(),
+            destination: "00000000000000000000000000000000".to_string(),
+            title: String::new(),
+            content: String::new(),
+            timestamp: 0,
+            direction: "out".to_string(),
+            fields: None,
+            receipt_status: Some("queued".to_string()),
+        })
+        .expect("insert message");
+    let daemon = Arc::new(RpcDaemon::with_store(store, "opportunistic-fallback-node".to_string()));
+    let signer = PrivateIdentity::new_from_name("oversized-opportunistic-fallback");
+    let transport_identity = rns_transport::identity_bridge::to_transport_private_identity(&signer);
+    let transport = Arc::new(Transport::new(TransportConfig::new(
+        "oversized-opportunistic-fallback",
+        &transport_identity,
+        true,
+    )));
+    let mut channel = transport
+        .iface_manager()
+        .lock()
+        .await
+        .new_channel_with_role(8, rns_transport::iface::IfaceRole::Unicast);
+    let iface = *channel.address();
+
+    let remote_signer = rns_transport::identity::PrivateIdentity::new_from_rand(OsRng);
+    let remote_identity = *remote_signer.as_identity();
+    let destination_desc = DestinationDesc {
+        identity: remote_identity,
+        address_hash: remote_identity.address_hash,
+        name: DestinationName::new("lxmf", "delivery"),
+    };
+    let mut destination = [0u8; 16];
+    destination.copy_from_slice(remote_identity.address_hash.as_slice());
+    let (receipt_tx, mut receipt_rx) = tokio::sync::mpsc::channel(16);
+    let task_transport = transport.clone();
+    let outbound_resource_map = Arc::new(Mutex::new(HashMap::new()));
+    let task = DeliveryTask {
+        daemon,
+        transport,
+        peer_crypto: Arc::new(Mutex::new(HashMap::new())),
+        outbound_propagation_identities: Arc::new(Mutex::new(HashMap::new())),
+        receipt_map: Arc::new(Mutex::new(HashMap::new())),
+        outbound_resource_map: outbound_resource_map.clone(),
+        outbound_propagation_link: Arc::new(tokio::sync::Mutex::new(None)),
+        receipt_tx,
+        message_id: message_id.to_string(),
+        source_hash: [1u8; 16],
+        destination,
+        destination_hash: remote_identity.address_hash,
+        destination_hex: hex::encode(destination),
+        title: String::new(),
+        content: "x".repeat(8192),
+        fields: None,
+        signer,
+        stamp_cost: None,
+        outbound_ticket: None,
+        include_ticket: None,
+        peer_identity: Some(remote_identity),
+        propagation_node_identity: None,
+        requested_method: RequestedDeliveryMethod::Opportunistic,
+        try_propagation_on_fail: false,
+        propagation_node_hex: None,
+    };
+
+    let task_handle = tokio::spawn(task.run());
+    let link_request = tokio::select! {
+        receipt = receipt_rx.recv() => {
+            let status = receipt.expect("receipt before link request").status;
+            assert!(
+                !status.starts_with("failed: opportunistic"),
+                "oversized opportunistic delivery should escalate to link delivery, got {status}"
+            );
+            panic!("expected link request before terminal receipt, got {status}");
+        }
+        request = channel.tx_channel.recv() => request.expect("link request message"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(8);
+    let mut inbound = Link::new_from_request(
+        &link_request.packet,
+        remote_signer.sign_key().clone(),
+        destination_desc,
+        tx,
+    )
+    .expect("link request should parse");
+    let link_id = *inbound.id();
+    let outbound_link = task_transport.find_out_link(&link_id).await.expect("outbound link");
+    assert!(matches!(
+        outbound_link.lock().await.handle_packet(&inbound.prove(), iface),
+        rns_transport::destination::link::LinkHandleResult::Activated
+    ));
+
+    let advertisement = tokio::time::timeout(Duration::from_secs(2), channel.tx_channel.recv())
+        .await
+        .expect("resource advertisement")
+        .expect("resource advertisement");
+    assert_eq!(advertisement.packet.context, PacketContext::ResourceAdvrtisement);
+
+    let receipt = tokio::time::timeout(Duration::from_secs(2), receipt_rx.recv())
+        .await
+        .expect("delivery receipt")
+        .expect("delivery receipt");
+    assert!(
+        receipt.status == "sent: link" || receipt.status == "sending: link resource",
+        "oversized opportunistic delivery should escalate to link delivery, got {}",
+        receipt.status
+    );
+    {
+        let tracked = outbound_resource_map.lock().expect("map");
+        let resource_tracking = tracked.values().next().expect("tracked outbound resource");
+        assert_eq!(resource_tracking.message_id, message_id);
+        assert_eq!(resource_tracking.peer, hex::encode(remote_identity.address_hash.as_slice()));
+        assert_eq!(resource_tracking.sent_status, OUTBOUND_RESOURCE_SENT_STATUS);
+    }
+    task_handle.await.expect("delivery task join");
+}
+
+#[tokio::test]
 async fn build_payload_records_normal_stamp_lifecycle_metadata() {
     let message_id = "stamped-delivery-task";
     let store = MessagesStore::in_memory().expect("store");

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -57,6 +57,8 @@ The project is best described by capability level:
   are ignored is obsolete.
 - Direct and propagated resource sends support receipt-state separation,
   timeout/failure propagation, and active resource cancellation.
+- Oversized opportunistic peer delivery now falls back to link/resource delivery
+  instead of terminating at the opportunistic packet-size boundary.
 - Ticket validity, renewal, derivation, persistence, and inbound ticket reuse
   are implemented.
 - Propagation peers have real queue, policy, maintenance, throttling, peering,

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -76,6 +76,8 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Direct, opportunistic, propagated, and paper modes are distinct.
 - Transport completion remains `sent`; final delivery receipts produce
   `delivered`.
+- Oversized opportunistic peer sends fall back to link/resource delivery, with
+  resource advertisement and outbound tracking coverage.
 - Resource advertisement failure, retry exhaustion, timeout, and explicit
   cancellation reach daemon message state.
 


### PR DESCRIPTION
## Gap analysis

- Oversized opportunistic peer delivery stopped at the opportunistic packet-size boundary with `failed: opportunistic payload too large` / `failed: opportunistic ciphertext too large`.
- Link/resource delivery already handled large peer payloads, resource advertisements, receipt-state separation, and outbound resource tracking.
- The smallest high-impact parity patch was to route oversized opportunistic sends into that existing link/resource path instead of introducing a second large-payload implementation.

## Update roadmap

- Continue tightening peer and propagation behavior around retries, transfer budgets, and restart/export queue state.
- Add more live interop coverage for propagation-node fetch/download/sync and peer rows.
- Keep closing delivery fallbacks by reusing existing state machines where behavior already exists.

## Patch

- Falls back from oversized opportunistic payload/ciphertext construction to link delivery.
- Uses link packet delivery for small fallback payloads and link resource delivery for oversized fallback payloads.
- Adds regression coverage proving link activation, resource advertisement, receipt status, and outbound resource tracking.
- Updates the roadmap and LXMF parity matrix.

## Reference behavior note

The local reference implementations treat opportunistic delivery as a best-effort packet path and use link/resource transfer for payloads that exceed packet constraints. This patch independently reuses the project’s existing link/resource machinery to preserve that behavior without vendoring or copying code.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p reticulumd oversized_opportunistic_delivery_falls_back_to_link_delivery --bin reticulumd`
- `cargo clippy -p reticulumd --all-features --tests --no-deps -- -D warnings`
- Forbidden local reference-name scan over touched files returned no matches.

## Known local limitation

- `cargo run -p xtask -- architecture-checks` is blocked in this Windows environment because the WSL/bash bridge cannot exec `/bin/bash`.