### PR TITLE
[codex] Accept history message body aliases

### DIFF
--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/history.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/history.rs
@@ -82,3 +82,68 @@ fn list_message_history_uses_zmq_sdk_method_and_preserves_receipts_and_fields() 
     );
     server.join().expect("server joined");
 }
+
+#[test]
+fn list_message_history_accepts_direct_chat_message_id_and_body_aliases() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "response": {
+                "operation_id": "app.message.history.list",
+                "kind": "result",
+                "accepted": true,
+                "correlation_id": null,
+                "payload": {
+                    "messages": [{
+                        "message_id": "msg-history-legacy",
+                        "source": "peer-destination",
+                        "destination": "local-destination",
+                        "title": "legacy chat",
+                        "body": "legacy body https://example.invalid/recovery",
+                        "timestamp": 1_700_000_222,
+                        "direction": "inbound",
+                        "fields": {
+                            "body": "legacy body https://example.invalid/recovery",
+                            "FIELD_THREAD": "thread-recovered"
+                        },
+                        "receipt_status": "received"
+                    }],
+                    "next_cursor": null
+                }
+            }
+        }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let page = client
+        .list_message_history(crate::MessageHistoryListRequest {
+            peer_id: Some("peer-destination".to_string()),
+            conversation_id: None,
+            include_receipts: Some(true),
+            limit: Some(10),
+            before_ts: None,
+            cursor: None,
+        })
+        .expect("history page");
+
+    assert_eq!(page.messages.len(), 1);
+    let message = &page.messages[0];
+    assert_eq!(message.id, "msg-history-legacy");
+    assert_eq!(message.content, "legacy body https://example.invalid/recovery");
+    assert_eq!(message.receipt_status.as_deref(), Some("received"));
+    assert_eq!(message.fields.as_ref().expect("fields")["FIELD_THREAD"], json!("thread-recovered"));
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "sdk_envelope_execute_v2");
+    assert_eq!(
+        request.params.as_ref().expect("params")["payload"]["peer_id"],
+        json!("peer-destination")
+    );
+    server.join().expect("server joined");
+}

--- a/crates/libs/lxmf-sdk/src/messaging.rs
+++ b/crates/libs/lxmf-sdk/src/messaging.rs
@@ -161,10 +161,12 @@ pub struct MessageHistoryPage {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MessageHistoryRecord {
+    #[serde(alias = "message_id")]
     pub id: String,
     pub source: String,
     pub destination: String,
     pub title: String,
+    #[serde(alias = "body")]
     pub content: String,
     pub timestamp: i64,
     pub direction: String,

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -341,6 +341,10 @@ The project is best described by capability level:
   `peer_id`/`conversation_id` filters, `include_receipts`, and restart
   pagination cursors through the daemon `app.message.history.list` SDK envelope
   path.
+- `ZmqPipelineBackendClient::list_message_history` now accepts both canonical
+  `id`/`content` records and legacy direct-chat `message_id`/`body` records
+  from `app.message.history.list`, keeping restart-recovered conversation
+  history readable without raw envelope decoding.
 - The typed ZeroMQ SDK backend now exposes the local runtime delivery
   destination through `ZmqPipelineBackendClient::local_delivery_destination_hash`,
   while still routing `app.delivery.destination_hash` through SDK envelope

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -349,6 +349,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   `peer_id`/`conversation_id` filters, `include_receipts`, and daemon
   pagination cursors for restart recovery through the
   `app.message.history.list` SDK envelope path.
+- `ZmqPipelineBackendClient::list_message_history` accepts canonical
+  `id`/`content` history rows and legacy direct-chat `message_id`/`body` rows,
+  so recovered history remains typed even when the daemon returns the older app
+  chat field names.
 - The typed ZeroMQ SDK backend exposes the local runtime delivery destination
   through `ZmqPipelineBackendClient::local_delivery_destination_hash` while
   retaining `app.delivery.destination_hash` envelope execution, so direct-chat


### PR DESCRIPTION
## Summary
- accept `message_id` as an alias for typed history record `id`
- accept `body` as an alias for typed history record `content`
- document the ZeroMQ SDK direct-chat history compatibility for REM/RCH restart recovery

## Why
`app.message.history.list` can return legacy direct-chat rows using `message_id`/`body`, while `ZmqPipelineBackendClient::list_message_history` only decoded canonical `id`/`content`. That forced clients to fall back to raw envelope payloads for recovered history.

## Validation
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend list_message_history_accepts_direct_chat_message_id_and_body_aliases -- --nocapture` failed before the fix with missing field `id`
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend list_message_history_accepts_direct_chat_message_id_and_body_aliases -- --nocapture`
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend zmq_pipeline -- --nocapture --test-threads=1`
- `cargo check -p lxmf-sdk --features zmq-pipeline-backend`
- `cargo clippy -p lxmf-sdk --features zmq-pipeline-backend --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `C:\Program Files\Git\bin\bash.exe tools/scripts/check-module-size.sh`