### PR TITLE
Preserve held UDP announce source

### DIFF
--- a/crates/libs/rns-transport/src/transport/announce.rs
+++ b/crates/libs/rns-transport/src/transport/announce.rs
@@ -116,7 +116,7 @@ pub(super) async fn handle_announce<'a>(
     let destination_known = handler.has_destination(&packet.destination)
         || handler.knows_destination(&packet.destination);
     if let AnnounceLimitAction::Hold(delay) =
-        handler.announce_limits.check(iface, packet, destination_known)
+        handler.announce_limits.check(iface, packet, source, destination_known)
     {
         log::debug!(
             "tp({}): holding announce for {} for {:?}",
@@ -146,6 +146,7 @@ pub(super) async fn release_held_announces<'a>(handler: MutexGuard<'a, Transport
     for released_announce in released {
         let packet = released_announce.packet;
         let iface = released_announce.iface;
+        let source = released_announce.source;
         let announce = match DestinationAnnounce::validate(&packet) {
             Ok(result) => result,
             Err(err) => {
@@ -158,11 +159,6 @@ pub(super) async fn release_held_announces<'a>(handler: MutexGuard<'a, Transport
             }
         };
 
-        // Held announces predate auto-unicast redirection because we
-        // don't persist the `IfaceSource` across the hold queue.
-        // Replay on the stored iface; if that iface was multicast, the
-        // route won't get the unicast redirect until the next fresh
-        // announce from this peer arrives.
-        handler = process_announce(&packet, handler, iface, IfaceSource::None, announce).await;
+        handler = process_announce(&packet, handler, iface, source, announce).await;
     }
 }

--- a/crates/libs/rns-transport/src/transport/announce_limits.rs
+++ b/crates/libs/rns-transport/src/transport/announce_limits.rs
@@ -7,6 +7,7 @@ use tokio::time::Duration;
 use tokio::time::Instant;
 
 use crate::hash::AddressHash;
+use crate::iface::IfaceSource;
 use crate::packet::{Packet, PacketContext};
 
 pub struct AnnounceRateLimit {
@@ -47,6 +48,7 @@ pub enum AnnounceLimitAction {
 #[derive(Clone, Copy)]
 struct HeldAnnounce {
     packet: Packet,
+    source: IfaceSource,
     held_at: Instant,
 }
 
@@ -143,9 +145,15 @@ impl AnnounceLimitEntry {
     }
 
     #[allow(dead_code)]
-    fn hold(&mut self, packet: &Packet, now: Instant, rate_limit: &AnnounceRateLimit) -> bool {
+    fn hold(
+        &mut self,
+        packet: &Packet,
+        source: IfaceSource,
+        now: Instant,
+        rate_limit: &AnnounceRateLimit,
+    ) -> bool {
         if let Entry::Occupied(mut entry) = self.held_announces.entry(packet.destination) {
-            entry.insert(HeldAnnounce { packet: *packet, held_at: now });
+            entry.insert(HeldAnnounce { packet: *packet, source, held_at: now });
             return true;
         }
 
@@ -166,7 +174,7 @@ impl AnnounceLimitEntry {
         }
 
         self.held_announces
-            .insert(packet.destination, HeldAnnounce { packet: *packet, held_at: now });
+            .insert(packet.destination, HeldAnnounce { packet: *packet, source, held_at: now });
         true
     }
 
@@ -183,7 +191,11 @@ impl AnnounceLimitEntry {
         self.held_release.saturating_duration_since(now)
     }
 
-    fn release_one(&mut self, now: Instant, rate_limit: &AnnounceRateLimit) -> Option<Packet> {
+    fn release_one(
+        &mut self,
+        now: Instant,
+        rate_limit: &AnnounceRateLimit,
+    ) -> Option<(Packet, IfaceSource)> {
         if self.held_announces.is_empty() || self.should_ingress_limit(now, rate_limit) {
             return None;
         }
@@ -196,19 +208,20 @@ impl AnnounceLimitEntry {
             .held_announces
             .iter()
             .min_by_key(|(_, held)| (held.packet.header.hops, held.held_at))
-            .map(|(destination, held)| (*destination, held.packet));
+            .map(|(destination, held)| (*destination, held.packet, held.source));
 
-        let (destination, packet) = selected?;
+        let (destination, packet, source) = selected?;
 
         self.held_announces.remove(&destination);
         self.held_release = now + rate_limit.held_release_interval;
-        Some(packet)
+        Some((packet, source))
     }
 }
 
 pub struct ReleasedAnnounce {
     pub iface: AddressHash,
     pub packet: Packet,
+    pub source: IfaceSource,
 }
 
 pub struct AnnounceLimits {
@@ -230,15 +243,17 @@ impl AnnounceLimits {
         &mut self,
         iface: AddressHash,
         packet: &Packet,
+        source: IfaceSource,
         destination_known: bool,
     ) -> AnnounceLimitAction {
-        self.check_at(iface, packet, destination_known, Instant::now())
+        self.check_at(iface, packet, source, destination_known, Instant::now())
     }
 
     fn check_at(
         &mut self,
         iface: AddressHash,
         packet: &Packet,
+        source: IfaceSource,
         destination_known: bool,
         now: Instant,
     ) -> AnnounceLimitAction {
@@ -254,7 +269,7 @@ impl AnnounceLimits {
         }
 
         if entry.should_ingress_limit(now, &self.rate_limit)
-            && entry.hold(packet, now, &self.rate_limit)
+            && entry.hold(packet, source, now, &self.rate_limit)
         {
             return AnnounceLimitAction::Hold(entry.next_release_delay(now, &self.rate_limit));
         }
@@ -270,8 +285,8 @@ impl AnnounceLimits {
         let mut released = Vec::new();
 
         for (iface, entry) in self.limits.iter_mut() {
-            if let Some(packet) = entry.release_one(now, &self.rate_limit) {
-                released.push(ReleasedAnnounce { iface: *iface, packet });
+            if let Some((packet, source)) = entry.release_one(now, &self.rate_limit) {
+                released.push(ReleasedAnnounce { iface: *iface, packet, source });
             } else {
                 continue;
             }
@@ -315,13 +330,20 @@ mod tests {
         let now = Instant::now();
 
         assert_eq!(
-            limits.check_at(iface_a, &announce_packet(AddressHash::new([1; 16]), 1), false, now),
+            limits.check_at(
+                iface_a,
+                &announce_packet(AddressHash::new([1; 16]), 1),
+                IfaceSource::None,
+                false,
+                now,
+            ),
             AnnounceLimitAction::Allow
         );
         assert!(matches!(
             limits.check_at(
                 iface_a,
                 &announce_packet(AddressHash::new([2; 16]), 1),
+                IfaceSource::None,
                 false,
                 now + Duration::from_millis(5)
             ),
@@ -331,6 +353,7 @@ mod tests {
             limits.check_at(
                 iface_b,
                 &announce_packet(AddressHash::new([3; 16]), 1),
+                IfaceSource::None,
                 false,
                 now + Duration::from_millis(5)
             ),
@@ -345,13 +368,20 @@ mod tests {
         let now = Instant::now();
 
         assert_eq!(
-            limits.check_at(iface, &announce_packet(AddressHash::new([1; 16]), 4), false, now),
+            limits.check_at(
+                iface,
+                &announce_packet(AddressHash::new([1; 16]), 4),
+                IfaceSource::None,
+                false,
+                now,
+            ),
             AnnounceLimitAction::Allow
         );
         assert!(matches!(
             limits.check_at(
                 iface,
                 &announce_packet(AddressHash::new([2; 16]), 3),
+                IfaceSource::None,
                 false,
                 now + Duration::from_millis(5)
             ),
@@ -361,6 +391,7 @@ mod tests {
             limits.check_at(
                 iface,
                 &announce_packet(AddressHash::new([3; 16]), 1),
+                IfaceSource::None,
                 false,
                 now + Duration::from_millis(10)
             ),
@@ -388,13 +419,20 @@ mod tests {
         let now = Instant::now();
 
         assert_eq!(
-            limits.check_at(iface, &announce_packet(AddressHash::new([1; 16]), 4), false, now),
+            limits.check_at(
+                iface,
+                &announce_packet(AddressHash::new([1; 16]), 4),
+                IfaceSource::None,
+                false,
+                now,
+            ),
             AnnounceLimitAction::Allow
         );
         assert!(matches!(
             limits.check_at(
                 iface,
                 &announce_packet(AddressHash::new([2; 16]), 5),
+                IfaceSource::None,
                 false,
                 now + Duration::from_millis(5)
             ),
@@ -404,6 +442,7 @@ mod tests {
             limits.check_at(
                 iface,
                 &announce_packet(AddressHash::new([3; 16]), 1),
+                IfaceSource::None,
                 false,
                 now + Duration::from_millis(10)
             ),

--- a/crates/libs/rns-transport/src/transport/tests.rs
+++ b/crates/libs/rns-transport/src/transport/tests.rs
@@ -406,6 +406,98 @@ async fn unknown_announces_are_held_per_interface_and_released_by_lowest_hops() 
 }
 
 #[tokio::test]
+async fn held_udp_announce_preserves_peer_source_for_unicast_route() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let config = TransportConfig::new("test", &local_identity, true);
+    let transport = Transport::new(config);
+    let handler = transport.get_handler();
+    let mut announce_rx = transport.recv_announces().await;
+    let iface = register_fake_multicast_iface(&transport).await;
+
+    handler.lock().await.announce_limits = AnnounceLimits::with_rate_limit(AnnounceRateLimit {
+        incoming_freq_samples: 3,
+        max_held_announces: 8,
+        new_time: Duration::from_secs(3600),
+        burst_freq_new: 100.0,
+        burst_freq: 100.0,
+        burst_hold: Duration::from_millis(20),
+        burst_penalty: Duration::from_millis(20),
+        held_release_interval: Duration::from_millis(10),
+    });
+
+    let first_peer = peer_addr(4242);
+    let mut first_destination = SingleInputDestination::new(
+        PrivateIdentity::new_from_rand(OsRng),
+        DestinationName::new("lxmf", "delivery"),
+    );
+    let first_announce = first_destination.announce(OsRng, None).expect("first announce");
+    handle_announce(
+        &first_announce,
+        handler.lock().await,
+        iface,
+        crate::iface::IfaceSource::Udp(first_peer),
+    )
+    .await;
+    timeout(Duration::from_millis(200), announce_rx.recv())
+        .await
+        .expect("first announce should emit")
+        .expect("broadcast receive");
+
+    for idx in 0..3 {
+        let mut packet = Packet::default();
+        packet.header.packet_type = PacketType::Announce;
+        packet.header.hops = 15;
+        packet.destination = AddressHash::new([0xA0 + idx; crate::hash::ADDRESS_HASH_SIZE]);
+        let _ = handler.lock().await.announce_limits.check(
+            iface,
+            &packet,
+            crate::iface::IfaceSource::None,
+            false,
+        );
+    }
+
+    let held_peer = peer_addr(5252);
+    let mut held_destination = SingleInputDestination::new(
+        PrivateIdentity::new_from_rand(OsRng),
+        DestinationName::new("lxmf", "delivery"),
+    );
+    let held_announce = held_destination.announce(OsRng, None).expect("held announce");
+    handle_announce(
+        &held_announce,
+        handler.lock().await,
+        iface,
+        crate::iface::IfaceSource::Udp(held_peer),
+    )
+    .await;
+    assert!(matches!(
+        announce_rx.try_recv(),
+        Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+    ));
+
+    let mut released = None;
+    for _ in 0..5 {
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        release_held_announces(handler.lock().await).await;
+        if let Ok(event) = timeout(Duration::from_millis(80), announce_rx.recv()).await {
+            released = Some(event.expect("broadcast receive"));
+            break;
+        }
+    }
+    let released = released.expect("held announce should release");
+
+    let guard = handler.lock().await;
+    let virtual_hash = guard
+        .unicast_udp_ifaces
+        .get(&held_peer)
+        .map(|(hash, _)| *hash)
+        .expect("held peer should register virtual iface");
+    assert_eq!(released.interface, virtual_hash.as_slice().to_vec());
+
+    let routing = guard.multicast_peer_routings.get(&iface).expect("routing").lock().await;
+    assert_eq!(routing.hash_for_addr(&held_peer), Some(virtual_hash));
+}
+
+#[tokio::test]
 async fn learned_announces_are_not_held_after_route_is_known() {
     let local_identity = PrivateIdentity::new_from_rand(OsRng);
     let config = TransportConfig::new("test", &local_identity, true);

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -424,6 +424,9 @@ the implemented subset.
 4. **Reticulum behavioral breadth**
    - Finish channel ordering, resolver/bootstrap, announce/path edge behavior,
      and runtime mutation parity.
+   - Held UDP announces now retain their peer source through delayed release,
+     so multicast discovery still installs the per-peer virtual unicast route
+     after announce limiting.
 5. **Operational breadth**
    - Add prepared-host hardware evidence for BLE/RNode paths.
    - Implement or explicitly defer missing Python interface families and

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -43,6 +43,8 @@ placeholders:
 
 - TCP client and server, including fixed-MTU and KISS-framed client modes.
 - UDP unicast and multicast with peer routing and multicast proof fallback.
+- Held UDP multicast announces retain peer source metadata through delayed
+  release, preserving virtual unicast route installation after announce limiting.
 - Serial and serial KISS.
 - AutoInterface discovery, authenticated peering, peer lifecycle, duplicate
   suppression, multicast announcements, data sockets, and transport bridging.


### PR DESCRIPTION
## Gap analysis

- Current Reticulum status docs still track announce/path/discovery edge behavior as a release blocker.
- The smallest peer/propagation gap found here was held UDP multicast announce release: normal announce ingress preserved the UDP peer source for virtual unicast routing, but delayed release replayed held announces without the original source.
- That meant announce-limited multicast discovery could learn the path while missing the per-peer virtual unicast route until a later fresh announce arrived.

## Patch

- Carry `IfaceSource` through the announce-limit hold queue and released announce records.
- Replay released held announces with the preserved source so UDP multicast peers still install virtual unicast routing.
- Add a regression covering a held UDP announce released from a multicast iface and asserting the virtual unicast route is registered.
- Update the status roadmap and Reticulum parity matrix for this specific edge case.

## Update roadmap

1. Continue peer/propagation state-machine slices: offer retry/fetch/download synchronization and stale-peer cleanup.
2. Add Rust/Python interop coverage for completed propagation-node rows before promoting broader parity.
3. Continue Reticulum discovery work with resolver/bootstrap and channel ordering edge behavior.
4. Keep interface/tool parity scoped to behavior-backed rows, not parser-only support.

## Verification

- `cargo test -p reticulum-rs-transport held_udp_announce_preserves_peer_source_for_unicast_route`
- `cargo test -p reticulum-rs-transport unknown_announces_are_held_per_interface_and_released_by_lowest_hops`
- `cargo test -p reticulum-rs-transport unicast_iface_for_source_registers_virtual_iface_and_peer_routing`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p reticulum-rs-transport --all-features --tests --no-deps -- -D warnings`
- `cargo test -p reticulum-rs-transport`
- touched-file reference-name scan: no matches

`cargo run -p xtask -- architecture-checks` was attempted and failed locally because WSL could not launch `/bin/bash` for `tools/scripts/check-boundaries.sh`.

## Reference behavior note

This was inspired by read-only comparison against local reference implementations: UDP announce source attribution should survive delayed announce handling so peer-specific routing remains consistent after rate-limit release. The implementation is independent and does not vendor or copy reference code.