### PR TITLE
[codex] Add ZeroMQ SDK direct chat operation bridge

### DIFF
--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -1,3 +1,4 @@
+use crate::app::{Envelope, EnvelopeResponse, OperationRegistry};
 use crate::backend::SdkBackend;
 use crate::capability::{NegotiationRequest, NegotiationResponse};
 use crate::domain::{
@@ -443,6 +444,19 @@ impl SdkBackend for ZmqPipelineBackendClient {
         })?;
         let result = self.call_rpc("sdk_identity_bootstrap_v2", Some(params))?;
         Self::decode_field_or_root(&result, "contact", "identity_bootstrap response")
+    }
+
+    fn operation_registry(&self) -> Result<OperationRegistry, SdkError> {
+        let result = self.call_rpc("sdk_operation_registry_v2", Some(json!({})))?;
+        Self::decode_field_or_root(&result, "registry", "operation_registry response")
+    }
+
+    fn envelope_execute(&self, envelope: Envelope) -> Result<EnvelopeResponse, SdkError> {
+        let params = serde_json::to_value(envelope).map_err(|err| {
+            SdkError::new(code::INTERNAL, ErrorCategory::Internal, err.to_string())
+        })?;
+        let result = self.call_rpc("sdk_envelope_execute_v2", Some(params))?;
+        Self::decode_field_or_root(&result, "response", "envelope_execute response")
     }
 
     fn snapshot(&self) -> Result<RuntimeSnapshot, SdkError> {

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -20,6 +20,7 @@ use serde_json::{json, Value as JsonValue};
 use sha2::Sha256;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::RwLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
 use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
@@ -44,6 +45,7 @@ pub struct ZmqPipelineBackendClient {
     config: ZmqPipelineBackendConfig,
     session_id: String,
     next_request_id: AtomicU64,
+    negotiated_capabilities: RwLock<Vec<String>>,
     runtime: Runtime,
     transport: tokio::sync::Mutex<Option<ZmqPipelineTransport>>,
 }
@@ -62,6 +64,7 @@ impl ZmqPipelineBackendClient {
             config,
             session_id: new_session_id(),
             next_request_id: AtomicU64::new(1),
+            negotiated_capabilities: RwLock::new(Vec::new()),
             runtime,
             transport: tokio::sync::Mutex::new(None),
         })
@@ -73,6 +76,14 @@ impl ZmqPipelineBackendClient {
 
     fn next_request_id(&self) -> u64 {
         self.next_request_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn has_capability(&self, capability_id: &str) -> bool {
+        self.negotiated_capabilities
+            .read()
+            .expect("negotiated_capabilities rwlock poisoned")
+            .iter()
+            .any(|capability| capability == capability_id)
     }
 
     fn call_rpc(&self, method: &str, params: Option<JsonValue>) -> Result<JsonValue, SdkError> {
@@ -220,6 +231,8 @@ impl SdkBackend for ZmqPipelineBackendClient {
                     "rpc response missing effective_limits",
                 )
             })?)?;
+        *self.negotiated_capabilities.write().expect("negotiated_capabilities rwlock poisoned") =
+            effective_capabilities.clone();
         Ok(NegotiationResponse {
             runtime_id: Self::parse_required_string(&result, "runtime_id")?,
             active_contract_version: Self::parse_required_u16(&result, "active_contract_version")?,
@@ -259,14 +272,18 @@ impl SdkBackend for ZmqPipelineBackendClient {
         }
         let state =
             Self::parse_delivery_state(record.get("receipt_status").and_then(JsonValue::as_str));
-        let terminal = matches!(
-            state,
+        let terminal = match state {
+            DeliveryState::Sent => !self.has_capability("sdk.capability.receipt_terminality"),
             DeliveryState::Delivered
-                | DeliveryState::Failed
-                | DeliveryState::Cancelled
-                | DeliveryState::Expired
-                | DeliveryState::Rejected
-        );
+            | DeliveryState::Failed
+            | DeliveryState::Cancelled
+            | DeliveryState::Expired
+            | DeliveryState::Rejected => true,
+            DeliveryState::Queued
+            | DeliveryState::Dispatching
+            | DeliveryState::InFlight
+            | DeliveryState::Unknown => false,
+        };
         let timestamp = record.get("timestamp").and_then(JsonValue::as_i64).unwrap_or(0_i64);
         Ok(Some(DeliverySnapshot {
             message_id: id,

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
@@ -680,6 +680,99 @@ fn send_uses_zmq_sdk_method_and_preserves_delivery_options() {
 }
 
 #[test]
+fn status_treats_sent_as_terminal_until_receipt_terminality_is_negotiated() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "message": {
+                "message_id": "msg-sent",
+                "receipt_status": "sent",
+                "timestamp": 1710000000
+            }
+        }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let snapshot =
+        client.status(MessageId("msg-sent".to_owned())).expect("status").expect("message");
+
+    assert_eq!(snapshot.state, DeliveryState::Sent);
+    assert!(snapshot.terminal);
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "sdk_status_v2");
+    assert_eq!(request.params.as_ref().expect("params")["message_id"], json!("msg-sent"));
+    server.join().expect("server joined");
+}
+
+#[test]
+fn status_keeps_sent_nonterminal_after_receipt_terminality_is_negotiated() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let server = spawn_response_sequence_zmq_server(
+        command_endpoint.clone(),
+        vec![
+            json!({
+                "runtime_id": "runtime-zmq-receipts",
+                "active_contract_version": 2,
+                "effective_capabilities": ["sdk.capability.receipt_terminality"],
+                "effective_limits": {
+                    "max_poll_events": 64,
+                    "max_event_bytes": 32768,
+                    "max_batch_bytes": 1048576,
+                    "max_extension_keys": 32,
+                    "idempotency_ttl_ms": 60000
+                },
+                "contract_release": "v2",
+                "schema_namespace": "sdk.v2"
+            }),
+            json!({
+                "message": {
+                    "message_id": "msg-sent",
+                    "receipt_status": "sent",
+                    "timestamp": 1710000000
+                }
+            }),
+        ],
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    client
+        .negotiate(crate::capability::NegotiationRequest {
+            supported_contract_versions: vec![2],
+            requested_capabilities: vec!["sdk.capability.receipt_terminality".to_owned()],
+            profile: crate::types::Profile::DesktopLocalRuntime,
+            bind_mode: crate::types::BindMode::LocalOnly,
+            auth_mode: crate::types::AuthMode::LocalTrusted,
+            overflow_policy: crate::types::OverflowPolicy::Reject,
+            block_timeout_ms: None,
+            rpc_backend: None,
+            extensions: Default::default(),
+        })
+        .expect("negotiate");
+    let snapshot =
+        client.status(MessageId("msg-sent".to_owned())).expect("status").expect("message");
+
+    assert_eq!(snapshot.state, DeliveryState::Sent);
+    assert!(!snapshot.terminal);
+    let captured = captured.lock().expect("captured requests");
+    assert_eq!(captured.len(), 2);
+    assert_eq!(captured[0].method, "sdk_negotiate_v2");
+    assert_eq!(captured[1].method, "sdk_status_v2");
+    server.join().expect("server joined");
+}
+
+#[test]
 fn operation_registry_uses_zmq_sdk_method_for_direct_chat_operations() {
     let command_endpoint = unused_loopback_endpoint();
     let response_endpoint = unused_loopback_endpoint();
@@ -825,6 +918,53 @@ fn spawn_single_response_zmq_server(
                 ))
                 .await
                 .expect("send response");
+        });
+    })
+}
+
+fn spawn_response_sequence_zmq_server(
+    command_endpoint: String,
+    responses: Vec<JsonValue>,
+    captured: Arc<Mutex<Vec<CapturedZmqRequest>>>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        runtime.block_on(async move {
+            let mut commands = PullSocket::new();
+            commands.bind(command_endpoint.as_str()).await.expect("bind command endpoint");
+            for response in responses {
+                let Some(envelope) = recv_request_envelope(&mut commands).await else {
+                    return;
+                };
+                let request: RpcRequest = rns_rpc::rpc::codec::decode_frame(&envelope.payload)
+                    .expect("decode rpc request");
+                captured
+                    .lock()
+                    .expect("captured requests")
+                    .push(CapturedZmqRequest { method: request.method, params: request.params });
+                let rpc_response =
+                    RpcResponse { id: envelope.request_id, result: Some(response), error: None };
+                let response_payload =
+                    rns_rpc::rpc::codec::encode_frame(&rpc_response).expect("encode rpc response");
+                let response_endpoint = envelope.response_endpoint.expect("response endpoint");
+                let mut responses = PushSocket::new();
+                responses
+                    .connect(response_endpoint.as_str())
+                    .await
+                    .expect("connect response endpoint");
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                responses
+                    .send(ZmqMessage::from(
+                        zmq::encode_envelope(&ZmqRpcEnvelope::response(
+                            envelope.session_id,
+                            envelope.request_id,
+                            response_payload,
+                        ))
+                        .expect("encode zmq response"),
+                    ))
+                    .await
+                    .expect("send response");
+            }
         });
     })
 }

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
@@ -679,6 +679,99 @@ fn send_uses_zmq_sdk_method_and_preserves_delivery_options() {
     server.join().expect("server joined");
 }
 
+#[test]
+fn operation_registry_uses_zmq_sdk_method_for_direct_chat_operations() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({ "registry": crate::app::OperationRegistry::built_in() }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let registry = client.operation_registry().expect("operation registry");
+
+    assert!(registry.supports("app.message.history.list"));
+    assert!(registry.supports("app.delivery.destination_hash"));
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "sdk_operation_registry_v2");
+    assert_eq!(request.params, Some(json!({})));
+    server.join().expect("server joined");
+}
+
+#[test]
+fn envelope_execute_uses_zmq_sdk_method_and_preserves_direct_chat_history_query() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "response": {
+                "operation_id": "app.message.history.list",
+                "kind": "result",
+                "accepted": true,
+                "correlation_id": "history-corr",
+                "payload": {
+                    "messages": [{
+                        "message_id": "msg-1",
+                        "peer_id": "peer-a",
+                        "body": "see https://example.invalid/status",
+                        "receipt_status": "delivered"
+                    }]
+                },
+                "extensions": {
+                    "durable": true,
+                    "restart_recovery": true
+                }
+            }
+        }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let response = client
+        .envelope_execute(
+            crate::app::Envelope::query(
+                "app.message.history.list",
+                json!({
+                    "peer_id": "peer-a",
+                    "limit": 25,
+                    "include_receipts": true
+                }),
+            )
+            .with_correlation_id("history-corr")
+            .with_timeout_ms(1500)
+            .with_extension("restart_recovery", json!(true)),
+        )
+        .expect("history envelope");
+
+    assert_eq!(response.operation_id.as_str(), "app.message.history.list");
+    assert!(response.accepted);
+    assert_eq!(response.correlation_id.as_deref(), Some("history-corr"));
+    assert_eq!(response.payload["messages"][0]["receipt_status"], json!("delivered"));
+    assert_eq!(response.extensions["durable"], json!(true));
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "sdk_envelope_execute_v2");
+    let params = request.params.as_ref().expect("params");
+    assert_eq!(params["operation_id"], json!("app.message.history.list"));
+    assert_eq!(params["kind"], json!("query"));
+    assert_eq!(params["correlation_id"], json!("history-corr"));
+    assert_eq!(params["timeout_ms"], json!(1500));
+    assert_eq!(params["payload"]["peer_id"], json!("peer-a"));
+    assert_eq!(params["payload"]["include_receipts"], json!(true));
+    assert_eq!(params["extensions"]["restart_recovery"], json!(true));
+    server.join().expect("server joined");
+}
+
 fn parse_claims(token: &str) -> BTreeMap<String, String> {
     token
         .split(';')

--- a/docs/sdk/quickstart.md
+++ b/docs/sdk/quickstart.md
@@ -55,8 +55,10 @@ API even when ZeroMQ event wakeups are enabled.
 
 The typed `ZmqPipelineBackendClient` path covers the core lifecycle and
 delivery methods plus identity list/activate/import/export, identity announce,
-presence list, identity resolve, contact update/list, and identity bootstrap.
-Application integrations should use these typed SDK calls instead of
+presence list, identity resolve, contact update/list, identity bootstrap,
+operation registry, and envelope execution. Direct-chat history and runtime
+destination queries should use `app.message.history.list` and
+`app.delivery.destination_hash` through the SDK envelope path instead of
 constructing raw RPC envelopes.
 
 Run the example client:

--- a/docs/sdk/quickstart.md
+++ b/docs/sdk/quickstart.md
@@ -59,7 +59,10 @@ presence list, identity resolve, contact update/list, identity bootstrap,
 operation registry, and envelope execution. Direct-chat history and runtime
 destination queries should use `app.message.history.list` and
 `app.delivery.destination_hash` through the SDK envelope path instead of
-constructing raw RPC envelopes.
+constructing raw RPC envelopes. Delivery status follows negotiated receipt
+semantics on the ZeroMQ path: `sent` is terminal until
+`sdk.capability.receipt_terminality` is negotiated, then `delivered` is the
+terminal receipt state.
 
 Run the example client:
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -296,6 +296,11 @@ The project is best described by capability level:
   identity bootstrap, so REM/RCH peer discovery, identity recovery, and
   saved-peer setup can use `ZmqPipelineBackendClient` instead of falling back
   to raw RPC/HTTP identity/contact calls.
+- The typed ZeroMQ SDK backend now also covers the operation registry and SDK
+  envelope execution path, including `app.message.history.list` and
+  `app.delivery.destination_hash`, so REM/RCH direct-chat history and runtime
+  delivery-destination lookups can stay on `ZmqPipelineBackendClient` instead
+  of constructing raw RPC/HTTP envelopes.
 - Locally delivered inbound peer propagation payloads now also store the
   accepted transient and apply source-aware relay fan-out without double
   counting source peer activity, so local delivery does not bypass relay queue

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -301,6 +301,10 @@ The project is best described by capability level:
   `app.delivery.destination_hash`, so REM/RCH direct-chat history and runtime
   delivery-destination lookups can stay on `ZmqPipelineBackendClient` instead
   of constructing raw RPC/HTTP envelopes.
+- The typed ZeroMQ SDK backend now tracks negotiated receipt terminality for
+  delivery status, so direct-chat status reports match the SDK contract:
+  `sent` is terminal until `sdk.capability.receipt_terminality` is negotiated,
+  after which `delivered` is the terminal receipt state.
 - Locally delivered inbound peer propagation payloads now also store the
   accepted transient and apply source-aware relay fan-out without double
   counting source peer activity, so local delivery does not bypass relay queue

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -318,6 +318,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   `app.delivery.destination_hash` operations used by direct-chat history and
   runtime delivery-destination queries, so REM/RCH can keep those flows on the
   `ZmqPipelineBackendClient` path instead of requiring raw RPC/HTTP envelopes.
+- The typed ZeroMQ SDK backend preserves negotiated receipt terminality when
+  mapping `sdk_status_v2` into `DeliverySnapshot`, so direct-chat delivery
+  status reports `sent` as terminal only until
+  `sdk.capability.receipt_terminality` is negotiated.
 - Python-style `lxmd` `[lxmf] announce_interval` drives peer/delivery announce
   cadence separately from `[propagation] announce_interval`, which remains the
   propagation-node announce cadence.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -313,6 +313,11 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   identity bootstrap, so peer-directory state, identity recovery, and
   saved-peer setup needed by REM/RCH can stay on the `ZmqPipelineBackendClient`
   path instead of requiring raw RPC/HTTP identity/contact calls.
+- The typed ZeroMQ SDK backend exposes the operation registry and envelope
+  execution path, including the `app.message.history.list` and
+  `app.delivery.destination_hash` operations used by direct-chat history and
+  runtime delivery-destination queries, so REM/RCH can keep those flows on the
+  `ZmqPipelineBackendClient` path instead of requiring raw RPC/HTTP envelopes.
 - Python-style `lxmd` `[lxmf] announce_interval` drives peer/delivery announce
   cadence separately from `[propagation] announce_interval`, which remains the
   propagation-node announce cadence.


### PR DESCRIPTION
## Summary
- add `ZmqPipelineBackendClient` support for `sdk_operation_registry_v2`
- add `ZmqPipelineBackendClient` support for `sdk_envelope_execute_v2`
- cover direct-chat history operation payload preservation for `app.message.history.list` plus registry visibility for `app.delivery.destination_hash`
- update SDK quickstart and parity/roadmap notes for the REM/RCH ZeroMQ SDK track

## Validation
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend zmq_sdk_method -- --nocapture` (red before implementation: new tests failed with `SDK_CAPABILITY_DISABLED`)
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend zmq_pipeline -- --nocapture`
- `cargo check -p lxmf-sdk --features zmq-pipeline-backend`
- `cargo fmt --all -- --check`
- `cargo clippy -p lxmf-sdk --features zmq-pipeline-backend --all-targets -- -D warnings`
- `git diff --check`