### PR TITLE
Publish failed remote unpeer peer events

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/handle_rpc_legacy_remote_unpeer.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/handle_rpc_legacy_remote_unpeer.rs
@@ -73,6 +73,14 @@ impl RpcDaemon {
                         } else {
                             let _ = self
                                 .record_payload_backed_peer_queue_snapshot(snapshot_peer.as_str());
+                            self.publish_failed_remote_peer_sync_event(
+                                snapshot_peer.as_str(),
+                                remote_id.as_str(),
+                                error.as_str(),
+                                None,
+                                None,
+                                None,
+                            );
                         }
                         return Err(err);
                     }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_unpeer_reports_ex.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_unpeer_reports_ex.rs
@@ -171,6 +171,7 @@ fn failed_propagation_remote_unpeer_preserves_local_peer_and_queue_state() {
         .store
         .mark_peer_unhandled_propagation("peer-remote-unpeer-fail", entry.transient_id.as_str())
         .expect("mark unhandled");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
 
     let err = daemon
         .handle_rpc(rpc_request(
@@ -213,6 +214,26 @@ fn failed_propagation_remote_unpeer_preserves_local_peer_and_queue_state() {
             .list_peer_unhandled_propagation("peer-remote-unpeer-fail")
             .expect("list unhandled"),
         vec![entry]
+    );
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_sync")
+        .cloned()
+        .expect("failed remote unpeer peer-sync event");
+    assert_eq!(event.payload["peer"].as_str(), Some("peer-remote-unpeer-fail"));
+    assert_eq!(event.payload["remote"].as_str(), Some("remote-node"));
+    assert_eq!(event.payload["remote_sync"].as_bool(), Some(true));
+    assert_eq!(event.payload["synced"].as_bool(), Some(false));
+    assert_eq!(event.payload["state_name"].as_str(), Some("failed"));
+    assert_eq!(event.payload["propagation"]["error"].as_str(), Some("remote unpeer failed"));
+    assert_eq!(
+        event.payload["messages"]["unhandled_ids"].as_array().expect("event unhandled ids"),
+        &[json!("e2".repeat(32))]
     );
 }
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -166,6 +166,10 @@ The project is best described by capability level:
   case-insensitive peer requests, so restart/export state preserves queued retry
   work when peering teardown fails; these failed attempts also mark the
   propagation lifecycle failed instead of leaving stale idle/completed state.
+- Failed remote unpeer bridge-execution errors for active peers now also
+  publish the failed peer-sync event after queue snapshot refresh, keeping
+  observer-visible peering failure state aligned with remote sync/fetch/download
+  failures.
 - Access-denied remote unpeer failures now follow the same local peering break
   path as access-denied remote sync/fetch/download, clearing local peer and
   propagation queue state instead of leaving denied teardown work retryable.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -207,6 +207,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   case-insensitive peer requests, so failed peering teardown preserves queued
   retry work across restart/export and marks the propagation lifecycle failed
   instead of leaving stale idle/completed state.
+- Failed remote unpeer bridge-execution errors for active peers publish the
+  failed peer-sync event after queue snapshot refresh, keeping observer-visible
+  peering failure state aligned with remote sync/fetch/download failures.
 - Access-denied remote unpeer failures follow the same local peering break path
   as access-denied remote sync/fetch/download, clearing local peer and
   propagation queue state instead of leaving denied teardown work retryable.


### PR DESCRIPTION
## Summary
- publish a failed peer-sync event when remote unpeer bridge execution fails for an active peer
- assert the failed event preserves remote, failed state, error, and queued unhandled IDs
- update the current roadmap and LXMF parity matrix for the remote-unpeer observer behavior

## Verification
- cargo test -p reticulum-rs-rpc --lib failed_propagation_remote_unpeer_preserves_local_peer_and_queue_state -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_unpeer -- --nocapture
- cargo fmt --check
- git diff --check
- cargo check -p reticulum-rs-rpc
- cargo clippy -p reticulum-rs-rpc --lib -- -D warnings
- cargo test -p reticulum-rs-rpc --lib