### PR TITLE
Filter retained haves for completed peers

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
@@ -25,7 +25,22 @@ pub(super) fn handle_message_get_request(
     if entries.first().is_some_and(rmpv::Value::is_nil)
         && entries.get(1).is_some_and(rmpv::Value::is_nil)
     {
-        let available = daemon.list_propagation_payloads_for_destination(&remote_delivery_hash);
+        let mut available = Vec::new();
+        for (transient_id, size) in
+            daemon.list_propagation_payloads_for_destination(&remote_delivery_hash)
+        {
+            let transient_id_hex = hex::encode(transient_id.as_slice());
+            let completed = match daemon.has_peer_completed_propagation_mark(
+                remote_propagation_hash.as_str(),
+                transient_id_hex.as_str(),
+            ) {
+                Ok(completed) => completed,
+                Err(_) => return ControlResponse::Code(error_no_access),
+            };
+            if !completed {
+                available.push((transient_id, size));
+            }
+        }
         if !available.is_empty()
             && daemon.record_propagation_offer_peer(remote_propagation_hash.as_str()).is_err()
         {
@@ -1750,7 +1765,10 @@ mod tests {
         let ControlResponse::Rmpv(rmpv::Value::Array(available)) = list_response else {
             panic!("expected retained available transient id list");
         };
-        assert_eq!(available, vec![rmpv::Value::Binary(have.to_vec())]);
+        assert!(
+            available.is_empty(),
+            "retained haves should not be listed back to the peer that completed them"
+        );
     }
 
     #[test]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -257,6 +257,9 @@ The project is best described by capability level:
   haves as received/completed work for the requesting propagation peer after
   purge, so reintroduced payloads are not queued back to peers that already
   declared them.
+- Retained propagation payload listings now filter IDs already completed by
+  the requesting peer, so `retain_synced_on_node` keeps payloads available for
+  other peers without re-offering them to the peer that declared the haves.
 - Link-based remote propagation downloads now wait for the final haves
   acknowledgement response after imported or duplicate payloads are reported,
   so node-side rejection or timeout is surfaced instead of reporting a

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -321,7 +321,8 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   already completed them.
 - Propagation nodes honor `retain_synced_on_node` during message-get haves
   handling: requesting peers are still marked completed, while retained payloads
-  remain stored and queued for peers that have not completed them.
+  remain stored and queued for peers that have not completed them; retained
+  payload listings now filter IDs already completed by the requesting peer.
 - Inbound propagation message-get requests mark wanted payloads skipped by the
   peer's transfer budget as transfer-limited completed work after peer
   admission, so oversized fetch attempts do not remain retryable queue entries.


### PR DESCRIPTION
## Gap analysis

The inbound propagation `/get` nil/nil listing path returned every retained payload for a delivery destination. With `retain_synced_on_node` enabled, a peer that had already declared a payload in `haves` could later receive that same retained payload ID in the available-list response. That is not the intended peer replication lifecycle: retention should keep payloads available for other peers, not re-offer them to the peer that already completed the item.

## Patch

- Filters retained propagation list responses against the requesting peer's completed propagation marks.
- Preserves the existing behavior that retained payloads remain stored and queued for other peers.
- Strengthens the retained-haves regression test to prove the declaring peer is not offered its completed retained ID again.
- Updates the roadmap and LXMF parity matrix for the narrowed haves/retention behavior.

## Roadmap

- Next peer/propagation candidates remain remote download purge-only haves ack validation and remote download transient-ID canonicalization/deduplication.
- Persistent peer sync and broader live Python propagation interop remain partial and should stay tracked separately.

## Reference behavior note

Read-only reference behavior models peer replication as per-peer completed work. This patch independently applies that state-machine decision to retained payload listing without copying implementation code.

## Verification

- RED: `cargo test -p reticulumd message_get_haves_retains_payload_when_retain_synced_on_node_enabled -- --nocapture` failed before the handler filter.
- GREEN: `cargo test -p reticulumd message_get_haves_retains_payload_when_retain_synced_on_node_enabled -- --nocapture`
- `cargo test -p reticulumd inbound_worker::control::propagation_commands::tests -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p reticulumd --all-targets -- -D warnings`
- `C:\Program Files\Git\bin\bash.exe tools/scripts/check-boundaries.sh`
- `git diff --check`
- forbidden local-reference-name scan on the diff