### PR TITLE
Refresh remote transfer success attempt time

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/init_parts/rpcdaemon_sections/issue_ticket.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init_parts/rpcdaemon_sections/issue_ticket.rs
@@ -363,11 +363,13 @@ impl RpcDaemon {
                 record.peer_type.as_deref() != Some("unpeered")
                     && record.peer.eq_ignore_ascii_case(peer)
             }) {
+                let now = now_i64();
                 existing.alive = true;
-                existing.last_seen = now_i64();
+                existing.last_seen = now;
                 existing.incoming = existing.incoming.saturating_add(messages as u64);
                 existing.rx_bytes = existing.rx_bytes.saturating_add(bytes as u64);
                 if clear_backoff {
+                    existing.last_sync_attempt = now;
                     existing.sync_backoff = 0;
                     existing.next_sync_attempt = 0;
                 }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_download_success_clears_backoff.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_download_success_clears_backoff.rs
@@ -12,6 +12,7 @@ fn propagation_remote_download_success_clears_source_peer_retry_backoff() {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
         let peer = peers.get_mut(source_peer).expect("source peer record");
         peer.alive = false;
+        peer.last_sync_attempt = 111;
         peer.sync_backoff = 12 * 60;
         peer.next_sync_attempt = now_i64().saturating_add(12 * 60);
     }
@@ -45,6 +46,10 @@ fn propagation_remote_download_success_clears_source_peer_retry_backoff() {
         .find(|row| row["peer"].as_str() == Some(source_peer))
         .expect("source peer row");
     assert_eq!(source_row["alive"].as_bool(), Some(true));
+    assert!(
+        source_row["last_sync_attempt"].as_i64().is_some_and(|value| value > 111),
+        "successful remote download should refresh source peer sync attempt timestamp"
+    );
     assert_eq!(source_row["rx_bytes"].as_u64(), Some(payload.len() as u64));
     assert_eq!(source_row["sync_backoff"].as_u64(), Some(0));
     assert_eq!(source_row["next_sync_attempt"].as_i64(), Some(0));

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_sync_ignores_payl.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_sync_ignores_payl.rs
@@ -280,6 +280,7 @@ fn propagation_remote_fetch_success_clears_source_peer_retry_backoff() {
         let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
         let peer = peers.get_mut(source_peer).expect("source peer record");
         peer.alive = false;
+        peer.last_sync_attempt = 111;
         peer.sync_backoff = 12 * 60;
         peer.next_sync_attempt = now_i64().saturating_add(12 * 60);
     }
@@ -315,6 +316,10 @@ fn propagation_remote_fetch_success_clears_source_peer_retry_backoff() {
         .expect("source peer row");
     assert_eq!(source_row["alive"].as_bool(), Some(true));
     assert_eq!(source_row["rx_bytes"].as_u64(), Some(payload.len() as u64));
+    assert!(
+        source_row["last_sync_attempt"].as_i64().is_some_and(|value| value > 111),
+        "successful remote fetch should refresh source peer sync attempt timestamp"
+    );
     assert_eq!(source_row["sync_backoff"].as_u64(), Some(0));
     assert_eq!(source_row["next_sync_attempt"].as_i64(), Some(0));
     assert_eq!(

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -135,6 +135,10 @@ The project is best described by capability level:
 - Successful remote fetch and download now clear stale retry backoff on the
   active source peer when newly accepted payloads prove the source recovered,
   so later maintenance does not keep postponing a healthy replication peer.
+- Successful remote fetch and download now also refresh the active source
+  peer's sync-attempt timestamp while clearing stale backoff, so restart and
+  status views reflect the successful recovery attempt instead of an obsolete
+  failed transfer time.
 - Remote peer-sync backoff postponements now mirror existing payload-backed live
   queue marks into active peer record snapshots before returning, so
   restart/export state preserves queued retry work even when sync is deferred.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -414,6 +414,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Successful remote fetch/download imports clear stale retry backoff on an
   active source peer after newly accepted payloads, so recovered propagation
   sources are not left postponed by an earlier failed transfer attempt.
+- Successful remote fetch/download imports also refresh the active source
+  peer's sync-attempt timestamp while clearing stale backoff, so status and
+  restart/export views do not retain an obsolete failed transfer attempt time.
 - Link-based remote propagation downloads classify listed transient IDs before
   payload retrieval, report locally known IDs as `/get` haves, and use the
   purge-only `[nil, haves]` request when every listed ID is already local, so


### PR DESCRIPTION
## Summary
- refresh source peer last_sync_attempt when successful remote fetch/download clears stale backoff
- strengthen remote fetch/download success-backoff regressions with stale attempt timestamp assertions
- update current roadmap and LXMF parity matrix evidence

## Verification
- cargo test -p reticulum-rs-rpc --lib success_clears_source_peer_retry_backoff -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_fetch -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_download -- --nocapture
- cargo fmt --check
- git diff --check
- cargo check -p reticulum-rs-rpc
- cargo clippy -p reticulum-rs-rpc --lib -- -D warnings