### PR TITLE
Report stored peer on denied remote transfer cleanup

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -240,7 +240,7 @@ impl RpcDaemon {
         self.publish_event(RpcEvent {
             event_type: "peer_unpeer".into(),
             payload: json!({
-                "peer": peer_id,
+                "peer": cleanup.peer,
                 "remote": remote,
                 "removed": cleanup.removed,
                 "reason": "access_denied",

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -17017,6 +17017,47 @@ fn denied_access_propagation_remote_fetch_breaks_source_peering_like_python() {
 }
 
 #[test]
+fn denied_access_propagation_remote_fetch_reports_stored_peer_case_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(RemoteTransferErrorBridge {
+        kind: std::io::ErrorKind::PermissionDenied,
+        message: "propagation node denied access",
+        fail_download: false,
+        fail_fetch: true,
+    }));
+    let stored_peer = "Peer-Remote-Fetch-Denied-Case";
+    let request_peer = stored_peer.to_ascii_lowercase();
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": stored_peer })))
+        .expect("initial peer sync");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            81,
+            "propagation_remote_fetch",
+            json!({
+                "remote": request_peer,
+            }),
+        ))
+        .expect_err("denied remote fetch should return the bridge error");
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_unpeer")
+        .cloned()
+        .expect("denied access unpeer event");
+    assert_eq!(event.payload["peer"].as_str(), Some(stored_peer));
+    assert_eq!(event.payload["remote"].as_str(), Some(request_peer.as_str()));
+    assert_eq!(event.payload["reason"].as_str(), Some("access_denied"));
+}
+
+#[test]
 fn failed_propagation_remote_sync_updates_lifecycle_error() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -111,6 +111,10 @@ The project is best described by capability level:
 - Remote fetch and download access-denied bridge errors now preserve the
   propagation `no_access` lifecycle state instead of collapsing the denial into
   generic failure, while retaining the bridge error text for operators.
+- Access-denied remote transfer cleanup now reports the stored peer identifier
+  in peer-unpeer events even when callers address the remote with different hex
+  casing, keeping operator-visible teardown events aligned with the peer record
+  that was actually removed.
 - Remote fetch and download bridge-unavailable errors now mirror existing
   payload-backed live queue marks into active peer record snapshots before
   returning and mark the propagation sync lifecycle failed, so already queued

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -151,6 +151,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   peer-sync denial path for the source peer, clearing local peering and queued
   propagation marks instead of preserving denied relay work for retry, while
   preserving the propagation `no_access` lifecycle state and bridge error text.
+- Access-denied remote transfer cleanup emits peer-unpeer events with the
+  stored peer identifier even when the remote request uses alternate casing,
+  keeping event observability tied to the removed peer record.
 - Remote fetch and download bridge-unavailable errors mirror existing
   payload-backed queue marks into active peer record snapshots before
   returning and mark the propagation sync lifecycle failed, so queued relay work


### PR DESCRIPTION
## Summary
- report the stored peer identifier in access-denied remote transfer peer-unpeer events
- add a regression for mixed-case stored peer IDs addressed through alternate request casing
- update parity/status docs for the peer cleanup observability change

## Reference behavior note
Read-only comparison showed peer teardown/reporting should stay tied to the peer record that actually changed, while request/remote identifiers remain separate operator context. This patch independently applies that event-observability rule to denied remote transfer cleanup.

## Verification
- cargo fmt --all -- --check
- cargo test -p reticulum-rs-rpc denied_access_propagation_remote_fetch_reports_stored_peer_case_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc denied_access_propagation_remote_ -- --nocapture
- cargo clippy -p reticulum-rs-rpc --all-targets -- -D warnings
- C:\Program Files\Git\bin\bash.exe tools/scripts/check-boundaries.sh
- git diff --check
- diff scan for forbidden reference names