### PR TITLE
Validate full peer sync payload batch

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/localunpeercleanup.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/localunpeercleanup.rs
@@ -369,6 +369,34 @@ fn validate_peer_sync_wanted_ids_in_offer(
     Ok(())
 }
 
+fn validate_peer_sync_full_offer_payloads(
+    pending_propagation: &[PropagationEntryRecord],
+    transfer_limit_bytes: Option<usize>,
+    sync_limit_bytes: Option<usize>,
+    start_size: usize,
+) -> Result<(), std::io::Error> {
+    let mut cumulative_size = start_size;
+    for entry in pending_propagation {
+        let entry_size = usize::try_from(entry.size_bytes).unwrap_or(usize::MAX);
+        let transfer_size = entry_size.saturating_add(16);
+        if transfer_limit_bytes.is_some_and(|limit| transfer_size > limit) {
+            continue;
+        }
+        let next_size = cumulative_size.saturating_add(transfer_size);
+        if sync_limit_bytes.is_some_and(|limit| next_size >= limit) {
+            continue;
+        }
+        cumulative_size = next_size;
+        hex::decode(entry.payload_hex.as_str()).map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid propagation payload hex: {err}"),
+            )
+        })?;
+    }
+    Ok(())
+}
+
 fn peer_sync_resource_data_size(payloads: &[Vec<u8>]) -> Result<u64, std::io::Error> {
     if payloads.is_empty() {
         return Ok(0);

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/handle_rpc_legacy_peer_sync.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/handle_rpc_legacy_peer_sync.rs
@@ -242,6 +242,12 @@ impl RpcDaemon {
         let selected_response_ids =
             wanted_ids.as_ref().and_then(PeerSyncWantedIds::selected_ids).map(<[_]>::to_vec);
         let mut selected_offer_entries = std::collections::HashMap::new();
+        if selected_response_ids.is_none() {
+            validate_peer_sync_full_offer_payloads(
+                pending_propagation.as_slice(), transfer_limit_bytes, sync_limit_bytes,
+                cumulative_size,
+            )?;
+        }
         for entry in pending_propagation {
             let entry_size = usize::try_from(entry.size_bytes).unwrap_or(usize::MAX);
             let transfer_size = entry_size.saturating_add(16);

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/peer_sync_preserves_transfer_rate_wh.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/peer_sync_preserves_transfer_rate_wh.rs
@@ -350,3 +350,79 @@ fn peer_sync_invalid_response_payload_does_not_partially_mark_transferred_like_p
         &[json!(valid.transient_id.as_str()), json!(invalid.transient_id.as_str())]
     );
 }
+
+#[test]
+fn peer_sync_invalid_full_offer_payload_does_not_partially_mark_transferred_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-invalid-full-offer-payload";
+    daemon
+        .handle_rpc(rpc_request(65, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.propagation_stamp_cost = Some(0);
+        record.propagation_transfer_limit = Some(1_000);
+        record.propagation_sync_limit = Some(1_000);
+    }
+
+    let valid = PropagationEntryRecord {
+        transient_id: "a3".repeat(32),
+        destination: "19".repeat(16),
+        payload_hex: "24".repeat(24),
+        received_at: 1_700_000_619,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    let invalid = PropagationEntryRecord {
+        transient_id: "a4".repeat(32),
+        destination: "19".repeat(16),
+        payload_hex: "not-hex".to_string(),
+        received_at: 1_700_000_620,
+        size_bytes: 200,
+        stamp_value: None,
+    };
+    for entry in [&valid, &invalid] {
+        daemon.store.upsert_propagation_entry(entry).expect("store propagation entry");
+        daemon
+            .store
+            .mark_peer_unhandled_propagation(peer, entry.transient_id.as_str())
+            .expect("mark unhandled");
+        daemon.record_peer_queue_unhandled_id(peer, entry.transient_id.as_str());
+    }
+
+    let err = daemon
+        .handle_rpc(rpc_request(66, "peer_sync", json!({ "peer": peer })))
+        .expect_err("invalid full-offer payload should fail peer sync");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("invalid propagation payload hex"),
+        "unexpected error: {err}"
+    );
+
+    let pending = daemon
+        .store
+        .list_peer_unhandled_propagation(peer)
+        .expect("pending propagation");
+    assert_eq!(pending, vec![valid.clone(), invalid.clone()]);
+    assert!(
+        daemon
+            .store
+            .list_peer_handled_propagation_ids(peer)
+            .expect("handled propagation")
+            .is_empty()
+    );
+    let peers = daemon.peers.lock().expect("peers mutex poisoned");
+    let record = peers.get(peer).expect("peer record");
+    let serialized = serde_json::to_value(record).expect("serialize peer record");
+    assert!(
+        serialized["handled_ids"]
+            .as_array()
+            .expect("serialized handled ids")
+            .is_empty()
+    );
+    assert_eq!(
+        serialized["unhandled_ids"].as_array().expect("serialized unhandled ids"),
+        &[json!(valid.transient_id.as_str()), json!(invalid.transient_id.as_str())]
+    );
+}

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -254,6 +254,9 @@ The project is best described by capability level:
 - Local peer offer-error responses now publish failed peer-sync state fields at
   both the top-level peer event and nested propagation result while preserving
   the retryable peer queue, improving parity with the peer sync state machine.
+- Ordinary full-offer peer sync now validates the propagation payload batch
+  before marking any queued ID transferred, so a later malformed queued payload
+  cannot partially drain peer retry state.
 - Inbound and remotely imported propagation payloads update active peer record
   snapshots when they queue new unhandled IDs or mark source peers handled,
   keeping restart/export state aligned with live queue fan-out and source

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -142,6 +142,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Selected local peer-sync offer responses validate the full selected
   propagation response payload batch before marking any selected ID transferred,
   so malformed queued payloads cannot partially drain peer retry state.
+- Ordinary full-offer peer sync validates the propagation payload batch before
+  marking any queued ID transferred, so a later malformed queued payload cannot
+  partially drain peer retry state.
 - Malformed remote fetch and download imports mirror existing payload-backed
   queue marks into active peer record snapshots before returning the import
   failure, so already queued relay work remains visible after restart/export.


### PR DESCRIPTION
## Summary
- validate ordinary full-offer peer-sync propagation payloads before marking any queued ID transferred
- preserve unhandled peer retry state when a later queued payload has malformed hex
- update the current roadmap and LXMF parity matrix with the behavior delta

## Verification
- cargo fmt --check
- cargo test -p reticulum-rs-rpc peer_sync_invalid_full_offer_payload_does_not_partially_mark_transferred_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc peer_sync_invalid_response_payload_does_not_partially_mark_transferred_like_python -- --nocapture
- cargo test -p reticulum-rs-rpc peer_sync -- --nocapture
- cargo test -p reticulum-rs-rpc --lib
- cargo check -p reticulum-rs-rpc
- cargo clippy -p reticulum-rs-rpc --all-targets -- -D warnings
- git diff --check