### PR TITLE
Advance remote sync bridge retry backoff

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/handle_rpc_legacy_remote_sync.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/handle_rpc_legacy_remote_sync.rs
@@ -93,15 +93,13 @@ impl RpcDaemon {
                                 state.last_sync_error =
                                     Some("remote control bridge unavailable".to_string());
                             });
-                            self.record_payload_backed_peer_queue_snapshot(record.peer.as_str())?;
-                            self.publish_failed_remote_peer_sync_event(
+                            self.record_retryable_remote_peer_sync_error(
                                 record.peer.as_str(),
                                 remote_id.as_str(),
                                 "remote control bridge unavailable",
                                 transfer_limit,
                                 sync_limit,
-                                None,
-                            );
+                            )?;
                         }
                         return Err(std::io::Error::other("remote control bridge unavailable"));
                     }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_sync_respects_pee.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_sync_respects_pee.rs
@@ -357,6 +357,22 @@ fn propagation_remote_sync_missing_bridge_reports_existing_peer_failure_like_pyt
         Some("remote control bridge unavailable")
     );
 
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 99, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(peer))
+        .expect("peer should remain queued for retry");
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
+
     let event = daemon
         .event_queue
         .lock()
@@ -373,6 +389,12 @@ fn propagation_remote_sync_missing_bridge_reports_existing_peer_failure_like_pyt
     assert_eq!(
         event.payload["propagation"]["error"].as_str(),
         Some("remote control bridge unavailable")
+    );
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(event.payload["last_sync_attempt"].as_i64(), Some(last_sync_attempt));
+    assert_eq!(
+        event.payload["next_sync_attempt"].as_i64(),
+        Some(last_sync_attempt + 12 * 60)
     );
     assert_eq!(
         event.payload["messages"]["unhandled_ids"].as_array().expect("event unhandled ids"),

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -144,8 +144,9 @@ The project is best described by capability level:
   case-insensitive requests, while still avoiding peer creation when the bridge
   is absent.
 - Remote peer-sync bridge-unavailable errors for already known peers now also
-  publish the failed peer-sync event and mark the propagation sync lifecycle
-  failed, keeping queue retry state observable without creating new peers.
+  advance that peer's retry backoff, publish the failed peer-sync event, and
+  mark the propagation sync lifecycle failed, keeping queue retry state
+  observable without creating new peers.
 - Peer sync RPC rows and events now preserve the Python-compatible peer `state`
   namespace while exposing backoff and policy postponement through separate
   scheduling fields; failed attempts continue to use the established error state.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -181,8 +181,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   case-insensitive requests, without creating new peers when the bridge is
   absent.
 - Remote peer-sync bridge-unavailable errors for already known peers also
-  publish the failed peer-sync event and mark the propagation sync lifecycle
-  failed, keeping queued retry state observable without creating new peers.
+  advance that peer's retry backoff, publish the failed peer-sync event, and
+  mark the propagation sync lifecycle failed, keeping queued retry state
+  observable without creating new peers.
 - Peer sync RPC rows and events preserve the Python-compatible peer `state`
   namespace while exposing backoff and policy postponement through separate
   scheduling fields; failed attempts continue to use the established error state.


### PR DESCRIPTION
## Summary
- route known-peer remote sync bridge-unavailable failures through the retryable peer-sync path
- assert retry backoff and next-attempt fields on the peer row and failed event
- update roadmap and LXMF parity matrix notes for the completed behavior

## Verification
- cargo test -p reticulum-rs-rpc propagation_remote_sync_missing_bridge_reports_existing_peer_failure_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc propagation_remote_sync_missing_bridge -- --nocapture
- cargo test -p reticulum-rs-rpc propagation_remote_sync -- --nocapture
- cargo fmt --check
- cargo test -p reticulum-rs-rpc --lib
- cargo check -p reticulum-rs-rpc
- cargo clippy -p reticulum-rs-rpc --all-targets -- -D warnings
- git diff --check