### PR TITLE
[codex] Preserve ZeroMQ SDK status retry metadata

### DIFF
--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -236,8 +236,8 @@ impl SdkBackend for ZmqPipelineBackendClient {
             state,
             terminal,
             last_updated_ms: u64::try_from(timestamp.max(0)).unwrap_or(0).saturating_mul(1000),
-            attempts: 0,
-            reason_code: None,
+            attempts: Self::parse_optional_u32(record, "attempts").unwrap_or(0),
+            reason_code: Self::parse_optional_string(record, "reason_code"),
         }))
     }
 

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -236,8 +236,8 @@ impl SdkBackend for ZmqPipelineBackendClient {
             state,
             terminal,
             last_updated_ms: u64::try_from(timestamp.max(0)).unwrap_or(0).saturating_mul(1000),
-            attempts: Self::parse_optional_u32(record, "attempts").unwrap_or(0),
-            reason_code: Self::parse_optional_string(record, "reason_code"),
+            attempts: Self::parse_optional_u32(record, "attempts")?.unwrap_or(0),
+            reason_code: Self::parse_optional_string(record, "reason_code")?,
         }))
     }
 

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/parsing.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/parsing.rs
@@ -33,6 +33,15 @@ impl ZmqPipelineBackendClient {
         })
     }
 
+    pub(super) fn parse_optional_u32(value: &JsonValue, key: &'static str) -> Option<u32> {
+        let raw = value.get(key)?.as_u64()?;
+        u32::try_from(raw).ok()
+    }
+
+    pub(super) fn parse_optional_string(value: &JsonValue, key: &'static str) -> Option<String> {
+        value.get(key).and_then(JsonValue::as_str).map(str::to_owned)
+    }
+
     pub(super) fn parse_optional_string_or_default(
         value: &JsonValue,
         key: &'static str,

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/parsing.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/parsing.rs
@@ -33,13 +33,46 @@ impl ZmqPipelineBackendClient {
         })
     }
 
-    pub(super) fn parse_optional_u32(value: &JsonValue, key: &'static str) -> Option<u32> {
-        let raw = value.get(key)?.as_u64()?;
-        u32::try_from(raw).ok()
+    pub(super) fn parse_optional_u32(
+        value: &JsonValue,
+        key: &'static str,
+    ) -> Result<Option<u32>, SdkError> {
+        match value.get(key) {
+            None | Some(JsonValue::Null) => Ok(None),
+            Some(raw) => {
+                let raw = raw.as_u64().ok_or_else(|| {
+                    SdkError::new(
+                        code::INTERNAL,
+                        ErrorCategory::Internal,
+                        format!("rpc response field '{key}' must be an unsigned integer"),
+                    )
+                })?;
+                let parsed = u32::try_from(raw).map_err(|_| {
+                    SdkError::new(
+                        code::INTERNAL,
+                        ErrorCategory::Internal,
+                        format!("rpc response field '{key}' is out of range"),
+                    )
+                })?;
+                Ok(Some(parsed))
+            }
+        }
     }
 
-    pub(super) fn parse_optional_string(value: &JsonValue, key: &'static str) -> Option<String> {
-        value.get(key).and_then(JsonValue::as_str).map(str::to_owned)
+    pub(super) fn parse_optional_string(
+        value: &JsonValue,
+        key: &'static str,
+    ) -> Result<Option<String>, SdkError> {
+        match value.get(key) {
+            None | Some(JsonValue::Null) => Ok(None),
+            Some(raw) => raw.as_str().map(str::to_owned).map(Some).ok_or_else(|| {
+                SdkError::new(
+                    code::INTERNAL,
+                    ErrorCategory::Internal,
+                    format!("rpc response field '{key}' must be a string"),
+                )
+            }),
+        }
     }
 
     pub(super) fn parse_optional_string_or_default(

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/mod.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/mod.rs
@@ -8,6 +8,7 @@ use zeromq::{PullSocket, PushSocket, Socket, SocketRecv, SocketSend, ZmqMessage}
 mod batch;
 mod destination;
 mod history;
+mod status;
 mod workflow;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -754,99 +755,6 @@ fn cancel_uses_zmq_sdk_method_and_decodes_result() {
     let request = captured.as_ref().expect("zmq request");
     assert_eq!(request.method, "sdk_cancel_message_v2");
     assert_eq!(request.params.as_ref().expect("params")["message_id"], json!("msg-cancel"));
-    server.join().expect("server joined");
-}
-
-#[test]
-fn status_treats_sent_as_terminal_until_receipt_terminality_is_negotiated() {
-    let command_endpoint = unused_loopback_endpoint();
-    let response_endpoint = unused_loopback_endpoint();
-    let captured = Arc::new(Mutex::new(None));
-    let server = spawn_single_response_zmq_server(
-        command_endpoint.clone(),
-        json!({
-            "message": {
-                "message_id": "msg-sent",
-                "receipt_status": "sent",
-                "timestamp": 1710000000
-            }
-        }),
-        Arc::clone(&captured),
-    );
-    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
-    config.request_timeout = std::time::Duration::from_secs(2);
-    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
-
-    let snapshot =
-        client.status(MessageId("msg-sent".to_owned())).expect("status").expect("message");
-
-    assert_eq!(snapshot.state, DeliveryState::Sent);
-    assert!(snapshot.terminal);
-    let captured = captured.lock().expect("captured request");
-    let request = captured.as_ref().expect("zmq request");
-    assert_eq!(request.method, "sdk_status_v2");
-    assert_eq!(request.params.as_ref().expect("params")["message_id"], json!("msg-sent"));
-    server.join().expect("server joined");
-}
-
-#[test]
-fn status_keeps_sent_nonterminal_after_receipt_terminality_is_negotiated() {
-    let command_endpoint = unused_loopback_endpoint();
-    let response_endpoint = unused_loopback_endpoint();
-    let captured = Arc::new(Mutex::new(Vec::new()));
-    let server = spawn_response_sequence_zmq_server(
-        command_endpoint.clone(),
-        vec![
-            json!({
-                "runtime_id": "runtime-zmq-receipts",
-                "active_contract_version": 2,
-                "effective_capabilities": ["sdk.capability.receipt_terminality"],
-                "effective_limits": {
-                    "max_poll_events": 64,
-                    "max_event_bytes": 32768,
-                    "max_batch_bytes": 1048576,
-                    "max_extension_keys": 32,
-                    "idempotency_ttl_ms": 60000
-                },
-                "contract_release": "v2",
-                "schema_namespace": "sdk.v2"
-            }),
-            json!({
-                "message": {
-                    "message_id": "msg-sent",
-                    "receipt_status": "sent",
-                    "timestamp": 1710000000
-                }
-            }),
-        ],
-        Arc::clone(&captured),
-    );
-    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
-    config.request_timeout = std::time::Duration::from_secs(2);
-    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
-
-    client
-        .negotiate(crate::capability::NegotiationRequest {
-            supported_contract_versions: vec![2],
-            requested_capabilities: vec!["sdk.capability.receipt_terminality".to_owned()],
-            profile: crate::types::Profile::DesktopLocalRuntime,
-            bind_mode: crate::types::BindMode::LocalOnly,
-            auth_mode: crate::types::AuthMode::LocalTrusted,
-            overflow_policy: crate::types::OverflowPolicy::Reject,
-            block_timeout_ms: None,
-            rpc_backend: None,
-            extensions: Default::default(),
-        })
-        .expect("negotiate");
-    let snapshot =
-        client.status(MessageId("msg-sent".to_owned())).expect("status").expect("message");
-
-    assert_eq!(snapshot.state, DeliveryState::Sent);
-    assert!(!snapshot.terminal);
-    let captured = captured.lock().expect("captured requests");
-    assert_eq!(captured.len(), 2);
-    assert_eq!(captured[0].method, "sdk_negotiate_v2");
-    assert_eq!(captured[1].method, "sdk_status_v2");
     server.join().expect("server joined");
 }
 

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/status.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/status.rs
@@ -129,3 +129,36 @@ fn status_preserves_retry_attempts_and_reason_code_from_zmq_sdk_response() {
     assert_eq!(request.params.as_ref().expect("params")["message_id"], json!("msg-retry"));
     server.join().expect("server joined");
 }
+
+#[test]
+fn status_rejects_malformed_retry_metadata_from_zmq_sdk_response() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "message": {
+                "message_id": "msg-retry-invalid",
+                "receipt_status": "failed: no path",
+                "timestamp": 1710000101,
+                "attempts": "3",
+                "reason_code": 404
+            }
+        }),
+        Arc::new(Mutex::new(None)),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let err = client
+        .status(MessageId("msg-retry-invalid".to_owned()))
+        .expect_err("malformed retry metadata should fail status decoding");
+
+    assert_eq!(err.category, ErrorCategory::Internal);
+    assert!(
+        err.message.contains("attempts") || err.message.contains("reason_code"),
+        "unexpected error: {err:?}"
+    );
+    server.join().expect("server joined");
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/status.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/status.rs
@@ -1,0 +1,131 @@
+use super::*;
+
+#[test]
+fn status_treats_sent_as_terminal_until_receipt_terminality_is_negotiated() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "message": {
+                "message_id": "msg-sent",
+                "receipt_status": "sent",
+                "timestamp": 1710000000
+            }
+        }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let snapshot =
+        client.status(MessageId("msg-sent".to_owned())).expect("status").expect("message");
+
+    assert_eq!(snapshot.state, DeliveryState::Sent);
+    assert!(snapshot.terminal);
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "sdk_status_v2");
+    assert_eq!(request.params.as_ref().expect("params")["message_id"], json!("msg-sent"));
+    server.join().expect("server joined");
+}
+
+#[test]
+fn status_keeps_sent_nonterminal_after_receipt_terminality_is_negotiated() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let server = spawn_response_sequence_zmq_server(
+        command_endpoint.clone(),
+        vec![
+            json!({
+                "runtime_id": "runtime-zmq-receipts",
+                "active_contract_version": 2,
+                "effective_capabilities": ["sdk.capability.receipt_terminality"],
+                "effective_limits": {
+                    "max_poll_events": 64,
+                    "max_event_bytes": 32768,
+                    "max_batch_bytes": 1048576,
+                    "max_extension_keys": 32,
+                    "idempotency_ttl_ms": 60000
+                },
+                "contract_release": "v2",
+                "schema_namespace": "sdk.v2"
+            }),
+            json!({
+                "message": {
+                    "message_id": "msg-sent",
+                    "receipt_status": "sent",
+                    "timestamp": 1710000000
+                }
+            }),
+        ],
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    client
+        .negotiate(crate::capability::NegotiationRequest {
+            supported_contract_versions: vec![2],
+            requested_capabilities: vec!["sdk.capability.receipt_terminality".to_owned()],
+            profile: crate::types::Profile::DesktopLocalRuntime,
+            bind_mode: crate::types::BindMode::LocalOnly,
+            auth_mode: crate::types::AuthMode::LocalTrusted,
+            overflow_policy: crate::types::OverflowPolicy::Reject,
+            block_timeout_ms: None,
+            rpc_backend: None,
+            extensions: Default::default(),
+        })
+        .expect("negotiate");
+    let snapshot =
+        client.status(MessageId("msg-sent".to_owned())).expect("status").expect("message");
+
+    assert_eq!(snapshot.state, DeliveryState::Sent);
+    assert!(!snapshot.terminal);
+    let captured = captured.lock().expect("captured requests");
+    assert_eq!(captured.len(), 2);
+    assert_eq!(captured[0].method, "sdk_negotiate_v2");
+    assert_eq!(captured[1].method, "sdk_status_v2");
+    server.join().expect("server joined");
+}
+
+#[test]
+fn status_preserves_retry_attempts_and_reason_code_from_zmq_sdk_response() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "message": {
+                "message_id": "msg-retry",
+                "receipt_status": "failed: no path",
+                "timestamp": 1710000100,
+                "attempts": 3,
+                "reason_code": "no_path"
+            }
+        }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let snapshot =
+        client.status(MessageId("msg-retry".to_owned())).expect("status").expect("message");
+
+    assert_eq!(snapshot.state, DeliveryState::Failed);
+    assert!(snapshot.terminal);
+    assert_eq!(snapshot.attempts, 3);
+    assert_eq!(snapshot.reason_code.as_deref(), Some("no_path"));
+    assert_eq!(snapshot.last_updated_ms, 1_710_000_100_000);
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "sdk_status_v2");
+    assert_eq!(request.params.as_ref().expect("params")["message_id"], json!("msg-retry"));
+    server.join().expect("server joined");
+}

--- a/docs/architecture/module-size-allowlist.txt
+++ b/docs/architecture/module-size-allowlist.txt
@@ -1,2 +1,4 @@
 # Temporary exceptions to module size budgets.
 # Keep this list short and remove entries as files are split.
+crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/localunpeercleanup.rs
+crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/handle_rpc_legacy_peer_sync.rs

--- a/docs/architecture/module-size-allowlist.txt
+++ b/docs/architecture/module-size-allowlist.txt
@@ -1,4 +1,2 @@
 # Temporary exceptions to module size budgets.
 # Keep this list short and remove entries as files are split.
-crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/localunpeercleanup.rs
-crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/handle_rpc_legacy_peer_sync.rs

--- a/docs/sdk/quickstart.md
+++ b/docs/sdk/quickstart.md
@@ -72,12 +72,10 @@ cancellation can use either `sdk_cancel_message_v2` via
 envelope execution, preserving `Accepted`, `AlreadyTerminal`, `NotFound`, and
 `TooLateToCancel` results. Delivery status follows negotiated receipt semantics
 on the ZeroMQ path: `sent` is terminal until
-on the ZeroMQ path: `app.message.history.list`, `app.delivery.destination_hash`,
-`app.delivery.send_batch`, and `app.delivery.cancel` stay on the SDK envelope
-path instead of raw RPC envelopes. Delivery status follows negotiated receipt
-semantics on the ZeroMQ path: `sent` is terminal until
 `sdk.capability.receipt_terminality` is negotiated, then `delivered` is the
-terminal receipt state.
+terminal receipt state. Status snapshots also preserve daemon-reported
+retry-attempt counts and reason codes so REM/RCH can surface restart/retry
+state without raw RPC status calls.
 
 Run the example client:
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -60,6 +60,9 @@ The project is best described by capability level:
   are ignored is obsolete.
 - Direct and propagated resource sends support receipt-state separation,
   timeout/failure propagation, and active resource cancellation.
+- The typed ZeroMQ SDK delivery status path now preserves daemon-reported
+  retry-attempt counts and reason codes in `DeliverySnapshot`, so REM/RCH can
+  inspect retry and recovery state without dropping to raw RPC status calls.
 - Ticket validity, renewal, derivation, persistence, and inbound ticket reuse
   are implemented.
 - Propagation peers have real queue, policy, maintenance, throttling, peering,

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -343,6 +343,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   mapping `sdk_status_v2` into `DeliverySnapshot`, so direct-chat delivery
   status reports `sent` as terminal only until
   `sdk.capability.receipt_terminality` is negotiated.
+- The typed ZeroMQ SDK backend preserves daemon-reported retry-attempt counts
+  and reason codes when mapping `sdk_status_v2` into `DeliverySnapshot`, so
+  direct-chat restart and retry recovery state remains visible to REM/RCH over
+  `ZmqPipelineBackendClient`.
 - The typed ZeroMQ SDK backend exposes burst sends through
   `ZmqPipelineBackendClient::send_batch` and also supports
   `app.delivery.send_batch` envelope execution, preserving ordered per-message


### PR DESCRIPTION
﻿## Summary
- preserve daemon-reported retry attempts and reason codes in `ZmqPipelineBackendClient::status`
- move ZeroMQ status tests into a dedicated status test module and add RED/GREEN coverage for retry metadata
- update SDK quickstart and parity/roadmap docs for REM/RCH retry-state visibility
- refresh module-size allowlist entries for two current propagation files on `main` so the architecture gate passes

## Validation
- cargo test -p lxmf-sdk --features zmq-pipeline-backend status_preserves_retry_attempts_and_reason_code_from_zmq_sdk_response -- --nocapture
- cargo test -p lxmf-sdk --features zmq-pipeline-backend zmq_pipeline -- --nocapture --test-threads=1
- cargo check -p lxmf-sdk --features zmq-pipeline-backend
- cargo fmt --all -- --check
- cargo clippy -p lxmf-sdk --features zmq-pipeline-backend --all-targets -- -D warnings
- git diff --check
- `C:\Program Files\Git\bin\bash.exe` tools/scripts/check-module-size.sh
