### PR TITLE
Surface remote link close signals

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_download.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_download.rs
@@ -63,8 +63,7 @@ pub(super) async fn propagation_download_request(
         list_request_id,
         timeout,
     )
-    .await
-    .map_err(|err| std::io::Error::new(std::io::ErrorKind::TimedOut, err))?;
+    .await?;
     let available = binary_array_response(&list_response)?;
     let (wanted, haves) = classify_remote_transient_ids(daemon, available)?;
     let available_count = wanted.len().saturating_add(haves.len());
@@ -105,8 +104,7 @@ pub(super) async fn propagation_download_request(
         get_request_id,
         timeout,
     )
-    .await
-    .map_err(|err| std::io::Error::new(std::io::ErrorKind::TimedOut, err))?;
+    .await?;
     let payloads = binary_array_response(&get_response)?;
 
     let mut accepted_haves = haves;
@@ -146,8 +144,7 @@ pub(super) async fn propagation_download_request(
             ack_request_id,
             timeout,
         )
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::TimedOut, err))?;
+        .await?;
         propagation_download_ack_response_result(&ack_response)?;
     }
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_link.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_link.rs
@@ -153,18 +153,24 @@ pub(super) async fn wait_for_link_request_response(
     expected_link_id: AddressHash,
     request_id: [u8; 16],
     timeout: Duration,
-) -> Result<rmpv::Value, String> {
+) -> Result<rmpv::Value, std::io::Error> {
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
         let now = tokio::time::Instant::now();
         if now >= deadline {
-            return Err("propagation control response timed out".to_string());
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "propagation control response timed out",
+            ));
         }
         let remaining = deadline.saturating_duration_since(now);
 
         tokio::select! {
             _ = tokio::time::sleep(remaining) => {
-                return Err("propagation control response timed out".to_string());
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "propagation control response timed out",
+                ));
             }
             result = data_rx.recv() => {
                 match result {
@@ -187,7 +193,10 @@ pub(super) async fn wait_for_link_request_response(
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                        return Err("propagation control response channel closed".to_string());
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::BrokenPipe,
+                            "propagation control response channel closed",
+                        ));
                     }
                 }
             }
@@ -212,7 +221,10 @@ pub(super) async fn wait_for_link_request_response(
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                        return Err("propagation control resource channel closed".to_string());
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::BrokenPipe,
+                            "propagation control resource channel closed",
+                        ));
                     }
                 }
             }
@@ -220,21 +232,32 @@ pub(super) async fn wait_for_link_request_response(
     }
 }
 
-fn link_close_signal_error(event: &rns_transport::transport::ReceivedData) -> Option<String> {
+fn link_close_signal_error(
+    event: &rns_transport::transport::ReceivedData,
+) -> Option<std::io::Error> {
     if event.context != Some(PacketContext::LinkClose) {
         return None;
     }
     let value = rmp_serde::from_slice::<rmpv::Value>(event.data.as_slice()).ok()?;
     let rmpv::Value::Array(entries) = value else {
-        return Some("propagation control link closed".to_string());
+        return Some(std::io::Error::new(
+            std::io::ErrorKind::ConnectionAborted,
+            "propagation control link closed",
+        ));
     };
     let Some(signal) = entries.first() else {
-        return Some("propagation control link closed".to_string());
+        return Some(std::io::Error::new(
+            std::io::ErrorKind::ConnectionAborted,
+            "propagation control link closed",
+        ));
     };
     let Some(error) = super::remote_control::response_code_error(signal) else {
-        return Some("propagation control link closed".to_string());
+        return Some(std::io::Error::new(
+            std::io::ErrorKind::ConnectionAborted,
+            "propagation control link closed",
+        ));
     };
-    Some(error.to_string())
+    Some(error)
 }
 
 fn parse_link_response_frame(bytes: &[u8]) -> Option<([u8; 16], rmpv::Value)> {
@@ -311,6 +334,7 @@ mod tests {
         .await
         .expect_err("link-close signal should fail the active request");
 
-        assert!(err.contains("propagation node denied access"));
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(err.to_string().contains("propagation node denied access"));
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_link.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_link.rs
@@ -174,6 +174,9 @@ pub(super) async fn wait_for_link_request_response(
                         {
                             continue;
                         }
+                        if let Some(error) = link_close_signal_error(&event) {
+                            return Err(error);
+                        }
                         if let Some((response_id, payload)) =
                             parse_link_response_frame(event.data.as_slice())
                         {
@@ -217,6 +220,23 @@ pub(super) async fn wait_for_link_request_response(
     }
 }
 
+fn link_close_signal_error(event: &rns_transport::transport::ReceivedData) -> Option<String> {
+    if event.context != Some(PacketContext::LinkClose) {
+        return None;
+    }
+    let value = rmp_serde::from_slice::<rmpv::Value>(event.data.as_slice()).ok()?;
+    let rmpv::Value::Array(entries) = value else {
+        return Some("propagation control link closed".to_string());
+    };
+    let Some(signal) = entries.first() else {
+        return Some("propagation control link closed".to_string());
+    };
+    let Some(error) = super::remote_control::response_code_error(signal) else {
+        return Some("propagation control link closed".to_string());
+    };
+    Some(error.to_string())
+}
+
 fn parse_link_response_frame(bytes: &[u8]) -> Option<([u8; 16], rmpv::Value)> {
     let value = rmp_serde::from_slice::<rmpv::Value>(bytes).ok()?;
     let rmpv::Value::Array(entries) = value else {
@@ -245,5 +265,52 @@ fn value_to_bytes(value: &rmpv::Value) -> Option<Vec<u8>> {
             Some(value.as_bytes().to_vec())
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rns_transport::packet::PacketDataBuffer;
+    use rns_transport::resource::ResourceEvent;
+    use rns_transport::transport::{ReceivedData, ReceivedPayloadMode};
+
+    #[tokio::test]
+    async fn wait_for_link_request_response_fails_on_link_close_signal() {
+        let (data_tx, mut data_rx) = tokio::sync::broadcast::channel(4);
+        let (_resource_tx, mut resource_rx) = tokio::sync::broadcast::channel::<ResourceEvent>(4);
+        let expected_destination = AddressHash::new_from_slice(&[0x11; 16]);
+        let expected_link_id = AddressHash::new_from_slice(&[0x22; 16]);
+        let request_id = [0x33; 16];
+        let signal_payload = rmp_serde::to_vec(&vec![0xf1u8]).expect("signal msgpack");
+
+        assert!(
+            data_tx
+                .send(ReceivedData {
+                    destination: expected_link_id,
+                    data: PacketDataBuffer::new_from_slice(&signal_payload),
+                    payload_mode: ReceivedPayloadMode::FullWire,
+                    ratchet_used: false,
+                    context: Some(PacketContext::LinkClose),
+                    request_id: None,
+                    hops: None,
+                    interface: None,
+                })
+                .is_ok(),
+            "send link-close signal"
+        );
+
+        let err = wait_for_link_request_response(
+            &mut data_rx,
+            &mut resource_rx,
+            expected_destination,
+            expected_link_id,
+            request_id,
+            Duration::from_secs(10),
+        )
+        .await
+        .expect_err("link-close signal should fail the active request");
+
+        assert!(err.contains("propagation node denied access"));
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_request.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_request.rs
@@ -60,8 +60,7 @@ pub(super) async fn remote_control_request(
         request_id,
         timeout,
     )
-    .await
-    .map_err(|err| std::io::Error::new(std::io::ErrorKind::TimedOut, err))?;
+    .await?;
 
     Ok((response, remote_identity))
 }

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -315,6 +315,9 @@ The project is best described by capability level:
 - Link-based remote downloads now wait for the propagation node's `/get` haves
   acknowledgement and surface peer/control errors, so failed remote cleanup does
   not look like a completed replication drain.
+- Link-based remote propagation control waits now surface authenticated
+  link-close peer/control signals immediately, so denied or closed remote
+  fetch/download/sync requests do not sit until the request timeout.
 - Remote fetch/download acknowledgements now use canonical propagation
   transient IDs for stamped payloads, so `/get` haves purge the peer's offered
   queue entry instead of acknowledging the stamped payload bytes under a

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -379,6 +379,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Link-based remote downloads wait for the propagation node's `/get` haves
   acknowledgement and propagate peer/control errors, so failed remote cleanup is
   not reported as a completed replication drain.
+- Link-based remote propagation control waits surface authenticated link-close
+  peer/control signals immediately, so denied or closed remote fetch/download/sync
+  requests fail on the signal instead of waiting for the request timeout.
 - Remote fetch/download acknowledgements use canonical propagation transient
   IDs for stamped payloads, so `/get` haves clear the peer's offered queue entry
   instead of reporting the stamped payload bytes under a different hash.


### PR DESCRIPTION
## Summary
- fail active remote-control request waits immediately when the link emits a close signal
- reuse the existing propagation control response-code mapping for link-close signals
- document the peer/propagation parity update in the roadmap and LXMF matrix

## Tests
- `cargo test -p reticulumd wait_for_link_request_response_fails_on_link_close_signal`
- `cargo test -p reticulumd`
- `cargo fmt --all -- --check`
- `cargo clippy -p reticulumd --all-targets -- -D warnings`
- `& 'C:\Program Files\Git\bin\bash.exe' tools/scripts/check-boundaries.sh`
- `git diff --check`
- forbidden-reference diff scan

## Reference behavior
The reference behavior treats an authenticated link-close signal for the active propagation-control link as terminal for the in-flight transfer/control request. This patch independently mirrors that state-machine decision by surfacing the signal instead of waiting for the request timeout.