### PR TITLE
Back off failed remote transfer source peers

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -8,6 +8,22 @@ const PR_IDLE: u32 = 0x00;
 const PR_NO_ACCESS: u32 = 0xf4;
 const PR_FAILED: u32 = 0xfe;
 
+fn is_remote_transfer_attempt_error(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        std::io::ErrorKind::BrokenPipe
+            | std::io::ErrorKind::ConnectionAborted
+            | std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::ConnectionReset
+            | std::io::ErrorKind::InvalidData
+            | std::io::ErrorKind::NotConnected
+            | std::io::ErrorKind::NotFound
+            | std::io::ErrorKind::TimedOut
+            | std::io::ErrorKind::UnexpectedEof
+            | std::io::ErrorKind::WouldBlock
+    )
+}
+
 struct RemotePropagationImportSummary {
     imported_count: usize,
     duplicate_count: usize,
@@ -186,8 +202,12 @@ impl RpcDaemon {
         &self,
         source_peer: &str,
         remote: &str,
-        error: &str,
+        error: &std::io::Error,
     ) -> Result<bool, std::io::Error> {
+        if !is_remote_transfer_attempt_error(error) {
+            return Ok(false);
+        }
+
         let source_peer_key =
             self.active_peer_ids().into_iter().find(|peer| peer.eq_ignore_ascii_case(source_peer));
         let Some(source_peer_key) = source_peer_key else {
@@ -199,7 +219,7 @@ impl RpcDaemon {
         self.publish_failed_remote_peer_sync_event(
             source_peer_key.as_str(),
             remote,
-            error,
+            error.to_string().as_str(),
             None,
             None,
             None,
@@ -2312,7 +2332,7 @@ impl RpcDaemon {
                             self.record_failed_remote_transfer_for_active_source_peer(
                                 remote_id.as_str(),
                                 remote_id.as_str(),
-                                err.to_string().as_str(),
+                                &err,
                             )?;
                             for peer in self.active_peer_ids() {
                                 self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
@@ -2434,7 +2454,7 @@ impl RpcDaemon {
                             self.record_failed_remote_transfer_for_active_source_peer(
                                 remote_id.as_str(),
                                 remote_id.as_str(),
-                                err.to_string().as_str(),
+                                &err,
                             )?;
                             for peer in self.active_peer_ids() {
                                 self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -182,6 +182,31 @@ impl RpcDaemon {
         Ok(())
     }
 
+    fn record_failed_remote_transfer_for_active_source_peer(
+        &self,
+        source_peer: &str,
+        remote: &str,
+        error: &str,
+    ) -> Result<bool, std::io::Error> {
+        let source_peer_key =
+            self.active_peer_ids().into_iter().find(|peer| peer.eq_ignore_ascii_case(source_peer));
+        let Some(source_peer_key) = source_peer_key else {
+            return Ok(false);
+        };
+
+        self.record_outbound_peer_activity(source_peer_key.as_str(), 0, false);
+        self.record_payload_backed_peer_queue_snapshot(source_peer_key.as_str())?;
+        self.publish_failed_remote_peer_sync_event(
+            source_peer_key.as_str(),
+            remote,
+            error,
+            None,
+            None,
+            None,
+        );
+        Ok(true)
+    }
+
     fn break_remote_peer_sync_peering_on_denied_access(
         &self,
         peer_id: &str,
@@ -2284,6 +2309,11 @@ impl RpcDaemon {
                                 err.to_string().as_str(),
                             )?;
                         } else {
+                            self.record_failed_remote_transfer_for_active_source_peer(
+                                remote_id.as_str(),
+                                remote_id.as_str(),
+                                err.to_string().as_str(),
+                            )?;
                             for peer in self.active_peer_ids() {
                                 self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
                             }
@@ -2401,6 +2431,11 @@ impl RpcDaemon {
                                 err.to_string().as_str(),
                             )?;
                         } else {
+                            self.record_failed_remote_transfer_for_active_source_peer(
+                                remote_id.as_str(),
+                                remote_id.as_str(),
+                                err.to_string().as_str(),
+                            )?;
                             for peer in self.active_peer_ids() {
                                 self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
                             }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -16780,6 +16780,75 @@ fn failed_propagation_remote_fetch_updates_source_peer_backoff_like_python() {
     );
 }
 
+fn assert_local_remote_transfer_error_does_not_backoff_source_peer(
+    method: &str,
+    kind: std::io::ErrorKind,
+) {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge { result: Err(kind) }));
+    let peer = format!("peer-{method}-local-error");
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.alive = true;
+        record.sync_backoff = 60;
+        record.last_sync_attempt = 321;
+        record.next_sync_attempt = 654;
+        record.acceptance_rate = 0.5;
+    }
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            81,
+            method,
+            json!({
+                "remote": peer,
+                "identity_private_key_hex": "not-hex",
+            }),
+        ))
+        .expect_err("local bridge failure should be returned");
+    assert_eq!(err.kind(), kind);
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer.as_str()).expect("stored peer");
+    assert!(record.alive);
+    assert_eq!(record.sync_backoff, 60);
+    assert_eq!(record.last_sync_attempt, 321);
+    assert_eq!(record.next_sync_attempt, 654);
+    assert_eq!(record.acceptance_rate, 0.5);
+    drop(peers);
+
+    assert!(
+        daemon
+            .event_queue
+            .lock()
+            .expect("event_queue mutex poisoned")
+            .iter()
+            .all(|event| event.event_type != "peer_sync"),
+        "local bridge failures must not publish a failed peer sync event"
+    );
+}
+
+#[test]
+fn invalid_input_propagation_remote_download_does_not_backoff_source_peer() {
+    assert_local_remote_transfer_error_does_not_backoff_source_peer(
+        "propagation_remote_download",
+        std::io::ErrorKind::InvalidInput,
+    );
+}
+
+#[test]
+fn local_setup_propagation_remote_fetch_error_does_not_backoff_source_peer() {
+    assert_local_remote_transfer_error_does_not_backoff_source_peer(
+        "propagation_remote_fetch",
+        std::io::ErrorKind::Other,
+    );
+}
+
 #[test]
 fn failed_propagation_remote_fetch_prunes_stale_queue_snapshot_ids_like_python() {
     let daemon = RpcDaemon::test_instance();

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -16476,6 +16476,94 @@ fn failed_propagation_remote_download_records_existing_queue_snapshot_like_pytho
 }
 
 #[test]
+fn failed_propagation_remote_download_updates_source_peer_backoff_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Err(std::io::ErrorKind::TimedOut),
+    }));
+    let peer = "peer-remote-download-fail-backoff";
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.alive = true;
+        record.sync_backoff = 0;
+        record.next_sync_attempt = 0;
+        record.acceptance_rate = 0.5;
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "bd".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_624,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            81,
+            "propagation_remote_download",
+            json!({
+                "remote": peer,
+            }),
+        ))
+        .expect_err("remote download bridge failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 82, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(peer))
+        .expect("peer row");
+    assert_eq!(row["alive"].as_bool(), Some(false));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
+    assert_eq!(
+        row["messages"]["unhandled_ids"].as_array().expect("unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_sync")
+        .cloned()
+        .expect("failed remote download peer event");
+    assert_eq!(event.payload["peer"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote_sync"].as_bool(), Some(true));
+    assert_eq!(event.payload["synced"].as_bool(), Some(false));
+    assert_eq!(event.payload["alive"].as_bool(), Some(false));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(
+        event.payload["propagation"]["error"].as_str(),
+        Some("remote download failed")
+    );
+}
+
+#[test]
 fn failed_propagation_remote_fetch_import_records_existing_queue_snapshot_like_python() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
@@ -16601,6 +16689,94 @@ fn failed_propagation_remote_fetch_records_existing_queue_snapshot_like_python()
     assert_eq!(
         serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
         &[json!(pending.transient_id.as_str())]
+    );
+}
+
+#[test]
+fn failed_propagation_remote_fetch_updates_source_peer_backoff_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Err(std::io::ErrorKind::TimedOut),
+    }));
+    let peer = "peer-remote-fetch-fail-backoff";
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.alive = true;
+        record.sync_backoff = 0;
+        record.next_sync_attempt = 0;
+        record.acceptance_rate = 0.5;
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "bc".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_623,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            81,
+            "propagation_remote_fetch",
+            json!({
+                "remote": peer,
+            }),
+        ))
+        .expect_err("remote fetch bridge failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 82, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(peer))
+        .expect("peer row");
+    assert_eq!(row["alive"].as_bool(), Some(false));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
+    assert_eq!(
+        row["messages"]["unhandled_ids"].as_array().expect("unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_sync")
+        .cloned()
+        .expect("failed remote fetch peer event");
+    assert_eq!(event.payload["peer"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote_sync"].as_bool(), Some(true));
+    assert_eq!(event.payload["synced"].as_bool(), Some(false));
+    assert_eq!(event.payload["alive"].as_bool(), Some(false));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(
+        event.payload["propagation"]["error"].as_str(),
+        Some("remote fetch failed")
     );
 }
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -104,6 +104,10 @@ The project is best described by capability level:
 - Remote fetch and download bridge failures now mirror existing payload-backed
   live queue marks into active peer record snapshots before returning the
   failure, preserving restart/export retry state for already queued relay work.
+- Remote fetch and download bridge failures from an already active source peer
+  now also update that peer's failure backoff and publish the failed peer-sync
+  event, so retry scheduling and observability match the preserved queue
+  snapshot.
 - Remote fetch and download access-denied bridge errors now preserve the
   propagation `no_access` lifecycle state instead of collapsing the denial into
   generic failure, while retaining the bridge error text for operators.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -143,6 +143,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote fetch and download bridge failures mirror existing payload-backed
   queue marks into active peer record snapshots before returning the failure,
   so already queued relay work remains visible after restart/export.
+- Remote fetch and download bridge failures from an already active source peer
+  also update that peer's failure backoff and publish the failed peer-sync
+  event, aligning retry scheduling and observability with the preserved queue
+  snapshot.
 - Remote fetch and download access-denied bridge failures follow the remote
   peer-sync denial path for the source peer, clearing local peering and queued
   propagation marks instead of preserving denied relay work for retry, while


### PR DESCRIPTION
## Gap analysis
- The roadmap still calls out propagation peer/router transfer and retry lifecycle gaps.
- Remote fetch/download failures already preserved payload-backed queue snapshots, but when `remote` matched an active source peer they did not update that peer's failure backoff or publish the failed peer-sync event.
- That left retry scheduling and operator-visible peer state weaker than the remote sync path for the same source-peer relationship.

## Patch
- On non-denied `propagation_remote_fetch` and `propagation_remote_download` bridge failures, resolve `remote` only against existing active peers.
- If an active source peer exists, record failed outbound peer activity, snapshot its queue, and publish the standard failed peer-sync event.
- Preserve the existing generic snapshot path for other active peers and avoid creating or penalizing unknown peers.

## Tests
- Added source-peer backoff tests for failed remote fetch and failed remote download, covering alive=false, backoff, next attempt, preserved queue snapshot, and failed peer event payload.
- Re-ran existing fetch/download failure/import and remote sync backoff tests to guard non-target paths.

## Update roadmap
- Next peer/propagation candidates: preserve source context through restart/requeue paths, add live interop cases for failed fetch/download source-peer lifecycle, and tighten link/session cleanup invariants for terminal transfer failures.

## Reference behavior note
- The local Rust reference pass emphasized sync backoff as peer lifecycle state, terminal transfer failures as explicit session cleanup points, and router-owned peer failures as backoff-driving events. This patch independently applies that model to this repo's active source-peer remote fetch/download paths without copying code or changing unknown-peer behavior.

## Verification
- cargo test -p reticulum-rs-rpc failed_propagation_remote_download_updates_source_peer_backoff_like_python
- cargo test -p reticulum-rs-rpc failed_propagation_remote_fetch_updates_source_peer_backoff_like_python
- cargo test -p reticulum-rs-rpc failed_propagation_remote_download_records_existing_queue_snapshot_like_python
- cargo test -p reticulum-rs-rpc failed_propagation_remote_sync_updates_peer_backoff
- cargo test -p reticulum-rs-rpc propagation_remote_download
- cargo test -p reticulum-rs-rpc propagation_remote_fetch
- cargo test -p reticulum-rs-rpc
- cargo fmt --all -- --check
- git diff --check
- cargo clippy -p reticulum-rs-rpc --all-features --tests --no-deps -- -D warnings

Boundary check note: `cargo run -p xtask -- architecture-checks` is still blocked locally because WSL cannot launch `/bin/bash` (`execvpe(/bin/bash) failed: No such file or directory`).