### PR TITLE
[codex] Deduplicate full CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,19 +264,10 @@ jobs:
       - interfaces-test-mobile-contract
       - interfaces-boundary-check
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Linux BLE build dependencies
+      - name: Interface full-CI aggregate
         run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libdbus-1-dev
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-targets: true
-          cache-on-failure: false
-      - name: Interfaces required checks
-        run: cargo xtask ci --stage interfaces-required
+          echo "All required interface jobs completed successfully."
+          echo "This aggregate job intentionally does not rerun interface checks."
 
   embedded-node-build:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
@@ -1089,6 +1080,9 @@ jobs:
   release-scorecard-check:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
+    needs:
+      - sdk-soak-check
+      - supply-chain-check
     steps:
       - uses: actions/checkout@v4
       - name: Install Linux BLE build dependencies
@@ -1101,6 +1095,14 @@ jobs:
         with:
           cache-targets: true
           cache-on-failure: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdk-soak-report
+          path: target/soak
+      - uses: actions/download-artifact@v4
+        with:
+          name: supply-chain-artifacts
+          path: target/supply-chain
       - name: Release scorecard generation gate
         run: cargo xtask ci --stage release-scorecard-check
       - uses: actions/upload-artifact@v4
@@ -1113,6 +1115,8 @@ jobs:
   canary-criteria-check:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-CI'))
     runs-on: ubuntu-latest
+    needs:
+      - release-scorecard-check
     steps:
       - uses: actions/checkout@v4
       - name: Install Linux BLE build dependencies
@@ -1125,6 +1129,10 @@ jobs:
         with:
           cache-targets: true
           cache-on-failure: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-scorecard
+          path: target/release-scorecard
       - name: Canary criteria and rollback trigger gate
         run: cargo xtask ci --stage canary-criteria-check
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/python-interop.yml
+++ b/.github/workflows/python-interop.yml
@@ -97,18 +97,6 @@ jobs:
           PYTHON_LXMF_PATH: ${{ github.workspace }}/LXMF
         run: python -m pytest tests/ --reference-only -v --tb=short
 
-      - name: Rust interop artifact gate
-        working-directory: lxmf-rs
-        run: cargo xtask ci --stage interop-artifacts
-
-      - name: Rust SDK conformance gate
-        working-directory: lxmf-rs
-        run: cargo xtask ci --stage sdk-conformance
-
-      - name: Rust E2E compatibility gate
-        working-directory: lxmf-rs
-        run: cargo xtask ci --stage e2e-compatibility
-
       - name: Rust/Python Reticulum channel interop
         working-directory: lxmf-rs
         env:

--- a/xtask/src/main_parts/run_ci_stage.rs
+++ b/xtask/src/main_parts/run_ci_stage.rs
@@ -125,6 +125,7 @@ fn run_release_check() -> Result<()> {
     run_compliance_profile_check()?;
     run_support_policy_check()?;
     run_unsafe_audit_check()?;
+    run_supply_chain_check()?;
     run_release_scorecard_check()?;
     run_canary_criteria_check()?;
     run_extension_registry_check()?;
@@ -135,7 +136,6 @@ fn run_release_check() -> Result<()> {
     run_changelog_migration_check()?;
     run_crypto_agility_check()?;
     run_key_management_check()?;
-    run_supply_chain_check()?;
     run_sdk_fuzz_check()?;
     run_sdk_property_check()?;
     run_sdk_model_check()?;

--- a/xtask/src/main_parts/run_release_scorecard_check.rs
+++ b/xtask/src/main_parts/run_release_scorecard_check.rs
@@ -1,6 +1,4 @@
 fn run_release_scorecard_check() -> Result<()> {
-    run_sdk_soak_check()?;
-    run_supply_chain_check()?;
     run("bash", &["-lc", "SCORECARD_MAX_SOAK_FAILURES=1 tools/scripts/release-scorecard.sh"])?;
 
     let markdown_path = "target/release-scorecard/release-scorecard.md";
@@ -27,7 +25,6 @@ fn run_release_scorecard_check() -> Result<()> {
 }
 
 fn run_canary_criteria_check() -> Result<()> {
-    run_release_scorecard_check()?;
     run(
         "bash",
         &[


### PR DESCRIPTION
﻿## Summary

This trims duplicated work from the full CI path without removing the underlying gates.

- make `interfaces-required` an aggregate job that depends on the individual interface jobs instead of rerunning them
- have `release-scorecard-check` consume the soak and supply-chain artifacts produced by their existing jobs
- have `canary-criteria-check` consume the release scorecard artifact instead of regenerating it
- remove duplicate Rust `interop-artifacts`, `sdk-conformance`, and `e2e-compatibility` gates from the Python reference interop workflow

## Impact

Normal PR CI is unchanged. Full CI should spend less time repeating the same interface, scorecard, canary, and interop prerequisites while preserving the same required signals through `needs` and artifact handoff.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p xtask`
- parsed `.github/workflows/ci.yml` and `.github/workflows/python-interop.yml` with PyYAML
- `git diff --check`
- `LXMF_RS_BASH="C:\Program Files\Git\bin\bash.exe" cargo xtask ci --stage release-scorecard-check`
- `LXMF_RS_BASH="C:\Program Files\Git\bin\bash.exe" cargo xtask ci --stage canary-criteria-check`

`actionlint` was not available locally.
