### PR TITLE
Back off failed remote unpeer retries

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/handle_rpc_legacy_remote_unpeer.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/handle_rpc_legacy_remote_unpeer.rs
@@ -71,6 +71,17 @@ impl RpcDaemon {
                                 error.as_str(),
                             )?;
                         } else {
+                            let timestamp = now_i64();
+                            if let Ok(mut peers) = self.peers.lock() {
+                                if let Some(peer) = peers.get_mut(snapshot_peer.as_str()) {
+                                    peer.last_sync_attempt = timestamp;
+                                    peer.sync_backoff = peer
+                                        .sync_backoff
+                                        .saturating_add(super::init::LXMF_PEER_SYNC_BACKOFF_STEP_SECS);
+                                    peer.next_sync_attempt =
+                                        timestamp.saturating_add(i64::from(peer.sync_backoff));
+                                }
+                            }
                             let _ = self
                                 .record_payload_backed_peer_queue_snapshot(snapshot_peer.as_str());
                         }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_unpeer_reports_ex.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_unpeer_reports_ex.rs
@@ -207,6 +207,10 @@ fn failed_propagation_remote_unpeer_preserves_local_peer_and_queue_state() {
     assert_eq!(row["peer"].as_str(), Some("peer-remote-unpeer-fail"));
     assert_eq!(row["messages"]["unhandled"].as_u64(), Some(1));
     assert_eq!(row["messages"]["unhandled_bytes"].as_u64(), Some(20));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
     assert_eq!(
         daemon
             .store

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -166,6 +166,10 @@ The project is best described by capability level:
   case-insensitive peer requests, so restart/export state preserves queued retry
   work when peering teardown fails; these failed attempts also mark the
   propagation lifecycle failed instead of leaving stale idle/completed state.
+- Failed remote unpeer bridge-execution errors for active peers now also
+  advance the peer's retry backoff window before refreshing queue snapshots, so
+  failed peering teardown does not leave retryable queue work in an immediate
+  retry loop.
 - Access-denied remote unpeer failures now follow the same local peering break
   path as access-denied remote sync/fetch/download, clearing local peer and
   propagation queue state instead of leaving denied teardown work retryable.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -207,6 +207,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   case-insensitive peer requests, so failed peering teardown preserves queued
   retry work across restart/export and marks the propagation lifecycle failed
   instead of leaving stale idle/completed state.
+- Failed remote unpeer bridge-execution errors for active peers advance the
+  peer's retry backoff window before refreshing queue snapshots, so failed
+  peering teardown does not leave retryable queue work in an immediate retry
+  loop.
 - Access-denied remote unpeer failures follow the same local peering break path
   as access-denied remote sync/fetch/download, clearing local peer and
   propagation queue state instead of leaving denied teardown work retryable.


### PR DESCRIPTION
## Summary
- advance active peer retry backoff when `propagation_remote_unpeer` bridge execution fails
- keep the existing queue-preservation path intact while preventing immediate retry loops after failed peering teardown
- update the maintained roadmap and LXMF parity matrix for the new retry behavior

## Verification
- RED: `cargo test -p reticulum-rs-rpc --lib failed_propagation_remote_unpeer_preserves_local_peer_and_queue_state -- --nocapture` failed before implementation with `sync_backoff` still `0`
- `cargo fmt --check`
- `cargo test -p reticulum-rs-rpc --lib propagation_remote_unpeer -- --nocapture`
- `cargo check -p reticulum-rs-rpc`
- `cargo clippy -p reticulum-rs-rpc --lib -- -D warnings`
- `cargo test -p reticulum-rs-rpc --lib`
- `git diff --check`