### PR TITLE
[codex] Add typed ZeroMQ SDK history

### DIFF
--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -14,7 +14,7 @@ use crate::types::{
 };
 use hmac::{Hmac, Mac};
 use rns_rpc::e2e_harness::{build_rpc_frame, parse_rpc_frame};
-use rns_rpc::rpc::zmq::{self, ZmqRpcAuthMetadata, ZmqRpcEnvelope, ZmqRpcEnvelopeKind};
+use rns_rpc::rpc::zmq::{self, ZmqRpcAuthMetadata, ZmqRpcEnvelope};
 use rns_rpc::RpcError;
 use serde_json::{json, Value as JsonValue};
 use sha2::Sha256;
@@ -23,23 +23,27 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
-use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
 
 #[path = "zmq_pipeline/config.rs"]
 mod config;
+#[path = "zmq_pipeline/history.rs"]
+mod history;
 #[path = "zmq_pipeline/negotiation.rs"]
 mod negotiation;
 #[path = "zmq_pipeline/parsing.rs"]
 mod parsing;
 #[path = "zmq_pipeline/send.rs"]
 mod send;
+#[path = "zmq_pipeline/transport.rs"]
+mod transport;
 
 #[cfg(test)]
-#[path = "zmq_pipeline/tests.rs"]
+#[path = "zmq_pipeline/tests/mod.rs"]
 mod tests;
 
 pub use config::{ZmqEndpointRole, ZmqPipelineBackendConfig, ZmqPipelineTokenAuth};
 use negotiation::new_session_id;
+use transport::ZmqPipelineTransport;
 
 pub struct ZmqPipelineBackendClient {
     config: ZmqPipelineBackendConfig,
@@ -48,11 +52,6 @@ pub struct ZmqPipelineBackendClient {
     negotiated_capabilities: RwLock<Vec<String>>,
     runtime: Runtime,
     transport: tokio::sync::Mutex<Option<ZmqPipelineTransport>>,
-}
-
-struct ZmqPipelineTransport {
-    command: PushSocket,
-    responses: PullSocket,
 }
 
 impl ZmqPipelineBackendClient {
@@ -115,54 +114,6 @@ impl ZmqPipelineBackendClient {
         Ok(rpc_response.result.unwrap_or(JsonValue::Null))
     }
 
-    async fn send_and_recv(
-        &self,
-        encoded: Vec<u8>,
-        request_id: u64,
-    ) -> Result<ZmqRpcEnvelope, SdkError> {
-        let mut transport = self.transport.lock().await;
-        if transport.is_none() {
-            *transport = Some(ZmqPipelineTransport::connect(&self.config).await?);
-        }
-        let transport = transport
-            .as_mut()
-            .ok_or_else(|| sdk_error(ErrorCategory::Internal, "missing zmq transport"))?;
-
-        transport
-            .command
-            .send(ZmqMessage::from(encoded))
-            .await
-            .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
-
-        let deadline = tokio::time::sleep(self.config.request_timeout);
-        tokio::pin!(deadline);
-        loop {
-            tokio::select! {
-                _ = &mut deadline => {
-                    return Err(SdkError::new(
-                        "SDK_TRANSPORT_ZMQ_TIMEOUT",
-                        ErrorCategory::Timeout,
-                        "zmq rpc request timed out waiting for correlated response",
-                    ));
-                }
-                message = transport.responses.recv() => {
-                    let bytes = Vec::<u8>::try_from(message.map_err(|err| {
-                        sdk_error(ErrorCategory::Transport, err.to_string())
-                    })?)
-                    .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
-                    let envelope = zmq::decode_envelope(&bytes)
-                        .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
-                    if envelope.kind == ZmqRpcEnvelopeKind::Response
-                        && envelope.session_id == self.session_id
-                        && envelope.request_id == request_id
-                    {
-                        return Ok(envelope);
-                    }
-                }
-            }
-        }
-    }
-
     fn auth_metadata_for_request(&self, request_id: u64) -> Option<ZmqRpcAuthMetadata> {
         let auth = self.config.token_auth.as_ref()?;
         let now = SystemTime::now()
@@ -183,17 +134,6 @@ impl ZmqPipelineBackendClient {
             scheme: "bearer".to_string(),
             value: format!("{};sig={}", payload, sig),
         })
-    }
-}
-
-impl ZmqPipelineTransport {
-    async fn connect(config: &ZmqPipelineBackendConfig) -> Result<Self, SdkError> {
-        let mut command = PushSocket::new();
-        apply_role(&mut command, config.command_role, &config.command_endpoint).await?;
-        let mut responses = PullSocket::new();
-        apply_role(&mut responses, config.response_role, &config.response_endpoint).await?;
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        Ok(Self { command, responses })
     }
 }
 
@@ -506,24 +446,6 @@ impl SdkBackend for ZmqPipelineBackendClient {
             accepted: result.get("accepted").and_then(JsonValue::as_bool).unwrap_or(false),
             revision: None,
         })
-    }
-}
-
-async fn apply_role<S>(
-    socket: &mut S,
-    role: ZmqEndpointRole,
-    endpoint: &str,
-) -> Result<(), SdkError>
-where
-    S: Socket,
-{
-    match role {
-        ZmqEndpointRole::Bind => socket.bind(endpoint).await.map(|_| ()).map_err(|err| {
-            sdk_error(ErrorCategory::Transport, format!("zmq bind {} failed: {}", endpoint, err))
-        }),
-        ZmqEndpointRole::Connect => socket.connect(endpoint).await.map_err(|err| {
-            sdk_error(ErrorCategory::Transport, format!("zmq connect {} failed: {}", endpoint, err))
-        }),
     }
 }
 

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/history.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/history.rs
@@ -1,0 +1,15 @@
+use super::{code, ErrorCategory, SdkError, ZmqPipelineBackendClient};
+use crate::messaging::{MessageHistoryListRequest, MessageHistoryPage};
+
+impl ZmqPipelineBackendClient {
+    pub fn list_message_history(
+        &self,
+        req: MessageHistoryListRequest,
+    ) -> Result<MessageHistoryPage, SdkError> {
+        let params = serde_json::to_value(req).map_err(|err| {
+            SdkError::new(code::INTERNAL, ErrorCategory::Internal, err.to_string())
+        })?;
+        let result = self.call_rpc("list_messages", Some(params))?;
+        Self::decode_value(result, "message history response")
+    }
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/history.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/history.rs
@@ -1,0 +1,59 @@
+use super::*;
+
+#[test]
+fn list_message_history_uses_zmq_sdk_method_and_preserves_receipts_and_fields() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "messages": [{
+                "id": "msg-history-1",
+                "source": "local-destination",
+                "destination": "peer-destination",
+                "title": "chat",
+                "content": "see https://example.invalid/status",
+                "timestamp": 1_700_000_111,
+                "direction": "outbound",
+                "fields": {
+                    "FIELD_THREAD": "thread-1",
+                    "renderer": { "kind": "plain" }
+                },
+                "receipt_status": "delivered"
+            }],
+            "next_cursor": "1700000111:msg-history-1"
+        }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let page = client
+        .list_message_history(crate::MessageHistoryListRequest {
+            limit: Some(25),
+            cursor: Some("1700000120:msg-history-2".to_string()),
+            before_ts: None,
+        })
+        .expect("history page");
+
+    assert_eq!(page.next_cursor.as_deref(), Some("1700000111:msg-history-1"));
+    assert_eq!(page.messages.len(), 1);
+    let message = &page.messages[0];
+    assert_eq!(message.id, "msg-history-1");
+    assert_eq!(message.content, "see https://example.invalid/status");
+    assert_eq!(message.receipt_status.as_deref(), Some("delivered"));
+    assert_eq!(message.fields.as_ref().expect("fields")["FIELD_THREAD"], json!("thread-1"));
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "list_messages");
+    assert_eq!(
+        request.params,
+        Some(json!({
+            "limit": 25,
+            "cursor": "1700000120:msg-history-2"
+        }))
+    );
+    server.join().expect("server joined");
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/mod.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/mod.rs
@@ -1,7 +1,11 @@
 use super::*;
+use rns_rpc::rpc::zmq::ZmqRpcEnvelopeKind;
 use rns_rpc::rpc::{RpcRequest, RpcResponse};
 use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
+use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
+
+mod history;
 
 #[derive(Debug, Clone, PartialEq)]
 struct CapturedZmqRequest {

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/transport.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/transport.rs
@@ -1,0 +1,90 @@
+use super::{
+    sdk_error, ErrorCategory, SdkError, ZmqEndpointRole, ZmqPipelineBackendClient,
+    ZmqPipelineBackendConfig,
+};
+use rns_rpc::rpc::zmq::{self, ZmqRpcEnvelope, ZmqRpcEnvelopeKind};
+use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
+
+pub(super) struct ZmqPipelineTransport {
+    pub(super) command: PushSocket,
+    pub(super) responses: PullSocket,
+}
+
+impl ZmqPipelineTransport {
+    pub(super) async fn connect(config: &ZmqPipelineBackendConfig) -> Result<Self, SdkError> {
+        let mut command = PushSocket::new();
+        apply_role(&mut command, config.command_role, &config.command_endpoint).await?;
+        let mut responses = PullSocket::new();
+        apply_role(&mut responses, config.response_role, &config.response_endpoint).await?;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        Ok(Self { command, responses })
+    }
+}
+
+impl ZmqPipelineBackendClient {
+    pub(super) async fn send_and_recv(
+        &self,
+        encoded: Vec<u8>,
+        request_id: u64,
+    ) -> Result<ZmqRpcEnvelope, SdkError> {
+        let mut transport = self.transport.lock().await;
+        if transport.is_none() {
+            *transport = Some(ZmqPipelineTransport::connect(&self.config).await?);
+        }
+        let transport = transport
+            .as_mut()
+            .ok_or_else(|| sdk_error(ErrorCategory::Internal, "missing zmq transport"))?;
+
+        transport
+            .command
+            .send(ZmqMessage::from(encoded))
+            .await
+            .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+
+        let deadline = tokio::time::sleep(self.config.request_timeout);
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                _ = &mut deadline => {
+                    return Err(SdkError::new(
+                        "SDK_TRANSPORT_ZMQ_TIMEOUT",
+                        ErrorCategory::Timeout,
+                        "zmq rpc request timed out waiting for correlated response",
+                    ));
+                }
+                message = transport.responses.recv() => {
+                    let bytes = Vec::<u8>::try_from(message.map_err(|err| {
+                        sdk_error(ErrorCategory::Transport, err.to_string())
+                    })?)
+                    .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+                    let envelope = zmq::decode_envelope(&bytes)
+                        .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+                    if envelope.kind == ZmqRpcEnvelopeKind::Response
+                        && envelope.session_id == self.session_id
+                        && envelope.request_id == request_id
+                    {
+                        return Ok(envelope);
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn apply_role<S>(
+    socket: &mut S,
+    role: ZmqEndpointRole,
+    endpoint: &str,
+) -> Result<(), SdkError>
+where
+    S: Socket,
+{
+    match role {
+        ZmqEndpointRole::Bind => socket.bind(endpoint).await.map(|_| ()).map_err(|err| {
+            sdk_error(ErrorCategory::Transport, format!("zmq bind {endpoint} failed: {err}"))
+        }),
+        ZmqEndpointRole::Connect => socket.connect(endpoint).await.map_err(|err| {
+            sdk_error(ErrorCategory::Transport, format!("zmq connect {endpoint} failed: {err}"))
+        }),
+    }
+}

--- a/crates/libs/lxmf-sdk/src/lib.rs
+++ b/crates/libs/lxmf-sdk/src/lib.rs
@@ -76,9 +76,10 @@ pub use event::{
 pub use lifecycle::{Lifecycle, SdkMethod};
 #[cfg(feature = "std")]
 pub use messaging::{
-    AnnounceRecord, ConversationRecord, MessageDirection, MessageMethod, MessageRecord,
-    MessageState, MessagingStore, PeerRecord, PeerState, SendMessageRequest, StoredOutboundMessage,
-    SyncPhase, SyncStatus,
+    AnnounceRecord, ConversationRecord, MessageDirection, MessageHistoryListRequest,
+    MessageHistoryPage, MessageHistoryRecord, MessageMethod, MessageRecord, MessageState,
+    MessagingStore, PeerRecord, PeerState, SendMessageRequest, StoredOutboundMessage, SyncPhase,
+    SyncStatus,
 };
 pub use profiles::{
     default_effective_limits, default_memory_budget, required_capabilities, supports_capability,

--- a/crates/libs/lxmf-sdk/src/messaging.rs
+++ b/crates/libs/lxmf-sdk/src/messaging.rs
@@ -1,5 +1,6 @@
 use lxmf_core::announce::display_name_from_delivery_app_data;
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 
@@ -134,6 +135,35 @@ pub struct MessageRecord {
     pub sent_at_ms: Option<u64>,
     pub received_at_ms: Option<u64>,
     pub updated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageHistoryListRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_ts: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MessageHistoryPage {
+    pub messages: Vec<MessageHistoryRecord>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MessageHistoryRecord {
+    pub id: String,
+    pub source: String,
+    pub destination: String,
+    pub title: String,
+    pub content: String,
+    pub timestamp: i64,
+    pub direction: String,
+    pub fields: Option<JsonValue>,
+    pub receipt_status: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/docs/sdk/quickstart.md
+++ b/docs/sdk/quickstart.md
@@ -56,10 +56,10 @@ API even when ZeroMQ event wakeups are enabled.
 The typed `ZmqPipelineBackendClient` path covers the core lifecycle and
 delivery methods plus identity list/activate/import/export, identity announce,
 presence list, identity resolve, contact update/list, identity bootstrap,
-operation registry, and envelope execution. Direct-chat history and runtime
-destination queries should use `app.message.history.list` and
-`app.delivery.destination_hash` through the SDK envelope path instead of
-constructing raw RPC envelopes. Burst sends should use
+operation registry, envelope execution, and typed durable direct-chat history
+through `ZmqPipelineBackendClient::list_message_history`. Runtime destination
+queries should use `app.delivery.destination_hash` through the SDK envelope
+path instead of constructing raw RPC envelopes. Burst sends should use
 `app.delivery.send_batch` through the same SDK envelope path so ordered
 per-message acceptance and rejection results remain visible without raw RPC
 calls. Direct-chat cancellation can use either `sdk_cancel_message_v2` via

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -301,6 +301,10 @@ The project is best described by capability level:
   `app.delivery.destination_hash`, so REM/RCH direct-chat history and runtime
   delivery-destination lookups can stay on `ZmqPipelineBackendClient` instead
   of constructing raw RPC/HTTP envelopes.
+- The typed ZeroMQ SDK backend now exposes durable direct-chat history through
+  `ZmqPipelineBackendClient::list_message_history`, preserving message bodies
+  with links, receipt status, basic LXMF fields, and restart pagination cursors
+  from the daemon `list_messages` store.
 - The typed ZeroMQ SDK backend now tracks negotiated receipt terminality for
   delivery status, so direct-chat status reports match the SDK contract:
   `sent` is terminal until `sdk.capability.receipt_terminality` is negotiated,

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -318,6 +318,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   `app.delivery.destination_hash` operations used by direct-chat history and
   runtime delivery-destination queries, so REM/RCH can keep those flows on the
   `ZmqPipelineBackendClient` path instead of requiring raw RPC/HTTP envelopes.
+- The typed ZeroMQ SDK backend also exposes durable direct-chat history as
+  `ZmqPipelineBackendClient::list_message_history`, preserving link-bearing
+  message bodies, receipt status, basic LXMF fields, and daemon pagination
+  cursors for restart recovery.
 - The typed ZeroMQ SDK backend preserves negotiated receipt terminality when
   mapping `sdk_status_v2` into `DeliverySnapshot`, so direct-chat delivery
   status reports `sent` as terminal only until


### PR DESCRIPTION
﻿## Summary
- add typed `MessageHistoryListRequest`, `MessageHistoryPage`, and `MessageHistoryRecord` SDK types
- expose `ZmqPipelineBackendClient::list_message_history` over the existing daemon `list_messages` operation
- split ZeroMQ transport mechanics and the oversized ZMQ test module so module-size checks stay clean
- update SDK quickstart and roadmap/parity notes for the typed durable history path

## Validation
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend zmq_pipeline -- --nocapture --test-threads=1`
- `cargo check -p lxmf-sdk --features zmq-pipeline-backend`
- `cargo fmt --all -- --check`
- `cargo clippy -p lxmf-sdk --features zmq-pipeline-backend --all-targets -- -D warnings`
- `git diff --check`
- `& 'C:\Program Files\Git\bin\bash.exe' tools/scripts/check-module-size.sh`
