### PR TITLE
Preserve postponed remote transfer results

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/module_prelude.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/module_prelude.rs
@@ -28,6 +28,24 @@ fn is_remote_transfer_attempt_error(error: &std::io::Error) -> bool {
     )
 }
 
+fn remote_transfer_incomplete_error(
+    result: &JsonValue,
+    default_message: &str,
+) -> Option<std::io::Error> {
+    let postponed = result.get("postponed").and_then(JsonValue::as_bool).unwrap_or(false);
+    let unsynced = result.get("synced").and_then(JsonValue::as_bool) == Some(false);
+    if !postponed && !unsynced {
+        return None;
+    }
+
+    let message = result
+        .get("error")
+        .and_then(JsonValue::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(default_message);
+    Some(std::io::Error::new(std::io::ErrorKind::WouldBlock, message))
+}
+
 struct RemotePropagationImportSummary {
     imported_count: usize,
     duplicate_count: usize,

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/handle_rpc_legacy_remote_download_fetch.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/handle_rpc_legacy_remote_download_fetch.rs
@@ -57,57 +57,82 @@ impl RpcDaemon {
                     parsed.transfer_limit_kb,
                 ) {
                     Ok(mut result) => {
-                        let imported = match self.import_remote_propagation_payloads(&result) {
-                            Ok(imported) => imported,
-                            Err(err) => {
-                                self.update_propagation_sync_state(|state| {
-                                    state.sync_state = PR_FAILED;
-                                    state.state_name = "failed".to_string();
-                                    state.sync_progress = 0.0;
-                                    state.last_sync_error = Some(err.to_string());
-                                });
-                                self.record_failed_remote_import_for_active_source_peer(
-                                    remote_id.as_str(),
-                                    remote_id.as_str(),
-                                    &err,
-                                )?;
-                                for peer in self.active_peer_ids() {
-                                    self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
-                                }
-                                return Err(err);
+                        if let Some(err) =
+                            remote_transfer_incomplete_error(&result, "remote download postponed")
+                        {
+                            self.update_propagation_sync_state(|state| {
+                                state.sync_state = PR_FAILED;
+                                state.state_name = "failed".to_string();
+                                state.sync_progress = 0.0;
+                                state.last_sync_error = Some(err.to_string());
+                            });
+                            self.record_failed_remote_transfer_for_active_source_peer(
+                                remote_id.as_str(),
+                                remote_id.as_str(),
+                                &err,
+                            )?;
+                            for peer in self.active_peer_ids() {
+                                self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
                             }
-                        };
-                        if let Some(result) = result.as_object_mut() {
-                            result.insert(
-                                "imported_count".to_string(),
-                                json!(imported.imported_count),
-                            );
-                            result.insert(
-                                "duplicate_count".to_string(),
-                                json!(imported.duplicate_count),
-                            );
-                            result.insert("imported_ids".to_string(), json!(imported.imported_ids));
-                            result.insert(
-                                "transferred_bytes".to_string(),
-                                json!(imported.transferred_bytes),
-                            );
+                            result
+                        } else {
+                            let imported = match self.import_remote_propagation_payloads(&result) {
+                                Ok(imported) => imported,
+                                Err(err) => {
+                                    self.update_propagation_sync_state(|state| {
+                                        state.sync_state = PR_FAILED;
+                                        state.state_name = "failed".to_string();
+                                        state.sync_progress = 0.0;
+                                        state.last_sync_error = Some(err.to_string());
+                                    });
+                                    self.record_failed_remote_import_for_active_source_peer(
+                                        remote_id.as_str(),
+                                        remote_id.as_str(),
+                                        &err,
+                                    )?;
+                                    for peer in self.active_peer_ids() {
+                                        self.record_payload_backed_peer_queue_snapshot(
+                                            peer.as_str(),
+                                        )?;
+                                    }
+                                    return Err(err);
+                                }
+                            };
+                            if let Some(result) = result.as_object_mut() {
+                                result.insert(
+                                    "imported_count".to_string(),
+                                    json!(imported.imported_count),
+                                );
+                                result.insert(
+                                    "duplicate_count".to_string(),
+                                    json!(imported.duplicate_count),
+                                );
+                                result.insert(
+                                    "imported_ids".to_string(),
+                                    json!(imported.imported_ids),
+                                );
+                                result.insert(
+                                    "transferred_bytes".to_string(),
+                                    json!(imported.transferred_bytes),
+                                );
+                            }
+                            self.queue_remote_imports_from_source_for_active_peers(
+                                remote_id.as_str(),
+                                imported.accepted_ids.as_slice(),
+                                imported.transferred_bytes,
+                            )?;
+                            for peer in self.active_peer_ids() {
+                                self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
+                            }
+                            self.update_propagation_sync_state(|state| {
+                                state.sync_state = PR_COMPLETE;
+                                state.state_name = "completed".to_string();
+                                state.sync_progress = 1.0;
+                                state.last_sync_completed = Some(now_i64());
+                                state.last_sync_error = None;
+                            });
+                            result
                         }
-                        self.queue_remote_imports_from_source_for_active_peers(
-                            remote_id.as_str(),
-                            imported.accepted_ids.as_slice(),
-                            imported.transferred_bytes,
-                        )?;
-                        for peer in self.active_peer_ids() {
-                            self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
-                        }
-                        self.update_propagation_sync_state(|state| {
-                            state.sync_state = PR_COMPLETE;
-                            state.state_name = "completed".to_string();
-                            state.sync_progress = 1.0;
-                            state.last_sync_completed = Some(now_i64());
-                            state.last_sync_error = None;
-                        });
-                        result
                     }
                     Err(err) => {
                         let sync_state = remote_propagation_failure_state(&err);
@@ -258,6 +283,35 @@ impl RpcDaemon {
                         return Err(err);
                     }
                 };
+                if let Some(err) =
+                    remote_transfer_incomplete_error(&result, "remote fetch postponed")
+                {
+                    self.update_propagation_sync_state(|state| {
+                        state.sync_state = PR_FAILED;
+                        state.state_name = "failed".to_string();
+                        state.sync_progress = 0.0;
+                        state.last_sync_error = Some(err.to_string());
+                    });
+                    self.record_failed_remote_transfer_for_active_source_peer(
+                        remote_id.as_str(),
+                        remote_id.as_str(),
+                        &err,
+                    )?;
+                    for peer in self.active_peer_ids() {
+                        self.record_payload_backed_peer_queue_snapshot(peer.as_str())?;
+                    }
+                    let propagation =
+                        self.propagation_state.lock().expect("propagation mutex poisoned").clone();
+                    return Ok(RpcResponse {
+                        id: request.id,
+                        result: Some(json!({
+                            "remote": remote_id,
+                            "propagation": propagation,
+                            "result": result,
+                        })),
+                        error: None,
+                    });
+                }
                 let imported = match self.import_remote_propagation_payloads(&result) {
                     Ok(imported) => imported,
                     Err(err) => {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot.rs
@@ -80,6 +80,8 @@ include!("status_snapshot_parts/propagation_remote_imports_match_sou.rs");
 
 include!("status_snapshot_parts/propagation_remote_fetch_updates_lif.rs");
 
+include!("status_snapshot_parts/propagation_remote_fetch_postponed_result.rs");
+
 include!("status_snapshot_parts/propagation_remote_download_success_clears_backoff.rs");
 
 include!("status_snapshot_parts/propagation_remote_download_success_queue_snapshot.rs");

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_fetch_postponed_result.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_fetch_postponed_result.rs
@@ -1,0 +1,93 @@
+#[test]
+fn postponed_propagation_remote_fetch_updates_source_peer_backoff_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "available_count": 0,
+            "fetched_count": 0,
+            "messages": [],
+            "postponed": true,
+            "postpone_reason": "throttled",
+            "synced": false,
+            "error": "remote fetch postponed",
+        })),
+    }));
+    let peer = "peer-remote-fetch-postponed-backoff";
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.alive = true;
+        record.sync_backoff = 0;
+        record.next_sync_attempt = 0;
+        record.acceptance_rate = 0.5;
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "c8".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_627,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let result = daemon
+        .handle_rpc(rpc_request(81, "propagation_remote_fetch", json!({ "remote": peer })))
+        .expect("postponed remote fetch should return the bridge envelope")
+        .result
+        .expect("remote fetch result");
+    assert_eq!(result["result"]["postponed"].as_bool(), Some(true));
+    assert_eq!(result["result"]["postpone_reason"].as_str(), Some("throttled"));
+    assert_eq!(result["result"]["synced"].as_bool(), Some(false));
+    assert_eq!(result["propagation"]["sync_state"].as_u64(), Some(0xfe));
+    assert_eq!(result["propagation"]["state_name"].as_str(), Some("failed"));
+    assert_eq!(result["propagation"]["last_sync_error"].as_str(), Some("remote fetch postponed"));
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 82, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(peer))
+        .expect("peer row");
+    assert_eq!(row["alive"].as_bool(), Some(false));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(
+        row["messages"]["unhandled_ids"].as_array().expect("unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_sync")
+        .cloned()
+        .expect("postponed remote fetch peer event");
+    assert_eq!(event.payload["peer"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote"].as_str(), Some(peer));
+    assert_eq!(event.payload["remote_sync"].as_bool(), Some(true));
+    assert_eq!(event.payload["synced"].as_bool(), Some(false));
+    assert_eq!(event.payload["alive"].as_bool(), Some(false));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(
+        event.payload["propagation"]["error"].as_str(),
+        Some("remote fetch postponed")
+    );
+}

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -128,6 +128,10 @@ The project is best described by capability level:
   returning and mark the propagation sync lifecycle failed, so already queued
   relay work stays restart/export visible without leaving stale lifecycle state
   when no bridge is configured.
+- Remote fetch and download bridge envelopes that return successfully while
+  reporting `postponed` or `synced: false` now preserve the failed transfer
+  lifecycle, source-peer backoff, peer event, and queue snapshot instead of
+  importing an empty result and marking propagation complete.
 - Successful remote fetch and download now also mirror existing payload-backed
   live queue marks into active peer record snapshots after applying imports, so
   restart/export state preserves queued retry work even when the remote

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -411,6 +411,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   counts and receive bytes only for payload IDs not already marked received
   from that source, while still replaying known payloads into relay queues when
   their live marks were cleared.
+- Remote fetch/download bridge envelopes that successfully return `postponed`
+  or `synced: false` preserve the failed transfer lifecycle, source-peer
+  backoff, failed peer event, and retryable queue snapshot instead of treating
+  the transfer as an empty completed import.
 - Successful remote fetch/download imports clear stale retry backoff on an
   active source peer after newly accepted payloads, so recovered propagation
   sources are not left postponed by an earlier failed transfer attempt.


### PR DESCRIPTION
## Summary
- treat remote fetch/download OK envelopes with `postponed` or `synced: false` as failed transfer lifecycle results instead of completed empty imports
- preserve source-peer backoff, failed peer events, and payload-backed queue snapshots for postponed remote fetch/download results
- update the roadmap and LXMF parity matrix with the landed transfer behavior

## Verification
- `cargo test -p reticulum-rs-rpc postponed_propagation_remote_fetch_updates_source_peer_backoff_like_python -- --nocapture`
- `cargo test -p reticulum-rs-rpc propagation_remote_fetch -- --nocapture`
- `cargo test -p reticulum-rs-rpc propagation_remote_download -- --nocapture`
- `cargo check -p reticulum-rs-rpc`
- `cargo clippy -p reticulum-rs-rpc --lib -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p reticulum-rs-rpc --lib`