### PR TITLE
Remember stale propagation haves

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
@@ -45,6 +45,7 @@ pub(super) fn handle_message_get_request(
         _ => return ControlResponse::Code(error_invalid_data),
     };
     if !haves.is_empty() {
+        let have_ids = haves.iter().map(hex::encode).collect::<Vec<_>>();
         let matched_haves = daemon
             .list_propagation_payloads_for_destination(&remote_delivery_hash)
             .into_iter()
@@ -63,9 +64,9 @@ pub(super) fn handle_message_get_request(
         if !daemon.current_propagation_state().retain_synced_on_node {
             daemon.purge_propagation_payloads_for_destination(&remote_delivery_hash, &haves);
         }
-        for transient_id in matched_haves {
+        for transient_id in have_ids {
             if daemon
-                .record_peer_received_propagation(
+                .record_existing_peer_received_propagation(
                     remote_propagation_hash.as_str(),
                     transient_id.as_str(),
                 )
@@ -333,6 +334,20 @@ mod tests {
 
     fn test_link_id() -> AddressHash {
         AddressHash::new([0xA6; 16])
+    }
+
+    fn list_peer_row(daemon: &RpcDaemon, peer: &str) -> serde_json::Value {
+        daemon
+            .handle_rpc(RpcRequest { id: 90, method: "list_peers".to_string(), params: None })
+            .expect("list peers")
+            .result
+            .expect("list peers result")["peers"]
+            .as_array()
+            .expect("peer rows")
+            .iter()
+            .find(|row| row["peer"].as_str() == Some(peer))
+            .cloned()
+            .expect("peer row")
     }
 
     #[test]
@@ -1785,6 +1800,83 @@ mod tests {
             row["messages"]["unhandled_ids"],
             json!([]),
             "reingested payload must not be requeued to a peer that already completed it"
+        );
+    }
+
+    #[test]
+    fn message_get_haves_clear_stale_unhandled_peer_mark_like_python() {
+        let daemon = RpcDaemon::test_instance();
+        let remote_private =
+            rns_transport::identity::PrivateIdentity::new_from_rand(rand_core::OsRng);
+        let remote_identity = *remote_private.as_identity();
+        let remote_delivery_hash = delivery_destination_hash_for_identity(&remote_identity);
+        let remote_propagation_hash =
+            hex::encode(propagation_destination_hash_for_identity(&remote_identity));
+        let have = [0x38; 32];
+        let have_hex = hex::encode(have);
+        let mut have_payload = remote_delivery_hash.to_vec();
+        have_payload.extend_from_slice(b" stale haves cleanup propagation");
+        daemon
+            .record_propagation_offer_peer(remote_propagation_hash.as_str())
+            .expect("activate peer");
+        daemon
+            .ingest_propagation_payload_bytes_with_aliases(
+                have_payload.as_slice(),
+                have_hex.as_str(),
+                &[],
+            )
+            .expect("store have payload");
+        daemon
+            .record_peer_unhandled_propagation(remote_propagation_hash.as_str(), have_hex.as_str())
+            .expect("mark unhandled");
+        let purged = daemon.purge_propagation_payloads_for_destination(
+            &remote_delivery_hash,
+            std::slice::from_ref(&have.to_vec()),
+        );
+        assert!(purged > 0);
+        daemon
+            .record_peer_unhandled_propagation(remote_propagation_hash.as_str(), have_hex.as_str())
+            .expect("restore stale unhandled mark");
+
+        let response = handle_message_get_request(
+            &daemon,
+            &remote_identity,
+            Some(rmpv::Value::Array(vec![
+                rmpv::Value::Nil,
+                rmpv::Value::Array(vec![rmpv::Value::Binary(have.to_vec())]),
+            ])),
+            0xF1,
+            0xF4,
+        );
+
+        assert!(matches!(response, ControlResponse::Bool(true)));
+        assert!(list_peer_row(&daemon, remote_propagation_hash.as_str())["messages"]
+            ["unhandled_ids"]
+            .as_array()
+            .expect("unhandled ids")
+            .is_empty());
+        assert!(
+            daemon
+                .has_peer_completed_propagation_mark(
+                    remote_propagation_hash.as_str(),
+                    have_hex.as_str(),
+                )
+                .expect("completed propagation mark"),
+            "declared haves should survive as completed peer accounting"
+        );
+        daemon
+            .ingest_propagation_payload_bytes_with_aliases(
+                have_payload.as_slice(),
+                have_hex.as_str(),
+                &[],
+            )
+            .expect("reingest stale have payload");
+        assert!(
+            list_peer_row(&daemon, remote_propagation_hash.as_str())["messages"]["unhandled_ids"]
+                .as_array()
+                .expect("reingested unhandled ids")
+                .is_empty(),
+            "reintroduced payload must not be queued back to the declaring peer"
         );
     }
 

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -903,6 +903,40 @@ impl RpcDaemon {
         Ok(())
     }
 
+    pub fn record_existing_peer_received_propagation(
+        &self,
+        peer: &str,
+        transient_id: &str,
+    ) -> Result<bool, std::io::Error> {
+        let transient_id = normalize_propagation_transient_key(transient_id);
+        let peer_key = {
+            let guard = self.peers.lock().expect("peers mutex poisoned");
+            guard.keys().find(|existing| existing.eq_ignore_ascii_case(peer)).cloned()
+        };
+        let Some(peer_key) = peer_key else {
+            return Ok(false);
+        };
+        self.store
+            .mark_peer_received_propagation(peer_key.as_str(), transient_id.as_str())
+            .map_err(std::io::Error::other)?;
+        self.record_peer_queue_handled_id(peer_key.as_str(), transient_id.as_str());
+        Ok(true)
+    }
+
+    pub fn record_peer_unhandled_propagation(
+        &self,
+        peer: &str,
+        transient_id: &str,
+    ) -> Result<(), std::io::Error> {
+        let transient_id = normalize_propagation_transient_key(transient_id);
+        let peer_key = self.peer_store_key_or_input(peer);
+        self.store
+            .mark_peer_unhandled_propagation(peer_key.as_str(), transient_id.as_str())
+            .map_err(std::io::Error::other)?;
+        self.record_peer_queue_unhandled_id(peer_key.as_str(), transient_id.as_str());
+        Ok(())
+    }
+
     pub fn has_peer_completed_propagation_mark(
         &self,
         peer: &str,

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -249,9 +249,13 @@ The project is best described by capability level:
   haves as received/completed work for the requesting propagation peer after
   purge, so reintroduced payloads are not queued back to peers that already
   declared them.
-- Propagation nodes can now retain synced payloads after message-get `haves`
-  while still marking the declaring peer completed, matching the router setting
-  used by operators that keep node-side LXMs available for other peers.
+- Inbound propagation message-get `haves` handling now records declared haves for
+  already-known requesting peers even when the local payload row is already
+  gone, clearing stale retry marks and preventing reintroduced payloads from
+  being offered back to the declaring peer.
+- `retain_synced_on_node` policy is still honored, so payloads can remain local
+  for reuse after peer `haves` acknowledgement while accounting is still
+  completed for the declaring peer.
 - Link-based remote propagation downloads now wait for the final haves
   acknowledgement response after imported or duplicate payloads are reported,
   so node-side rejection or timeout is surfaced instead of reporting a

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -283,8 +283,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   received/completed work for the requesting propagation peer after purge, so
   reintroduced payloads are not queued back to peers that already declared
   them.
-- Propagation-node `haves` handling honors retained synced payload settings,
-  keeping local LXMs available while completing the declaring peer's accounting.
+- Inbound propagation message-get `haves` handling records stale peer-acknowledged
+  IDs even when local payload rows are already absent, while still honoring
+  `retain_synced_on_node` payload-retention behavior so completed peers are
+  marked without regressing local payload reuse.
 - Link-based remote propagation downloads wait for the final haves
   acknowledgement response after imported or duplicate payloads are reported,
   so node-side rejection or timeout is surfaced instead of reporting a


### PR DESCRIPTION
## Gap analysis
- Inbound propagation message-get `haves` only recorded received/completed peer accounting when the declared transient ID still matched a local payload row.
- If the local payload row was already gone but the requesting peer still had a stale unhandled retry mark, a haves-only acknowledgement returned success without clearing that retry state.
- That left a restart/reingest parity gap: the same payload could be offered back to a peer that had already declared it.

## Patch
- Record declared haves for already-known requesting peers even when the local payload row is missing.
- Keep the existing admission behavior for matched local payload haves; missing haves do not create a peer record by themselves.
- Add a focused reticulumd message-get regression proving stale unhandled marks are cleared, completed accounting survives, and reintroduced payloads are not requeued to the declaring peer.
- Add a small public daemon helper for unhandled peer queue marking so daemon/control tests and callers can set peer retry state through the same snapshot path.
- Update roadmap and LXMF parity matrix notes for the haves retry-state behavior.

## Update roadmap
- Continue auditing peer replication retry cleanup for haves, postponed sync, and sync-limit skipped IDs.
- Keep local haves cleanup aligned with peer-sync stale queue cleanup while preserving peer admission gates.
- Add live Python interop coverage for stale/reintroduced haves once the daemon-side behavior settles.

## Verification
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p reticulumd message_get_haves_clear_stale_unhandled_peer_mark_like_python`
- `cargo test -p reticulumd message_get_haves_mark_requesting_peer_received_across_purge_and_reingest`
- `cargo test -p reticulumd message_get_rejected_peer_cannot_purge_haves`
- `cargo test -p reticulum-rs-rpc peer_sync_drops_stale_unhandled_propagation_marks`
- `cargo clippy -p reticulumd -p reticulum-rs-rpc --all-features --tests --no-deps -- -D warnings`

## Boundary checks
- Touched-file forbidden-name scan: clean.
- `cargo run -p xtask -- architecture-checks` could not run locally because WSL failed to launch `/bin/bash` (`CreateProcessCommon:818: execvpe(/bin/bash) failed: No such file or directory`).

## Reference behavior note
- Inspired by the local read-only implementations' peer replication lifecycle: a peer's declared haves should be treated as durable completion knowledge for that peer, not only as a delete request for payload rows that still happen to be present.
