### PR TITLE
[codex] Expose ZeroMQ SDK cancel envelopes

### DIFF
--- a/crates/libs/lxmf-sdk/src/app/operations_parts/built_in_entries.rs
+++ b/crates/libs/lxmf-sdk/src/app/operations_parts/built_in_entries.rs
@@ -59,6 +59,14 @@ fn built_in_entries() -> Vec<OperationEntry> {
         )
         .with_alias("sdk_status_v2"),
         OperationEntry::new(
+            "app.delivery.cancel",
+            "delivery",
+            OperationKind::Command,
+            TransportVariant::Rpc,
+            "Cancel a queued outbound message when it has not reached a terminal state.",
+        )
+        .with_alias("sdk_cancel_message_v2"),
+        OperationEntry::new(
             "app.event.poll",
             "events",
             OperationKind::Query,

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -14,7 +14,7 @@ use crate::types::{
 };
 use hmac::{Hmac, Mac};
 use rns_rpc::e2e_harness::{build_rpc_frame, parse_rpc_frame};
-use rns_rpc::rpc::zmq::{self, ZmqRpcAuthMetadata, ZmqRpcEnvelope, ZmqRpcEnvelopeKind};
+use rns_rpc::rpc::zmq::{self, ZmqRpcAuthMetadata, ZmqRpcEnvelope};
 use rns_rpc::RpcError;
 use serde_json::{json, Value as JsonValue};
 use sha2::Sha256;
@@ -23,23 +23,27 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
-use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
 
 #[path = "zmq_pipeline/config.rs"]
 mod config;
+#[path = "zmq_pipeline/history.rs"]
+mod history;
 #[path = "zmq_pipeline/negotiation.rs"]
 mod negotiation;
 #[path = "zmq_pipeline/parsing.rs"]
 mod parsing;
 #[path = "zmq_pipeline/send.rs"]
 mod send;
+#[path = "zmq_pipeline/transport.rs"]
+mod transport;
 
 #[cfg(test)]
-#[path = "zmq_pipeline/tests.rs"]
+#[path = "zmq_pipeline/tests/mod.rs"]
 mod tests;
 
 pub use config::{ZmqEndpointRole, ZmqPipelineBackendConfig, ZmqPipelineTokenAuth};
 use negotiation::new_session_id;
+use transport::ZmqPipelineTransport;
 
 pub struct ZmqPipelineBackendClient {
     config: ZmqPipelineBackendConfig,
@@ -48,11 +52,6 @@ pub struct ZmqPipelineBackendClient {
     negotiated_capabilities: RwLock<Vec<String>>,
     runtime: Runtime,
     transport: tokio::sync::Mutex<Option<ZmqPipelineTransport>>,
-}
-
-struct ZmqPipelineTransport {
-    command: PushSocket,
-    responses: PullSocket,
 }
 
 impl ZmqPipelineBackendClient {
@@ -115,54 +114,6 @@ impl ZmqPipelineBackendClient {
         Ok(rpc_response.result.unwrap_or(JsonValue::Null))
     }
 
-    async fn send_and_recv(
-        &self,
-        encoded: Vec<u8>,
-        request_id: u64,
-    ) -> Result<ZmqRpcEnvelope, SdkError> {
-        let mut transport = self.transport.lock().await;
-        if transport.is_none() {
-            *transport = Some(ZmqPipelineTransport::connect(&self.config).await?);
-        }
-        let transport = transport
-            .as_mut()
-            .ok_or_else(|| sdk_error(ErrorCategory::Internal, "missing zmq transport"))?;
-
-        transport
-            .command
-            .send(ZmqMessage::from(encoded))
-            .await
-            .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
-
-        let deadline = tokio::time::sleep(self.config.request_timeout);
-        tokio::pin!(deadline);
-        loop {
-            tokio::select! {
-                _ = &mut deadline => {
-                    return Err(SdkError::new(
-                        "SDK_TRANSPORT_ZMQ_TIMEOUT",
-                        ErrorCategory::Timeout,
-                        "zmq rpc request timed out waiting for correlated response",
-                    ));
-                }
-                message = transport.responses.recv() => {
-                    let bytes = Vec::<u8>::try_from(message.map_err(|err| {
-                        sdk_error(ErrorCategory::Transport, err.to_string())
-                    })?)
-                    .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
-                    let envelope = zmq::decode_envelope(&bytes)
-                        .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
-                    if envelope.kind == ZmqRpcEnvelopeKind::Response
-                        && envelope.session_id == self.session_id
-                        && envelope.request_id == request_id
-                    {
-                        return Ok(envelope);
-                    }
-                }
-            }
-        }
-    }
-
     fn auth_metadata_for_request(&self, request_id: u64) -> Option<ZmqRpcAuthMetadata> {
         let auth = self.config.token_auth.as_ref()?;
         let now = SystemTime::now()
@@ -183,17 +134,6 @@ impl ZmqPipelineBackendClient {
             scheme: "bearer".to_string(),
             value: format!("{};sig={}", payload, sig),
         })
-    }
-}
-
-impl ZmqPipelineTransport {
-    async fn connect(config: &ZmqPipelineBackendConfig) -> Result<Self, SdkError> {
-        let mut command = PushSocket::new();
-        apply_role(&mut command, config.command_role, &config.command_endpoint).await?;
-        let mut responses = PullSocket::new();
-        apply_role(&mut responses, config.response_role, &config.response_endpoint).await?;
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        Ok(Self { command, responses })
     }
 }
 
@@ -506,24 +446,6 @@ impl SdkBackend for ZmqPipelineBackendClient {
             accepted: result.get("accepted").and_then(JsonValue::as_bool).unwrap_or(false),
             revision: None,
         })
-    }
-}
-
-async fn apply_role<S>(
-    socket: &mut S,
-    role: ZmqEndpointRole,
-    endpoint: &str,
-) -> Result<(), SdkError>
-where
-    S: Socket,
-{
-    match role {
-        ZmqEndpointRole::Bind => socket.bind(endpoint).await.map(|_| ()).map_err(|err| {
-            sdk_error(ErrorCategory::Transport, format!("zmq bind {} failed: {}", endpoint, err))
-        }),
-        ZmqEndpointRole::Connect => socket.connect(endpoint).await.map_err(|err| {
-            sdk_error(ErrorCategory::Transport, format!("zmq connect {} failed: {}", endpoint, err))
-        }),
     }
 }
 

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/history.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/history.rs
@@ -1,0 +1,15 @@
+use super::{code, ErrorCategory, SdkError, ZmqPipelineBackendClient};
+use crate::messaging::{MessageHistoryListRequest, MessageHistoryPage};
+
+impl ZmqPipelineBackendClient {
+    pub fn list_message_history(
+        &self,
+        req: MessageHistoryListRequest,
+    ) -> Result<MessageHistoryPage, SdkError> {
+        let params = serde_json::to_value(req).map_err(|err| {
+            SdkError::new(code::INTERNAL, ErrorCategory::Internal, err.to_string())
+        })?;
+        let result = self.call_rpc("list_messages", Some(params))?;
+        Self::decode_value(result, "message history response")
+    }
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests.rs
@@ -680,6 +680,30 @@ fn send_uses_zmq_sdk_method_and_preserves_delivery_options() {
 }
 
 #[test]
+fn cancel_uses_zmq_sdk_method_and_decodes_result() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({ "message_id": "msg-cancel", "result": "Accepted" }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let result = client.cancel(MessageId("msg-cancel".to_owned())).expect("cancel");
+
+    assert_eq!(result, CancelResult::Accepted);
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "sdk_cancel_message_v2");
+    assert_eq!(request.params.as_ref().expect("params")["message_id"], json!("msg-cancel"));
+    server.join().expect("server joined");
+}
+
+#[test]
 fn status_treats_sent_as_terminal_until_receipt_terminality_is_negotiated() {
     let command_endpoint = unused_loopback_endpoint();
     let response_endpoint = unused_loopback_endpoint();
@@ -790,10 +814,64 @@ fn operation_registry_uses_zmq_sdk_method_for_direct_chat_operations() {
 
     assert!(registry.supports("app.message.history.list"));
     assert!(registry.supports("app.delivery.destination_hash"));
+    assert!(registry.supports("app.delivery.cancel"));
     let captured = captured.lock().expect("captured request");
     let request = captured.as_ref().expect("zmq request");
     assert_eq!(request.method, "sdk_operation_registry_v2");
     assert_eq!(request.params, Some(json!({})));
+    server.join().expect("server joined");
+}
+
+#[test]
+fn envelope_execute_uses_zmq_sdk_method_and_preserves_cancel_result() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "response": {
+                "operation_id": "app.delivery.cancel",
+                "kind": "result",
+                "accepted": true,
+                "correlation_id": "cancel-corr",
+                "payload": {
+                    "message_id": "msg-cancel",
+                    "result": "Accepted"
+                }
+            }
+        }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let response = client
+        .envelope_execute(
+            crate::app::Envelope::command(
+                "app.delivery.cancel",
+                json!({
+                    "message_id": "msg-cancel"
+                }),
+            )
+            .with_correlation_id("cancel-corr"),
+        )
+        .expect("cancel envelope");
+
+    assert_eq!(response.operation_id.as_str(), "app.delivery.cancel");
+    assert!(response.accepted);
+    assert_eq!(response.correlation_id.as_deref(), Some("cancel-corr"));
+    assert_eq!(response.payload["message_id"], json!("msg-cancel"));
+    assert_eq!(response.payload["result"], json!("Accepted"));
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "sdk_envelope_execute_v2");
+    let params = request.params.as_ref().expect("params");
+    assert_eq!(params["operation_id"], json!("app.delivery.cancel"));
+    assert_eq!(params["kind"], json!("command"));
+    assert_eq!(params["correlation_id"], json!("cancel-corr"));
+    assert_eq!(params["payload"]["message_id"], json!("msg-cancel"));
     server.join().expect("server joined");
 }
 

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/history.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/history.rs
@@ -1,0 +1,59 @@
+use super::*;
+
+#[test]
+fn list_message_history_uses_zmq_sdk_method_and_preserves_receipts_and_fields() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "messages": [{
+                "id": "msg-history-1",
+                "source": "local-destination",
+                "destination": "peer-destination",
+                "title": "chat",
+                "content": "see https://example.invalid/status",
+                "timestamp": 1_700_000_111,
+                "direction": "outbound",
+                "fields": {
+                    "FIELD_THREAD": "thread-1",
+                    "renderer": { "kind": "plain" }
+                },
+                "receipt_status": "delivered"
+            }],
+            "next_cursor": "1700000111:msg-history-1"
+        }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let page = client
+        .list_message_history(crate::MessageHistoryListRequest {
+            limit: Some(25),
+            cursor: Some("1700000120:msg-history-2".to_string()),
+            before_ts: None,
+        })
+        .expect("history page");
+
+    assert_eq!(page.next_cursor.as_deref(), Some("1700000111:msg-history-1"));
+    assert_eq!(page.messages.len(), 1);
+    let message = &page.messages[0];
+    assert_eq!(message.id, "msg-history-1");
+    assert_eq!(message.content, "see https://example.invalid/status");
+    assert_eq!(message.receipt_status.as_deref(), Some("delivered"));
+    assert_eq!(message.fields.as_ref().expect("fields")["FIELD_THREAD"], json!("thread-1"));
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "list_messages");
+    assert_eq!(
+        request.params,
+        Some(json!({
+            "limit": 25,
+            "cursor": "1700000120:msg-history-2"
+        }))
+    );
+    server.join().expect("server joined");
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/mod.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/mod.rs
@@ -1,7 +1,11 @@
 use super::*;
+use rns_rpc::rpc::zmq::ZmqRpcEnvelopeKind;
 use rns_rpc::rpc::{RpcRequest, RpcResponse};
 use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
+use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
+
+mod history;
 
 #[derive(Debug, Clone, PartialEq)]
 struct CapturedZmqRequest {

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/transport.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/transport.rs
@@ -1,0 +1,90 @@
+use super::{
+    sdk_error, ErrorCategory, SdkError, ZmqEndpointRole, ZmqPipelineBackendClient,
+    ZmqPipelineBackendConfig,
+};
+use rns_rpc::rpc::zmq::{self, ZmqRpcEnvelope, ZmqRpcEnvelopeKind};
+use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
+
+pub(super) struct ZmqPipelineTransport {
+    pub(super) command: PushSocket,
+    pub(super) responses: PullSocket,
+}
+
+impl ZmqPipelineTransport {
+    pub(super) async fn connect(config: &ZmqPipelineBackendConfig) -> Result<Self, SdkError> {
+        let mut command = PushSocket::new();
+        apply_role(&mut command, config.command_role, &config.command_endpoint).await?;
+        let mut responses = PullSocket::new();
+        apply_role(&mut responses, config.response_role, &config.response_endpoint).await?;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        Ok(Self { command, responses })
+    }
+}
+
+impl ZmqPipelineBackendClient {
+    pub(super) async fn send_and_recv(
+        &self,
+        encoded: Vec<u8>,
+        request_id: u64,
+    ) -> Result<ZmqRpcEnvelope, SdkError> {
+        let mut transport = self.transport.lock().await;
+        if transport.is_none() {
+            *transport = Some(ZmqPipelineTransport::connect(&self.config).await?);
+        }
+        let transport = transport
+            .as_mut()
+            .ok_or_else(|| sdk_error(ErrorCategory::Internal, "missing zmq transport"))?;
+
+        transport
+            .command
+            .send(ZmqMessage::from(encoded))
+            .await
+            .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+
+        let deadline = tokio::time::sleep(self.config.request_timeout);
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                _ = &mut deadline => {
+                    return Err(SdkError::new(
+                        "SDK_TRANSPORT_ZMQ_TIMEOUT",
+                        ErrorCategory::Timeout,
+                        "zmq rpc request timed out waiting for correlated response",
+                    ));
+                }
+                message = transport.responses.recv() => {
+                    let bytes = Vec::<u8>::try_from(message.map_err(|err| {
+                        sdk_error(ErrorCategory::Transport, err.to_string())
+                    })?)
+                    .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+                    let envelope = zmq::decode_envelope(&bytes)
+                        .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+                    if envelope.kind == ZmqRpcEnvelopeKind::Response
+                        && envelope.session_id == self.session_id
+                        && envelope.request_id == request_id
+                    {
+                        return Ok(envelope);
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn apply_role<S>(
+    socket: &mut S,
+    role: ZmqEndpointRole,
+    endpoint: &str,
+) -> Result<(), SdkError>
+where
+    S: Socket,
+{
+    match role {
+        ZmqEndpointRole::Bind => socket.bind(endpoint).await.map(|_| ()).map_err(|err| {
+            sdk_error(ErrorCategory::Transport, format!("zmq bind {endpoint} failed: {err}"))
+        }),
+        ZmqEndpointRole::Connect => socket.connect(endpoint).await.map_err(|err| {
+            sdk_error(ErrorCategory::Transport, format!("zmq connect {endpoint} failed: {err}"))
+        }),
+    }
+}

--- a/crates/libs/lxmf-sdk/src/lib.rs
+++ b/crates/libs/lxmf-sdk/src/lib.rs
@@ -76,9 +76,10 @@ pub use event::{
 pub use lifecycle::{Lifecycle, SdkMethod};
 #[cfg(feature = "std")]
 pub use messaging::{
-    AnnounceRecord, ConversationRecord, MessageDirection, MessageMethod, MessageRecord,
-    MessageState, MessagingStore, PeerRecord, PeerState, SendMessageRequest, StoredOutboundMessage,
-    SyncPhase, SyncStatus,
+    AnnounceRecord, ConversationRecord, MessageDirection, MessageHistoryListRequest,
+    MessageHistoryPage, MessageHistoryRecord, MessageMethod, MessageRecord, MessageState,
+    MessagingStore, PeerRecord, PeerState, SendMessageRequest, StoredOutboundMessage, SyncPhase,
+    SyncStatus,
 };
 pub use profiles::{
     default_effective_limits, default_memory_budget, required_capabilities, supports_capability,

--- a/crates/libs/lxmf-sdk/src/messaging.rs
+++ b/crates/libs/lxmf-sdk/src/messaging.rs
@@ -1,5 +1,6 @@
 use lxmf_core::announce::display_name_from_delivery_app_data;
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 
@@ -134,6 +135,35 @@ pub struct MessageRecord {
     pub sent_at_ms: Option<u64>,
     pub received_at_ms: Option<u64>,
     pub updated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageHistoryListRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_ts: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MessageHistoryPage {
+    pub messages: Vec<MessageHistoryRecord>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MessageHistoryRecord {
+    pub id: String,
+    pub source: String,
+    pub destination: String,
+    pub title: String,
+    pub content: String,
+    pub timestamp: i64,
+    pub direction: String,
+    pub fields: Option<JsonValue>,
+    pub receipt_status: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/rpcdaemon_sections/handle_sdk_envelope_execute_v2.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/rpcdaemon_sections/handle_sdk_envelope_execute_v2.rs
@@ -41,6 +41,9 @@ impl RpcDaemon {
             "sdk_status_v2" => json!({
                 "message_id": parsed.payload.get("message_id").and_then(JsonValue::as_str),
             }),
+            "sdk_cancel_message_v2" => json!({
+                "message_id": parsed.payload.get("message_id").and_then(JsonValue::as_str),
+            }),
             "sdk_poll_events_v2" => json!({
                 "cursor": parsed.payload.get("cursor").cloned().unwrap_or(JsonValue::Null),
                 "max": parsed.payload.get("max").cloned().unwrap_or(JsonValue::from(32_u64)),

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/rpcdaemon_sections/operation_spec.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/rpcdaemon_sections/operation_spec.rs
@@ -124,6 +124,11 @@ impl RpcDaemon {
                 method: method.to_owned(),
                 params: Some(params),
             })?,
+            "sdk_cancel_message_v2" => self.handle_sdk_cancel_message_v2(RpcRequest {
+                id: request_id,
+                method: method.to_owned(),
+                params: Some(params),
+            })?,
             "sdk_poll_events_v2" => self.handle_sdk_poll_events_v2(RpcRequest {
                 id: request_id,
                 method: method.to_owned(),

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/sdk_operation_specs.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/sdk_operation_specs.rs
@@ -51,6 +51,16 @@ const SDK_OPERATION_SPECS: &[SdkOperationSpec] = &[
         rpc_method: "sdk_status_v2",
     },
     SdkOperationSpec {
+        id: "app.delivery.cancel",
+        group: "delivery",
+        kind: "command",
+        transport_variant: "rpc",
+        description: "Cancel a queued outbound message when it has not reached a terminal state.",
+        aliases: &["sdk_cancel_message_v2"],
+        required_capabilities: &[],
+        rpc_method: "sdk_cancel_message_v2",
+    },
+    SdkOperationSpec {
         id: "app.event.poll",
         group: "events",
         kind: "query",

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/release_domains_parts/sdk_release_c_domain_methods_roundtr.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/release_domains_parts/sdk_release_c_domain_methods_roundtr.rs
@@ -36,6 +36,7 @@ fn sdk_release_c_domain_methods_roundtrip() {
         .iter()
         .any(|entry| entry["id"] == json!("app.workflow.mission_update_send")));
     assert!(registry_entries.iter().any(|entry| entry["id"] == json!("app.delivery.send_batch")));
+    assert!(registry_entries.iter().any(|entry| entry["id"] == json!("app.delivery.cancel")));
 
     let list_before =
         daemon.handle_rpc(rpc_request(120, "sdk_identity_list_v2", json!({}))).expect("list");
@@ -125,6 +126,39 @@ fn sdk_release_c_domain_methods_roundtrip() {
         batch_response["response"]["payload"]["results"][1]["message_id"],
         json!("batch-envelope-msg-2")
     );
+
+    let cancel_envelope = daemon
+        .handle_rpc(rpc_request(
+            1204,
+            "sdk_envelope_execute_v2",
+            json!({
+                "operation_id": "app.delivery.cancel",
+                "kind": "command",
+                "correlation_id": "cancel-corr-1",
+                "payload": {
+                    "message_id": "batch-envelope-msg-1"
+                },
+            }),
+        ))
+        .expect("cancel envelope");
+    assert!(cancel_envelope.error.is_none());
+    let cancel_response = cancel_envelope.result.expect("cancel envelope result");
+    assert_eq!(cancel_response["response"]["operation_id"], json!("app.delivery.cancel"));
+    assert_eq!(cancel_response["response"]["correlation_id"], json!("cancel-corr-1"));
+    assert_eq!(cancel_response["response"]["payload"]["message_id"], json!("batch-envelope-msg-1"));
+    assert_eq!(cancel_response["response"]["payload"]["result"], json!("TooLateToCancel"));
+    let cancelled_status = daemon
+        .handle_rpc(rpc_request(
+            1205,
+            "sdk_status_v2",
+            json!({ "message_id": "batch-envelope-msg-1" }),
+        ))
+        .expect("cancelled status");
+    let cancelled_status_result = cancelled_status.result.expect("cancelled status result");
+    assert!(cancelled_status_result["message"]["receipt_status"]
+        .as_str()
+        .expect("receipt status")
+        .starts_with("sent"));
 
     let identity_bundle = json!({
         "identity": "node-b",

--- a/docs/sdk/quickstart.md
+++ b/docs/sdk/quickstart.md
@@ -62,8 +62,11 @@ destination queries should use `app.message.history.list` and
 constructing raw RPC envelopes. Burst sends should use
 `app.delivery.send_batch` through the same SDK envelope path so ordered
 per-message acceptance and rejection results remain visible without raw RPC
-calls. Delivery status follows negotiated receipt semantics on the ZeroMQ path:
-`sent` is terminal until
+calls. Direct-chat cancellation can use either `sdk_cancel_message_v2` via
+`ZmqPipelineBackendClient::cancel` or `app.delivery.cancel` through SDK
+envelope execution, preserving `Accepted`, `AlreadyTerminal`, `NotFound`, and
+`TooLateToCancel` results. Delivery status follows negotiated receipt semantics
+on the ZeroMQ path: `sent` is terminal until
 `sdk.capability.receipt_terminality` is negotiated, then `delivered` is the
 terminal receipt state.
 

--- a/docs/sdk/quickstart.md
+++ b/docs/sdk/quickstart.md
@@ -56,10 +56,10 @@ API even when ZeroMQ event wakeups are enabled.
 The typed `ZmqPipelineBackendClient` path covers the core lifecycle and
 delivery methods plus identity list/activate/import/export, identity announce,
 presence list, identity resolve, contact update/list, identity bootstrap,
-operation registry, and envelope execution. Direct-chat history and runtime
-destination queries should use `app.message.history.list` and
-`app.delivery.destination_hash` through the SDK envelope path instead of
-constructing raw RPC envelopes. Burst sends should use
+operation registry, envelope execution, and typed durable direct-chat history
+through `ZmqPipelineBackendClient::list_message_history`. Runtime destination
+queries should use `app.delivery.destination_hash` through the SDK envelope
+path instead of constructing raw RPC envelopes. Burst sends should use
 `app.delivery.send_batch` through the same SDK envelope path so ordered
 per-message acceptance and rejection results remain visible without raw RPC
 calls. Direct-chat cancellation can use either `sdk_cancel_message_v2` via

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -308,6 +308,10 @@ The project is best described by capability level:
 - The typed ZeroMQ SDK envelope path now routes `app.delivery.send_batch` to
   `sdk_send_batch_v2` and preserves ordered per-message batch results, giving
   REM/RCH burst-send flows a ZeroMQ SDK path without raw RPC envelopes.
+- The typed ZeroMQ SDK backend and operation registry now expose direct-chat
+  cancellation through both `ZmqPipelineBackendClient::cancel` and
+  `app.delivery.cancel` envelope execution, preserving daemon cancellation
+  outcomes without raw RPC envelopes.
 - Locally delivered inbound peer propagation payloads now also store the
   accepted transient and apply source-aware relay fan-out without double
   counting source peer activity, so local delivery does not bypass relay queue

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -301,6 +301,10 @@ The project is best described by capability level:
   `app.delivery.destination_hash`, so REM/RCH direct-chat history and runtime
   delivery-destination lookups can stay on `ZmqPipelineBackendClient` instead
   of constructing raw RPC/HTTP envelopes.
+- The typed ZeroMQ SDK backend now exposes durable direct-chat history through
+  `ZmqPipelineBackendClient::list_message_history`, preserving message bodies
+  with links, receipt status, basic LXMF fields, and restart pagination cursors
+  from the daemon `list_messages` store.
 - The typed ZeroMQ SDK backend now tracks negotiated receipt terminality for
   delivery status, so direct-chat status reports match the SDK contract:
   `sent` is terminal until `sdk.capability.receipt_terminality` is negotiated,

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -325,6 +325,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - The typed ZeroMQ SDK envelope path exposes `app.delivery.send_batch` through
   `sdk_send_batch_v2` and preserves ordered per-message batch results, so
   REM/RCH burst-send flows do not need raw RPC envelopes.
+- The typed ZeroMQ SDK backend and operation registry expose direct-chat
+  cancellation through both `ZmqPipelineBackendClient::cancel` and
+  `app.delivery.cancel` envelope execution, preserving daemon cancellation
+  outcomes for REM/RCH without raw RPC envelopes.
 - Python-style `lxmd` `[lxmf] announce_interval` drives peer/delivery announce
   cadence separately from `[propagation] announce_interval`, which remains the
   propagation-node announce cadence.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -318,6 +318,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   `app.delivery.destination_hash` operations used by direct-chat history and
   runtime delivery-destination queries, so REM/RCH can keep those flows on the
   `ZmqPipelineBackendClient` path instead of requiring raw RPC/HTTP envelopes.
+- The typed ZeroMQ SDK backend also exposes durable direct-chat history as
+  `ZmqPipelineBackendClient::list_message_history`, preserving link-bearing
+  message bodies, receipt status, basic LXMF fields, and daemon pagination
+  cursors for restart recovery.
 - The typed ZeroMQ SDK backend preserves negotiated receipt terminality when
   mapping `sdk_status_v2` into `DeliverySnapshot`, so direct-chat delivery
   status reports `sent` as terminal only until


### PR DESCRIPTION
## Summary

- register `app.delivery.cancel` in the app and daemon SDK operation registries with the `sdk_cancel_message_v2` alias
- route cancel SDK envelopes through the existing daemon cancellation handler while preserving cancellation outcomes in the envelope payload
- add ZeroMQ SDK tests for direct `ZmqPipelineBackendClient::cancel`, cancel envelope execution, and operation-registry discovery
- update SDK quickstart and status docs for the direct-chat cancel path

## Why

REM/RCH direct-chat flows need cancel behavior available through the typed ZeroMQ SDK surface, not raw RPC envelopes. Before this slice, `sdk_cancel_message_v2` existed but `app.delivery.cancel` was not discoverable or executable through the SDK operation registry/envelope path.

## Validation

- `cargo test -p reticulum-rs-rpc sdk_release_c_domain_methods_roundtrip -- --nocapture`
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend zmq_pipeline -- --nocapture --test-threads=1`
- `cargo check -p reticulum-rs-rpc`
- `cargo check -p lxmf-sdk --features zmq-pipeline-backend`
- `cargo fmt --all -- --check`
- `cargo clippy -p reticulum-rs-rpc --all-targets -- -D warnings`
- `cargo clippy -p lxmf-sdk --features zmq-pipeline-backend --all-targets -- -D warnings`
- `git diff --check`
