### PR TITLE
[codex] Reject ignored remote propagation imports

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/import_remote_propagation_payloads.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/import_remote_propagation_payloads.rs
@@ -32,6 +32,12 @@ impl RpcDaemon {
             let Some((payload, payload_hex)) = remote_propagation_message_payload(message)? else {
                 continue;
             };
+            if self.propagation_payload_destination_is_ignored(payload.as_slice()) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "ignored propagation destination",
+                ));
+            }
             let canonical_transient_id = {
                 let mut hasher = Sha256::new();
                 hasher.update(payload.as_slice());

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_sync_ignores_payl.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_sync_ignores_payl.rs
@@ -198,6 +198,75 @@ fn propagation_remote_fetch_imports_payloads_into_local_store() {
 }
 
 #[test]
+fn propagation_remote_fetch_rejects_ignored_destination_without_queueing() {
+    let mut payload = vec![0x44_u8; 16];
+    payload.extend_from_slice(b"remote-fetch-ignored-destination-payload");
+    let payload_hex = hex::encode(&payload);
+    let transient_id = hex::encode(Sha256::digest(&payload));
+    let destination_hex = "44".repeat(16);
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(
+            72,
+            "set_delivery_policy",
+            json!({
+                "ignored_destinations": [destination_hex],
+            }),
+        ))
+        .expect("configure ignored destination");
+    daemon
+        .handle_rpc(rpc_request(73, "peer_sync", json!({ "peer": "peer-fetch-ignored-relay" })))
+        .expect("seed relay peer");
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(json!({
+            "available_count": 1,
+            "fetched_count": 1,
+            "messages": [{
+                "transient_id": transient_id,
+                "destination": destination_hex,
+                "payload_hex": payload_hex,
+            }],
+        })),
+    }));
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            74,
+            "propagation_remote_fetch",
+            json!({
+                "remote": "remote-node",
+            }),
+        ))
+        .expect_err("remote fetch for ignored destination should be rejected");
+    assert!(err.to_string().contains("ignored propagation destination"));
+
+    assert!(
+        daemon
+            .store
+            .get_propagation_entry(transient_id.as_str())
+            .expect("lookup ignored payload")
+            .is_none()
+    );
+    assert!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation("peer-fetch-ignored-relay")
+            .expect("relay queue after ignored import")
+            .is_empty()
+    );
+    let status = daemon
+        .handle_rpc(RpcRequest { id: 75, method: "propagation_status".to_string(), params: None })
+        .expect("propagation status")
+        .result
+        .expect("propagation status result");
+    assert_eq!(status["propagation"]["state_name"].as_str(), Some("failed"));
+    assert_eq!(
+        status["propagation"]["last_sync_error"].as_str(),
+        Some("ignored propagation destination")
+    );
+}
+
+#[test]
 fn propagation_remote_fetch_marks_source_received_and_queues_other_peers() {
     let payload = b"remote-fetch-source-peer-payload";
     let payload_hex = hex::encode(payload);

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -102,6 +102,9 @@ The project is best described by capability level:
 - Remote fetch/download/sync imports now validate the full returned propagation
   payload batch before mutating the local store or in-memory payload cache, so a
   mixed valid/invalid remote response fails without leaving partial relay state.
+- Remote fetch/download/sync imports now also reject payloads for ignored
+  destinations during batch validation, so remote relay responses cannot bypass
+  local replication policy or queue ignored work to peers.
 - Malformed remote fetch and download imports now mirror existing
   payload-backed live queue marks into active peer record snapshots before
   failing, preserving restart/export retry state for already queued relay work.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -139,6 +139,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Remote fetch/download/sync imports validate the full returned propagation
   payload batch before mutating the local store or in-memory payload cache, so
   mixed valid/invalid remote responses fail without leaving partial relay state.
+- Remote fetch/download/sync imports reject payloads for ignored destinations
+  during batch validation, so remote relay responses cannot bypass local
+  replication policy or queue ignored work to peers.
 - Selected local peer-sync offer responses validate the full selected
   propagation response payload batch before marking any selected ID transferred,
   so malformed queued payloads cannot partially drain peer retry state.


### PR DESCRIPTION
## Summary

- reject remote fetch/download/sync propagation payload imports whose destination is ignored by local delivery policy
- add a regression proving ignored remote fetch payloads fail before storage or relay queueing
- update the current roadmap and LXMF parity matrix with the new remote import policy behavior

## Validation

- `cargo test -p reticulum-rs-rpc propagation_remote_fetch_rejects_ignored_destination_without_queueing -- --nocapture` (red without guard, green with guard)
- `cargo test -p reticulum-rs-rpc propagation_remote_fetch -- --nocapture`
- `cargo test -p reticulum-rs-rpc propagation_remote_sync_import -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo test -p reticulum-rs-rpc propagation_remote_download -- --nocapture`
- `cargo test -p reticulum-rs-rpc propagation_remote_sync -- --nocapture`
- `cargo clippy -p reticulum-rs-rpc --all-targets -- -D warnings`