### PR TITLE
[codex] Add BLE MTU readiness diagnostics

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/mod.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/mod.rs
@@ -17,6 +17,7 @@ mod windows;
 
 const BLE_STARTUP_MAX_RETRY_ATTEMPTS: u32 = 5;
 const BLE_STARTUP_PROBE_PAYLOAD: &[u8] = b"LXMF-BLE-PROBE";
+const DEFAULT_ATT_NOTIFICATION_PAYLOAD_BYTES: usize = 20;
 
 #[derive(Debug, Clone)]
 pub(crate) struct BleRuntimeSettings {
@@ -281,13 +282,18 @@ pub(crate) async fn run_startup_lifecycle<B: BleBackend>(
         if let Ok(payload) = notification_result {
             if payload != BLE_STARTUP_PROBE_PAYLOAD {
                 cleanup_backend(backend, settings).await;
+                let diagnostic = startup_probe_mismatch_diagnostic(
+                    BLE_STARTUP_PROBE_PAYLOAD.len(),
+                    payload.len(),
+                );
                 return Err(format!(
-                    "ble_gatt startup failed backend={} phase={} attempt={} err=probe payload mismatch expected_len={} actual_len={}",
+                    "ble_gatt startup failed backend={} phase={} attempt={} err=probe payload mismatch expected_len={} actual_len={}{}",
                     backend.backend_name(),
                     BleLifecyclePhase::NotificationProbe.as_str(),
                     attempt,
                     BLE_STARTUP_PROBE_PAYLOAD.len(),
-                    payload.len()
+                    payload.len(),
+                    diagnostic,
                 ));
             }
         }
@@ -425,6 +431,16 @@ fn required_non_empty(value: Option<&str>, field: &str) -> Result<String, String
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
         .ok_or_else(|| format!("ble_gatt.{field} is required"))
+}
+
+fn startup_probe_mismatch_diagnostic(expected_len: usize, actual_len: usize) -> &'static str {
+    if actual_len == DEFAULT_ATT_NOTIFICATION_PAYLOAD_BYTES
+        || actual_len < expected_len && actual_len < DEFAULT_ATT_NOTIFICATION_PAYLOAD_BYTES
+    {
+        "; likely ATT MTU 23 / 20-byte notification payload; btleplug cannot request a larger MTU in this backend, so configure a host adapter that negotiates MTU before enabling notifications"
+    } else {
+        ""
+    }
 }
 
 #[cfg(test)]
@@ -697,5 +713,21 @@ mod tests {
             .await
             .expect_err("mismatched probe payload should fail lifecycle");
         assert!(err.contains("probe payload mismatch"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ble_lifecycle_reports_likely_att_mtu_truncation() {
+        let settings = runtime_settings(&ble_iface()).expect("runtime settings");
+        let mut backend = MockBackend {
+            notification_payload_override: Some(vec![0x42; 20]),
+            ..Default::default()
+        };
+
+        let err = run_startup_lifecycle(&mut backend, &settings)
+            .await
+            .expect_err("20-byte notification should fail lifecycle with MTU diagnostic");
+
+        assert!(err.contains("likely ATT MTU 23"));
+        assert!(err.contains("btleplug cannot request a larger MTU"));
     }
 }

--- a/crates/libs/lxmf-sdk/src/backend/mobile_ble.rs
+++ b/crates/libs/lxmf-sdk/src/backend/mobile_ble.rs
@@ -3,6 +3,9 @@ use crate::types::Ack;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
+pub const RNODE_LXMF_MIN_NOTIFICATION_PAYLOAD_BYTES: usize = 170;
+pub const RNODE_LXMF_MIN_ATT_MTU: u16 = (RNODE_LXMF_MIN_NOTIFICATION_PAYLOAD_BYTES as u16) + 3;
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum MobileBleEventKind {
@@ -212,4 +215,49 @@ pub fn validate_event_payload_bounds(
         }
     }
     Ok(())
+}
+
+pub fn validate_rnode_lxmf_readiness(
+    descriptor: &MobileBleSessionDescriptor,
+    capabilities: &MobileBleCapabilities,
+) -> Result<(), SdkError> {
+    validate_capabilities(capabilities)?;
+
+    if descriptor.negotiated_mtu < RNODE_LXMF_MIN_ATT_MTU {
+        return Err(rnode_lxmf_mtu_error(descriptor, capabilities));
+    }
+    if capabilities.max_payload_bytes < RNODE_LXMF_MIN_NOTIFICATION_PAYLOAD_BYTES {
+        return Err(rnode_lxmf_mtu_error(descriptor, capabilities));
+    }
+
+    Ok(())
+}
+
+fn rnode_lxmf_mtu_error(
+    descriptor: &MobileBleSessionDescriptor,
+    capabilities: &MobileBleCapabilities,
+) -> SdkError {
+    SdkError::new(
+        code::VALIDATION_INVALID_ARGUMENT,
+        ErrorCategory::Validation,
+        format!(
+            "RNode/LXMF BLE notifications require at least {RNODE_LXMF_MIN_NOTIFICATION_PAYLOAD_BYTES} payload bytes; negotiate ATT MTU {RNODE_LXMF_MIN_ATT_MTU} or larger before marking the session connected",
+        ),
+    )
+    .with_user_actionable(true)
+    .with_detail("session_id", serde_json::json!(descriptor.session_id))
+    .with_detail("peripheral_id", serde_json::json!(descriptor.peripheral_id))
+    .with_detail("negotiated_mtu", serde_json::json!(descriptor.negotiated_mtu))
+    .with_detail(
+        "min_negotiated_mtu",
+        serde_json::json!(RNODE_LXMF_MIN_ATT_MTU),
+    )
+    .with_detail(
+        "max_payload_bytes",
+        serde_json::json!(capabilities.max_payload_bytes),
+    )
+    .with_detail(
+        "min_payload_bytes",
+        serde_json::json!(RNODE_LXMF_MIN_NOTIFICATION_PAYLOAD_BYTES),
+    )
 }

--- a/crates/libs/lxmf-sdk/src/lib.rs
+++ b/crates/libs/lxmf-sdk/src/lib.rs
@@ -25,10 +25,11 @@ pub use api::{
 pub use backend::mobile_ble::{
     validate_capabilities as validate_mobile_ble_capabilities,
     validate_event_payload_bounds as validate_mobile_ble_event_payload_bounds,
-    validate_event_sequence as validate_mobile_ble_event_sequence, MobileBleCapabilities,
-    MobileBleConnectRequest, MobileBleEvent, MobileBleEventKind, MobileBleHostAdapter,
-    MobileBleReadRequest, MobileBleReadResult, MobileBleSessionDescriptor, MobileBleWriteAck,
-    MobileBleWriteRequest,
+    validate_event_sequence as validate_mobile_ble_event_sequence,
+    validate_rnode_lxmf_readiness as validate_mobile_ble_rnode_lxmf_readiness,
+    MobileBleCapabilities, MobileBleConnectRequest, MobileBleEvent, MobileBleEventKind,
+    MobileBleHostAdapter, MobileBleReadRequest, MobileBleReadResult, MobileBleSessionDescriptor,
+    MobileBleWriteAck, MobileBleWriteRequest,
 };
 #[cfg(all(feature = "rpc-backend", feature = "std"))]
 pub use backend::rpc::RpcBackendClient;

--- a/crates/libs/lxmf-sdk/tests/mobile_ble_contract.rs
+++ b/crates/libs/lxmf-sdk/tests/mobile_ble_contract.rs
@@ -1,8 +1,9 @@
 use lxmf_sdk::{
     validate_mobile_ble_capabilities, validate_mobile_ble_event_payload_bounds,
-    validate_mobile_ble_event_sequence, MobileBleCapabilities, MobileBleConnectRequest,
-    MobileBleEvent, MobileBleEventKind, MobileBleHostAdapter, MobileBleReadRequest,
-    MobileBleReadResult, MobileBleSessionDescriptor, MobileBleWriteAck, MobileBleWriteRequest,
+    validate_mobile_ble_event_sequence, validate_mobile_ble_rnode_lxmf_readiness,
+    MobileBleCapabilities, MobileBleConnectRequest, MobileBleEvent, MobileBleEventKind,
+    MobileBleHostAdapter, MobileBleReadRequest, MobileBleReadResult, MobileBleSessionDescriptor,
+    MobileBleWriteAck, MobileBleWriteRequest,
 };
 
 struct DefaultCancelAdapter;
@@ -177,6 +178,47 @@ fn mobile_ble_payload_bound_validation_rejects_oversized_notifications() {
     let err = validate_mobile_ble_event_payload_bounds(&events, &capabilities)
         .expect_err("payload over max should fail");
     assert_eq!(err.machine_code, lxmf_sdk::error_code::VALIDATION_INVALID_ARGUMENT);
+}
+
+#[test]
+fn mobile_ble_rnode_lxmf_readiness_rejects_default_att_mtu() {
+    let descriptor = MobileBleSessionDescriptor {
+        session_id: "session-1".to_string(),
+        peripheral_id: "AA:BB:CC:DD:EE:FF".to_string(),
+        negotiated_mtu: 23,
+    };
+    let capabilities = MobileBleCapabilities {
+        supports_background_restore: true,
+        supports_write_without_response: true,
+        supports_operation_cancel: false,
+        max_notification_queue: 32,
+        max_payload_bytes: 20,
+    };
+
+    let err = validate_mobile_ble_rnode_lxmf_readiness(&descriptor, &capabilities)
+        .expect_err("default ATT MTU must not be ready for RNode/LXMF");
+
+    assert_eq!(err.machine_code, lxmf_sdk::error_code::VALIDATION_INVALID_ARGUMENT);
+    assert!(err.message.contains("RNode/LXMF BLE notifications require"));
+}
+
+#[test]
+fn mobile_ble_rnode_lxmf_readiness_accepts_usable_notification_payload() {
+    let descriptor = MobileBleSessionDescriptor {
+        session_id: "session-1".to_string(),
+        peripheral_id: "AA:BB:CC:DD:EE:FF".to_string(),
+        negotiated_mtu: 173,
+    };
+    let capabilities = MobileBleCapabilities {
+        supports_background_restore: true,
+        supports_write_without_response: true,
+        supports_operation_cancel: false,
+        max_notification_queue: 32,
+        max_payload_bytes: 170,
+    };
+
+    validate_mobile_ble_rnode_lxmf_readiness(&descriptor, &capabilities)
+        .expect("usable MTU and payload should be ready for RNode/LXMF");
 }
 
 #[test]

--- a/crates/libs/rns-transport/src/iface/rnode_ble.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble.rs
@@ -37,6 +37,7 @@ pub const RNODE_BLE_TX_CHARACTERISTIC_UUID: &str = "6E400003-B5A3-F393-E0A9-E50E
 pub const RNODE_BLE_SCAN_TIMEOUT: Duration = Duration::from_secs(2);
 pub const RNODE_BLE_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 pub const RNODE_BLE_READ_FRAME_TIMEOUT: Duration = Duration::from_millis(1_250);
+const DEFAULT_ATT_NOTIFICATION_PAYLOAD_BYTES: usize = 20;
 #[cfg(feature = "rnode-ble")]
 const RNODE_BLE_STARTUP_STABILIZATION_TIMEOUT: Duration = Duration::from_secs(2);
 #[cfg(feature = "rnode-ble")]
@@ -1102,6 +1103,15 @@ impl RnodeBleKissSession {
         }
         self.last_read_at = Instant::now();
         let frames = self.decoder.push_bytes(payload)?;
+        if frames.is_empty()
+            && payload.len() == DEFAULT_ATT_NOTIFICATION_PAYLOAD_BYTES
+            && self.decoder.has_partial_frame()
+        {
+            return Err(RnodeBleKissError::Backend {
+                operation: "accept_notification_events",
+                message: "incomplete 20-byte RNode BLE notification; likely ATT MTU 23 / 20-byte notification payload, and btleplug cannot request a larger MTU before notifications in this backend".to_string(),
+            });
+        }
         let mut notification = RnodeBleNotification::default();
         for frame in frames {
             match frame {
@@ -1155,5 +1165,27 @@ impl RnodeBleKissSession {
                 payload: chunk.to_vec(),
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RnodeBleKissConfig, RnodeBleKissError, RnodeBleKissSession};
+
+    #[test]
+    fn rnode_ble_notification_reports_likely_default_att_mtu_cap() {
+        let mut session = RnodeBleKissSession::new(RnodeBleKissConfig::default());
+        let err = session
+            .accept_notification_events(&[0x42; 20])
+            .expect_err("20-byte incomplete notification should be diagnosed");
+
+        match err {
+            RnodeBleKissError::Backend { operation, message } => {
+                assert_eq!(operation, "accept_notification_events");
+                assert!(message.contains("likely ATT MTU 23"));
+                assert!(message.contains("btleplug cannot request a larger MTU"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }

--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -8,8 +8,8 @@
     },
     {
       "path": "docs/contracts/baselines/lxmf-sdk-public-api.txt",
-      "bytes": 246940,
-      "sha256": "284956d7d0c15f8492630b91c36117b205c062cd1bf97dcc67336157ce463d10"
+      "bytes": 247145,
+      "sha256": "6b0cbca40bf7612183a8cef3cb10dcd7f56c93089532d4d9fbbae4168646d9a9"
     },
     {
       "path": "docs/contracts/baselines/schema-client-generation-baseline.json",
@@ -68,8 +68,8 @@
     },
     {
       "path": "docs/contracts/mobile-ble-host-contract.md",
-      "bytes": 2097,
-      "sha256": "175e24b993eab811ecdda44580df086fad212acd63e390635307fb48fcbb6b3e"
+      "bytes": 2838,
+      "sha256": "4d25c8e2ac0b839f08120bcccd175baf955f28e8225a9831c5ebbf157f4b8409"
     },
     {
       "path": "docs/contracts/native-embedded-interop-profile-v1.md",

--- a/docs/contracts/baselines/lxmf-sdk-public-api.txt
+++ b/docs/contracts/baselines/lxmf-sdk-public-api.txt
@@ -2732,6 +2732,7 @@ pub fn lxmf_sdk::supports_capability(profile: lxmf_sdk::Profile, capability_id: 
 pub fn lxmf_sdk::validate_mobile_ble_capabilities(capabilities: &lxmf_sdk::MobileBleCapabilities) -> core::result::Result<(), lxmf_sdk::SdkError>
 pub fn lxmf_sdk::validate_mobile_ble_event_payload_bounds(events: &[lxmf_sdk::MobileBleEvent], capabilities: &lxmf_sdk::MobileBleCapabilities) -> core::result::Result<(), lxmf_sdk::SdkError>
 pub fn lxmf_sdk::validate_mobile_ble_event_sequence(events: &[lxmf_sdk::MobileBleEvent]) -> core::result::Result<(), lxmf_sdk::SdkError>
+pub fn lxmf_sdk::validate_mobile_ble_rnode_lxmf_readiness(descriptor: &lxmf_sdk::MobileBleSessionDescriptor, capabilities: &lxmf_sdk::MobileBleCapabilities) -> core::result::Result<(), lxmf_sdk::SdkError>
 pub type lxmf_sdk::ErrorDetails = alloc::collections::btree::map::BTreeMap<alloc::string::String, serde_json::value::Value>
 pub type lxmf_sdk::SdkBoxFuture<'a, T> = core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<T, lxmf_sdk::SdkError>> + core::marker::Send + 'a)>>
 pub type lxmf_sdk::SdkEventStream = core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = core::result::Result<lxmf_sdk::event::SdkEvent, lxmf_sdk::SdkError>> + core::marker::Send)>>

--- a/docs/contracts/mobile-ble-host-contract.md
+++ b/docs/contracts/mobile-ble-host-contract.md
@@ -34,6 +34,8 @@ Required request/response/event types:
 2. Session ordering:
 - `Connected` must precede `Notification`, `WriteComplete`, and `Disconnected` for a session.
 - `Disconnected` closes a session and no further session-bound events are valid.
+- RNode/LXMF sessions must not emit `Connected` until the host has negotiated and reported a
+  usable notification payload size.
 
 3. Cancellation:
 - `cancel_operation` is optional.
@@ -51,6 +53,15 @@ Required request/response/event types:
 - Adapter errors must map to stable `SdkError` categories/machine codes.
 - Validation errors (ordering/shape violations) use `SDK_VALIDATION_INVALID_ARGUMENT`.
 
+7. RNode/LXMF MTU readiness:
+- RNode firmware delivers a complete KISS frame in one BLE notification, so adapters must
+  negotiate/report at least `170` notification payload bytes (`ATT MTU >= 173`) before a
+  session is considered ready.
+- Hosts that remain at the Bluetooth default `ATT MTU 23` (`20` payload bytes) must fail
+  readiness with validation semantics instead of surfacing a healthy-but-silent session.
+- Native `btleplug` backends cannot request a larger MTU in version `0.11.8`; platform hosts
+  that can negotiate MTU must do so before enabling notifications.
+
 ## Conformance
 
 Reference validation helpers:
@@ -58,6 +69,7 @@ Reference validation helpers:
 - `validate_event_sequence`
 - `validate_capabilities`
 - `validate_event_payload_bounds`
+- `validate_rnode_lxmf_readiness`
 
 These are covered by tests in:
 

--- a/docs/runbooks/mobile-ble-conformance.md
+++ b/docs/runbooks/mobile-ble-conformance.md
@@ -10,6 +10,7 @@ mobile BLE host contract.
 - Contract doc: `docs/contracts/mobile-ble-host-contract.md`
 - Rust contract types: `crates/libs/lxmf-sdk/src/backend/mobile_ble.rs`
 - Shared validator: `validate_mobile_ble_event_sequence`
+- RNode/LXMF readiness validator: `validate_mobile_ble_rnode_lxmf_readiness`
 
 ## Required Artifacts Per Platform
 
@@ -19,7 +20,8 @@ mobile BLE host contract.
 - `supports_write_without_response`
 - `supports_operation_cancel`
 - queue/payload limits
-3. Pass/fail summary for ordering, timeout, and cancellation checks.
+3. Session descriptor including negotiated MTU.
+4. Pass/fail summary for ordering, timeout, cancellation, and RNode/LXMF MTU readiness checks.
 
 Reference fixture directories:
 
@@ -34,6 +36,8 @@ Reference fixture directories:
 3. `disconnected` terminates session event eligibility.
 4. Timeout/cancel semantics are explicit and deterministic.
 5. Queue/backpressure behavior is bounded and declared via capability values.
+6. RNode/LXMF readiness rejects Bluetooth default `ATT MTU 23` / `20` payload-byte sessions.
+7. RNode/LXMF readiness accepts sessions with `ATT MTU >= 173` and payload capacity `>= 170`.
 
 ## CI Commands
 
@@ -47,7 +51,9 @@ cargo test -p test-support --test mobile_ble_android_conformance --test mobile_b
 1. Preserve the failing transcript artifact and capability snapshot.
 2. Diff transcript against passing baseline fixtures.
 3. Resolve event ordering drift before merging runtime changes.
-4. Re-run both platform conformance tests before release promotion.
+4. If RNode/LXMF readiness fails with a `20` byte payload cap, fix host MTU negotiation before
+   treating the BLE session as connected.
+5. Re-run both platform conformance tests before release promotion.
 
 ## Release Gate
 


### PR DESCRIPTION
﻿## Summary

Partially addresses #285, reported by @IgorShishkin12.

This PR adds the repository-side mitigation for the BLE MTU truncation failure mode:

- adds an SDK readiness validator for RNode/LXMF BLE sessions so hosts reporting ATT MTU 23 / 20-byte payload capacity fail validation instead of appearing connected;
- adds clearer diagnostics in the native `reticulumd` BLE startup probe and RNode BLE KISS session path when a 20-byte notification suggests default ATT MTU truncation;
- updates the mobile BLE contract, runbook, and public API baseline with the RNode/LXMF MTU readiness rule.

## What this does not solve

This does not implement Android MTU negotiation inside LXMF-rs. The Android-specific part must be solved outside this repository in the Android host/application layer, because the current native path depends on `btleplug = 0.11.8`, which does not expose a cross-platform `request_mtu` API that LXMF-rs can call before subscribing to notifications. Android hosts that can call `BluetoothGatt.requestMtu(...)` need to do that before reporting the BLE session as connected/ready to this SDK.

## Validation

- `cargo test -p lxmf-sdk --test mobile_ble_contract`
- `cargo test -p reticulumd --bin reticulumd interfaces::ble::`
- `cargo test -p reticulum-rs-transport iface::rnode_ble -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

Note: `cargo xtask sdk-api-break` is blocked in this Windows environment because the gate invokes `/bin/bash`; the additive SDK public API baseline entry was updated manually.