### PR TITLE
Preserve remote sync postponements

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/handle_rpc_legacy_remote_sync.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/handle_rpc_legacy_remote_sync.rs
@@ -147,6 +147,69 @@ impl RpcDaemon {
                     transfer_limit_kb,
                 ) {
                     Ok(mut result) => {
+                        let remote_synced = result.get("synced").and_then(JsonValue::as_bool);
+                        let remote_postponed =
+                            result.get("postponed").and_then(JsonValue::as_bool) == Some(true);
+                        if remote_synced == Some(false) || remote_postponed {
+                            let postpone_reason =
+                                result.get("postpone_reason").and_then(JsonValue::as_str);
+                            let error = result
+                                .get("error")
+                                .and_then(JsonValue::as_str)
+                                .unwrap_or("remote sync postponed")
+                                .to_string();
+                            self.update_propagation_sync_state(|state| {
+                                state.sync_state = PR_FAILED;
+                                state.state_name = "failed".to_string();
+                                state.sync_progress = 0.0;
+                                state.last_sync_error = Some(error.clone());
+                            });
+                            if postpone_reason == Some("throttled") {
+                                self.record_throttled_remote_peer_sync(
+                                    peer_key.as_str(),
+                                    remote_id.as_str(),
+                                    error.as_str(),
+                                    transfer_limit,
+                                    sync_limit,
+                                )?;
+                            } else {
+                                self.record_retryable_remote_peer_sync_error(
+                                    peer_key.as_str(),
+                                    remote_id.as_str(),
+                                    error.as_str(),
+                                    transfer_limit,
+                                    sync_limit,
+                                )?;
+                            }
+                            let peer_sync_result = self
+                                .event_queue
+                                .lock()
+                                .expect("event_queue mutex poisoned")
+                                .iter()
+                                .rev()
+                                .find(|event| {
+                                    event.event_type == "peer_sync"
+                                        && event.payload["peer"].as_str() == Some(peer_key.as_str())
+                                })
+                                .map(|event| event.payload.clone())
+                                .unwrap_or(JsonValue::Null);
+                            let propagation = self
+                                .propagation_state
+                                .lock()
+                                .expect("propagation mutex poisoned")
+                                .clone();
+                            return Ok(RpcResponse {
+                                id: request.id,
+                                result: Some(json!({
+                                    "remote": remote_id,
+                                    "peer": peer_key,
+                                    "propagation": propagation,
+                                    "peer_sync": peer_sync_result,
+                                    "result": result,
+                                })),
+                                error: None,
+                            });
+                        }
                         let imported = match self.import_remote_propagation_payloads(&result) {
                             Ok(imported) => imported,
                             Err(err) => {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_sync_marks_source.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_sync_marks_source.rs
@@ -376,3 +376,89 @@ fn propagation_remote_sync_imports_binary_peer_sync_payloads_from_msgpack() {
         .expect("local fetch result");
     assert_eq!(fetched["payload_hex"].as_str(), Some(payload_hex.as_str()));
 }
+
+#[test]
+fn propagation_remote_sync_preserves_remote_postponement_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "synced": false,
+            "postponed": true,
+            "postpone_reason": "throttled",
+            "error": "remote peer throttled",
+        })),
+    }));
+    let peer = "peer-remote-sync-postponed";
+    daemon
+        .handle_rpc(rpc_request(75, "peer_sync", json!({ "peer": peer })))
+        .expect("seed peer");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.alive = true;
+        record.sync_backoff = 12 * 60;
+        record.next_sync_attempt = 0;
+        record.acceptance_rate = 0.5;
+    }
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let result = daemon
+        .handle_rpc(rpc_request(
+            76,
+            "propagation_remote_sync",
+            json!({
+                "remote": "remote-node",
+                "peer": peer,
+            }),
+        ))
+        .expect("remote postponed sync should return a peer-sync result")
+        .result
+        .expect("remote sync result");
+
+    let peer_sync = &result["peer_sync"];
+    assert_eq!(peer_sync["synced"].as_bool(), Some(false));
+    assert_eq!(peer_sync["postponed"].as_bool(), Some(true));
+    assert_eq!(peer_sync["postpone_reason"].as_str(), Some("throttled"));
+    assert_eq!(peer_sync["sync_backoff"].as_u64(), Some(12 * 60));
+    let next_sync_attempt =
+        peer_sync["next_sync_attempt"].as_i64().expect("next sync attempt");
+    assert!(next_sync_attempt > 0);
+    assert_eq!(peer_sync["propagation"]["synced"].as_bool(), Some(false));
+    assert_eq!(peer_sync["propagation"]["postponed"].as_bool(), Some(true));
+    assert_eq!(
+        peer_sync["propagation"]["postpone_reason"].as_str(),
+        Some("throttled")
+    );
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 77, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(peer))
+        .expect("peer row");
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(next_sync_attempt));
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_sync")
+        .cloned()
+        .expect("remote postponed peer sync event");
+    assert_eq!(event.payload["peer"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote"].as_str(), Some("remote-node"));
+    assert_eq!(event.payload["remote_sync"].as_bool(), Some(true));
+    assert_eq!(event.payload["synced"].as_bool(), Some(false));
+    assert_eq!(event.payload["postponed"].as_bool(), Some(true));
+    assert_eq!(event.payload["postpone_reason"].as_str(), Some("throttled"));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(event.payload["next_sync_attempt"].as_i64(), Some(next_sync_attempt));
+}

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -160,6 +160,10 @@ The project is best described by capability level:
 - Remote peer-sync now uses the stored peer ID case for the bridge call, import
   source accounting, state updates, and response envelope when callers use a
   case-variant peer request.
+- Remote peer-sync bridge results that explicitly report `synced: false` or
+  `postponed: true` now preserve the remote postponement in the peer-sync
+  result/event and keep retry scheduling intact instead of clearing the peer's
+  backoff as if the transfer completed.
 - Failed remote unpeer attempts now mirror existing payload-backed live queue
   marks and restored peer-record queue IDs into active peer record snapshots
   before returning bridge-unavailable or bridge-execution errors, including

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -201,6 +201,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote peer-sync uses the stored peer ID case for the bridge call, import
   source accounting, state updates, and response envelope when callers supply a
   case-variant peer request.
+- Remote peer-sync bridge results that explicitly report `synced: false` or
+  `postponed: true` preserve that remote postponement in the peer-sync
+  result/event and keep retry scheduling intact instead of clearing peer
+  backoff as a completed transfer.
 - Failed remote unpeer attempts mirror existing payload-backed queue marks and
   restored peer-record queue IDs into active peer record snapshots before
   returning bridge-unavailable or bridge-execution errors, including


### PR DESCRIPTION
## Summary
- preserve OK bridge results that report remote peer-sync postponement instead of treating them as completed syncs
- keep retry/backoff scheduling intact for remote-side throttled/postponed responses and surface the postponed peer-sync result/event
- update the maintained roadmap and LXMF parity matrix for the new remote postponement behavior

## Verification
- RED: `cargo test -p reticulum-rs-rpc --lib propagation_remote_sync_preserves_remote_postponement_like_python -- --nocapture` failed before implementation with `peer_sync.synced` still `true`
- `cargo test -p reticulum-rs-rpc --lib propagation_remote_sync_preserves_remote_postponement_like_python -- --nocapture`
- `cargo test -p reticulum-rs-rpc --lib propagation_remote_sync -- --nocapture`
- `cargo check -p reticulum-rs-rpc`
- `cargo clippy -p reticulum-rs-rpc --lib -- -D warnings`
- `cargo test -p reticulum-rs-rpc --lib`
- `cargo fmt --check`
- `git diff --check`