### PR TITLE
Back off source peers on malformed remote imports

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -208,6 +208,15 @@ impl RpcDaemon {
             return Ok(false);
         }
 
+        self.record_failed_remote_import_for_active_source_peer(source_peer, remote, error)
+    }
+
+    fn record_failed_remote_import_for_active_source_peer(
+        &self,
+        source_peer: &str,
+        remote: &str,
+        error: &std::io::Error,
+    ) -> Result<bool, std::io::Error> {
         let source_peer_key =
             self.active_peer_ids().into_iter().find(|peer| peer.eq_ignore_ascii_case(source_peer));
         let Some(source_peer_key) = source_peer_key else {
@@ -2276,6 +2285,11 @@ impl RpcDaemon {
                                     state.sync_progress = 0.0;
                                     state.last_sync_error = Some(err.to_string());
                                 });
+                                self.record_failed_remote_import_for_active_source_peer(
+                                    remote_id.as_str(),
+                                    remote_id.as_str(),
+                                    &err,
+                                )?;
                                 for peer in self.active_peer_ids() {
                                     self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
                                 }
@@ -2472,6 +2486,11 @@ impl RpcDaemon {
                             state.sync_progress = 0.0;
                             state.last_sync_error = Some(err.to_string());
                         });
+                        self.record_failed_remote_import_for_active_source_peer(
+                            remote_id.as_str(),
+                            remote_id.as_str(),
+                            &err,
+                        )?;
                         for peer in self.active_peer_ids() {
                             self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
                         }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -16564,6 +16564,100 @@ fn failed_propagation_remote_download_updates_source_peer_backoff_like_python() 
 }
 
 #[test]
+fn failed_propagation_remote_download_import_updates_source_peer_backoff_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "downloaded_count": 1,
+            "imported_count": 1,
+            "messages": [{
+                "payload_hex": "not-hex",
+            }],
+        })),
+    }));
+    let peer = "peer-remote-download-import-fail-backoff";
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.alive = true;
+        record.sync_backoff = 0;
+        record.next_sync_attempt = 0;
+        record.acceptance_rate = 0.5;
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "c7".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_626,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            81,
+            "propagation_remote_download",
+            json!({
+                "remote": peer,
+            }),
+        ))
+        .expect_err("remote download import failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(err.to_string().contains("invalid remote propagation payload hex"));
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 82, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(peer))
+        .expect("peer row");
+    assert_eq!(row["alive"].as_bool(), Some(false));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
+    assert_eq!(
+        row["messages"]["unhandled_ids"].as_array().expect("unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_sync")
+        .cloned()
+        .expect("failed remote download peer event");
+    assert_eq!(event.payload["peer"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote_sync"].as_bool(), Some(true));
+    assert_eq!(event.payload["synced"].as_bool(), Some(false));
+    assert_eq!(event.payload["alive"].as_bool(), Some(false));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert!(event.payload["propagation"]["error"]
+        .as_str()
+        .is_some_and(|value| value.contains("invalid remote propagation payload hex")));
+}
+
+#[test]
 fn failed_propagation_remote_fetch_import_records_existing_queue_snapshot_like_python() {
     let daemon = RpcDaemon::test_instance();
     daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
@@ -16629,6 +16723,100 @@ fn failed_propagation_remote_fetch_import_records_existing_queue_snapshot_like_p
         serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
         &[json!(pending.transient_id.as_str())]
     );
+}
+
+#[test]
+fn failed_propagation_remote_fetch_import_updates_source_peer_backoff_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "available_count": 1,
+            "fetched_count": 1,
+            "messages": [{
+                "payload_hex": "not-hex",
+            }],
+        })),
+    }));
+    let peer = "peer-remote-fetch-import-fail-backoff";
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.alive = true;
+        record.sync_backoff = 0;
+        record.next_sync_attempt = 0;
+        record.acceptance_rate = 0.5;
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "c6".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_625,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            81,
+            "propagation_remote_fetch",
+            json!({
+                "remote": peer,
+            }),
+        ))
+        .expect_err("remote fetch import failure should be returned");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(err.to_string().contains("invalid remote propagation payload hex"));
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 82, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(peer))
+        .expect("peer row");
+    assert_eq!(row["alive"].as_bool(), Some(false));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
+    assert_eq!(
+        row["messages"]["unhandled_ids"].as_array().expect("unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_sync")
+        .cloned()
+        .expect("failed remote fetch peer event");
+    assert_eq!(event.payload["peer"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote_sync"].as_bool(), Some(true));
+    assert_eq!(event.payload["synced"].as_bool(), Some(false));
+    assert_eq!(event.payload["alive"].as_bool(), Some(false));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert!(event.payload["propagation"]["error"]
+        .as_str()
+        .is_some_and(|value| value.contains("invalid remote propagation payload hex")));
 }
 
 #[test]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -101,6 +101,10 @@ The project is best described by capability level:
 - Malformed remote fetch and download imports now mirror existing
   payload-backed live queue marks into active peer record snapshots before
   failing, preserving restart/export retry state for already queued relay work.
+- Malformed remote fetch and download imports from an already active source
+  peer now also update that peer's failure backoff and publish the failed
+  peer-sync event, so invalid post-transfer payloads share retry scheduling and
+  observability with transport-level remote transfer failures.
 - Remote fetch and download bridge failures now mirror existing payload-backed
   live queue marks into active peer record snapshots before returning the
   failure, preserving restart/export retry state for already queued relay work.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -140,6 +140,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Malformed remote fetch and download imports mirror existing payload-backed
   queue marks into active peer record snapshots before returning the import
   failure, so already queued relay work remains visible after restart/export.
+- Malformed remote fetch and download imports from an already active source
+  peer update that peer's failure backoff and publish the failed peer-sync
+  event, so invalid post-transfer payloads use the same retry observability as
+  transport-level remote transfer failures.
 - Remote fetch and download bridge failures mirror existing payload-backed
   queue marks into active peer record snapshots before returning the failure,
   so already queued relay work remains visible after restart/export.


### PR DESCRIPTION
## Summary
- record failed peer-sync backoff/events when malformed remote fetch/download imports come from an active source peer
- preserve existing payload-backed queue snapshots while adding source-peer retry observability
- update parity/status docs for malformed post-transfer payload handling

## Gap analysis
Remote fetch/download bridge transport failures already updated active source-peer retry state, but syntactically successful remote responses that failed local import validation only updated propagation lifecycle and queue snapshots. That left the source peer looking healthy despite a failed replication attempt.

## Roadmap update
This narrows the peer transfer/retry lifecycle gap for propagation-node fetch/download by aligning malformed post-transfer payloads with other failed remote transfer attempts. Remaining peer/propagation work still includes broader router side effects, live Python interop expansion, and direct-delivery planning coverage.

## Reference behavior note
Read-only reference analysis showed failed peer-sync attempts should remain retryable and observable through peer retry/backoff state instead of silently preserving apparently healthy peer status. This patch independently applies that state-machine decision to malformed remote import failures after a fetch/download transfer attempt.

## Verification
- cargo fmt --all -- --check
- cargo test -p reticulum-rs-rpc failed_propagation_remote_fetch_import_updates_source_peer_backoff_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc failed_propagation_remote_download_import_updates_source_peer_backoff_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc failed_propagation_remote_ -- --nocapture
- cargo clippy -p reticulum-rs-rpc --all-targets -- -D warnings
- C:\Program Files\Git\bin\bash.exe tools/scripts/check-boundaries.sh
- git diff --check
- diff scan for forbidden reference names