### PR TITLE
Validate selected peer sync payload batches

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -1122,6 +1122,7 @@ impl RpcDaemon {
                     propagation_handled_ids.push(transient_id);
                 }
                 if let Some(selected_response_ids) = selected_response_ids.as_ref() {
+                    let mut selected_transfers = Vec::new();
                     for wanted_id in selected_response_ids {
                         let Some(entry) = selected_offer_entries.get(wanted_id) else {
                             continue;
@@ -1141,12 +1142,22 @@ impl RpcDaemon {
                             "size_bytes": entry.size_bytes,
                             "stamp_value": entry.stamp_value,
                         });
+                        selected_transfers.push((
+                            wanted_id.clone(),
+                            entry.size_bytes,
+                            propagation_message,
+                            payload_bytes,
+                        ));
+                    }
+                    for (wanted_id, size_bytes, propagation_message, payload_bytes) in
+                        selected_transfers
+                    {
                         self.store
                             .mark_peer_transferred_propagation(peer_key, wanted_id.as_str())
                             .map_err(std::io::Error::other)?;
                         self.record_peer_queue_handled(peer_key, wanted_id.as_str());
                         propagation_transferred = propagation_transferred.saturating_add(1);
-                        propagation_bytes = propagation_bytes.saturating_add(entry.size_bytes);
+                        propagation_bytes = propagation_bytes.saturating_add(size_bytes);
                         propagation_transferred_ids.push(wanted_id.clone());
                         propagation_messages.push(propagation_message);
                         propagation_resource_payloads.push(payload_bytes);

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -11224,6 +11224,87 @@ fn peer_sync_reports_transferred_propagation_messages() {
 }
 
 #[test]
+fn peer_sync_invalid_response_payload_does_not_partially_mark_transferred_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-invalid-response-payload";
+    daemon
+        .handle_rpc(rpc_request(63, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.propagation_stamp_cost = Some(0);
+    }
+
+    let valid = PropagationEntryRecord {
+        transient_id: "a1".repeat(32),
+        destination: "18".repeat(16),
+        payload_hex: "23".repeat(24),
+        received_at: 1_700_000_617,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    let invalid = PropagationEntryRecord {
+        transient_id: "a2".repeat(32),
+        destination: "18".repeat(16),
+        payload_hex: "not-hex".to_string(),
+        received_at: 1_700_000_618,
+        size_bytes: 7,
+        stamp_value: None,
+    };
+    for entry in [&valid, &invalid] {
+        daemon.store.upsert_propagation_entry(entry).expect("store propagation entry");
+        daemon
+            .store
+            .mark_peer_unhandled_propagation(peer, entry.transient_id.as_str())
+            .expect("mark unhandled");
+        daemon.record_peer_queue_unhandled_id(peer, entry.transient_id.as_str());
+    }
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            64,
+            "peer_sync",
+            json!({
+                "peer": peer,
+                "wanted_ids": [valid.transient_id.as_str(), invalid.transient_id.as_str()],
+            }),
+        ))
+        .expect_err("invalid response payload should fail peer sync");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("invalid propagation payload hex"),
+        "unexpected error: {err}"
+    );
+
+    let pending = daemon
+        .store
+        .list_peer_unhandled_propagation(peer)
+        .expect("pending propagation");
+    assert_eq!(pending, vec![valid.clone(), invalid.clone()]);
+    assert!(
+        daemon
+            .store
+            .list_peer_handled_propagation_ids(peer)
+            .expect("handled propagation")
+            .is_empty()
+    );
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("peer record");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert!(
+        serialized["handled_ids"]
+            .as_array()
+            .expect("serialized handled ids")
+            .is_empty()
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(valid.transient_id.as_str()), json!(invalid.transient_id.as_str())]
+    );
+}
+
+#[test]
 fn peer_sync_offers_low_value_stamped_entries_like_python() {
     let store = MessagesStore::in_memory().expect("store");
     let daemon = RpcDaemon::with_store(store, hex::encode([2u8; 16]));

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -94,6 +94,9 @@ The project is best described by capability level:
 - Remote fetch/download/sync imports now validate the full returned propagation
   payload batch before mutating the local store or in-memory payload cache, so a
   mixed valid/invalid remote response fails without leaving partial relay state.
+- Selected local peer-sync offer responses now also validate the full selected
+  propagation response payload batch before marking any selected ID transferred,
+  so malformed queued payloads cannot partially drain peer retry state.
 - Malformed remote fetch and download imports now mirror existing
   payload-backed live queue marks into active peer record snapshots before
   failing, preserving restart/export retry state for already queued relay work.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -127,6 +127,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote fetch/download/sync imports validate the full returned propagation
   payload batch before mutating the local store or in-memory payload cache, so
   mixed valid/invalid remote responses fail without leaving partial relay state.
+- Selected local peer-sync offer responses validate the full selected
+  propagation response payload batch before marking any selected ID transferred,
+  so malformed queued payloads cannot partially drain peer retry state.
 - Malformed remote fetch and download imports mirror existing payload-backed
   queue marks into active peer record snapshots before returning the import
   failure, so already queued relay work remains visible after restart/export.


### PR DESCRIPTION
## Gap analysis
- The parity docs already covered atomic validation for remote propagation import batches, but selected local peer-sync offer responses still had a narrower atomicity gap.
- When a peer requested multiple selected propagation IDs, the daemon decoded and marked each selected payload as transferred one-by-one. If a later selected queued payload was malformed, an earlier valid selected payload could be removed from retry state before the sync failed.
- That made selected peer replication less restart-safe than the remote fetch/download/sync paths and weaker than the reference lifecycle pattern where outbound transfer side effects are finalized only after the selected response payload set is ready.

## Patch
- Build and validate the full selected peer-sync propagation response payload batch before marking any selected ID transferred.
- Preserve existing selected wanted-ID behavior for successful transfers, duplicate selected IDs, and canonical transient-ID matching.
- Add a focused daemon regression for malformed selected response payloads proving the valid queued item remains retryable and serialized as unhandled after the failure.
- Update the roadmap and LXMF parity matrix for the narrowed peer replication lifecycle gap.

## Update roadmap
- Continue auditing peer replication paths for mutation-before-validation behavior, especially haves cleanup, stale queue marks, and explicit teardown.
- Keep local peer-sync and remote fetch/download/sync behavior shape-aligned as queue atomicity improves.
- Add live interop coverage for selected propagation offer responses after the daemon-side semantics are stable.

## Verification
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p reticulum-rs-rpc peer_sync_invalid_response_payload_does_not_partially_mark_transferred_like_python`
- `cargo test -p reticulum-rs-rpc peer_sync_offer_response_only_transfers_wanted_messages_like_python`
- `cargo test -p reticulum-rs-rpc peer_sync_preserves_duplicate_wanted_ids_like_python`
- `cargo test -p reticulum-rs-rpc peer_sync_matches_wanted_ids_by_canonical_transient_id`
- `cargo clippy -p reticulum-rs-rpc --all-features --tests --no-deps -- -D warnings`

## Boundary checks
- Touched-file forbidden-name scan: clean.
- `cargo run -p xtask -- architecture-checks` could not run locally because WSL failed to launch `/bin/bash` (`CreateProcessCommon:818: execvpe(/bin/bash) failed: No such file or directory`).
