### PR TITLE
Back off retryable remote peer sync errors

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -164,7 +164,9 @@ impl RpcDaemon {
         if let Ok(mut peers) = self.peers.lock() {
             if let Some(peer) = peers.get_mut(peer_id) {
                 peer.last_sync_attempt = timestamp;
-                peer.next_sync_attempt = 0;
+                peer.sync_backoff =
+                    peer.sync_backoff.saturating_add(super::init::LXMF_PEER_SYNC_BACKOFF_STEP_SECS);
+                peer.next_sync_attempt = timestamp.saturating_add(i64::from(peer.sync_backoff));
             }
         }
         self.record_payload_backed_peer_queue_snapshot(peer_id)?;

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -16794,7 +16794,7 @@ fn denied_access_propagation_remote_sync_breaks_peering_like_python() {
 }
 
 #[test]
-fn identity_required_propagation_remote_sync_preserves_peer_for_immediate_retry() {
+fn identity_required_propagation_remote_sync_preserves_peer_with_retry_backoff() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(RemoteSyncErrorBridge {
         kind: std::io::ErrorKind::PermissionDenied,
@@ -16836,12 +16836,13 @@ fn identity_required_propagation_remote_sync_preserves_peer_for_immediate_retry(
         .expect("peer rows")
         .iter()
         .find(|row| row["peer"].as_str() == Some("peer-remote-needs-id"))
-        .expect("peer should remain available for retry");
+        .expect("peer should remain queued for retry");
     assert_eq!(row["alive"].as_bool(), Some(true));
-    assert_eq!(row["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(row["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
     assert_eq!(row["acceptance_rate"].as_f64(), Some(0.8));
-    assert!(row["last_sync_attempt"].as_i64().expect("last sync attempt") > 0);
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
 
     let events = daemon.event_queue.lock().expect("event_queue mutex poisoned");
     assert!(
@@ -16856,8 +16857,12 @@ fn identity_required_propagation_remote_sync_preserves_peer_for_immediate_retry(
     assert_eq!(event.payload["peer"].as_str(), Some("peer-remote-needs-id"));
     assert_eq!(event.payload["remote"].as_str(), Some("remote-node"));
     assert_eq!(event.payload["alive"].as_bool(), Some(true));
-    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(event.payload["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(event.payload["last_sync_attempt"].as_i64(), Some(last_sync_attempt));
+    assert_eq!(
+        event.payload["next_sync_attempt"].as_i64(),
+        Some(last_sync_attempt + 12 * 60)
+    );
     assert_eq!(
         event.payload["propagation"]["error"].as_str(),
         Some("propagation node requires identity")
@@ -16865,7 +16870,7 @@ fn identity_required_propagation_remote_sync_preserves_peer_for_immediate_retry(
 }
 
 #[test]
-fn invalid_peering_key_propagation_remote_sync_preserves_peer_without_backoff() {
+fn invalid_peering_key_propagation_remote_sync_preserves_peer_with_retry_backoff() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(RemoteSyncErrorBridge {
         kind: std::io::ErrorKind::PermissionDenied,
@@ -16907,12 +16912,13 @@ fn invalid_peering_key_propagation_remote_sync_preserves_peer_without_backoff() 
         .expect("peer rows")
         .iter()
         .find(|row| row["peer"].as_str() == Some("peer-invalid-key"))
-        .expect("peer should remain available for another offer");
+        .expect("peer should remain queued for retry");
     assert_eq!(row["alive"].as_bool(), Some(true));
-    assert_eq!(row["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(row["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
     assert_eq!(row["acceptance_rate"].as_f64(), Some(0.7));
-    assert!(row["last_sync_attempt"].as_i64().expect("last sync attempt") > 0);
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
 
     let events = daemon.event_queue.lock().expect("event_queue mutex poisoned");
     assert!(
@@ -16927,8 +16933,12 @@ fn invalid_peering_key_propagation_remote_sync_preserves_peer_without_backoff() 
     assert_eq!(event.payload["peer"].as_str(), Some("peer-invalid-key"));
     assert_eq!(event.payload["remote"].as_str(), Some("remote-node"));
     assert_eq!(event.payload["alive"].as_bool(), Some(true));
-    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(event.payload["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(event.payload["last_sync_attempt"].as_i64(), Some(last_sync_attempt));
+    assert_eq!(
+        event.payload["next_sync_attempt"].as_i64(),
+        Some(last_sync_attempt + 12 * 60)
+    );
     assert_eq!(
         event.payload["propagation"]["error"].as_str(),
         Some("propagation peer invalid peering key")
@@ -16936,7 +16946,7 @@ fn invalid_peering_key_propagation_remote_sync_preserves_peer_without_backoff() 
 }
 
 #[test]
-fn invalid_data_propagation_remote_sync_preserves_peer_without_backoff() {
+fn invalid_data_propagation_remote_sync_preserves_peer_with_retry_backoff() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(RemoteSyncErrorBridge {
         kind: std::io::ErrorKind::InvalidInput,
@@ -16978,12 +16988,13 @@ fn invalid_data_propagation_remote_sync_preserves_peer_without_backoff() {
         .expect("peer rows")
         .iter()
         .find(|row| row["peer"].as_str() == Some("peer-invalid-data"))
-        .expect("peer should remain available for another offer");
+        .expect("peer should remain queued for retry");
     assert_eq!(row["alive"].as_bool(), Some(true));
-    assert_eq!(row["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(row["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
     assert_eq!(row["acceptance_rate"].as_f64(), Some(0.6));
-    assert!(row["last_sync_attempt"].as_i64().expect("last sync attempt") > 0);
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
 
     let events = daemon.event_queue.lock().expect("event_queue mutex poisoned");
     assert!(
@@ -16998,8 +17009,12 @@ fn invalid_data_propagation_remote_sync_preserves_peer_without_backoff() {
     assert_eq!(event.payload["peer"].as_str(), Some("peer-invalid-data"));
     assert_eq!(event.payload["remote"].as_str(), Some("remote-node"));
     assert_eq!(event.payload["alive"].as_bool(), Some(true));
-    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(event.payload["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(event.payload["last_sync_attempt"].as_i64(), Some(last_sync_attempt));
+    assert_eq!(
+        event.payload["next_sync_attempt"].as_i64(),
+        Some(last_sync_attempt + 12 * 60)
+    );
     assert_eq!(
         event.payload["propagation"]["error"].as_str(),
         Some("propagation node rejected the request")
@@ -17007,7 +17022,7 @@ fn invalid_data_propagation_remote_sync_preserves_peer_without_backoff() {
 }
 
 #[test]
-fn timeout_propagation_remote_sync_preserves_peer_without_backoff() {
+fn timeout_propagation_remote_sync_preserves_peer_with_retry_backoff() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(RemoteSyncErrorBridge {
         kind: std::io::ErrorKind::TimedOut,
@@ -17062,12 +17077,13 @@ fn timeout_propagation_remote_sync_preserves_peer_without_backoff() {
         .expect("peer rows")
         .iter()
         .find(|row| row["peer"].as_str() == Some("peer-timeout"))
-        .expect("peer should remain available for another offer");
+        .expect("peer should remain queued for retry");
     assert_eq!(row["alive"].as_bool(), Some(true));
-    assert_eq!(row["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(row["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
     assert_eq!(row["acceptance_rate"].as_f64(), Some(0.5));
-    assert!(row["last_sync_attempt"].as_i64().expect("last sync attempt") > 0);
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
     assert_eq!(row["messages"]["unhandled_ids"], json!([pending.transient_id.as_str()]));
 
     let peers = daemon.peers.lock().expect("peers mutex poisoned");
@@ -17092,8 +17108,12 @@ fn timeout_propagation_remote_sync_preserves_peer_without_backoff() {
     assert_eq!(event.payload["peer"].as_str(), Some("peer-timeout"));
     assert_eq!(event.payload["remote"].as_str(), Some("remote-node"));
     assert_eq!(event.payload["alive"].as_bool(), Some(true));
-    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(event.payload["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(event.payload["last_sync_attempt"].as_i64(), Some(last_sync_attempt));
+    assert_eq!(
+        event.payload["next_sync_attempt"].as_i64(),
+        Some(last_sync_attempt + 12 * 60)
+    );
     assert_eq!(
         event.payload["propagation"]["error"].as_str(),
         Some("propagation peer timed out")
@@ -17101,7 +17121,7 @@ fn timeout_propagation_remote_sync_preserves_peer_without_backoff() {
 }
 
 #[test]
-fn not_found_propagation_remote_sync_preserves_peer_without_backoff() {
+fn not_found_propagation_remote_sync_preserves_peer_with_retry_backoff() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(RemoteSyncErrorBridge {
         kind: std::io::ErrorKind::NotFound,
@@ -17143,12 +17163,13 @@ fn not_found_propagation_remote_sync_preserves_peer_without_backoff() {
         .expect("peer rows")
         .iter()
         .find(|row| row["peer"].as_str() == Some("peer-not-found"))
-        .expect("peer should remain available for another offer");
+        .expect("peer should remain queued for retry");
     assert_eq!(row["alive"].as_bool(), Some(true));
-    assert_eq!(row["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(row["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
     assert_eq!(row["acceptance_rate"].as_f64(), Some(0.4));
-    assert!(row["last_sync_attempt"].as_i64().expect("last sync attempt") > 0);
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
 
     let events = daemon.event_queue.lock().expect("event_queue mutex poisoned");
     assert!(
@@ -17163,8 +17184,12 @@ fn not_found_propagation_remote_sync_preserves_peer_without_backoff() {
     assert_eq!(event.payload["peer"].as_str(), Some("peer-not-found"));
     assert_eq!(event.payload["remote"].as_str(), Some("remote-node"));
     assert_eq!(event.payload["alive"].as_bool(), Some(true));
-    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(event.payload["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(event.payload["last_sync_attempt"].as_i64(), Some(last_sync_attempt));
+    assert_eq!(
+        event.payload["next_sync_attempt"].as_i64(),
+        Some(last_sync_attempt + 12 * 60)
+    );
     assert_eq!(
         event.payload["propagation"]["error"].as_str(),
         Some("propagation peer not found")
@@ -17172,7 +17197,7 @@ fn not_found_propagation_remote_sync_preserves_peer_without_backoff() {
 }
 
 #[test]
-fn invalid_stamp_propagation_remote_sync_preserves_peer_queue_without_backoff() {
+fn invalid_stamp_propagation_remote_sync_preserves_peer_queue_with_retry_backoff() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(RemoteSyncErrorBridge {
         kind: std::io::ErrorKind::PermissionDenied,
@@ -17227,12 +17252,13 @@ fn invalid_stamp_propagation_remote_sync_preserves_peer_queue_without_backoff() 
         .expect("peer rows")
         .iter()
         .find(|row| row["peer"].as_str() == Some("peer-invalid-stamp"))
-        .expect("peer should remain available for another offer");
+        .expect("peer should remain queued for retry");
     assert_eq!(row["alive"].as_bool(), Some(true));
-    assert_eq!(row["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(row["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
     assert_eq!(row["acceptance_rate"].as_f64(), Some(0.45));
-    assert!(row["last_sync_attempt"].as_i64().expect("last sync attempt") > 0);
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
     assert_eq!(
         daemon
             .store
@@ -17262,8 +17288,12 @@ fn invalid_stamp_propagation_remote_sync_preserves_peer_queue_without_backoff() 
     assert_eq!(event.payload["peer"].as_str(), Some("peer-invalid-stamp"));
     assert_eq!(event.payload["remote"].as_str(), Some("remote-node"));
     assert_eq!(event.payload["alive"].as_bool(), Some(true));
-    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(event.payload["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(event.payload["last_sync_attempt"].as_i64(), Some(last_sync_attempt));
+    assert_eq!(
+        event.payload["next_sync_attempt"].as_i64(),
+        Some(last_sync_attempt + 12 * 60)
+    );
     assert_eq!(
         event.payload["propagation"]["error"].as_str(),
         Some("propagation peer invalid stamp")
@@ -17454,12 +17484,13 @@ fn unknown_numeric_propagation_remote_sync_preserves_peer_queue_like_python() {
         .expect("peer rows")
         .iter()
         .find(|row| row["peer"].as_str() == Some("peer-unknown-response"))
-        .expect("peer should remain available for another offer");
+        .expect("peer should remain queued for retry");
     assert_eq!(row["alive"].as_bool(), Some(true));
-    assert_eq!(row["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(row["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
     assert_eq!(row["acceptance_rate"].as_f64(), Some(0.35));
-    assert!(row["last_sync_attempt"].as_i64().expect("last sync attempt") > 0);
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
     assert_eq!(
         daemon
             .store
@@ -17489,8 +17520,12 @@ fn unknown_numeric_propagation_remote_sync_preserves_peer_queue_like_python() {
     assert_eq!(event.payload["peer"].as_str(), Some("peer-unknown-response"));
     assert_eq!(event.payload["remote"].as_str(), Some("remote-node"));
     assert_eq!(event.payload["alive"].as_bool(), Some(true));
-    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(event.payload["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(event.payload["last_sync_attempt"].as_i64(), Some(last_sync_attempt));
+    assert_eq!(
+        event.payload["next_sync_attempt"].as_i64(),
+        Some(last_sync_attempt + 12 * 60)
+    );
     assert_eq!(
         event.payload["propagation"]["error"].as_str(),
         Some("unexpected propagation control response")

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -73,6 +73,9 @@ The project is best described by capability level:
   bridge-unavailable remote peer-sync paths now perform the same payload-backed
   live and restored queue snapshot mirroring before reporting the failed sync,
   keeping local and remote retry/export behavior aligned.
+- Retryable remote peer-sync errors now also retain the queued work while
+  advancing the peer's normal sync backoff window, preventing immediate retry
+  loops after transient propagation-control failures.
 - Payload-backed remote failure snapshots now replace stale serialized peer
   queue IDs with live payload-backed marks, so bridge failures do not preserve
   obsolete restart/export work after the underlying payload is gone.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -107,6 +107,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   and restored queue marks into active peer record snapshots before publishing
   the failed sync event, so local and remote retry/export behavior stays
   aligned.
+- Retryable remote peer-sync errors keep those queued snapshots but now advance
+  the peer's ordinary sync backoff window, avoiding immediate retry loops after
+  transient propagation-control failures.
 - Payload-backed remote failure snapshots replace stale serialized peer queue
   IDs with live payload-backed marks, so bridge failures do not preserve
   obsolete restart/export work after the underlying payload is gone.


### PR DESCRIPTION
## Gap analysis

- The maintained roadmap still lists propagation peer/router retry and synchronization lifecycle as incomplete.
- Local comparison showed retryable remote peer-sync errors preserved peer queue snapshots, but reset `next_sync_attempt` to zero.
- That made failed remote replication immediately eligible for another sync attempt, unlike the ordinary peer-sync lifecycle where failed attempts advance retry backoff while keeping queued work available.

## Patch

- Retryable `propagation_remote_sync` errors now increment the peer sync backoff and set `next_sync_attempt` from the failed attempt timestamp.
- Existing queue snapshot preservation is kept intact for live and restored queued propagation work.
- Retryable remote-sync tests now assert both preserved peer/queue state and the delayed retry window across identity-required, invalid key/data/stamp, timeout, not-found, and unexpected response cases.
- Roadmap and LXMF matrix notes updated for this specific retry lifecycle parity slice.

## Update roadmap

1. Continue remote fetch/download denial cleanup parity with remote sync.
2. Add observable peer event coverage for remote fetch/download source and relay side effects.
3. Expand live Python interop to cover a full store/fetch/download/sync drain, not only node selection.
4. Continue deferred stamp worker lifecycle after peer/router retry paths stabilize.

## Verification

- `cargo test -p reticulum-rs-rpc propagation_remote_sync`
- `cargo test -p reticulum-rs-rpc peer_sync`
- `cargo test -p reticulum-rs-rpc`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p reticulum-rs-rpc --all-features --tests --no-deps -- -D warnings`
- touched-file reference-name scan: no matches

`cargo run -p xtask -- architecture-checks` was attempted and failed locally because WSL could not launch `/bin/bash` for `tools/scripts/check-boundaries.sh`.

## Reference behavior note

This was inspired by read-only comparison against local Rust reference behavior: a retryable failed peer sync should leave queued replication work intact while moving the peer into its normal retry backoff window. The implementation is independent and does not vendor or copy reference code.