### PR TITLE
Allow peer sync control to find hidden peers

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_peer.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_peer.rs
@@ -18,7 +18,7 @@ pub(super) fn handle_peer_command(
     let Some((peer_hex, transfer_limit_kb)) = peer_request_from_data(data) else {
         return Some(ControlResponse::Code(error_invalid_data));
     };
-    if !peer_exists(daemon, peer_hex.as_str()) {
+    if !peer_exists(daemon, peer_hex.as_str(), sync_command) {
         return Some(ControlResponse::Code(error_not_found));
     }
     let mut params = json!({ "peer": peer_hex });
@@ -74,7 +74,10 @@ fn transfer_limit_kb_from_value(value: &rmpv::Value) -> Option<Option<f64>> {
     }
 }
 
-fn peer_exists(daemon: &RpcDaemon, peer_hex: &str) -> bool {
+fn peer_exists(daemon: &RpcDaemon, peer_hex: &str, include_unpeered: bool) -> bool {
+    if include_unpeered && daemon.peer_record_exists(peer_hex, true) {
+        return true;
+    }
     daemon
         .handle_rpc(RpcRequest { id: 0, method: "list_peers".to_string(), params: None })
         .ok()
@@ -95,7 +98,6 @@ fn peer_exists(daemon: &RpcDaemon, peer_hex: &str) -> bool {
 mod tests {
     use super::*;
     use rns_rpc::MessagesStore;
-
     const ERROR_INVALID_DATA: u8 = 0xF4;
     const ERROR_NOT_FOUND: u8 = 0xFD;
 

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -50,6 +50,13 @@ impl RpcDaemon {
             .collect()
     }
 
+    pub fn peer_record_exists(&self, peer: &str, include_unpeered: bool) -> bool {
+        self.peers.lock().expect("peers mutex poisoned").values().any(|record| {
+            record.peer.eq_ignore_ascii_case(peer)
+                && (include_unpeered || record.peer_type.as_deref() != Some("unpeered"))
+        })
+    }
+
     pub(super) fn queue_existing_propagation_for_peer(
         &self,
         peer: &str,

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -19023,6 +19023,29 @@ fn peer_types_drive_python_style_peer_counts() {
 }
 
 #[test]
+fn peer_record_exists_can_include_hidden_unpeered_records() {
+    let daemon = RpcDaemon::test_instance();
+    {
+        let mut guard = daemon.peers.lock().expect("peers mutex poisoned");
+        guard.insert(
+            "Peer-Hidden-Rejoin".to_string(),
+            daemon.transient_peer_record(
+                "Peer-Hidden-Rejoin".to_string(),
+                1_700_000_902,
+                Vec::new(),
+                None,
+                None,
+                Some("unpeered".to_string()),
+            ),
+        );
+    }
+
+    assert!(daemon.peer_record_exists("peer-hidden-rejoin", true));
+    assert!(!daemon.peer_record_exists("peer-hidden-rejoin", false));
+    assert!(!daemon.peer_record_exists("peer-hidden-missing", true));
+}
+
+#[test]
 fn list_peers_static_type_tracks_current_static_peer_config() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -150,7 +150,9 @@ The project is best described by capability level:
 - Inbound reticulumd `/pn/peer/sync` and `/pn/peer/unpeer` control commands now
   resolve stored peer IDs case-insensitively before dispatching to daemon RPCs,
   so binary peer-control requests do not report not-found for restored or
-  configured peers whose status rows preserve a different hex presentation.
+  configured peers whose status rows preserve a different hex presentation;
+  `/pn/peer/sync` also checks hidden unpeered peer records so operator-triggered
+  rejoin paths can reach the daemon reactivation state machine.
 - Payload-backed peer queue snapshot mirroring resolves stored peer IDs
   case-insensitively before reading live queue marks, so restart/export state
   preserves queued work when callers use Python-style peer case variants.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -194,7 +194,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Inbound reticulumd `/pn/peer/sync` and `/pn/peer/unpeer` control commands
   resolve stored peer IDs case-insensitively before dispatching to daemon RPCs,
   so binary peer-control requests do not report not-found for restored or
-  configured peers whose status rows preserve a different hex presentation.
+  configured peers whose status rows preserve a different hex presentation;
+  `/pn/peer/sync` also checks hidden unpeered peer records so operator-triggered
+  rejoin paths can reach the daemon reactivation state machine.
 - Payload-backed peer queue snapshot mirroring resolves stored peer IDs
   case-insensitively before reading live queue marks, preserving queued
   restart/export work when callers use Python-style peer case variants.


### PR DESCRIPTION
## Summary
- Let reticulumd `/pn/peer/sync` validate against hidden unpeered peer records before dispatching to daemon peer-sync.
- Add a daemon lookup test proving hidden unpeered records are only visible when explicitly requested.
- Update the LXMF parity docs to record the peer-control rejoin improvement while leaving broader propagation retry/restart/live interop gaps open.

## Gap analysis
- Current repo already had daemon-level reactivation for persisted `unpeered` peer records, but reticulumd control validation only looked at `list_peers`, which hides those records.
- The smallest safe peer/propagation patch was to expose a narrow read-only daemon lookup and use it only for `/pn/peer/sync`; `/pn/peer/unpeer` still requires an active visible peer.
- Remaining roadmap: complete propagation transfer/retry/restart lifecycle coverage, remote fetch/download/sync live scenarios, and broader peer/router interop.

## Reference behavior note
- Reference implementations keep peer-local handled/rejoin state separate from the visible active peer list and allow explicit sync/rejoin flows to reach hidden peer state. This patch independently reimplements that control-path decision without copying code.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p reticulum-rs-rpc peer_record_exists_can_include_hidden_unpeered_records -- --nocapture`
- `cargo test -p reticulumd inbound_worker::control::peer_commands::tests -- --nocapture`
- `cargo clippy -p reticulum-rs-rpc -p reticulumd --all-targets -- -D warnings`
- `C:\Program Files\Git\bin\bash.exe tools/scripts/check-boundaries.sh`
- `git diff --check`
- forbidden reference scan on the diff