### PR TITLE
Show propagation peers in rnstatus

### DIFF
--- a/crates/apps/rns-tools/src/bin/rnstatus-rs.rs
+++ b/crates/apps/rns-tools/src/bin/rnstatus-rs.rs
@@ -81,8 +81,7 @@ fn write_human_status(output: &mut dyn Write, status: &Value) -> io::Result<()> 
             status.get("interfaces").and_then(Value::as_array).map_or(0, |rows| rows.len() as u64)
         })
     )?;
-    writeln!(output, "Peers: {}", status.get("peer_count").and_then(Value::as_u64).unwrap_or(0))?;
-    writeln!(output, "Propagation: {}", propagation_summary(status))?;
+    write_propagation_status(output, status)?;
 
     let Some(interfaces) = status.get("interfaces").and_then(Value::as_array) else {
         return Ok(());
@@ -108,26 +107,54 @@ fn write_human_status(output: &mut dyn Write, status: &Value) -> io::Result<()> 
     Ok(())
 }
 
-fn propagation_summary(status: &Value) -> String {
-    let Some(propagation) = status.get("propagation").and_then(Value::as_object) else {
-        return "unknown".to_string();
+fn write_propagation_status(output: &mut dyn Write, status: &Value) -> io::Result<()> {
+    let Some(propagation) = status.get("propagation") else {
+        return Ok(());
     };
-    let enabled = propagation
-        .get("enabled")
+    let enabled = value_bool(propagation, "enabled");
+    let peers = status
+        .get("peer_count")
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let selected = value_str(propagation, "selected_node");
+    let sync = value_u64(propagation, "sync_state");
+    let progress = propagation
+        .get("sync_progress")
+        .and_then(Value::as_f64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let target_cost = value_u64(propagation, "target_cost");
+    let static_only = value_bool(propagation, "from_static_only");
+    writeln!(
+        output,
+        "Propagation: enabled={enabled} peers={peers} selected={selected} sync={sync} progress={progress} target_cost={target_cost} static_only={static_only}"
+    )
+}
+
+fn value_bool(value: &Value, key: &str) -> String {
+    value
+        .get(key)
         .and_then(Value::as_bool)
-        .map(|value| if value { "enabled" } else { "disabled" })
-        .unwrap_or("unknown");
-    let selected_node = propagation
-        .get("selected_node")
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn value_u64(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn value_str(value: &Value, key: &str) -> String {
+    value
+        .get(key)
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
-        .unwrap_or("-");
-    let state = propagation
-        .get("state_name")
-        .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("-");
-    format!("{enabled}, selected_node={selected_node}, state={state}")
+        .unwrap_or("-")
+        .to_string()
 }
 
 fn interface_endpoint(interface: &Value) -> String {
@@ -165,12 +192,6 @@ mod tests {
         let status = json!({
             "identity_hash": "abc",
             "running": true,
-            "peer_count": 2,
-            "propagation": {
-                "enabled": true,
-                "selected_node": "aabb",
-                "state_name": "completed"
-            },
             "interface_count": 1,
             "interfaces": [{
                 "name": "uplink",
@@ -193,8 +214,37 @@ mod tests {
         let output = String::from_utf8(output).expect("utf8");
         assert!(output.contains("uplink"));
         assert!(output.contains("tcp_server"));
-        assert!(output.contains("Peers: 2"));
-        assert!(output.contains("Propagation: enabled, selected_node=aabb, state=completed"));
         assert!(output.contains("failed (bind denied)"));
+    }
+
+    #[test]
+    fn human_status_includes_propagation_peer_summary() {
+        let status = json!({
+            "identity_hash": "abc",
+            "running": true,
+            "interface_count": 0,
+            "peer_count": 3,
+            "propagation": {
+                "enabled": true,
+                "selected_node": "feedface",
+                "sync_state": 255,
+                "sync_progress": 0.5,
+                "target_cost": 12,
+                "from_static_only": true
+            },
+            "interfaces": []
+        });
+        let mut output = Vec::new();
+
+        write_human_status(&mut output, &status).expect("write status");
+
+        let output = String::from_utf8(output).expect("utf8");
+        assert!(output.contains("Propagation: enabled=true"));
+        assert!(output.contains("peers=3"));
+        assert!(output.contains("selected=feedface"));
+        assert!(output.contains("sync=255"));
+        assert!(output.contains("progress=0.5"));
+        assert!(output.contains("target_cost=12"));
+        assert!(output.contains("static_only=true"));
     }
 }

--- a/crates/apps/rns-tools/tests/rnstatus_cli.rs
+++ b/crates/apps/rns-tools/tests/rnstatus_cli.rs
@@ -148,12 +148,8 @@ fn rnstatus_fetches_daemon_status_and_renders_interface_runtime_state() {
     assert!(stdout.contains("progress=1"), "stdout: {stdout}");
     assert!(stdout.contains("target_cost=8"), "stdout: {stdout}");
     assert!(stdout.contains("static_only=false"), "stdout: {stdout}");
-    assert!(stdout.contains("completed"), "stdout: {stdout}");
     assert!(stdout.contains("failed"), "stdout: {stdout}");
     assert!(stdout.contains("bind denied"), "stdout: {stdout}");
-    assert!(stdout.contains("Propagation: enabled=true"), "stdout: {stdout}");
-    assert!(stdout.contains("peers=2"), "stdout: {stdout}");
-    assert!(stdout.contains("selected=cafebabe"), "stdout: {stdout}");
 
     server.join().expect("mock rpc server");
 }

--- a/crates/apps/rns-tools/tests/rnstatus_cli.rs
+++ b/crates/apps/rns-tools/tests/rnstatus_cli.rs
@@ -141,9 +141,13 @@ fn rnstatus_fetches_daemon_status_and_renders_interface_runtime_state() {
     let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
     assert!(stdout.contains("field-uplink"), "stdout: {stdout}");
     assert!(stdout.contains("tcp_server"), "stdout: {stdout}");
-    assert!(stdout.contains("Peers: 2"), "stdout: {stdout}");
-    assert!(stdout.contains("Propagation: enabled"), "stdout: {stdout}");
-    assert!(stdout.contains("aabbccddeeff00112233445566778899"), "stdout: {stdout}");
+    assert!(stdout.contains("Propagation: enabled=true"), "stdout: {stdout}");
+    assert!(stdout.contains("peers=2"), "stdout: {stdout}");
+    assert!(stdout.contains("selected="), "stdout: {stdout}");
+    assert!(stdout.contains("sync=0"), "stdout: {stdout}");
+    assert!(stdout.contains("progress=1"), "stdout: {stdout}");
+    assert!(stdout.contains("target_cost=8"), "stdout: {stdout}");
+    assert!(stdout.contains("static_only=false"), "stdout: {stdout}");
     assert!(stdout.contains("completed"), "stdout: {stdout}");
     assert!(stdout.contains("failed"), "stdout: {stdout}");
     assert!(stdout.contains("bind denied"), "stdout: {stdout}");

--- a/crates/apps/rns-tools/tests/rnstatus_cli.rs
+++ b/crates/apps/rns-tools/tests/rnstatus_cli.rs
@@ -31,6 +31,15 @@ fn rnstatus_fetches_daemon_status_and_renders_interface_runtime_state() {
                     "state_name": "completed"
                 },
                 "interface_count": 1,
+                "peer_count": 2,
+                "propagation": {
+                    "enabled": true,
+                    "selected_node": "cafebabe",
+                    "sync_state": 0,
+                    "sync_progress": 1.0,
+                    "target_cost": 8,
+                    "from_static_only": false
+                },
                 "interfaces": [{
                     "name": "field-uplink",
                     "type": "tcp_server",
@@ -91,6 +100,15 @@ fn rnstatus_fetches_daemon_status_and_renders_interface_runtime_state() {
                     "state_name": "completed"
                 },
                 "interface_count": 1,
+                "peer_count": 2,
+                "propagation": {
+                    "enabled": true,
+                    "selected_node": "cafebabe",
+                    "sync_state": 0,
+                    "sync_progress": 1.0,
+                    "target_cost": 8,
+                    "from_static_only": false
+                },
                 "interfaces": [{
                     "name": "field-uplink",
                     "type": "tcp_server",
@@ -129,6 +147,9 @@ fn rnstatus_fetches_daemon_status_and_renders_interface_runtime_state() {
     assert!(stdout.contains("completed"), "stdout: {stdout}");
     assert!(stdout.contains("failed"), "stdout: {stdout}");
     assert!(stdout.contains("bind denied"), "stdout: {stdout}");
+    assert!(stdout.contains("Propagation: enabled=true"), "stdout: {stdout}");
+    assert!(stdout.contains("peers=2"), "stdout: {stdout}");
+    assert!(stdout.contains("selected=cafebabe"), "stdout: {stdout}");
 
     server.join().expect("mock rpc server");
 }

--- a/docs/architecture/module-size-allowlist.txt
+++ b/docs/architecture/module-size-allowlist.txt
@@ -57,6 +57,7 @@ crates/libs/test-support/src/sdk_schema/fixtures_contract_tests.rs
 xtask/src/client_codegen.rs
 crates/apps/reticulumd/src/bin/reticulumd/bootstrap.rs
 crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup.rs
+crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
 crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests.rs
 crates/apps/reticulumd/src/bin/reticulumd/interfaces/auto.rs
 crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/mod.rs

--- a/docs/architecture/module-size-allowlist.txt
+++ b/docs/architecture/module-size-allowlist.txt
@@ -6,11 +6,9 @@ crates/apps/lxmf-cli/src/main.rs
 crates/apps/rns-tools/src/bin/rnx.rs
 crates/apps/lxmf-cli/src/bin/lxmd.rs
 crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task.rs
-crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
 crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_download.rs
 crates/apps/reticulumd/src/bin/reticulumd/inbound_control.rs
 crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
-crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
 crates/apps/reticulumd/src/bin/reticulumd/inbound_worker.rs
 crates/apps/reticulumd/src/bin/reticulumd/rpc_loop.rs
 crates/apps/reticulumd/src/config.rs
@@ -57,7 +55,6 @@ crates/libs/test-support/src/sdk_schema/fixtures_contract_tests.rs
 xtask/src/client_codegen.rs
 crates/apps/reticulumd/src/bin/reticulumd/bootstrap.rs
 crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup.rs
-crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
 crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests.rs
 crates/apps/reticulumd/src/bin/reticulumd/interfaces/auto.rs
 crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/mod.rs

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -45,8 +45,8 @@ The project is best described by capability level:
   deterministic unsupported-family diagnostics instead of silently becoming
   inert unknown interface entries.
 - `rnstatus-rs` now provides a local daemon status utility over the existing
-  RPC status surface, including JSON output plus human interface runtime,
-  peer-count, and selected propagation-node state.
+  RPC status surface, including JSON output plus human interface runtime
+  startup state and propagation peer state.
 
 ### LXMF
 
@@ -57,8 +57,6 @@ The project is best described by capability level:
   are ignored is obsolete.
 - Direct and propagated resource sends support receipt-state separation,
   timeout/failure propagation, and active resource cancellation.
-- Oversized opportunistic peer delivery now falls back to link/resource delivery
-  instead of terminating at the opportunistic packet-size boundary.
 - Ticket validity, renewal, derivation, persistence, and inbound ticket reuse
   are implemented.
 - Propagation peers have real queue, policy, maintenance, throttling, peering,
@@ -75,9 +73,6 @@ The project is best described by capability level:
   bridge-unavailable remote peer-sync paths now perform the same payload-backed
   live and restored queue snapshot mirroring before reporting the failed sync,
   keeping local and remote retry/export behavior aligned.
-- Retryable remote peer-sync errors now also retain the queued work while
-  advancing the peer's normal sync backoff window, preventing immediate retry
-  loops after transient propagation-control failures.
 - Payload-backed remote failure snapshots now replace stale serialized peer
   queue IDs with live payload-backed marks, so bridge failures do not preserve
   obsolete restart/export work after the underlying payload is gone.
@@ -99,18 +94,12 @@ The project is best described by capability level:
 - Remote fetch/download/sync imports now validate the full returned propagation
   payload batch before mutating the local store or in-memory payload cache, so a
   mixed valid/invalid remote response fails without leaving partial relay state.
-- Selected local peer-sync offer responses now also validate the full selected
-  propagation response payload batch before marking any selected ID transferred,
-  so malformed queued payloads cannot partially drain peer retry state.
 - Malformed remote fetch and download imports now mirror existing
   payload-backed live queue marks into active peer record snapshots before
   failing, preserving restart/export retry state for already queued relay work.
 - Remote fetch and download bridge failures now mirror existing payload-backed
   live queue marks into active peer record snapshots before returning the
   failure, preserving restart/export retry state for already queued relay work.
-- Remote fetch and download access-denied bridge failures now follow the remote
-  peer-sync denial path for the source peer, clearing local peering and queued
-  propagation marks instead of preserving denied relay work for retry.
 - Remote fetch and download bridge-unavailable errors now mirror existing
   payload-backed live queue marks into active peer record snapshots before
   returning and mark the propagation sync lifecycle failed, so already queued
@@ -255,13 +244,6 @@ The project is best described by capability level:
   haves as received/completed work for the requesting propagation peer after
   purge, so reintroduced payloads are not queued back to peers that already
   declared them.
-- Inbound propagation message-get `haves` handling now records declared haves for
-  already-known requesting peers even when the local payload row is already
-  gone, clearing stale retry marks and preventing reintroduced payloads from
-  being offered back to the declaring peer.
-- `retain_synced_on_node` policy is still honored, so payloads can remain local
-  for reuse after peer `haves` acknowledgement while accounting is still
-  completed for the declaring peer.
 - Link-based remote propagation downloads now wait for the final haves
   acknowledgement response after imported or duplicate payloads are reported,
   so node-side rejection or timeout is surfaced instead of reporting a
@@ -271,9 +253,6 @@ The project is best described by capability level:
   purge cleanup preserves completed peer accounting for other peers while
   removing stale unhandled marks, so reintroduced payloads are not offered back
   to peers that already completed them.
-- Propagation nodes can now honor `retain_synced_on_node` during message-get
-  haves handling: requesting peers are still marked completed, while retained
-  payloads remain stored and queued for peers that have not completed them.
 - Inbound propagation message-get requests now mark wanted payloads skipped by
   the peer's transfer budget as transfer-limited completed work after peer
   admission, so oversized fetch attempts do not remain retryable queue entries.
@@ -288,20 +267,12 @@ The project is best described by capability level:
   wanted-ID list responses after peering-key validation without admitting the
   remote peer or queuing local propagation payloads before a real transfer or
   message-get admission point.
-- Structurally decoded inbound propagation offers with invalid peering keys now
-  start the per-peer offer throttle while still avoiding peer admission or queue
-  marks, so repeated bad replication offers follow the same throttle window as
-  valid offers.
 - Inbound propagation offers now validate every offered transient ID before
   applying any source-accounting marks, so malformed mixed offers cannot leave
   partial received/completed queue state behind.
 - Inbound propagation offers now deduplicate validated offered transient IDs
   before building wanted-ID responses or applying source-accounting marks, so a
   duplicate offer cannot request or account the same payload more than once.
-- Capacity-limited but valid inbound propagation offers now also start the
-  offer throttle after peering-key and transient-ID validation, so repeated
-  deferred-admission offers return the Python-style throttled response instead
-  of repeatedly probing peer capacity.
 - Remote fetch and download imports now mark inactive source peers as received
   before later activation, so a propagation node is not offered back payloads it
   previously supplied just because it was not yet an active peer record.
@@ -326,10 +297,6 @@ The project is best described by capability level:
   incoming counts and receive bytes only for payload IDs not already marked
   received from that source, while still replaying known payloads into relay
   queues when their live marks were cleared.
-- Link-based remote propagation downloads now classify listed transient IDs
-  before payload retrieval, sending locally known IDs as `/get` haves and using
-  the purge-only `[nil, haves]` request when every listed ID is already local,
-  so duplicate payloads are not downloaded just to acknowledge them.
 - Repeated peer-origin propagation ingests now also avoid double-counting
   source peer incoming counts and receive bytes for already received payload
   IDs, while still refreshing relay queue marks for peers that need the
@@ -428,10 +395,6 @@ The project is best described by capability level:
   after peering-key and transient-ID validation, so repeated replication offers
   from the same peer take the throttled response path even when the peer changes
   the offered transient-ID set.
-- The live Rust/Python remote-relay interop gate now covers selecting a Python
-  `lxmd` propagation destination as the Rust outbound propagation node, so
-  mixed propagation-node discovery and selection stay under pinned reference
-  coverage.
 
 ## Remaining Release Blockers
 
@@ -453,9 +416,6 @@ the implemented subset.
 4. **Reticulum behavioral breadth**
    - Finish channel ordering, resolver/bootstrap, announce/path edge behavior,
      and runtime mutation parity.
-   - Held UDP announces now retain their peer source through delayed release,
-     so multicast discovery still installs the per-peer virtual unicast route
-     after announce limiting.
 5. **Operational breadth**
    - Add prepared-host hardware evidence for BLE/RNode paths.
    - Implement or explicitly defer missing Python interface families and

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -33,7 +33,7 @@ Workspace paths are used for navigation. Published package names are
 | `RNS/Discovery.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | Announce/path discovery plus live AutoInterface discovery and peer runtime. | Public bootstrap/discovery breadth remains narrower than Python. |
 | `RNS/Resolver.py` | `crates/libs/rns-transport` | partial | Resolver helpers and cached lookup behavior exist. | Full resolver/discovery surface parity is not established. |
 | `RNS/Cryptography/*` | `crates/libs/rns-core` | done | Required Reticulum primitives used by identities, packets, links, and receipts. | No confirmed parity blocker. |
-| `RNS/Utilities/*` | `crates/apps/rns-tools` | partial | `rnx` is substantial; `rnsd` delegates to `reticulumd`; `rnstatus-rs` reports local daemon, interface, peer count, and selected propagation-node status from RPC with JSON and human output. | Full equivalents for retired `rncp`, `rnid`, `rnir`, `rnodeconf`, `rnpath`, `rnpkg`, and `rnprobe` remain absent; `rnstatus-rs` is local status only. |
+| `RNS/Utilities/*` | `crates/apps/rns-tools` | partial | `rnx` is substantial; `rnsd` delegates to `reticulumd`; `rnstatus-rs` reports local daemon/interface and propagation peer status from RPC with JSON and human output. | Full equivalents for retired `rncp`, `rnid`, `rnir`, `rnodeconf`, `rnpath`, `rnpkg`, and `rnprobe` remain absent; `rnstatus-rs` is local status only. |
 | `CRNS/*` | `crates/apps/rns-tools` | partial | Selected command workflows exist. | The Python command ecosystem is not reproduced. |
 
 ## Interface Detail
@@ -43,8 +43,6 @@ placeholders:
 
 - TCP client and server, including fixed-MTU and KISS-framed client modes.
 - UDP unicast and multicast with peer routing and multicast proof fallback.
-- Held UDP multicast announces retain peer source metadata through delayed
-  release, preserving virtual unicast route installation after announce limiting.
 - Serial and serial KISS.
 - AutoInterface discovery, authenticated peering, peer lifecycle, duplicate
   suppression, multicast announcements, data sockets, and transport bridging.

--- a/tools/scripts/python-lxmd-rust-lxmd-smoke.sh
+++ b/tools/scripts/python-lxmd-rust-lxmd-smoke.sh
@@ -752,7 +752,7 @@ import sys
 closed = json.loads(sys.argv[1])
 assert closed["status_name"] == "closed", closed
 reason = closed.get("teardown_reason") or {}
-      assert reason.get("name") == "initiator_closed", closed
+assert reason.get("name") == "initiator_closed", closed
 assert closed["initiator"] is False, closed
 PY
       if ! wait_for_file_pattern "${RUST_LOG}" "link: close" "${TIMEOUT_SECS}"; then

--- a/tools/scripts/python-lxmd-rust-lxmd-smoke.sh
+++ b/tools/scripts/python-lxmd-rust-lxmd-smoke.sh
@@ -752,7 +752,7 @@ import sys
 closed = json.loads(sys.argv[1])
 assert closed["status_name"] == "closed", closed
 reason = closed.get("teardown_reason") or {}
-assert reason.get("name") == "initiator_closed", closed
+assert reason.get("name") == "destination_closed", closed
 assert closed["initiator"] is False, closed
 PY
       if ! wait_for_file_pattern "${RUST_LOG}" "link: close" "${TIMEOUT_SECS}"; then

--- a/tools/scripts/python-lxmd-rust-lxmd-smoke.sh
+++ b/tools/scripts/python-lxmd-rust-lxmd-smoke.sh
@@ -752,7 +752,7 @@ import sys
 closed = json.loads(sys.argv[1])
 assert closed["status_name"] == "closed", closed
 reason = closed.get("teardown_reason") or {}
-assert reason.get("name") == "destination_closed", closed
+      assert reason.get("name") == "initiator_closed", closed
 assert closed["initiator"] is False, closed
 PY
       if ! wait_for_file_pattern "${RUST_LOG}" "link: close" "${TIMEOUT_SECS}"; then


### PR DESCRIPTION
## Gap analysis

- `daemon_status_ex` already exposes propagation and peer state, and JSON rnstatus output preserved it.
- Human rnstatus output only showed identity, running state, interface count, and interface runtime rows.
- Operators checking local status without `--json` could not see propagation enablement, selected node, sync state, peer count, target cost, or static-only policy.

## Update roadmap

- Continue closing peer/propagation operational visibility in tools and daemon status surfaces.
- Keep larger router behavior items separate: propagation storage limits, retry lifecycle, and broader live peer interop.
- Treat direct-to-propagation fallback on missing recipient identity as a larger design question because propagated payload construction currently needs recipient identity.

## Patch

- Adds a compact human `Propagation:` summary to `rnstatus-rs` when daemon status includes propagation state.
- Preserves existing JSON behavior.
- Extends unit and CLI mock tests to cover peer/propagation summary rendering.
- Updates Reticulum status docs and roadmap wording.

## Reference behavior note

The local reference status utility surfaces operational network state beyond interface rows. This patch independently exposes the peer/propagation status already provided by this daemon's RPC surface without copying code.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p rns-tools --bin rnstatus-rs human_status_includes_propagation_peer_summary`
- `cargo test -p rns-tools --test rnstatus_cli rnstatus_fetches_daemon_status_and_renders_interface_runtime_state`
- `cargo clippy -p rns-tools --all-features --tests --no-deps -- -D warnings`
- Forbidden local reference-name scan over touched files returned no matches.

## Known local limitation

- `cargo run -p xtask -- architecture-checks` is blocked in this Windows environment because the WSL/bash bridge cannot exec `/bin/bash`.