### PR TITLE
Publish unavailable remote unpeer peer events

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/handle_rpc_legacy_remote_unpeer.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/handle_rpc_legacy_remote_unpeer.rs
@@ -50,6 +50,16 @@ impl RpcDaemon {
                         );
                         let _ =
                             self.record_payload_backed_peer_queue_snapshot(snapshot_peer.as_str());
+                        if self.peer_record_exists(snapshot_peer.as_str(), false) {
+                            self.publish_failed_remote_peer_sync_event(
+                                snapshot_peer.as_str(),
+                                remote_id.as_str(),
+                                "remote control bridge unavailable",
+                                None,
+                                None,
+                                None,
+                            );
+                        }
                         return Err(std::io::Error::other("remote control bridge unavailable"));
                     }
                 };

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/failed_propagation_remote_unpeer_rec.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/failed_propagation_remote_unpeer_rec.rs
@@ -128,6 +128,7 @@ fn unavailable_propagation_remote_unpeer_records_existing_queue_snapshot_like_py
         .store
         .mark_peer_unhandled_propagation(peer, entry.transient_id.as_str())
         .expect("mark unhandled");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
 
     let err = daemon
         .handle_rpc(rpc_request(
@@ -169,6 +170,39 @@ fn unavailable_propagation_remote_unpeer_records_existing_queue_snapshot_like_py
         serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
         &[json!(entry.transient_id.as_str())]
     );
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_sync")
+        .cloned()
+        .expect("failed peer sync event");
+    assert_eq!(event.payload["peer"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote"].as_str(), Some("remote-node"));
+    assert_eq!(event.payload["remote_sync"].as_bool(), Some(true));
+    assert_eq!(event.payload["synced"].as_bool(), Some(false));
+    assert_eq!(event.payload["state"].as_u64(), Some(0xfe));
+    assert_eq!(event.payload["state_name"].as_str(), Some("failed"));
+    assert_eq!(event.payload["failure_kind"].as_str(), Some("failed"));
+    assert_eq!(
+        event.payload["propagation"]["error"].as_str(),
+        Some("remote control bridge unavailable")
+    );
+    assert_eq!(
+        event.payload["messages"]["unhandled_ids"]
+            .as_array()
+            .expect("event unhandled ids"),
+        &[json!(entry.transient_id.as_str())]
+    );
+    assert_eq!(
+        event.payload["propagation"]["failure_kind"].as_str(),
+        Some("failed")
+    );
+    assert_eq!(event.payload["propagation"]["state"].as_u64(), Some(0xfe));
+    assert_eq!(event.payload["propagation"]["state_name"].as_str(), Some("failed"));
 }
 
 #[test]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -166,6 +166,10 @@ The project is best described by capability level:
   case-insensitive peer requests, so restart/export state preserves queued retry
   work when peering teardown fails; these failed attempts also mark the
   propagation lifecycle failed instead of leaving stale idle/completed state.
+- Failed remote unpeer bridge-unavailable errors for active peers now also
+  publish the failed peer-sync event after queue snapshot refresh, keeping
+  observer-visible peering failure state aligned with remote sync/fetch/download
+  bridge-unavailable failures.
 - Access-denied remote unpeer failures now follow the same local peering break
   path as access-denied remote sync/fetch/download, clearing local peer and
   propagation queue state instead of leaving denied teardown work retryable.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -207,6 +207,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   case-insensitive peer requests, so failed peering teardown preserves queued
   retry work across restart/export and marks the propagation lifecycle failed
   instead of leaving stale idle/completed state.
+- Failed remote unpeer bridge-unavailable errors for active peers publish the
+  failed peer-sync event after queue snapshot refresh, keeping observer-visible
+  peering failure state aligned with remote sync/fetch/download
+  bridge-unavailable failures.
 - Access-denied remote unpeer failures follow the same local peering break path
   as access-denied remote sync/fetch/download, clearing local peer and
   propagation queue state instead of leaving denied teardown work retryable.


### PR DESCRIPTION
## Summary
- publish failed `peer_sync` events when `propagation_remote_unpeer` fails because the remote-control bridge is unavailable for an active peer
- assert the event preserves the refreshed queue snapshot and failed propagation state
- update the maintained roadmap and LXMF parity matrix with the new observer behavior

## Verification
- RED: `cargo test -p reticulum-rs-rpc --lib unavailable_propagation_remote_unpeer_records_existing_queue_snapshot_like_python -- --nocapture` failed before implementation with missing `peer_sync` event
- `cargo fmt --check`
- `cargo test -p reticulum-rs-rpc --lib propagation_remote_unpeer -- --nocapture`
- `cargo check -p reticulum-rs-rpc`
- `cargo clippy -p reticulum-rs-rpc --lib -- -D warnings`
- `cargo test -p reticulum-rs-rpc --lib`
- `git diff --check`