### PR TITLE
Constrain haves completion to known work

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation.rs
@@ -65,6 +65,19 @@ pub(super) fn handle_message_get_request(
             daemon.purge_propagation_payloads_for_destination(&remote_delivery_hash, &haves);
         }
         for transient_id in have_ids {
+            let known_peer_work = matched_haves
+                .iter()
+                .any(|matched| matched.eq_ignore_ascii_case(transient_id.as_str()))
+                || match daemon.has_peer_propagation_mark(
+                    remote_propagation_hash.as_str(),
+                    transient_id.as_str(),
+                ) {
+                    Ok(value) => value,
+                    Err(_) => return ControlResponse::Code(error_no_access),
+                };
+            if !known_peer_work {
+                continue;
+            }
             if daemon
                 .record_existing_peer_received_propagation(
                     remote_propagation_hash.as_str(),
@@ -1662,6 +1675,60 @@ mod tests {
             row["messages"]["unhandled_ids"],
             json!([]),
             "reingested haves should not be queued back to the declaring peer"
+        );
+    }
+
+    #[test]
+    fn message_get_unknown_haves_do_not_complete_future_peer_work() {
+        let daemon = RpcDaemon::test_instance();
+        let remote_private =
+            rns_transport::identity::PrivateIdentity::new_from_rand(rand_core::OsRng);
+        let remote_identity = *remote_private.as_identity();
+        let remote_delivery_hash = delivery_destination_hash_for_identity(&remote_identity);
+        let remote_propagation_hash =
+            hex::encode(propagation_destination_hash_for_identity(&remote_identity));
+        daemon
+            .record_propagation_offer_peer(remote_propagation_hash.as_str())
+            .expect("activate requesting peer");
+        let future_have = [0x39; 32];
+        let future_have_hex = hex::encode(future_have);
+
+        let response = handle_message_get_request(
+            &daemon,
+            &remote_identity,
+            Some(rmpv::Value::Array(vec![
+                rmpv::Value::Nil,
+                rmpv::Value::Array(vec![rmpv::Value::Binary(future_have.to_vec())]),
+            ])),
+            0xF1,
+            0xF4,
+        );
+
+        assert!(matches!(response, ControlResponse::Bool(true)));
+        assert!(
+            !daemon
+                .has_peer_completed_propagation_mark(
+                    remote_propagation_hash.as_str(),
+                    future_have_hex.as_str(),
+                )
+                .expect("completed propagation mark lookup"),
+            "unknown haves must not pre-complete future propagation work"
+        );
+
+        let mut future_payload = remote_delivery_hash.to_vec();
+        future_payload.extend_from_slice(b" future haves should still queue");
+        daemon
+            .ingest_propagation_payload_bytes_with_aliases(
+                future_payload.as_slice(),
+                future_have_hex.as_str(),
+                &[],
+            )
+            .expect("ingest future payload");
+        let row = list_peer_row(&daemon, remote_propagation_hash.as_str());
+        assert_eq!(
+            row["messages"]["unhandled_ids"],
+            json!([future_have_hex.as_str()]),
+            "future payloads must still be queued to peers that only declared unknown haves"
         );
     }
 

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -1091,6 +1091,20 @@ impl RpcDaemon {
             .map_err(std::io::Error::other)
     }
 
+    pub fn has_peer_propagation_mark(
+        &self,
+        peer: &str,
+        transient_id: &str,
+    ) -> Result<bool, std::io::Error> {
+        let peer_key = self.peer_store_key_or_input(peer);
+        self.store
+            .peer_propagation_mark_exists(
+                peer_key.as_str(),
+                normalize_propagation_transient_key(transient_id).as_str(),
+            )
+            .map_err(std::io::Error::other)
+    }
+
     pub fn record_peer_transferred_propagation(
         &self,
         peer: &str,

--- a/crates/libs/rns-rpc/src/storage/messages.rs
+++ b/crates/libs/rns-rpc/src/storage/messages.rs
@@ -1254,6 +1254,26 @@ impl MessagesStore {
         })
     }
 
+    pub fn peer_propagation_mark_exists(
+        &self,
+        peer: &str,
+        transient_id: &str,
+    ) -> rusqlite::Result<bool> {
+        self.with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT EXISTS(
+                    SELECT 1
+                    FROM propagation_peer_entries
+                    WHERE LOWER(peer) = LOWER(?1)
+                      AND transient_id = ?2
+                    LIMIT 1
+                 )",
+                params![peer, normalize_hex_key(transient_id)],
+                |row| row.get(0),
+            )
+        })
+    }
+
     pub fn peer_received_propagation_mark_exists(
         &self,
         peer: &str,

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -431,6 +431,9 @@ The project is best described by capability level:
   after peering-key and transient-ID validation, so repeated replication offers
   from the same peer take the throttled response path even when the peer changes
   the offered transient-ID set.
+- Inbound propagation message-get `haves` completion now applies only to
+  locally known payloads or existing peer queue marks, preventing unknown haves
+  from suppressing future propagation work for the declaring peer.
 - The live Python compatibility gate now includes a Python-origin propagation
   `/get` haves-only case against Rust `reticulumd`, covering `true`
   acknowledgement, Rust-side payload purge, and suppression of retryable

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -326,6 +326,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   IDs even when local payload rows are already absent, while still honoring
   `retain_synced_on_node` payload-retention behavior so completed peers are
   marked without regressing local payload reuse.
+- Inbound propagation message-get `haves` completion is now constrained to
+  locally known payloads or existing peer queue marks, so arbitrary unknown
+  haves cannot pre-complete future propagation work for that peer.
 - Link-based remote propagation downloads wait for the final haves
   acknowledgement response after imported or duplicate payloads are reported,
   so node-side rejection or timeout is surfaced instead of reporting a


### PR DESCRIPTION
## Summary
- constrain inbound `/get` haves completion to locally known payloads or existing peer queue marks
- add a regression test proving arbitrary unknown haves do not pre-complete future propagation work
- keep known-payload haves and stale queue cleanup behavior intact, and update parity/status docs

## Verification
- RED: `cargo test -p reticulumd message_get_unknown_haves_do_not_complete_future_peer_work -- --nocapture` failed because unknown haves pre-completed future work
- `cargo fmt --all -- --check`
- `cargo test -p reticulumd message_get_unknown_haves_do_not_complete_future_peer_work -- --nocapture`
- `cargo test -p reticulumd message_get_haves -- --nocapture`
- `cargo clippy -p reticulumd --all-targets -- -D warnings`
- `cargo test -p reticulumd`
- `C:\Program Files\Git\bin\bash.exe tools/scripts/check-boundaries.sh`
- `git diff --check`
- forbidden-reference diff scan

## Notes
Read-only comparison of propagation haves handling pointed to a state-machine distinction: haves should acknowledge known local propagation work or existing queue cleanup, but should not create completed peer state for arbitrary future transient IDs.