### PR TITLE
[codex] Expose LXMF basic field constants

### DIFF
--- a/crates/libs/lxmf-core/src/constants.rs
+++ b/crates/libs/lxmf-core/src/constants.rs
@@ -1,4 +1,9 @@
+pub const FIELD_TELEMETRY: u8 = 0x02;
+pub const FIELD_FILE_ATTACHMENTS: u8 = 0x05;
 pub const FIELD_COMMANDS: u8 = 0x09;
+pub const FIELD_TICKET: u8 = 0x0C;
+pub const FIELD_RNR_REFS: u8 = 0x0E;
+pub const FIELD_APP_EXTENSIONS: u8 = 0x10;
 
 pub const DESTINATION_LENGTH: usize = 16;
 pub const SIGNATURE_LENGTH: usize = 64;

--- a/crates/libs/lxmf-core/src/lib.rs
+++ b/crates/libs/lxmf-core/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-mod constants;
+pub mod constants;
 mod error;
 
 pub mod announce;

--- a/crates/libs/lxmf-core/src/payload_fields.rs
+++ b/crates/libs/lxmf-core/src/payload_fields.rs
@@ -68,7 +68,10 @@ impl WireFields {
 #[cfg(test)]
 mod tests {
     use super::{CommandEntry, WireFields};
-    use crate::constants::FIELD_COMMANDS;
+    use crate::constants::{
+        FIELD_APP_EXTENSIONS, FIELD_COMMANDS, FIELD_FILE_ATTACHMENTS, FIELD_RNR_REFS,
+        FIELD_TELEMETRY, FIELD_TICKET,
+    };
 
     #[test]
     fn commands_encode_with_integer_field_ids() {
@@ -85,5 +88,33 @@ mod tests {
             panic!("commands array expected")
         };
         assert_eq!(cmds.len(), 2);
+    }
+
+    #[test]
+    fn documented_basic_fields_encode_with_integer_field_ids() {
+        let mut fields = WireFields::new();
+        fields
+            .insert_field(FIELD_TELEMETRY, rmpv::Value::String("telemetry".into()))
+            .insert_field(FIELD_FILE_ATTACHMENTS, rmpv::Value::Array(Vec::new()))
+            .insert_field(FIELD_TICKET, rmpv::Value::Binary(vec![0xAA]))
+            .insert_field(FIELD_RNR_REFS, rmpv::Value::Array(Vec::new()))
+            .insert_field(FIELD_APP_EXTENSIONS, rmpv::Value::Map(Vec::new()));
+
+        let rmpv::Value::Map(entries) = fields.to_rmpv() else { panic!("expected map") };
+        let keys = entries
+            .iter()
+            .map(|(key, _)| key.as_i64().expect("integer field key"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            keys,
+            vec![
+                FIELD_TELEMETRY as i64,
+                FIELD_FILE_ATTACHMENTS as i64,
+                FIELD_TICKET as i64,
+                FIELD_RNR_REFS as i64,
+                FIELD_APP_EXTENSIONS as i64
+            ]
+        );
     }
 }

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
@@ -329,6 +329,53 @@ fn send_uses_zmq_sdk_method_and_preserves_delivery_options() {
     server.join().expect("server joined");
 }
 
+#[test]
+fn send_preserves_documented_lxmf_field_keys_over_zmq_sdk_method() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({ "message_id": "sdk-zmq-message-fields" }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let message_id = client
+        .send(SendRequest::new(
+            "source-destination",
+            "target-destination",
+            json!({
+                "title": "REM/RCH fields",
+                "content": "field preservation",
+                "2": { "lat": 1.25, "lon": 2.5 },
+                "5": [["image.jpg", [1, 2, 3]]],
+                "9": [{ "command_type": "status.request" }],
+                "12": [170, 187],
+                "14": ["ref-a"],
+                "16": { "renderer": "basic" },
+                "_lxmf_fields_msgpack_b64": "gqECoQk="
+            }),
+        ))
+        .expect("send");
+
+    assert_eq!(message_id.0, "sdk-zmq-message-fields");
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "sdk_send_v2");
+    let fields = &request.params.as_ref().expect("params")["fields"];
+    assert_eq!(fields["2"]["lat"], json!(1.25));
+    assert_eq!(fields["5"][0][0], json!("image.jpg"));
+    assert_eq!(fields["9"][0]["command_type"], json!("status.request"));
+    assert_eq!(fields["12"], json!([170, 187]));
+    assert_eq!(fields["14"][0], json!("ref-a"));
+    assert_eq!(fields["16"]["renderer"], json!("basic"));
+    assert_eq!(fields["_lxmf_fields_msgpack_b64"], json!("gqECoQk="));
+    server.join().expect("server joined");
+}
+
 fn parse_claims(token: &str) -> BTreeMap<String, String> {
     token
         .split(';')

--- a/docs/architecture/json-lxmf-fields.md
+++ b/docs/architecture/json-lxmf-fields.md
@@ -94,12 +94,15 @@ This matters for canonical LXMF fields such as:
 - ticket: field `0x0C`, JSON key form `"12"`
 
 The canonical field mappings are defined in
-`docs/contracts/payload-contract.md`.
+`docs/contracts/payload-contract.md` and exported from `lxmf-wire` through
+`lxmf_core::constants`.
 
 ## Commands Field Example
 
 `FIELD_COMMANDS` is a real LXMF field in `lxmf-wire`, not a free-form JSON
-label. Its numeric field id is `0x09`.
+label. Its numeric field id is `0x09`. The same constants module also exposes
+the documented telemetry, attachment, ticket, RNR refs, and app-extension field
+IDs.
 
 If callers need explicit command-field control, the canonical API is:
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -53,6 +53,9 @@ The project is best described by capability level:
 - Message wire/storage packing, signatures, propagation packing, paper
   encoding, timestamp precision metadata, binary-field preservation, and
   Python-compatible storage containers are implemented.
+- Documented basic LXMF field IDs are exported through `lxmf-wire`, and the
+  typed ZeroMQ SDK send path preserves those field keys plus
+  `_lxmf_fields_msgpack_b64` for REM/RCH payload compatibility.
 - Delivery modes are honored by the daemon; the old claim that requested modes
   are ignored is obsolete.
 - Direct and propagated resource sends support receipt-state separation,

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -70,6 +70,8 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Propagation and paper packing use canonical `lxmf-wire` helpers.
 - Signed messages, fields, attachment aliases, floating timestamps, and
   non-UTF8 title/content bytes retain client-visible fidelity.
+- Documented basic field IDs are exported from `lxmf-wire`, and the typed
+  ZeroMQ SDK send path preserves those keys plus `_lxmf_fields_msgpack_b64`.
 
 ### Delivery and receipts
 


### PR DESCRIPTION
## Summary
- export documented basic LXMF field IDs from lxmf-wire
- add wire-field tests that encode the documented basic fields as integer keys
- add ZeroMQ SDK send-path evidence for preserving documented field keys and _lxmf_fields_msgpack_b64
- update field architecture and roadmap/parity docs for the REM/RCH 0.4.0 field slice

## Validation
- cargo test -p lxmf-wire payload_fields -- --nocapture
- cargo test -p lxmf-sdk --features zmq-pipeline-backend send_preserves_documented_lxmf_field_keys_over_zmq_sdk_method -- --nocapture
- cargo fmt --check
- cargo check -p lxmf-wire -p lxmf-sdk --features lxmf-sdk/zmq-pipeline-backend
- cargo clippy -p lxmf-wire -p lxmf-sdk --features lxmf-sdk/zmq-pipeline-backend --all-targets -- -D warnings
- git diff --check