### PR TITLE
Cover peer queue snapshots during propagation pruning

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_propagation_ingest.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_propagation_ingest.rs
@@ -665,6 +665,7 @@ fn propagation_ingest_prunes_oldest_payload_when_storage_limit_is_exceeded() {
             json!({
                 "enabled": true,
                 "message_storage_limit_mb": 1,
+                "static_peers": ["peer-storage-prune-snapshot"],
             }),
         ))
         .expect("enable propagation storage limit");
@@ -688,6 +689,22 @@ fn propagation_ingest_prunes_oldest_payload_when_storage_limit_is_exceeded() {
         .expect("first ingest result");
     let first_transient = first["transient_id"].as_str().expect("first transient id").to_string();
     assert!(daemon.has_propagation_payload(first_transient.as_str()));
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation_ids("peer-storage-prune-snapshot")
+            .expect("first live unhandled ids"),
+        vec![first_transient.clone()]
+    );
+    {
+        let peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get("peer-storage-prune-snapshot").expect("stored peer");
+        let serialized = serde_json::to_value(record).expect("serialize peer record");
+        assert_eq!(
+            serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+            &[json!(first_transient.as_str())]
+        );
+    }
 
     let second = daemon
         .handle_rpc(rpc_request(
@@ -707,6 +724,20 @@ fn propagation_ingest_prunes_oldest_payload_when_storage_limit_is_exceeded() {
         "oldest propagation payload should be pruned when storage limit is exceeded"
     );
     assert!(daemon.has_propagation_payload(second_transient.as_str()));
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation_ids("peer-storage-prune-snapshot")
+            .expect("pruned live unhandled ids"),
+        vec![second_transient.clone()]
+    );
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get("peer-storage-prune-snapshot").expect("stored peer");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(second_transient.as_str())]
+    );
     let stats = daemon.store.propagation_entry_stats().expect("propagation stats");
     assert!(stats.bytes <= 1_000_000, "stats after prune: {stats:?}");
 }


### PR DESCRIPTION
## Gap analysis
- Peer maintenance selection and source-preserving propagation paths are already covered in the current tree, including unknown-rate peer eligibility, source receive marks, retry/backoff snapshots, and stale queue cleanup.
- The highest-value remaining low-conflict gap was regression coverage for propagation storage-limit pruning: the daemon already removes pruned transient IDs from live payload storage and active peer queue snapshots, but the ingest test only asserted payload/cache state.

## Patch
- Extends the propagation storage-limit ingest regression to activate a static peer, verify the first payload is queued in live peer marks and serialized peer record state, then verify storage pruning replaces both with the surviving second transient ID.
- No production behavior changed; this locks existing peer/replication cleanup behavior against restart/export drift.

## Reference behavior notes
- Inspired by peer/propagation implementations that treat payload removal as a peer-mark cleanup boundary and keep serialized peer queue state aligned with the payload store.
- Also confirmed that unknown-rate peer maintenance and source-preserving distribution are already represented in this repo, so this patch targets the smaller uncovered pruning lifecycle.

## Verification
- `cargo test -p reticulum-rs-rpc propagation_ingest_prunes_oldest_payload_when_storage_limit_is_exceeded -- --nocapture`
- `cargo fmt --check`
- `cargo test -p reticulum-rs-rpc --lib`
- `cargo clippy -p reticulum-rs-rpc --all-targets -- -D warnings`
- `C:\Program Files\Git\bin\bash.exe tools/scripts/check-boundaries.sh`
- `git diff --check`
- Diff scan for forbidden local reference names

## Roadmap
- Next peer/propagation candidates: live peer interop for maintenance rotation, remote transfer retry lifecycle coverage across daemon restart, and Python fixture coverage for peer queue snapshots.
- Keep docs unchanged for this PR because it adds coverage for already-documented behavior rather than changing parity status.