### PR TITLE
Break remote unpeer peering on access denial

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -2582,8 +2582,16 @@ impl RpcDaemon {
                             state.last_sync_completed = None;
                             state.last_sync_error = Some(error);
                         });
-                        let _ =
-                            self.record_payload_backed_peer_queue_snapshot(snapshot_peer.as_str());
+                        if is_remote_access_denied_error(&err) {
+                            self.break_remote_peer_sync_peering_on_denied_access(
+                                snapshot_peer.as_str(),
+                                remote_id.as_str(),
+                                err.to_string().as_str(),
+                            )?;
+                        } else {
+                            let _ = self
+                                .record_payload_backed_peer_queue_snapshot(snapshot_peer.as_str());
+                        }
                         return Err(err);
                     }
                 };

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -12517,6 +12517,11 @@ struct RemoteSyncErrorBridge {
     message: &'static str,
 }
 
+struct RemoteUnpeerErrorBridge {
+    kind: std::io::ErrorKind,
+    message: &'static str,
+}
+
 struct RemoteTransferErrorBridge {
     kind: std::io::ErrorKind,
     message: &'static str,
@@ -12803,6 +12808,71 @@ impl RemoteControlBridge for RemoteSyncErrorBridge {
             "remote": remote,
             "peer": peer,
         }))
+    }
+}
+
+impl RemoteControlBridge for RemoteUnpeerErrorBridge {
+    fn propagation_remote_status(
+        &self,
+        remote: &str,
+        _identity_private_key_hex: Option<&str>,
+        _timeout_secs: f64,
+    ) -> Result<JsonValue, std::io::Error> {
+        Ok(json!({
+            "remote": remote,
+            "status": "ok",
+        }))
+    }
+
+    fn propagation_remote_sync(
+        &self,
+        remote: &str,
+        peer: &str,
+        _identity_private_key_hex: Option<&str>,
+        _timeout_secs: f64,
+        _transfer_limit_kb: Option<f64>,
+    ) -> Result<JsonValue, std::io::Error> {
+        Ok(json!({
+            "remote": remote,
+            "peer": peer,
+            "synced": true,
+        }))
+    }
+
+    fn propagation_remote_download(
+        &self,
+        remote: &str,
+        _identity_private_key_hex: Option<&str>,
+        _timeout_secs: f64,
+        _transfer_limit_kb: Option<f64>,
+    ) -> Result<JsonValue, std::io::Error> {
+        Ok(json!({
+            "remote": remote,
+            "messages": [],
+        }))
+    }
+
+    fn propagation_remote_fetch(
+        &self,
+        remote: &str,
+        _identity_private_key_hex: Option<&str>,
+        _timeout_secs: f64,
+        _transfer_limit_kb: Option<f64>,
+    ) -> Result<JsonValue, std::io::Error> {
+        Ok(json!({
+            "remote": remote,
+            "messages": [],
+        }))
+    }
+
+    fn propagation_remote_unpeer(
+        &self,
+        _remote: &str,
+        _peer: &str,
+        _identity_private_key_hex: Option<&str>,
+        _timeout_secs: f64,
+    ) -> Result<JsonValue, std::io::Error> {
+        Err(std::io::Error::new(self.kind, self.message))
     }
 }
 
@@ -18794,6 +18864,78 @@ fn failed_propagation_remote_unpeer_preserves_local_peer_and_queue_state() {
             .expect("list unhandled"),
         vec![entry]
     );
+}
+
+#[test]
+fn denied_access_propagation_remote_unpeer_breaks_peering_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(RemoteUnpeerErrorBridge {
+        kind: std::io::ErrorKind::PermissionDenied,
+        message: "propagation node denied access",
+    }));
+    let peer = "peer-remote-unpeer-denied";
+    daemon
+        .handle_rpc(rpc_request(79, "peer_sync", json!({ "peer": peer })))
+        .expect("peer sync");
+    let entry = PropagationEntryRecord {
+        transient_id: "d4".repeat(32),
+        destination: "24".repeat(16),
+        payload_hex: "24".repeat(20),
+        received_at: 1_700_000_812,
+        size_bytes: 20,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, entry.transient_id.as_str())
+        .expect("mark unhandled");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            80,
+            "propagation_remote_unpeer",
+            json!({
+                "remote": "remote-node",
+                "peer": peer,
+            }),
+        ))
+        .expect_err("remote unpeer access denial should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    assert_eq!(err.to_string(), "propagation node denied access");
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 81, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    assert_eq!(peers["peers"].as_array().map(Vec::len), Some(0));
+    assert!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer)
+            .expect("list unhandled")
+            .is_empty(),
+        "access-denied remote unpeer should clear retryable local queue marks"
+    );
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_unpeer")
+        .cloned()
+        .expect("peer unpeer event");
+    assert_eq!(event.payload["peer"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote"].as_str(), Some("remote-node"));
+    assert_eq!(event.payload["removed"].as_bool(), Some(true));
+    assert_eq!(event.payload["reason"].as_str(), Some("access_denied"));
+    assert_eq!(event.payload["error"].as_str(), Some("propagation node denied access"));
+    assert_eq!(event.payload["propagation_cleared"].as_u64(), Some(1));
+    assert_eq!(event.payload["messages"]["unhandled"].as_u64(), Some(1));
 }
 
 #[test]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -148,6 +148,9 @@ The project is best described by capability level:
   case-insensitive peer requests, so restart/export state preserves queued retry
   work when peering teardown fails; these failed attempts also mark the
   propagation lifecycle failed instead of leaving stale idle/completed state.
+- Access-denied remote unpeer failures now follow the same local peering break
+  path as access-denied remote sync/fetch/download, clearing local peer and
+  propagation queue state instead of leaving denied teardown work retryable.
 - Successful remote unpeer now also uses the stored peer ID case for the bridge
   call and nested bridge result when callers use a case-variant peer request,
   keeping remote teardown identity aligned with local queue cleanup.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -192,6 +192,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   case-insensitive peer requests, so failed peering teardown preserves queued
   retry work across restart/export and marks the propagation lifecycle failed
   instead of leaving stale idle/completed state.
+- Access-denied remote unpeer failures follow the same local peering break path
+  as access-denied remote sync/fetch/download, clearing local peer and
+  propagation queue state instead of leaving denied teardown work retryable.
 - Successful remote unpeer uses the stored peer ID case for the bridge call and
   nested bridge result when callers supply a case-variant peer request, keeping
   remote teardown identity aligned with local queue cleanup.


### PR DESCRIPTION
## Summary
- Treat access-denied `propagation_remote_unpeer` failures like other denied propagation-control paths by breaking local peering and clearing local propagation queue marks.
- Add a focused regression test proving denied remote unpeer removes the local peer, clears retryable queue state, and publishes an access-denied unpeer event.
- Update the roadmap and LXMF parity matrix for the newly covered router/control side effect.

## Gap analysis
- Current parity docs still call out propagation router lifecycle and command side effects as partial.
- Remote fetch/download/sync already route access-denied failures through local peering cleanup, but remote unpeer preserved the local peer and retry queue on the same denial class.
- Reference behavior inspection showed explicit peer lifecycle/state-machine separation for retryable failures versus access denial; this patch independently reuses the local daemon cleanup path for the denial branch only.

## Roadmap
- Keep ordinary remote-unpeer bridge failures retryable and snapshot-backed.
- Continue closing remaining propagation-node fetch/download/sync and live peer/router interop scenarios after this command side-effect patch.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p reticulum-rs-rpc denied_access_propagation_remote_unpeer_breaks_peering_like_python -- --nocapture`
- `cargo test -p reticulum-rs-rpc propagation_remote_unpeer -- --nocapture`
- `cargo clippy -p reticulum-rs-rpc --all-targets -- -D warnings`
- `C:\Program Files\Git\bin\bash.exe tools/scripts/check-boundaries.sh`
- `git diff --check`
- forbidden reference scan on the diff