### PR TITLE
Clear stale stamp retry errors

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_payload.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_payload.rs
@@ -80,6 +80,9 @@ impl DeliveryTask {
             entries
                 .push(("stamp_ticket_source".to_string(), JsonValue::String(ticket.to_string())));
         }
+        if state != "failed" {
+            entries.push(("stamp_error".to_string(), JsonValue::Null));
+        }
         let _ = self.daemon.record_message_lxmf_metadata_entries(&self.message_id, entries);
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_propagation.rs
@@ -88,6 +88,9 @@ impl DeliveryTask {
             };
             entries.push((key.to_string(), value));
         }
+        if state != "failed" {
+            entries.push(("propagation_stamp_error".to_string(), JsonValue::Null));
+        }
         let _ = self.daemon.record_message_lxmf_metadata_entries(&self.message_id, entries);
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests_parts/oversized_opportunistic_delivery_fal.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests_parts/oversized_opportunistic_delivery_fal.rs
@@ -261,7 +261,12 @@ async fn build_payload_records_normal_stamp_lifecycle_metadata() {
             content: String::new(),
             timestamp: 0,
             direction: "out".to_string(),
-            fields: Some(json!({"app": "value"})),
+            fields: Some(json!({
+                "app": "value",
+                "_lxmf": {
+                    "stamp_error": "previous failed stamp attempt"
+                }
+            })),
             receipt_status: Some("queued".to_string()),
         })
         .expect("insert message");
@@ -323,6 +328,7 @@ async fn build_payload_records_normal_stamp_lifecycle_metadata() {
     assert_eq!(message["fields"]["_lxmf"]["stamp_state"], json!("ready"));
     assert_eq!(message["fields"]["_lxmf"]["stamp_kind"], json!("pow"));
     assert_eq!(message["fields"]["_lxmf"]["stamp_target_cost"], json!(1));
+    assert_eq!(message["fields"]["_lxmf"]["stamp_error"], JsonValue::Null);
 }
 
 #[tokio::test]

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests_parts/record_propagation_payload_metadata.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests_parts/record_propagation_payload_metadata.rs
@@ -81,6 +81,48 @@ async fn record_propagation_payload_metadata_persists_packed_bytes() {
 }
 
 #[tokio::test]
+async fn propagation_stamp_retry_clears_stale_error_metadata() {
+    let message_id = "propagation-stamp-retry-clears-error";
+    let store = MessagesStore::in_memory().expect("store");
+    store
+        .insert_message(&MessageRecord {
+            id: message_id.to_string(),
+            source: "source".to_string(),
+            destination: "00000000000000000000000000000000".to_string(),
+            title: String::new(),
+            content: String::new(),
+            timestamp: 0,
+            direction: "out".to_string(),
+            fields: Some(json!({
+                "_lxmf": {
+                    "propagation_stamp_error": "previous propagation stamp failure"
+                }
+            })),
+            receipt_status: Some("queued".to_string()),
+        })
+        .expect("insert message");
+    let daemon = Arc::new(RpcDaemon::with_store(store, "propagation-stamp-retry-node".to_string()));
+    let mut task = delivery_task_for_propagation_cost_lookup(daemon.clone());
+    task.message_id = message_id.to_string();
+
+    task.record_propagation_stamp_work_metadata("generating", 5, None);
+
+    let result = daemon
+        .handle_rpc(RpcRequest { id: 79, method: "list_messages".to_string(), params: None })
+        .expect("list messages")
+        .result
+        .expect("result");
+    let message = result["messages"]
+        .as_array()
+        .expect("messages")
+        .iter()
+        .find(|message| message["id"].as_str() == Some(message_id))
+        .expect("message");
+    assert_eq!(message["fields"]["_lxmf"]["propagation_stamp_state"], json!("generating"));
+    assert_eq!(message["fields"]["_lxmf"]["propagation_stamp_error"], JsonValue::Null);
+}
+
+#[tokio::test]
 async fn propagation_target_cost_matches_selected_node_case_insensitively() {
     let daemon = Arc::new(RpcDaemon::test_instance());
     daemon

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -248,6 +248,9 @@ The project is best described by capability level:
 - Outbound propagated delivery now resolves selected propagation-node
   `propagation_stamp_cost` case-insensitively, so Python-style hash casing does
   not fall back to the default propagation stamp cost.
+- Normal and propagation stamp retry metadata now clears stale stamp error
+  fields when later work re-enters generating/ready state, so status no longer
+  reports a prior failed attempt after a successful retry.
 - Peer sync queue creation also records newly queued existing propagation IDs in
   the peer record snapshot, so postponed syncs can restart/export with the same
   unhandled queue visible in live status.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -87,6 +87,8 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Inbound normal and propagation stamps honor configured flexibility.
 - Outbound normal and propagation work records generating, ready, failed, and
   cancelled state.
+- Normal and propagation stamp retry metadata clears stale error fields when
+  later work re-enters generating/ready state.
 - The remaining gap is background queue/worker/retry behavior, not basic stamp
   cryptography or ticket semantics.
 


### PR DESCRIPTION
## Summary
- clear stale normal stamp errors when retry metadata returns to generating/ready
- clear stale propagation stamp errors when retry metadata returns to generating/ready
- update roadmap and parity matrix status notes

## Verification
- cargo test -p reticulumd build_payload_records_normal_stamp_lifecycle_metadata -- --nocapture (RED before fix)
- cargo test -p reticulumd stamp -- --nocapture (RED before fix, then GREEN)
- cargo test -p reticulumd bridge::delivery_task_tests -- --nocapture
- cargo test -p reticulumd --bin reticulumd -- --nocapture
- cargo check -p reticulumd
- cargo clippy -p reticulumd -- -D warnings
- cargo clippy -p reticulumd --all-targets -- -D warnings
- cargo fmt --check
- git diff --check