### PR TITLE
Report failed local peer offer state

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages.rs
@@ -308,6 +308,8 @@ impl RpcDaemon {
         let propagation_sync = json!({
             "synced": false,
             "postponed": false,
+            "state": PEER_SYNC_STATE_FAILED,
+            "state_name": "failed",
             "reason": reason,
             "offer_response": offer_response,
             "handled": 0,
@@ -335,7 +337,7 @@ impl RpcDaemon {
             "target_stamp_cost": peer.propagation_stamp_cost,
             "stamp_cost_flexibility": peer.propagation_stamp_cost_flexibility,
         });
-        let payload = json!({
+        let mut payload = json!({
             "peer": &peer.peer,
             "peer_type": peer_type_value,
             "type": peer_status_type,
@@ -378,6 +380,8 @@ impl RpcDaemon {
             "messages": messages,
             "propagation": propagation_sync,
         });
+        payload["state"] = json!(PEER_SYNC_STATE_FAILED);
+        payload["state_name"] = json!("failed");
         self.publish_event(RpcEvent { event_type: "peer_sync".into(), payload: payload.clone() });
 
         RpcResponse { id: request_id, result: Some(payload), error: None }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -8595,6 +8595,8 @@ fn peer_sync_retryable_offer_responses_preserve_peer_queue_like_python() {
 
         assert_eq!(result["peer"].as_str(), Some(peer_id.as_str()));
         assert_eq!(result["synced"].as_bool(), Some(false));
+        assert_eq!(result["state"].as_u64(), Some(0xfe));
+        assert_eq!(result["state_name"].as_str(), Some("failed"));
         assert_eq!(result["reason"].as_str(), Some(reason));
         assert_eq!(result["offer_response"].as_u64(), Some(offer_response));
         assert_eq!(result["alive"].as_bool(), Some(true));
@@ -8603,6 +8605,8 @@ fn peer_sync_retryable_offer_responses_preserve_peer_queue_like_python() {
         assert_eq!(result["acceptance_rate"].as_f64(), Some(0.6));
         assert_eq!(result["propagation"]["handled"].as_u64(), Some(0));
         assert_eq!(result["propagation"]["postponed"].as_bool(), Some(false));
+        assert_eq!(result["propagation"]["state"].as_u64(), Some(0xfe));
+        assert_eq!(result["propagation"]["state_name"].as_str(), Some("failed"));
         assert_eq!(
             daemon
                 .store
@@ -8649,11 +8653,15 @@ fn peer_sync_retryable_offer_responses_preserve_peer_queue_like_python() {
             .expect("retryable peer sync event");
         assert_eq!(event.payload["peer"].as_str(), Some(peer_id.as_str()));
         assert_eq!(event.payload["synced"].as_bool(), Some(false));
+        assert_eq!(event.payload["state"].as_u64(), Some(0xfe));
+        assert_eq!(event.payload["state_name"].as_str(), Some("failed"));
         assert_eq!(event.payload["reason"].as_str(), Some(reason));
         assert_eq!(event.payload["offer_response"].as_u64(), Some(offer_response));
         assert_eq!(event.payload["alive"].as_bool(), Some(true));
         assert_eq!(event.payload["sync_backoff"].as_u64(), Some(0));
         assert_eq!(event.payload["next_sync_attempt"].as_i64(), Some(0));
+        assert_eq!(event.payload["propagation"]["state"].as_u64(), Some(0xfe));
+        assert_eq!(event.payload["propagation"]["state_name"].as_str(), Some("failed"));
     }
 }
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -247,6 +247,9 @@ The project is best described by capability level:
 - Peer sync queue creation also records newly queued existing propagation IDs in
   the peer record snapshot, so postponed syncs can restart/export with the same
   unhandled queue visible in live status.
+- Local peer offer-error responses now publish failed peer-sync state fields at
+  both the top-level peer event and nested propagation result while preserving
+  the retryable peer queue, improving parity with the peer sync state machine.
 - Inbound and remotely imported propagation payloads update active peer record
   snapshots when they queue new unhandled IDs or mark source peers handled,
   keeping restart/export state aligned with live queue fan-out and source

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -491,6 +491,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   peering-key and transient-ID validation, so repeated replication offers from
   the same peer return the throttled response even when the peer changes the
   offered transient-ID set.
+- Local peer offer-error responses now expose failed peer-sync state fields at
+  both the top-level event/result and nested propagation result while keeping
+  retryable queue marks intact.
 - Inbound propagation distinguishes clients, validated peers, unpeered
   identified senders, and local delivery; source peers are accounted and not
   re-offered their own payloads.


### PR DESCRIPTION
## Summary
- report local peer offer-error sync responses as failed state at the top level and nested propagation level
- extend the retryable offer-response test to prove failed state is observable while queue marks remain retryable
- update parity docs for the peer sync state-machine observability improvement

## Tests
- cargo test -p reticulum-rs-rpc peer_sync_retryable_offer_responses_preserve_peer_queue_like_python
- cargo fmt --all -- --check
- git diff --check plus forbidden-reference diff scan
- cargo clippy -p reticulum-rs-rpc --lib -- -D warnings
- cargo test -p reticulum-rs-rpc
- bash tools/scripts/check-boundaries.sh

## Reference behavior
The reference peer sync state machine treats non-success offer responses as terminal failed sync outcomes while preserving retryable queue state for later attempts. This patch makes that failure state visible in local peer-sync result and event payloads without changing queue retention behavior.