### PR TITLE
[codex] Preserve batch item SDK metadata

### DIFF
--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/send.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/send.rs
@@ -75,14 +75,39 @@ fn batch_item_params(item: BatchSendItem) -> JsonValue {
         stamp_cost,
         include_ticket,
         try_propagation_on_fail,
+        idempotency_key,
+        ttl_ms,
+        correlation_id,
+        extensions,
     } = item;
     let content = message_content(&payload);
     let title =
         payload.get("title").and_then(JsonValue::as_str).map(str::to_owned).unwrap_or_default();
-    let fields = match payload {
+    let mut fields = match payload {
         JsonValue::Object(map) => JsonValue::Object(map),
         other => json!({ "payload": other }),
     };
+    if let JsonValue::Object(map) = &mut fields {
+        let mut sdk_meta = serde_json::Map::new();
+        if let Some(value) = idempotency_key {
+            sdk_meta.insert("idempotency_key".to_string(), JsonValue::String(value));
+        }
+        if let Some(value) = ttl_ms {
+            sdk_meta.insert("ttl_ms".to_string(), JsonValue::from(value));
+        }
+        if let Some(value) = correlation_id {
+            sdk_meta.insert("correlation_id".to_string(), JsonValue::String(value));
+        }
+        if !extensions.is_empty() {
+            sdk_meta.insert(
+                "extensions".to_string(),
+                JsonValue::Object(extensions.into_iter().collect()),
+            );
+        }
+        if !sdk_meta.is_empty() {
+            map.insert("_sdk".to_string(), JsonValue::Object(sdk_meta));
+        }
+    }
     json!({
         "id": id,
         "destination": destination,

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/batch.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/batch.rs
@@ -50,6 +50,10 @@ fn send_batch_uses_zmq_sdk_method_and_decodes_ordered_results() {
                     }),
                 )
                 .with_delivery_method("direct")
+                .with_idempotency_key("batch-msg-1-send-once")
+                .with_ttl_ms(30_000)
+                .with_correlation_id("batch-msg-1-corr")
+                .with_extension("burst_slot", json!(0))
                 .with_include_ticket(false),
                 crate::BatchSendItem::new(
                     "batch-msg-2",
@@ -90,6 +94,16 @@ fn send_batch_uses_zmq_sdk_method_and_decodes_ordered_results() {
         json!("payload a https://example.invalid/a")
     );
     assert_eq!(params["messages"][0]["fields"]["FIELD_THREAD"], json!("thread-a"));
+    assert_eq!(
+        params["messages"][0]["fields"]["_sdk"]["idempotency_key"],
+        json!("batch-msg-1-send-once")
+    );
+    assert_eq!(params["messages"][0]["fields"]["_sdk"]["ttl_ms"], json!(30_000));
+    assert_eq!(
+        params["messages"][0]["fields"]["_sdk"]["correlation_id"],
+        json!("batch-msg-1-corr")
+    );
+    assert_eq!(params["messages"][0]["fields"]["_sdk"]["extensions"]["burst_slot"], json!(0));
     assert_eq!(params["messages"][0]["method"], json!("direct"));
     assert_eq!(params["messages"][0]["include_ticket"], json!(false));
     assert_eq!(params["messages"][1]["fields"]["FIELD_GROUP"], json!("group-b"));

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/history.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/history.rs
@@ -82,3 +82,68 @@ fn list_message_history_uses_zmq_sdk_method_and_preserves_receipts_and_fields() 
     );
     server.join().expect("server joined");
 }
+
+#[test]
+fn list_message_history_accepts_direct_chat_message_id_and_body_aliases() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "response": {
+                "operation_id": "app.message.history.list",
+                "kind": "result",
+                "accepted": true,
+                "correlation_id": null,
+                "payload": {
+                    "messages": [{
+                        "message_id": "msg-history-legacy",
+                        "source": "peer-destination",
+                        "destination": "local-destination",
+                        "title": "legacy chat",
+                        "body": "legacy body https://example.invalid/recovery",
+                        "timestamp": 1_700_000_222,
+                        "direction": "inbound",
+                        "fields": {
+                            "body": "legacy body https://example.invalid/recovery",
+                            "FIELD_THREAD": "thread-recovered"
+                        },
+                        "receipt_status": "received"
+                    }],
+                    "next_cursor": null
+                }
+            }
+        }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let page = client
+        .list_message_history(crate::MessageHistoryListRequest {
+            peer_id: Some("peer-destination".to_string()),
+            conversation_id: None,
+            include_receipts: Some(true),
+            limit: Some(10),
+            before_ts: None,
+            cursor: None,
+        })
+        .expect("history page");
+
+    assert_eq!(page.messages.len(), 1);
+    let message = &page.messages[0];
+    assert_eq!(message.id, "msg-history-legacy");
+    assert_eq!(message.content, "legacy body https://example.invalid/recovery");
+    assert_eq!(message.receipt_status.as_deref(), Some("received"));
+    assert_eq!(message.fields.as_ref().expect("fields")["FIELD_THREAD"], json!("thread-recovered"));
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "sdk_envelope_execute_v2");
+    assert_eq!(
+        request.params.as_ref().expect("params")["payload"]["peer_id"],
+        json!("peer-destination")
+    );
+    server.join().expect("server joined");
+}

--- a/crates/libs/lxmf-sdk/src/messaging.rs
+++ b/crates/libs/lxmf-sdk/src/messaging.rs
@@ -161,10 +161,12 @@ pub struct MessageHistoryPage {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MessageHistoryRecord {
+    #[serde(alias = "message_id")]
     pub id: String,
     pub source: String,
     pub destination: String,
     pub title: String,
+    #[serde(alias = "body")]
     pub content: String,
     pub timestamp: i64,
     pub direction: String,

--- a/crates/libs/lxmf-sdk/src/types/delivery.rs
+++ b/crates/libs/lxmf-sdk/src/types/delivery.rs
@@ -187,6 +187,11 @@ pub struct BatchSendItem {
     pub include_ticket: Option<bool>,
     #[serde(default)]
     pub try_propagation_on_fail: Option<bool>,
+    pub idempotency_key: Option<String>,
+    pub ttl_ms: Option<u64>,
+    pub correlation_id: Option<String>,
+    #[serde(default)]
+    pub extensions: BTreeMap<String, JsonValue>,
 }
 
 impl BatchSendItem {
@@ -199,7 +204,31 @@ impl BatchSendItem {
             stamp_cost: None,
             include_ticket: None,
             try_propagation_on_fail: None,
+            idempotency_key: None,
+            ttl_ms: None,
+            correlation_id: None,
+            extensions: BTreeMap::new(),
         }
+    }
+
+    pub fn with_idempotency_key(mut self, key: impl Into<String>) -> Self {
+        self.idempotency_key = Some(key.into());
+        self
+    }
+
+    pub fn with_ttl_ms(mut self, ttl_ms: u64) -> Self {
+        self.ttl_ms = Some(ttl_ms);
+        self
+    }
+
+    pub fn with_correlation_id(mut self, correlation_id: impl Into<String>) -> Self {
+        self.correlation_id = Some(correlation_id.into());
+        self
+    }
+
+    pub fn with_extension(mut self, key: impl Into<String>, value: JsonValue) -> Self {
+        self.extensions.insert(key.into(), value);
+        self
     }
 
     pub fn with_delivery_method(mut self, method: impl Into<String>) -> Self {

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -359,6 +359,9 @@ The project is best described by capability level:
   `app.delivery.send_batch` envelope calls to `sdk_send_batch_v2`, preserving
   ordered per-message acceptance and rejection results without raw RPC
   envelopes.
+- `BatchSendItem` now carries per-message idempotency keys, TTL, correlation
+  IDs, and SDK extensions into each batch message's `_sdk` field metadata, so
+  burst direct-chat retries can remain stable across client restarts.
 - The typed ZeroMQ SDK backend and operation registry now expose direct-chat
   cancellation through both `ZmqPipelineBackendClient::cancel` and
   `app.delivery.cancel` envelope execution, preserving daemon cancellation

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -341,6 +341,10 @@ The project is best described by capability level:
   `peer_id`/`conversation_id` filters, `include_receipts`, and restart
   pagination cursors through the daemon `app.message.history.list` SDK envelope
   path.
+- `ZmqPipelineBackendClient::list_message_history` now accepts both canonical
+  `id`/`content` records and legacy direct-chat `message_id`/`body` records
+  from `app.message.history.list`, keeping restart-recovered conversation
+  history readable without raw envelope decoding.
 - The typed ZeroMQ SDK backend now exposes the local runtime delivery
   destination through `ZmqPipelineBackendClient::local_delivery_destination_hash`,
   while still routing `app.delivery.destination_hash` through SDK envelope

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -349,6 +349,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   `peer_id`/`conversation_id` filters, `include_receipts`, and daemon
   pagination cursors for restart recovery through the
   `app.message.history.list` SDK envelope path.
+- `ZmqPipelineBackendClient::list_message_history` accepts canonical
+  `id`/`content` history rows and legacy direct-chat `message_id`/`body` rows,
+  so recovered history remains typed even when the daemon returns the older app
+  chat field names.
 - The typed ZeroMQ SDK backend exposes the local runtime delivery destination
   through `ZmqPipelineBackendClient::local_delivery_destination_hash` while
   retaining `app.delivery.destination_hash` envelope execution, so direct-chat

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -369,6 +369,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   `ZmqPipelineBackendClient::send_batch` and also supports
   `app.delivery.send_batch` envelope execution, preserving ordered per-message
   acceptance and rejection results without raw RPC envelopes.
+- `BatchSendItem` preserves per-message idempotency keys, TTL, correlation IDs,
+  and SDK extensions in each batch message's `_sdk` field metadata, keeping
+  burst direct-chat retry and restart recovery state on the typed SDK path.
 - The typed ZeroMQ SDK backend and operation registry expose direct-chat
   cancellation through both `ZmqPipelineBackendClient::cancel` and
   `app.delivery.cancel` envelope execution, preserving daemon cancellation


### PR DESCRIPTION
## Summary
- add per-message idempotency, TTL, correlation, and extension metadata to `BatchSendItem`
- preserve that metadata under each batch message `fields._sdk` over `sdk_send_batch_v2`
- update the roadmap and LXMF parity matrix for burst-send restart/retry stability

## Why
Single-message sends already preserve SDK control metadata, but batch messages could not carry the same per-message idempotency and correlation controls. That left burst direct-chat retries less stable for REM/RCH clients using the typed ZeroMQ SDK path.

## Validation
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend send_batch_uses_zmq_sdk_method_and_decodes_ordered_results -- --nocapture` failed before the fix with missing `BatchSendItem::with_idempotency_key`
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend send_batch_uses_zmq_sdk_method_and_decodes_ordered_results -- --nocapture`
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend zmq_pipeline -- --nocapture --test-threads=1`
- `cargo check -p lxmf-sdk --features zmq-pipeline-backend`
- `cargo clippy -p lxmf-sdk --features zmq-pipeline-backend --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `C:\Program Files\Git\bin\bash.exe tools/scripts/check-module-size.sh`