### PR TITLE
Prioritize propagation storage pruning

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation.rs
@@ -350,9 +350,18 @@ impl RpcDaemon {
         let Some(limit_bytes) = limit_mb.checked_mul(1_000_000) else {
             return Ok(());
         };
+        let prioritised_destinations = self
+            .delivery_policy
+            .lock()
+            .expect("policy mutex poisoned")
+            .prioritised_destinations
+            .clone();
         let pruned = self
             .store
-            .prune_propagation_entries_to_limit_bytes(limit_bytes)
+            .prune_propagation_entries_to_limit_bytes_with_priorities(
+                limit_bytes,
+                prioritised_destinations.as_slice(),
+            )
             .map_err(std::io::Error::other)?;
         if pruned.is_empty() {
             return Ok(());

--- a/crates/libs/rns-rpc/src/storage/messages.rs
+++ b/crates/libs/rns-rpc/src/storage/messages.rs
@@ -164,6 +164,28 @@ fn propagation_entry_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Propa
     })
 }
 
+fn propagation_prune_weight(
+    destination: &str,
+    size_bytes: u64,
+    received_at: i64,
+    newest_received_at: Option<i64>,
+    prioritised_destinations: &[String],
+) -> f64 {
+    const FOUR_DAYS_SECS: f64 = 4.0 * 24.0 * 60.0 * 60.0;
+
+    let age_secs = newest_received_at.unwrap_or(received_at).saturating_sub(received_at) as f64;
+    let age_weight = (age_secs / FOUR_DAYS_SECS).max(1.0);
+    let priority_weight = if prioritised_destinations
+        .iter()
+        .any(|candidate| destination.eq_ignore_ascii_case(candidate.trim()))
+    {
+        0.1
+    } else {
+        1.0
+    };
+    priority_weight * age_weight * size_bytes as f64
+}
+
 fn normalize_hex_key(value: &str) -> String {
     value.trim().to_ascii_lowercase()
 }
@@ -1503,6 +1525,14 @@ impl MessagesStore {
         &self,
         limit_bytes: u64,
     ) -> rusqlite::Result<Vec<String>> {
+        self.prune_propagation_entries_to_limit_bytes_with_priorities(limit_bytes, &[])
+    }
+
+    pub fn prune_propagation_entries_to_limit_bytes_with_priorities(
+        &self,
+        limit_bytes: u64,
+        prioritised_destinations: &[String],
+    ) -> rusqlite::Result<Vec<String>> {
         self.with_write_conn(|conn| {
             let tx = conn.unchecked_transaction()?;
             let total: i64 = tx.query_row(
@@ -1518,20 +1548,46 @@ impl MessagesStore {
 
             let entries = {
                 let mut stmt = tx.prepare(
-                    "SELECT transient_id, size_bytes
+                    "SELECT transient_id, destination, size_bytes, received_at
                      FROM propagation_entries
                      ORDER BY received_at ASC, transient_id ASC",
                 )?;
                 let rows = stmt.query_map([], |row| {
                     let transient_id: String = row.get(0)?;
-                    let size_bytes: i64 = row.get(1)?;
-                    Ok((transient_id, size_bytes.max(0) as u64))
+                    let destination: String = row.get(1)?;
+                    let size_bytes: i64 = row.get(2)?;
+                    let received_at: i64 = row.get(3)?;
+                    Ok((transient_id, destination, size_bytes.max(0) as u64, received_at))
                 })?;
                 rows.collect::<rusqlite::Result<Vec<_>>>()?
             };
+            let newest_received_at =
+                entries.iter().map(|(_id, _destination, _size, received_at)| *received_at).max();
+            let mut entries = entries;
+            entries.sort_by(|left, right| {
+                let left_weight = propagation_prune_weight(
+                    left.1.as_str(),
+                    left.2,
+                    left.3,
+                    newest_received_at,
+                    prioritised_destinations,
+                );
+                let right_weight = propagation_prune_weight(
+                    right.1.as_str(),
+                    right.2,
+                    right.3,
+                    newest_received_at,
+                    prioritised_destinations,
+                );
+                right_weight
+                    .partial_cmp(&left_weight)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| left.3.cmp(&right.3))
+                    .then_with(|| left.0.cmp(&right.0))
+            });
 
             let mut pruned = Vec::new();
-            for (transient_id, size_bytes) in entries {
+            for (transient_id, _destination, size_bytes, _received_at) in entries {
                 if total <= limit_bytes {
                     break;
                 }
@@ -3531,6 +3587,56 @@ mod tests {
                 .peer_completed_propagation_mark_exists("peer-done", old.transient_id.as_str())
                 .expect("completed mark"),
             "completed peer accounting should survive propagation storage pruning"
+        );
+    }
+
+    #[test]
+    fn priority_pruning_preserves_prioritised_destination_payloads() {
+        let store = MessagesStore::in_memory().expect("in-memory store");
+        let prioritised = PropagationEntryRecord {
+            transient_id: "30".repeat(32),
+            destination: "66".repeat(16),
+            payload_hex: "30".repeat(80),
+            received_at: 1,
+            size_bytes: 80,
+            stamp_value: None,
+        };
+        let ordinary = PropagationEntryRecord {
+            transient_id: "40".repeat(32),
+            destination: "77".repeat(16),
+            payload_hex: "40".repeat(40),
+            received_at: 2,
+            size_bytes: 40,
+            stamp_value: None,
+        };
+        store.upsert_propagation_entry(&prioritised).expect("upsert prioritised");
+        store.upsert_propagation_entry(&ordinary).expect("upsert ordinary");
+        store
+            .mark_peer_unhandled_propagation("peer-prune", prioritised.transient_id.as_str())
+            .expect("mark prioritised unhandled");
+        store
+            .mark_peer_unhandled_propagation("peer-prune", ordinary.transient_id.as_str())
+            .expect("mark ordinary unhandled");
+
+        let pruned = store
+            .prune_propagation_entries_to_limit_bytes_with_priorities(
+                80,
+                std::slice::from_ref(&prioritised.destination),
+            )
+            .expect("priority prune propagation entries");
+
+        assert_eq!(pruned, vec![ordinary.transient_id.clone()]);
+        assert!(store
+            .get_propagation_entry(prioritised.transient_id.as_str())
+            .expect("prioritised lookup")
+            .is_some());
+        assert!(store
+            .get_propagation_entry(ordinary.transient_id.as_str())
+            .expect("ordinary lookup")
+            .is_none());
+        assert_eq!(
+            store.list_peer_unhandled_propagation_ids("peer-prune").expect("peer unhandled ids"),
+            vec![prioritised.transient_id]
         );
     }
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -325,8 +325,8 @@ The project is best described by capability level:
   acknowledgement can refresh relay state without inflating local received or
   ingested counters.
 - Propagation payload ingest now enforces the configured node message-storage
-  byte limit against retained propagation entries, pruning oldest payloads while
-  clearing retryable peer queue marks.
+  byte limit against retained propagation entries, using age, size, and
+  prioritised-destination weighting while clearing retryable peer queue marks.
 - Link-based remote downloads now wait for the propagation node's `/get` haves
   acknowledgement and surface peer/control errors, so failed remote cleanup does
   not look like a completed replication drain.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -386,8 +386,8 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   acknowledgement can refresh relay state without inflating local received or
   ingested counters.
 - Propagation-node ingest enforces the configured message-storage byte limit
-  against retained propagation entries, pruning oldest payloads and stale
-  retryable peer marks.
+  against retained propagation entries, using age, size, and
+  prioritised-destination weighting while pruning stale retryable peer marks.
 - Link-based remote downloads wait for the propagation node's `/get` haves
   acknowledgement and propagate peer/control errors, so failed remote cleanup is
   not reported as a completed replication drain.


### PR DESCRIPTION
## Summary
- make retained propagation storage pruning use weighted age, size, and prioritised-destination scoring
- wire daemon message-storage-limit pruning to the configured prioritised destinations
- add a regression test proving prioritised payloads survive store pressure while ordinary payloads are pruned
- update roadmap and parity matrix status text

## Gap analysis
Read-only comparison and current matrix review showed propagation store pressure was still oldest-first even though peer sync selection already uses priority-aware weighting. That left a peer/propagation replication parity gap: configured priority destinations did not survive local retained-payload pressure longer than ordinary destinations.

## Roadmap
1. Merge priority-aware retained propagation pruning.
2. Add age-based propagation entry expiry as a separate retention lifecycle patch.
3. Consider bounded cleanup for stale processed propagation marks after expiry semantics are explicit.
4. Continue live interop expansion for propagation offer/get/fetch/download lifecycle.

## Reference behavior note
Reference behavior used for this patch: retained propagation payload eviction is weighted by destination priority, age, and payload size so priority destinations are preserved longer under local store pressure. This implementation is independent and reuses this repo's existing policy fields and pruning invariants.

## Verification
- RED: `cargo test -p reticulum-rs-rpc priority_pruning_preserves_prioritised_destination_payloads -- --nocapture` failed first because the policy-aware prune method did not exist.
- `cargo fmt --all -- --check`
- `cargo test -p reticulum-rs-rpc priority_pruning_preserves_prioritised_destination_payloads -- --nocapture`
- `cargo test -p reticulum-rs-rpc prune_propagation -- --nocapture`
- `cargo clippy -p reticulum-rs-rpc --all-targets -- -D warnings`
- `cargo test -p reticulum-rs-rpc`
- `C:\Program Files\Git\bin\bash.exe tools/scripts/check-boundaries.sh`
- `git diff --check`
- forbidden-reference scan for local reference repo names