### PR TITLE
Enforce propagation storage limit

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -233,6 +233,38 @@ impl RpcDaemon {
             .map_err(std::io::Error::other)
     }
 
+    fn prune_propagation_payloads_to_storage_limit(&self) -> Result<(), std::io::Error> {
+        let Some(limit_mb) = self
+            .propagation_state
+            .lock()
+            .expect("propagation mutex poisoned")
+            .message_storage_limit_mb
+        else {
+            return Ok(());
+        };
+        let Some(limit_bytes) = limit_mb.checked_mul(1_000_000) else {
+            return Ok(());
+        };
+        let pruned = self
+            .store
+            .prune_propagation_entries_to_limit_bytes(limit_bytes)
+            .map_err(std::io::Error::other)?;
+        if pruned.is_empty() {
+            return Ok(());
+        }
+        {
+            let mut guard =
+                self.propagation_payloads.lock().expect("propagation payload mutex poisoned");
+            for transient_id in &pruned {
+                guard.remove(transient_id.as_str());
+            }
+        }
+        for transient_id in pruned {
+            self.remove_peer_queue_snapshot_id(transient_id.as_str());
+        }
+        Ok(())
+    }
+
     fn queue_propagation_entry_for_active_peers(
         &self,
         transient_id: &str,
@@ -382,6 +414,7 @@ impl RpcDaemon {
                 .expect("propagation payload mutex poisoned")
                 .insert(record.transient_id, record.payload_hex);
         }
+        self.prune_propagation_payloads_to_storage_limit()?;
         if !messages.is_empty() {
             self.note_client_propagation_messages_received(imported_count);
         }
@@ -650,6 +683,8 @@ impl RpcDaemon {
             self.store
                 .mark_local_propagation_processed(transient_id.as_str())
                 .map_err(std::io::Error::other)?;
+            drop(guard);
+            self.prune_propagation_payloads_to_storage_limit()?;
         }
 
         let state = {
@@ -736,6 +771,7 @@ impl RpcDaemon {
             self.store
                 .mark_local_propagation_processed(transient_id.as_str())
                 .map_err(std::io::Error::other)?;
+            self.prune_propagation_payloads_to_storage_limit()?;
         }
 
         self.note_client_propagation_messages_received(usize::from(
@@ -819,6 +855,7 @@ impl RpcDaemon {
             .lock()
             .expect("propagation payload mutex poisoned")
             .insert(transient_id.clone(), payload_hex);
+        self.prune_propagation_payloads_to_storage_limit()?;
         Ok(transient_id)
     }
 
@@ -860,6 +897,7 @@ impl RpcDaemon {
             .lock()
             .expect("propagation payload mutex poisoned")
             .insert(transient_id.clone(), payload_hex);
+        self.prune_propagation_payloads_to_storage_limit()?;
         Ok(transient_id)
     }
 
@@ -1468,6 +1506,7 @@ impl RpcDaemon {
                     self.store
                         .mark_local_propagation_processed(transient_id.as_str())
                         .map_err(std::io::Error::other)?;
+                    self.prune_propagation_payloads_to_storage_limit()?;
                 }
 
                 let state = {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_propagation_ingest.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_propagation_ingest.rs
@@ -655,6 +655,62 @@ fn purged_propagation_ingest_does_not_recount_processed_transient() {
     assert_eq!(status["propagation"]["last_ingest_count"].as_u64(), Some(0));
 }
 
+#[test]
+fn propagation_ingest_prunes_oldest_payload_when_storage_limit_is_exceeded() {
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(
+            86,
+            "propagation_enable",
+            json!({
+                "enabled": true,
+                "message_storage_limit_mb": 1,
+            }),
+        ))
+        .expect("enable propagation storage limit");
+
+    let destination = [0x5a_u8; 16];
+    let mut first_payload = destination.to_vec();
+    first_payload.extend(std::iter::repeat(0x11_u8).take(600_000));
+    let mut second_payload = destination.to_vec();
+    second_payload.extend(std::iter::repeat(0x22_u8).take(600_000));
+
+    let first = daemon
+        .handle_rpc(rpc_request(
+            87,
+            "propagation_ingest",
+            json!({
+                "payload_hex": hex::encode(&first_payload),
+            }),
+        ))
+        .expect("first propagation ingest")
+        .result
+        .expect("first ingest result");
+    let first_transient = first["transient_id"].as_str().expect("first transient id").to_string();
+    assert!(daemon.has_propagation_payload(first_transient.as_str()));
+
+    let second = daemon
+        .handle_rpc(rpc_request(
+            88,
+            "propagation_ingest",
+            json!({
+                "payload_hex": hex::encode(&second_payload),
+            }),
+        ))
+        .expect("second propagation ingest")
+        .result
+        .expect("second ingest result");
+    let second_transient = second["transient_id"].as_str().expect("second transient id").to_string();
+
+    assert!(
+        !daemon.has_propagation_payload(first_transient.as_str()),
+        "oldest propagation payload should be pruned when storage limit is exceeded"
+    );
+    assert!(daemon.has_propagation_payload(second_transient.as_str()));
+    let stats = daemon.store.propagation_entry_stats().expect("propagation stats");
+    assert!(stats.bytes <= 1_000_000, "stats after prune: {stats:?}");
+}
+
 fn stamped_propagation_payload(lxm_data: &[u8], target_cost: u32) -> Vec<u8> {
     use hkdf::Hkdf;
     use sha2::{Digest, Sha256};

--- a/crates/libs/rns-rpc/src/storage/messages.rs
+++ b/crates/libs/rns-rpc/src/storage/messages.rs
@@ -1499,6 +1499,62 @@ impl MessagesStore {
         })
     }
 
+    pub fn prune_propagation_entries_to_limit_bytes(
+        &self,
+        limit_bytes: u64,
+    ) -> rusqlite::Result<Vec<String>> {
+        self.with_write_conn(|conn| {
+            let tx = conn.unchecked_transaction()?;
+            let total: i64 = tx.query_row(
+                "SELECT COALESCE(SUM(size_bytes), 0) FROM propagation_entries",
+                [],
+                |row| row.get(0),
+            )?;
+            let mut total = total.max(0) as u64;
+            if total <= limit_bytes {
+                tx.commit()?;
+                return Ok(Vec::new());
+            }
+
+            let entries = {
+                let mut stmt = tx.prepare(
+                    "SELECT transient_id, size_bytes
+                     FROM propagation_entries
+                     ORDER BY received_at ASC, transient_id ASC",
+                )?;
+                let rows = stmt.query_map([], |row| {
+                    let transient_id: String = row.get(0)?;
+                    let size_bytes: i64 = row.get(1)?;
+                    Ok((transient_id, size_bytes.max(0) as u64))
+                })?;
+                rows.collect::<rusqlite::Result<Vec<_>>>()?
+            };
+
+            let mut pruned = Vec::new();
+            for (transient_id, size_bytes) in entries {
+                if total <= limit_bytes {
+                    break;
+                }
+                let affected = tx.execute(
+                    "DELETE FROM propagation_entries WHERE transient_id = ?1",
+                    params![transient_id],
+                )?;
+                if affected > 0 {
+                    tx.execute(
+                        "DELETE FROM propagation_peer_entries
+                         WHERE transient_id = ?1
+                           AND state = 'unhandled'",
+                        params![transient_id],
+                    )?;
+                    total = total.saturating_sub(size_bytes);
+                    pruned.push(transient_id);
+                }
+            }
+            tx.commit()?;
+            Ok(pruned)
+        })
+    }
+
     pub fn count_message_buckets(&self) -> rusqlite::Result<(u64, u64)> {
         let (queued, in_flight): (i64, i64) = self.with_read_conn(|conn| {
             let mut stmt = conn.prepare(
@@ -3420,6 +3476,61 @@ mod tests {
                 .expect("unhandled ids")
                 .is_empty(),
             "retryable marks for the deleted payload are stale and should be removed"
+        );
+    }
+
+    #[test]
+    fn prune_propagation_entries_to_limit_bytes_removes_oldest_payloads() {
+        let store = MessagesStore::in_memory().expect("in-memory store");
+        let old = PropagationEntryRecord {
+            transient_id: "10".repeat(32),
+            destination: "44".repeat(16),
+            payload_hex: "10".repeat(80),
+            received_at: 1,
+            size_bytes: 80,
+            stamp_value: None,
+        };
+        let new = PropagationEntryRecord {
+            transient_id: "20".repeat(32),
+            destination: "55".repeat(16),
+            payload_hex: "20".repeat(40),
+            received_at: 2,
+            size_bytes: 40,
+            stamp_value: None,
+        };
+        store.upsert_propagation_entry(&old).expect("upsert old");
+        store.upsert_propagation_entry(&new).expect("upsert new");
+        store
+            .mark_peer_unhandled_propagation("peer-prune", old.transient_id.as_str())
+            .expect("mark old unhandled");
+        store
+            .mark_peer_unhandled_propagation("peer-prune", new.transient_id.as_str())
+            .expect("mark new unhandled");
+        store
+            .mark_peer_handled_propagation("peer-done", old.transient_id.as_str())
+            .expect("mark old handled");
+
+        let pruned =
+            store.prune_propagation_entries_to_limit_bytes(64).expect("prune propagation entries");
+
+        assert_eq!(pruned, vec![old.transient_id.clone()]);
+        assert!(store
+            .get_propagation_entry(old.transient_id.as_str())
+            .expect("old lookup")
+            .is_none());
+        assert!(store
+            .get_propagation_entry(new.transient_id.as_str())
+            .expect("new lookup")
+            .is_some());
+        assert_eq!(
+            store.list_peer_unhandled_propagation_ids("peer-prune").expect("peer unhandled ids"),
+            vec![new.transient_id]
+        );
+        assert!(
+            store
+                .peer_completed_propagation_mark_exists("peer-done", old.transient_id.as_str())
+                .expect("completed mark"),
+            "completed peer accounting should survive propagation storage pruning"
         );
     }
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -286,6 +286,9 @@ The project is best described by capability level:
   from retained payload entries, so reintroduced payloads after purge or peer
   acknowledgement can refresh relay state without inflating local received or
   ingested counters.
+- Propagation payload ingest now enforces the configured node message-storage
+  byte limit against retained propagation entries, pruning oldest payloads while
+  clearing retryable peer queue marks.
 - Link-based remote downloads now wait for the propagation node's `/get` haves
   acknowledgement and surface peer/control errors, so failed remote cleanup does
   not look like a completed replication drain.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -316,6 +316,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   retained payload entries, so payloads reintroduced after purge or peer
   acknowledgement can refresh relay state without inflating local received or
   ingested counters.
+- Propagation-node ingest enforces the configured message-storage byte limit
+  against retained propagation entries, pruning oldest payloads and stale
+  retryable peer marks.
 - Link-based remote downloads wait for the propagation node's `/get` haves
   acknowledgement and propagate peer/control errors, so failed remote cleanup is
   not reported as a completed replication drain.


### PR DESCRIPTION
## Gap Analysis
- Propagation peers could retain payloads beyond the configured node message-storage budget.
- Regular inbound message pruning already existed, but retained propagation entries had no matching oldest-first limit enforcement.
- Peer retry queues could continue referencing pruned propagation payloads unless cleanup happened with the payload removal.

## Update Roadmap
- Keep tightening propagation storage/accounting before broad router work.
- Next useful peer/propagation steps: expose more peer queue pressure in status, add replication retry scheduling coverage, and extend interop fixtures around propagation haves/wants.
- Defer larger router/daemon reshaping until these state transitions are covered by narrow tests.

## Patch
- Adds oldest-first pruning for retained propagation entries using the configured `message_storage_limit_mb` byte budget.
- Applies pruning after local, remote, and peer propagation ingest paths update retained payload state.
- Removes pruned payloads from memory and retryable peer queue snapshots while preserving completed peer accounting.
- Updates parity/status docs for the changed behavior.

## Reference Behavior Note
- This was independently implemented after comparing peer/propagation behavior with local read-only reference implementations. The relevant behavioral cue was that propagation-node retained payloads have their own storage budget and cull oldest retained entries when the budget is exceeded.

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`
- `cargo test -p reticulum-rs-rpc prune_propagation_entries_to_limit_bytes_removes_oldest_payloads`
- `cargo test -p reticulum-rs-rpc propagation_ingest_prunes_oldest_payload_when_storage_limit_is_exceeded`
- `cargo clippy -p reticulum-rs-rpc --all-features --tests --no-deps -- -D warnings`
- Forbidden local reference-name scan over touched files returned no matches.

## Known Local Limitation
- `cargo run -p xtask -- architecture-checks` was attempted earlier and failed because local WSL cannot execute `/bin/bash` on this machine.