### PR TITLE
Clear source backoff after remote transfer success

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -576,27 +576,13 @@ impl RpcDaemon {
             }
         }
         if source_received_count > 0 {
-            self.record_inbound_propagation_peer_activity_count(
+            self.record_successful_remote_propagation_peer_activity_count(
                 source_peer_key,
                 source_received_bytes.min(transferred_bytes),
                 source_received_count,
             );
-            self.clear_successful_remote_source_backoff(source_peer_key);
         }
         Ok(())
-    }
-
-    fn clear_successful_remote_source_backoff(&self, source_peer: &str) {
-        let source_peer = source_peer.trim();
-        if let Ok(mut guard) = self.peers.lock() {
-            if let Some(existing) = guard.values_mut().find(|record| {
-                record.peer_type.as_deref() != Some("unpeered")
-                    && record.peer.eq_ignore_ascii_case(source_peer)
-            }) {
-                existing.sync_backoff = 0;
-                existing.next_sync_attempt = 0;
-            }
-        }
     }
 
     pub fn note_client_propagation_messages_received(&self, ingested_count: usize) {

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -581,8 +581,22 @@ impl RpcDaemon {
                 source_received_bytes.min(transferred_bytes),
                 source_received_count,
             );
+            self.clear_successful_remote_source_backoff(source_peer_key);
         }
         Ok(())
+    }
+
+    fn clear_successful_remote_source_backoff(&self, source_peer: &str) {
+        let source_peer = source_peer.trim();
+        if let Ok(mut guard) = self.peers.lock() {
+            if let Some(existing) = guard.values_mut().find(|record| {
+                record.peer_type.as_deref() != Some("unpeered")
+                    && record.peer.eq_ignore_ascii_case(source_peer)
+            }) {
+                existing.sync_backoff = 0;
+                existing.next_sync_attempt = 0;
+            }
+        }
     }
 
     pub fn note_client_propagation_messages_received(&self, ingested_count: usize) {

--- a/crates/libs/rns-rpc/src/rpc/daemon/init.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init.rs
@@ -798,6 +798,25 @@ impl RpcDaemon {
         bytes: usize,
         messages: usize,
     ) -> bool {
+        self.record_inbound_propagation_peer_activity_count_inner(peer, bytes, messages, false)
+    }
+
+    pub fn record_successful_remote_propagation_peer_activity_count(
+        &self,
+        peer: &str,
+        bytes: usize,
+        messages: usize,
+    ) -> bool {
+        self.record_inbound_propagation_peer_activity_count_inner(peer, bytes, messages, true)
+    }
+
+    fn record_inbound_propagation_peer_activity_count_inner(
+        &self,
+        peer: &str,
+        bytes: usize,
+        messages: usize,
+        clear_backoff: bool,
+    ) -> bool {
         let peer = peer.trim();
         if let Ok(mut guard) = self.peers.lock() {
             if let Some(existing) = guard.values_mut().find(|record| {
@@ -808,6 +827,10 @@ impl RpcDaemon {
                 existing.last_seen = now_i64();
                 existing.incoming = existing.incoming.saturating_add(messages as u64);
                 existing.rx_bytes = existing.rx_bytes.saturating_add(bytes as u64);
+                if clear_backoff {
+                    existing.sync_backoff = 0;
+                    existing.next_sync_attempt = 0;
+                }
                 return true;
             }
         }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -14985,6 +14985,63 @@ fn propagation_remote_fetch_marks_source_received_and_queues_other_peers() {
 }
 
 #[test]
+fn propagation_remote_fetch_success_clears_source_peer_retry_backoff() {
+    let payload = b"remote-fetch-source-peer-recovery-payload";
+    let payload_hex = hex::encode(payload);
+    let transient_id = hex::encode(Sha256::digest(payload));
+    let source_peer = "remote-fetch-source-recovery";
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(72, "peer_sync", json!({ "peer": source_peer })))
+        .expect("seed source peer");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let peer = peers.get_mut(source_peer).expect("source peer record");
+        peer.alive = false;
+        peer.sync_backoff = 12 * 60;
+        peer.next_sync_attempt = now_i64().saturating_add(12 * 60);
+    }
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "available_count": 1,
+            "fetched_count": 1,
+            "messages": [{
+                "transient_id": transient_id,
+                "payload_hex": payload_hex,
+            }],
+        })),
+    }));
+
+    daemon
+        .handle_rpc(rpc_request(
+            73,
+            "propagation_remote_fetch",
+            json!({ "remote": source_peer }),
+        ))
+        .expect("remote fetch from recovered source");
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 74, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let source_row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(source_peer))
+        .expect("source peer row");
+    assert_eq!(source_row["alive"].as_bool(), Some(true));
+    assert_eq!(source_row["rx_bytes"].as_u64(), Some(payload.len() as u64));
+    assert_eq!(source_row["sync_backoff"].as_u64(), Some(0));
+    assert_eq!(source_row["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(
+        source_row["messages"]["handled_ids"].as_array().expect("handled ids"),
+        &[json!(transient_id.as_str())]
+    );
+}
+
+#[test]
 fn propagation_remote_fetch_marks_inactive_source_received_for_later_activation_like_python() {
     let payload = b"remote-fetch-inactive-source-payload";
     let payload_hex = hex::encode(payload);
@@ -15832,6 +15889,62 @@ fn propagation_remote_download_marks_source_received_and_queues_other_peers() {
         .expect("relay pending");
     assert_eq!(relay_pending.len(), 1);
     assert_eq!(relay_pending[0].transient_id, transient_id);
+}
+
+#[test]
+fn propagation_remote_download_success_clears_source_peer_retry_backoff() {
+    let payload = b"remote-download-source-peer-recovery-payload";
+    let payload_hex = hex::encode(payload);
+    let transient_id = hex::encode(Sha256::digest(payload));
+    let source_peer = "remote-download-source-recovery";
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(78, "peer_sync", json!({ "peer": source_peer })))
+        .expect("seed source peer");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let peer = peers.get_mut(source_peer).expect("source peer record");
+        peer.alive = false;
+        peer.sync_backoff = 12 * 60;
+        peer.next_sync_attempt = now_i64().saturating_add(12 * 60);
+    }
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "downloaded_count": 1,
+            "messages": [{
+                "transient_id": transient_id,
+                "payload_hex": payload_hex,
+            }],
+        })),
+    }));
+
+    daemon
+        .handle_rpc(rpc_request(
+            79,
+            "propagation_remote_download",
+            json!({ "remote": source_peer }),
+        ))
+        .expect("remote download from recovered source");
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 80, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let source_row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(source_peer))
+        .expect("source peer row");
+    assert_eq!(source_row["alive"].as_bool(), Some(true));
+    assert_eq!(source_row["rx_bytes"].as_u64(), Some(payload.len() as u64));
+    assert_eq!(source_row["sync_backoff"].as_u64(), Some(0));
+    assert_eq!(source_row["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(
+        source_row["messages"]["handled_ids"].as_array().expect("handled ids"),
+        &[json!(transient_id.as_str())]
+    );
 }
 
 #[test]

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -4812,6 +4812,34 @@ fn peer_activity_updates_runtime_counters() {
 }
 
 #[test]
+fn successful_remote_peer_activity_keeps_newer_failure_backoff() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-remote-activity-order";
+    daemon
+        .handle_rpc(rpc_request(51, "peer_sync", json!({ "peer": peer })))
+        .expect("peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.alive = false;
+        record.sync_backoff = 12 * 60;
+        record.next_sync_attempt = now_i64().saturating_add(12 * 60);
+    }
+
+    assert!(daemon.record_successful_remote_propagation_peer_activity_count(peer, 120, 2));
+    daemon.record_outbound_peer_activity(peer, 40, false);
+
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("peer record");
+    assert_eq!(record.incoming, 2);
+    assert_eq!(record.rx_bytes, 120);
+    assert_eq!(record.tx_bytes, 40);
+    assert!(!record.alive);
+    assert_eq!(record.sync_backoff, 12 * 60);
+    assert_eq!(record.next_sync_attempt, record.last_sync_attempt.saturating_add(12 * 60));
+}
+
+#[test]
 fn inbound_peer_activity_matches_existing_peer_case_insensitively_like_python() {
     let daemon = RpcDaemon::test_instance();
     let stored_peer = "Peer-Inbound-Case";

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -120,6 +120,9 @@ The project is best described by capability level:
   live queue marks into active peer record snapshots after applying imports, so
   restart/export state preserves queued retry work even when the remote
   transfer succeeds without consuming those local queued offers.
+- Successful remote fetch and download now clear stale retry backoff on the
+  active source peer when newly accepted payloads prove the source recovered,
+  so later maintenance does not keep postponing a healthy replication peer.
 - Remote peer-sync backoff postponements now mirror existing payload-backed live
   queue marks into active peer record snapshots before returning, so
   restart/export state preserves queued retry work even when sync is deferred.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -372,6 +372,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   counts and receive bytes only for payload IDs not already marked received
   from that source, while still replaying known payloads into relay queues when
   their live marks were cleared.
+- Successful remote fetch/download imports clear stale retry backoff on an
+  active source peer after newly accepted payloads, so recovered propagation
+  sources are not left postponed by an earlier failed transfer attempt.
 - Link-based remote propagation downloads classify listed transient IDs before
   payload retrieval, report locally known IDs as `/get` haves, and use the
   purge-only `[nil, haves]` request when every listed ID is already local, so


### PR DESCRIPTION
## Summary
- clear stale source-peer retry backoff after successful remote fetch/download imports
- add focused regressions for recovered source peers on both remote transfer paths
- update peer propagation parity/status docs for the recovered-source lifecycle behavior

## Gap analysis
Failed remote fetch/download attempts already back off an active source peer. A later successful fetch/download from that same source marked the peer alive and recorded inbound payload accounting, but left the old `sync_backoff` and `next_sync_attempt` in place. That could keep a recovered replication source postponed after it had already supplied new payloads.

## Roadmap update
This narrows the peer transfer/retry lifecycle gap for propagation-node fetch/download recovery. Remaining peer/propagation work includes broader restart recovery, router queue lifecycle, direct-delivery planning, and expanded live interop coverage.

## Reference behavior note
Read-only reference analysis showed successful peer replication activity clears retry scheduling for recovered peers. This patch independently applies that state-machine decision to remote fetch/download source peers after newly accepted payloads.

## Verification
- cargo test -p reticulum-rs-rpc success_clears_source_peer_retry_backoff -- --nocapture
- cargo fmt --all -- --check
- cargo test -p reticulum-rs-rpc propagation_remote_fetch -- --nocapture
- cargo test -p reticulum-rs-rpc propagation_remote_download -- --nocapture
- cargo clippy -p reticulum-rs-rpc --all-targets -- -D warnings
- C:\Program Files\Git\bin\bash.exe tools/scripts/check-boundaries.sh
- git diff --check
- diff scan for forbidden reference names
