### PR TITLE
Throttle invalid propagation offers

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
@@ -184,6 +184,9 @@ pub(super) fn handle_offer_request(
         Some(rmpv::Value::Array(values)) => values,
         _ => return ControlResponse::Code(error_invalid_data),
     };
+    if daemon.propagation_peer_offer_is_throttled(remote_propagation_hash_hex.as_str()) {
+        return ControlResponse::Code(error_throttled);
+    }
     let peering_cost = daemon.current_propagation_state().peering_cost.unwrap_or_else(|| {
         reticulum_daemon::announce_names::PropagationNodeAnnounceConfig::default().peering_cost
     });
@@ -191,6 +194,11 @@ pub(super) fn handle_offer_request(
     peering_id.extend_from_slice(control.local_identity_hash.as_slice());
     peering_id.extend_from_slice(remote_identity.address_hash.as_slice());
     if validate_peering_key(peering_id.as_slice(), peering_key, peering_cost).is_none() {
+        if transient_ids.iter().all(
+            |transient_id| matches!(transient_id, rmpv::Value::Binary(bytes) if bytes.len() == 32),
+        ) {
+            daemon.throttle_propagation_peer_offer(remote_propagation_hash_hex.as_str());
+        }
         return ControlResponse::Code(error_invalid_key);
     }
 
@@ -207,10 +215,6 @@ pub(super) fn handle_offer_request(
             offered_ids.push(bytes.clone());
         }
     }
-    if daemon.propagation_peer_offer_is_throttled(remote_propagation_hash_hex.as_str()) {
-        return ControlResponse::Code(error_throttled);
-    }
-
     let mut wanted = Vec::new();
     for bytes in &offered_ids {
         let transient_hex = hex::encode(bytes);
@@ -726,6 +730,100 @@ mod tests {
         assert!(matches!(first, ControlResponse::Bool(true)));
         assert!(matches!(second, ControlResponse::Code(0xF6)));
         assert!(matches!(different_offer, ControlResponse::Code(0xF6)));
+    }
+
+    #[test]
+    fn offer_request_invalid_peering_key_starts_offer_throttle_like_python() {
+        let daemon = RpcDaemon::test_instance();
+        daemon
+            .handle_rpc(RpcRequest {
+                id: 10,
+                method: "propagation_enable".to_string(),
+                params: Some(json!({
+                    "enabled": true,
+                    "peering_cost": 255,
+                })),
+            })
+            .expect("enable propagation");
+        let local_identity_hash = [0x11; 16];
+        let remote_private =
+            rns_transport::identity::PrivateIdentity::new_from_rand(rand_core::OsRng);
+        let remote_identity = *remote_private.as_identity();
+        let offered = [0xBB; 32];
+        let other_offered = [0xBC; 32];
+        let invalid_peering_key = vec![0x00; 1];
+        let control = PropagationControlContext {
+            enabled: true,
+            local_identity_hash,
+            propagation_destination_hash_hex: Some("propagation".to_string()),
+            control_destination_hash_hex: Some("control".to_string()),
+            delivery_destination: None,
+            allowed_control_identities: Vec::new(),
+            validated_peer_links: test_validated_peer_links(),
+        };
+
+        let first = handle_offer_request(
+            &daemon,
+            &control,
+            &test_link_id(),
+            &remote_identity,
+            Some(rmpv::Value::Array(vec![
+                rmpv::Value::Binary(invalid_peering_key.clone()),
+                rmpv::Value::Array(vec![rmpv::Value::Binary(offered.to_vec())]),
+            ])),
+            0xF1,
+            0xF3,
+            0xF4,
+            0xF6,
+        );
+        let second = handle_offer_request(
+            &daemon,
+            &control,
+            &test_link_id(),
+            &remote_identity,
+            Some(rmpv::Value::Array(vec![
+                rmpv::Value::Binary(invalid_peering_key),
+                rmpv::Value::Array(vec![rmpv::Value::Binary(other_offered.to_vec())]),
+            ])),
+            0xF1,
+            0xF3,
+            0xF4,
+            0xF6,
+        );
+
+        assert!(matches!(first, ControlResponse::Code(0xF3)));
+        assert!(matches!(second, ControlResponse::Code(0xF6)));
+        let remote_propagation_hash =
+            hex::encode(propagation_destination_hash_for_identity(&remote_identity));
+        let peers = daemon
+            .handle_rpc(RpcRequest {
+                id: 11,
+                method: "list_propagation_nodes".to_string(),
+                params: None,
+            })
+            .expect("list propagation nodes")
+            .result
+            .expect("peer rows");
+        let peer_rows = peers["nodes"].as_array().expect("peer rows");
+        assert!(
+            !peer_rows
+                .iter()
+                .any(|row| row["peer"].as_str() == Some(remote_propagation_hash.as_str())),
+            "invalid peering keys should not admit the peer"
+        );
+        assert!(
+            control.validated_peer_links.lock().expect("validated peer links").is_empty(),
+            "invalid peering keys should not validate the offer link"
+        );
+        assert!(
+            !daemon
+                .has_peer_completed_propagation_mark(
+                    remote_propagation_hash.as_str(),
+                    hex::encode(offered).as_str(),
+                )
+                .expect("completed mark"),
+            "invalid peering keys should not create peer queue marks"
+        );
     }
 
     #[test]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -267,6 +267,10 @@ The project is best described by capability level:
   wanted-ID list responses after peering-key validation without admitting the
   remote peer or queuing local propagation payloads before a real transfer or
   message-get admission point.
+- Structurally decoded inbound propagation offers with invalid peering keys now
+  start the per-peer offer throttle while still avoiding peer admission or queue
+  marks, so repeated bad replication offers follow the same throttle window as
+  valid offers.
 - Inbound propagation offers now validate every offered transient ID before
   applying any source-accounting marks, so malformed mixed offers cannot leave
   partial received/completed queue state behind.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -297,6 +297,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   wanted-ID list responses after peering-key validation without admitting the
   remote propagation peer or queuing local payloads before a real transfer or
   message-get admission point.
+- Structurally decoded inbound propagation offers with invalid peering keys
+  start the per-peer offer throttle while still avoiding peer admission or
+  queue marks, so repeated bad replication offers share the valid-offer
+  throttle window.
 - Inbound propagation offers validate every offered transient ID before
   applying source-accounting marks, so malformed mixed offers cannot leave
   partial received/completed queue state behind.


### PR DESCRIPTION
## Gap Analysis
- Decoded inbound propagation `/offer` requests with an invalid peering key returned `invalid_key` without starting the per-peer offer throttle.
- That let repeated bad replication offers from the same peer avoid the throttle window used for valid offers.
- The handler already had a separate malformed-data path, so the safe fix is limited to structurally decoded offers.

## Update Roadmap
- Continue tightening peer/propagation state-machine parity in narrow increments.
- Next peer/propagation candidates: remote fetch/download no-access lifecycle reporting, expired link metadata for path retry, and broader peer retry/backoff observability.
- Keep larger router and transport retry wiring behind focused tests.

## Patch
- Checks offer-specific throttling as soon as an offer is structurally decoded.
- Starts the offer throttle when a decoded offer has an invalid peering key and valid transient-ID list shape.
- Preserves malformed transient-ID handling and avoids peer admission, link validation, or queue marks on invalid keys.
- Updates the roadmap and LXMF parity matrix.

## Reference Behavior Note
- This was independently implemented after read-only comparison with local reference implementations. The behavior cue was that decoded propagation offers that fail peering-key validation still enter the same per-peer offer throttle window as normal offers.

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`
- `cargo test -p reticulumd offer_request_invalid_peering_key_starts_offer_throttle_like_python`
- `cargo test -p reticulumd offer_request_repeated_valid_offer_is_throttled_like_python`
- `cargo test -p reticulumd offer_request_rejects_invalid_transient_id_without_recording_peer`
- `cargo clippy -p reticulumd --all-features --tests --no-deps -- -D warnings`
- Forbidden local reference-name scan over touched files returned no matches.

## Known Local Limitation
- `cargo run -p xtask -- architecture-checks` was attempted and failed because local WSL cannot execute `/bin/bash` on this machine.