### PR TITLE
[codex] Add typed ZeroMQ SDK destination hash

### DIFF
--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -28,6 +28,8 @@ use tokio::runtime::Runtime;
 mod batch;
 #[path = "zmq_pipeline/config.rs"]
 mod config;
+#[path = "zmq_pipeline/destination.rs"]
+mod destination;
 #[path = "zmq_pipeline/history.rs"]
 mod history;
 #[path = "zmq_pipeline/negotiation.rs"]

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/destination.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/destination.rs
@@ -1,0 +1,8 @@
+use super::{json, SdkError, ZmqPipelineBackendClient};
+
+impl ZmqPipelineBackendClient {
+    pub fn local_delivery_destination_hash(&self) -> Result<String, SdkError> {
+        let result = self.call_rpc("status", Some(json!({})))?;
+        Self::parse_required_string(&result, "delivery_destination_hash")
+    }
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/destination.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/destination.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+#[test]
+fn local_delivery_destination_hash_uses_zmq_sdk_status_method() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "identity_hash": "identity-destination",
+            "delivery_destination_hash": "delivery-destination"
+        }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let destination_hash =
+        client.local_delivery_destination_hash().expect("delivery destination hash");
+
+    assert_eq!(destination_hash, "delivery-destination");
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "status");
+    assert_eq!(request.params, Some(json!({})));
+    server.join().expect("server joined");
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/mod.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/mod.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
 
 mod batch;
+mod destination;
 mod history;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/docs/sdk/quickstart.md
+++ b/docs/sdk/quickstart.md
@@ -58,8 +58,9 @@ delivery methods plus identity list/activate/import/export, identity announce,
 presence list, identity resolve, contact update/list, identity bootstrap,
 operation registry, envelope execution, and typed durable direct-chat history
 through `ZmqPipelineBackendClient::list_message_history`. Runtime destination
-queries should use `app.delivery.destination_hash` through the SDK envelope
-path instead of constructing raw RPC envelopes. Burst sends can use
+queries can use `ZmqPipelineBackendClient::local_delivery_destination_hash`;
+operation-driven clients can still use `app.delivery.destination_hash` through
+SDK envelope execution. Burst sends can use
 `ZmqPipelineBackendClient::send_batch` for typed ordered per-message
 acceptance and rejection results; operation-driven clients can use
 `app.delivery.send_batch` through SDK envelope execution. Direct-chat

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -305,6 +305,11 @@ The project is best described by capability level:
   `ZmqPipelineBackendClient::list_message_history`, preserving message bodies
   with links, receipt status, basic LXMF fields, and restart pagination cursors
   from the daemon `list_messages` store.
+- The typed ZeroMQ SDK backend now exposes the local runtime delivery
+  destination through `ZmqPipelineBackendClient::local_delivery_destination_hash`,
+  while still routing `app.delivery.destination_hash` through SDK envelope
+  execution, so REM/RCH direct-chat source selection does not need raw RPC/HTTP
+  status calls.
 - The typed ZeroMQ SDK backend now tracks negotiated receipt terminality for
   delivery status, so direct-chat status reports match the SDK contract:
   `sent` is terminal until `sdk.capability.receipt_terminality` is negotiated,

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -322,6 +322,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   `ZmqPipelineBackendClient::list_message_history`, preserving link-bearing
   message bodies, receipt status, basic LXMF fields, and daemon pagination
   cursors for restart recovery.
+- The typed ZeroMQ SDK backend exposes the local runtime delivery destination
+  through `ZmqPipelineBackendClient::local_delivery_destination_hash` while
+  retaining `app.delivery.destination_hash` envelope execution, so direct-chat
+  source selection can stay on the typed ZeroMQ SDK path.
 - The typed ZeroMQ SDK backend preserves negotiated receipt terminality when
   mapping `sdk_status_v2` into `DeliverySnapshot`, so direct-chat delivery
   status reports `sent` as terminal only until


### PR DESCRIPTION
## Summary
- add `ZmqPipelineBackendClient::local_delivery_destination_hash` for typed access to the runtime delivery destination hash
- route the typed helper through the daemon `status` SDK operation instead of requiring clients to construct raw RPC/HTTP requests
- cover the ZeroMQ method and params with a focused pipeline test and update SDK/parity docs

## Validation
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend local_delivery_destination_hash_uses_zmq_sdk_status_method -- --nocapture`
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend zmq_pipeline -- --nocapture --test-threads=1`
- `cargo check -p lxmf-sdk --features zmq-pipeline-backend`
- `cargo fmt --all -- --check`
- `cargo clippy -p lxmf-sdk --features zmq-pipeline-backend --all-targets -- -D warnings`
- `git diff --check`
- `tools/scripts/check-module-size.sh`