### PR TITLE
Make peer sync offer transfers atomic

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/localunpeercleanup.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/localunpeercleanup.rs
@@ -377,6 +377,28 @@ fn peer_sync_resource_data_size(payloads: &[Vec<u8>]) -> Result<u64, std::io::Er
     Ok(packed.len() as u64)
 }
 
+fn decode_peer_sync_transfer(
+    entry: &PropagationEntryRecord,
+) -> Result<(JsonValue, Vec<u8>), std::io::Error> {
+    let payload_bytes = hex::decode(entry.payload_hex.as_str()).map_err(|err| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid propagation payload hex: {err}"),
+        )
+    })?;
+    Ok((
+        json!({
+            "transient_id": entry.transient_id,
+            "destination": entry.destination,
+            "payload_hex": entry.payload_hex,
+            "received_at": entry.received_at,
+            "size_bytes": entry.size_bytes,
+            "stamp_value": entry.stamp_value,
+        }),
+        payload_bytes,
+    ))
+}
+
 fn propagation_peer_sync_weight(
     entry: &PropagationEntryRecord,
     now: i64,

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/handle_rpc_legacy_peer_sync.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/handle_rpc_legacy_peer_sync.rs
@@ -239,6 +239,9 @@ impl RpcDaemon {
         let mut propagation_skipped_ids = Vec::new();
         let mut propagation_messages = Vec::new();
         let mut propagation_resource_payloads = Vec::new();
+        let mut propagation_transfer_limited_marks = Vec::new();
+        let mut propagation_handled_marks = Vec::new();
+        let mut propagation_transfer_marks = Vec::new();
         let selected_response_ids =
             wanted_ids.as_ref().and_then(PeerSyncWantedIds::selected_ids).map(<[_]>::to_vec);
         let mut selected_offer_entries = std::collections::HashMap::new();
@@ -250,10 +253,7 @@ impl RpcDaemon {
                 propagation_transfer_limited_bytes =
                     propagation_transfer_limited_bytes.saturating_add(entry.size_bytes);
                 let transient_id = entry.transient_id;
-                self.store
-                    .mark_peer_transfer_limited_propagation(peer_key, transient_id.as_str())
-                    .map_err(std::io::Error::other)?;
-                self.record_peer_queue_handled(peer_key, transient_id.as_str());
+                propagation_transfer_limited_marks.push(transient_id.clone());
                 propagation_transfer_limited_ids.push(transient_id);
                 continue;
             }
@@ -275,28 +275,18 @@ impl RpcDaemon {
                 if selected_response_ids.is_some() {
                     selected_offer_entries.insert(transient_id.clone(), entry);
                 } else {
-                    let payload_bytes = hex::decode(entry.payload_hex.as_str()).map_err(|err| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            format!("invalid propagation payload hex: {err}"),
-                        )
-                    })?;
-                    let propagation_message = json!({ "transient_id": entry.transient_id, "destination": entry.destination, "payload_hex": entry.payload_hex, "received_at": entry.received_at, "size_bytes": entry.size_bytes, "stamp_value": entry.stamp_value, });
-                    self.store
-                        .mark_peer_transferred_propagation(peer_key, transient_id.as_str())
-                        .map_err(std::io::Error::other)?;
-                    self.record_peer_queue_handled(peer_key, transient_id.as_str());
+                    let (propagation_message, payload_bytes) = decode_peer_sync_transfer(&entry)?;
+                    propagation_transfer_marks.push((
+                        transient_id.clone(),
+                        propagation_message,
+                        payload_bytes,
+                    ));
                     propagation_transferred = propagation_transferred.saturating_add(1);
                     propagation_bytes = propagation_bytes.saturating_add(entry.size_bytes);
                     propagation_transferred_ids.push(transient_id.clone());
-                    propagation_messages.push(propagation_message);
-                    propagation_resource_payloads.push(payload_bytes);
                 }
             } else {
-                self.store
-                    .mark_peer_handled_propagation(peer_key, transient_id.as_str())
-                    .map_err(std::io::Error::other)?;
-                self.record_peer_queue_handled(peer_key, transient_id.as_str());
+                propagation_handled_marks.push(transient_id.clone());
             }
             propagation_handled_ids.push(transient_id);
         }
@@ -306,13 +296,7 @@ impl RpcDaemon {
                 let Some(entry) = selected_offer_entries.get(wanted_id) else {
                     continue;
                 };
-                let payload_bytes = hex::decode(entry.payload_hex.as_str()).map_err(|err| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("invalid propagation payload hex: {err}"),
-                    )
-                })?;
-                let propagation_message = json!({ "transient_id": entry.transient_id, "destination": entry.destination, "payload_hex": entry.payload_hex, "received_at": entry.received_at, "size_bytes": entry.size_bytes, "stamp_value": entry.stamp_value, });
+                let (propagation_message, payload_bytes) = decode_peer_sync_transfer(entry)?;
                 selected_transfers.push((
                     wanted_id.clone(),
                     entry.size_bytes,
@@ -321,16 +305,35 @@ impl RpcDaemon {
                 ));
             }
             for (wanted_id, size_bytes, propagation_message, payload_bytes) in selected_transfers {
-                self.store
-                    .mark_peer_transferred_propagation(peer_key, wanted_id.as_str())
-                    .map_err(std::io::Error::other)?;
-                self.record_peer_queue_handled(peer_key, wanted_id.as_str());
+                propagation_transfer_marks.push((
+                    wanted_id.clone(),
+                    propagation_message,
+                    payload_bytes,
+                ));
                 propagation_transferred = propagation_transferred.saturating_add(1);
                 propagation_bytes = propagation_bytes.saturating_add(size_bytes);
                 propagation_transferred_ids.push(wanted_id.clone());
-                propagation_messages.push(propagation_message);
-                propagation_resource_payloads.push(payload_bytes);
             }
+        }
+        for transient_id in propagation_transfer_limited_marks {
+            self.store
+                .mark_peer_transfer_limited_propagation(peer_key, transient_id.as_str())
+                .map_err(std::io::Error::other)?;
+            self.record_peer_queue_handled(peer_key, transient_id.as_str());
+        }
+        for transient_id in propagation_handled_marks {
+            self.store
+                .mark_peer_handled_propagation(peer_key, transient_id.as_str())
+                .map_err(std::io::Error::other)?;
+            self.record_peer_queue_handled(peer_key, transient_id.as_str());
+        }
+        for (transient_id, propagation_message, payload_bytes) in propagation_transfer_marks {
+            self.store
+                .mark_peer_transferred_propagation(peer_key, transient_id.as_str())
+                .map_err(std::io::Error::other)?;
+            self.record_peer_queue_handled(peer_key, transient_id.as_str());
+            propagation_messages.push(propagation_message);
+            propagation_resource_payloads.push(payload_bytes);
         }
         let mut propagation_resource_bytes =
             peer_sync_resource_data_size(propagation_resource_payloads.as_slice())?;

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/peer_sync_preserves_transfer_rate_wh.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/peer_sync_preserves_transfer_rate_wh.rs
@@ -350,3 +350,84 @@ fn peer_sync_invalid_response_payload_does_not_partially_mark_transferred_like_p
         &[json!(valid.transient_id.as_str()), json!(invalid.transient_id.as_str())]
     );
 }
+
+#[test]
+fn peer_sync_true_response_invalid_payload_does_not_partially_mark_transferred_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-invalid-true-response-payload";
+    daemon
+        .handle_rpc(rpc_request(65, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.propagation_stamp_cost = Some(0);
+    }
+
+    let valid = PropagationEntryRecord {
+        transient_id: "a3".repeat(32),
+        destination: "18".repeat(16),
+        payload_hex: "24".repeat(24),
+        received_at: 1_700_000_619,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    let invalid = PropagationEntryRecord {
+        transient_id: "a4".repeat(32),
+        destination: "18".repeat(16),
+        payload_hex: "not-hex".to_string(),
+        received_at: 1_700_000_620,
+        size_bytes: 30,
+        stamp_value: None,
+    };
+    for entry in [&valid, &invalid] {
+        daemon.store.upsert_propagation_entry(entry).expect("store propagation entry");
+        daemon
+            .store
+            .mark_peer_unhandled_propagation(peer, entry.transient_id.as_str())
+            .expect("mark unhandled");
+        daemon.record_peer_queue_unhandled_id(peer, entry.transient_id.as_str());
+    }
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            66,
+            "peer_sync",
+            json!({
+                "peer": peer,
+                "wanted_ids": true,
+            }),
+        ))
+        .expect_err("invalid true response payload should fail peer sync");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("invalid propagation payload hex"),
+        "unexpected error: {err}"
+    );
+
+    let pending = daemon
+        .store
+        .list_peer_unhandled_propagation(peer)
+        .expect("pending propagation");
+    assert_eq!(pending, vec![valid.clone(), invalid.clone()]);
+    assert!(
+        daemon
+            .store
+            .list_peer_handled_propagation_ids(peer)
+            .expect("handled propagation")
+            .is_empty()
+    );
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("peer record");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert!(
+        serialized["handled_ids"]
+            .as_array()
+            .expect("serialized handled ids")
+            .is_empty()
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(valid.transient_id.as_str()), json!(invalid.transient_id.as_str())]
+    );
+}

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -220,6 +220,10 @@ The project is best described by capability level:
 - Restored Python peer records now update their serialized queue ID snapshot
   when peer sync handles, transfers, or transfer-limits queued offers, reducing
   restart/export drift after live offer-response processing.
+- Peer sync offer acceptance now validates all transfer payload hex before
+  marking any offered payload transferred, handled, or transfer-limited, so a
+  malformed response batch cannot partially mutate live marks or serialized
+  restart/export queue snapshots.
 - Restored Python peer records now parse fractional `propagation_sync_limit`
   values through Python's integer-kilobyte restore path before peer-sync queue
   selection, preventing restored fractional sync limits from transferring work

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -262,6 +262,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   peer snapshot, source-peer handled IDs are preserved for restart/export, and
   offer-response handling keeps IDs in sync when queued messages become handled,
   transferred, or transfer-limited.
+- Peer sync offer acceptance validates all transfer payload hex before marking
+  any offered payload transferred, handled, or transfer-limited, so malformed
+  response batches cannot partially mutate live marks or serialized
+  restart/export queue snapshots.
 - Restored Python peer records parse fractional `propagation_sync_limit` values
   through Python's integer-kilobyte restore path before peer-sync queue
   selection, so restored fractional sync limits leave the same queued work


### PR DESCRIPTION
## Summary
- make peer-sync offer acceptance validate transfer payload hex before mutating peer queue marks
- keep malformed `wanted_ids: true` response batches from partially moving live or serialized queue state
- update roadmap and LXMF parity matrix with the landed queue lifecycle behavior

## Verification
- cargo test -p reticulum-rs-rpc peer_sync_true_response_invalid_payload_does_not_partially_mark_transferred_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc peer_sync_invalid_response_payload_does_not_partially_mark_transferred_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc peer_sync_offer_response_only_transfers_wanted_messages_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc peer_sync_preserves_transfer_rate -- --nocapture
- cargo test -p reticulum-rs-rpc peer_sync -- --nocapture
- cargo test -p reticulum-rs-rpc --lib -- --nocapture
- cargo check -p reticulum-rs-rpc
- cargo fmt --check
- cargo clippy -p reticulum-rs-rpc -- -D warnings
- cargo clippy -p reticulum-rs-rpc --all-targets -- -D warnings
- git diff --check