### PR TITLE
[codex] Add ZeroMQ SDK peer lifecycle

### DIFF
--- a/crates/libs/lxmf-sdk/src/api.rs
+++ b/crates/libs/lxmf-sdk/src/api.rs
@@ -9,11 +9,12 @@ use crate::domain::{
     ContactUpdateRequest, IdentityBootstrapRequest, IdentityBundle, IdentityImportRequest,
     IdentityRef, IdentityResolveRequest, MarkerCreateRequest, MarkerDeleteRequest,
     MarkerListRequest, MarkerListResult, MarkerRecord, MarkerUpdatePositionRequest,
-    PaperMessageEnvelope, PresenceListRequest, PresenceListResult, RemoteCommandRequest,
-    RemoteCommandResponse, RemoteCommandSession, RemoteCommandSessionListRequest,
-    RemoteCommandSessionListResult, TelemetryPoint, TelemetryQuery, TopicCreateRequest, TopicId,
-    TopicListRequest, TopicListResult, TopicPublishRequest, TopicRecord, TopicSubscriptionRequest,
-    VoiceSessionId, VoiceSessionOpenRequest, VoiceSessionState, VoiceSessionUpdateRequest,
+    PaperMessageEnvelope, PeerConnectionRequest, PeerConnectionResult, PresenceListRequest,
+    PresenceListResult, RemoteCommandRequest, RemoteCommandResponse, RemoteCommandSession,
+    RemoteCommandSessionListRequest, RemoteCommandSessionListResult, TelemetryPoint,
+    TelemetryQuery, TopicCreateRequest, TopicId, TopicListRequest, TopicListResult,
+    TopicPublishRequest, TopicRecord, TopicSubscriptionRequest, VoiceSessionId,
+    VoiceSessionOpenRequest, VoiceSessionState, VoiceSessionUpdateRequest,
 };
 use crate::error::SdkError;
 use crate::event::{EventBatch, EventCursor};
@@ -228,6 +229,26 @@ pub trait LxmfSdkIdentity {
         _req: IdentityBootstrapRequest,
     ) -> Result<ContactRecord, SdkError> {
         Err(SdkError::capability_disabled("sdk.capability.contact_management"))
+    }
+}
+
+pub trait LxmfSdkPeerLifecycle {
+    fn peer_connect(&self, _req: PeerConnectionRequest) -> Result<PeerConnectionResult, SdkError> {
+        Err(SdkError::capability_disabled("sdk.capability.peer_lifecycle"))
+    }
+
+    fn peer_disconnect(
+        &self,
+        _req: PeerConnectionRequest,
+    ) -> Result<PeerConnectionResult, SdkError> {
+        Err(SdkError::capability_disabled("sdk.capability.peer_lifecycle"))
+    }
+
+    fn peer_reconnect(
+        &self,
+        _req: PeerConnectionRequest,
+    ) -> Result<PeerConnectionResult, SdkError> {
+        Err(SdkError::capability_disabled("sdk.capability.peer_lifecycle"))
     }
 }
 

--- a/crates/libs/lxmf-sdk/src/app/operations_parts/built_in_entries.rs
+++ b/crates/libs/lxmf-sdk/src/app/operations_parts/built_in_entries.rs
@@ -138,6 +138,33 @@ fn built_in_entries() -> Vec<OperationEntry> {
         .with_alias("sdk_identity_bootstrap_v2")
         .with_required_capability("sdk.capability.contact_management"),
         OperationEntry::new(
+            "app.peer.connect",
+            "peer",
+            OperationKind::Command,
+            TransportVariant::Rpc,
+            "Connect to a saved peer and surface the resulting lifecycle state.",
+        )
+        .with_alias("sdk_peer_connect_v2")
+        .with_required_capability("sdk.capability.peer_lifecycle"),
+        OperationEntry::new(
+            "app.peer.disconnect",
+            "peer",
+            OperationKind::Command,
+            TransportVariant::Rpc,
+            "Disconnect a saved peer while preserving lifecycle metadata.",
+        )
+        .with_alias("sdk_peer_disconnect_v2")
+        .with_required_capability("sdk.capability.peer_lifecycle"),
+        OperationEntry::new(
+            "app.peer.reconnect",
+            "peer",
+            OperationKind::Command,
+            TransportVariant::Rpc,
+            "Reconnect a saved peer after transport or runtime recovery.",
+        )
+        .with_alias("sdk_peer_reconnect_v2")
+        .with_required_capability("sdk.capability.peer_lifecycle"),
+        OperationEntry::new(
             "app.topic.create",
             "topics",
             OperationKind::Command,

--- a/crates/libs/lxmf-sdk/src/backend.rs
+++ b/crates/libs/lxmf-sdk/src/backend.rs
@@ -8,11 +8,12 @@ use crate::domain::{
     ContactUpdateRequest, IdentityBootstrapRequest, IdentityBundle, IdentityImportRequest,
     IdentityRef, IdentityResolveRequest, MarkerCreateRequest, MarkerDeleteRequest,
     MarkerListRequest, MarkerListResult, MarkerRecord, MarkerUpdatePositionRequest,
-    PaperMessageEnvelope, PresenceListRequest, PresenceListResult, RemoteCommandRequest,
-    RemoteCommandResponse, RemoteCommandSession, RemoteCommandSessionListRequest,
-    RemoteCommandSessionListResult, TelemetryPoint, TelemetryQuery, TopicCreateRequest, TopicId,
-    TopicListRequest, TopicListResult, TopicPublishRequest, TopicRecord, TopicSubscriptionRequest,
-    VoiceSessionId, VoiceSessionOpenRequest, VoiceSessionState, VoiceSessionUpdateRequest,
+    PaperMessageEnvelope, PeerConnectionRequest, PeerConnectionResult, PresenceListRequest,
+    PresenceListResult, RemoteCommandRequest, RemoteCommandResponse, RemoteCommandSession,
+    RemoteCommandSessionListRequest, RemoteCommandSessionListResult, TelemetryPoint,
+    TelemetryQuery, TopicCreateRequest, TopicId, TopicListRequest, TopicListResult,
+    TopicPublishRequest, TopicRecord, TopicSubscriptionRequest, VoiceSessionId,
+    VoiceSessionOpenRequest, VoiceSessionState, VoiceSessionUpdateRequest,
 };
 use crate::error::{code, ErrorCategory, SdkError};
 use crate::event::{EventBatch, EventCursor};
@@ -249,6 +250,24 @@ pub trait SdkBackend: Send + Sync {
         _req: IdentityBootstrapRequest,
     ) -> Result<ContactRecord, SdkError> {
         Err(SdkError::capability_disabled("sdk.capability.contact_management"))
+    }
+
+    fn peer_connect(&self, _req: PeerConnectionRequest) -> Result<PeerConnectionResult, SdkError> {
+        Err(SdkError::capability_disabled("sdk.capability.peer_lifecycle"))
+    }
+
+    fn peer_disconnect(
+        &self,
+        _req: PeerConnectionRequest,
+    ) -> Result<PeerConnectionResult, SdkError> {
+        Err(SdkError::capability_disabled("sdk.capability.peer_lifecycle"))
+    }
+
+    fn peer_reconnect(
+        &self,
+        _req: PeerConnectionRequest,
+    ) -> Result<PeerConnectionResult, SdkError> {
+        Err(SdkError::capability_disabled("sdk.capability.peer_lifecycle"))
     }
 
     fn paper_encode(&self, _message_id: MessageId) -> Result<PaperMessageEnvelope, SdkError> {

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -4,7 +4,8 @@ use crate::capability::{NegotiationRequest, NegotiationResponse};
 use crate::domain::{
     ContactListRequest, ContactListResult, ContactRecord, ContactUpdateRequest,
     IdentityBootstrapRequest, IdentityBundle, IdentityImportRequest, IdentityRef,
-    IdentityResolveRequest, PresenceListRequest, PresenceListResult,
+    IdentityResolveRequest, PeerConnectionRequest, PeerConnectionResult, PresenceListRequest,
+    PresenceListResult,
 };
 use crate::error::{code, ErrorCategory, SdkError};
 use crate::event::{EventBatch, EventCursor, SdkEvent, Severity};
@@ -38,6 +39,8 @@ mod history;
 mod negotiation;
 #[path = "zmq_pipeline/parsing.rs"]
 mod parsing;
+#[path = "zmq_pipeline/peer.rs"]
+mod peer;
 #[path = "zmq_pipeline/send.rs"]
 mod send;
 #[path = "zmq_pipeline/transport.rs"]
@@ -52,7 +55,6 @@ mod tests;
 pub use config::{ZmqEndpointRole, ZmqPipelineBackendConfig, ZmqPipelineTokenAuth};
 use negotiation::new_session_id;
 use transport::ZmqPipelineTransport;
-
 pub struct ZmqPipelineBackendClient {
     config: ZmqPipelineBackendConfig,
     session_id: String,
@@ -61,7 +63,6 @@ pub struct ZmqPipelineBackendClient {
     runtime: Runtime,
     transport: tokio::sync::Mutex<Option<ZmqPipelineTransport>>,
 }
-
 impl ZmqPipelineBackendClient {
     pub fn new(config: ZmqPipelineBackendConfig) -> Result<Self, SdkError> {
         config.validate()?;
@@ -410,6 +411,19 @@ impl SdkBackend for ZmqPipelineBackendClient {
         Self::decode_field_or_root(&result, "contact", "identity_bootstrap response")
     }
 
+    fn peer_connect(&self, req: PeerConnectionRequest) -> Result<PeerConnectionResult, SdkError> {
+        ZmqPipelineBackendClient::peer_connect(self, req)
+    }
+    fn peer_disconnect(
+        &self,
+        req: PeerConnectionRequest,
+    ) -> Result<PeerConnectionResult, SdkError> {
+        ZmqPipelineBackendClient::peer_disconnect(self, req)
+    }
+
+    fn peer_reconnect(&self, req: PeerConnectionRequest) -> Result<PeerConnectionResult, SdkError> {
+        ZmqPipelineBackendClient::peer_reconnect(self, req)
+    }
     fn operation_registry(&self) -> Result<OperationRegistry, SdkError> {
         let result = self.call_rpc("sdk_operation_registry_v2", Some(json!({})))?;
         Self::decode_field_or_root(&result, "registry", "operation_registry response")

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/peer.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/peer.rs
@@ -1,0 +1,38 @@
+use super::{code, ErrorCategory, SdkError, ZmqPipelineBackendClient};
+use crate::domain::{PeerConnectionRequest, PeerConnectionResult};
+
+impl ZmqPipelineBackendClient {
+    pub fn peer_connect(
+        &self,
+        req: PeerConnectionRequest,
+    ) -> Result<PeerConnectionResult, SdkError> {
+        self.peer_lifecycle_call("sdk_peer_connect_v2", req, "peer_connect response")
+    }
+
+    pub fn peer_disconnect(
+        &self,
+        req: PeerConnectionRequest,
+    ) -> Result<PeerConnectionResult, SdkError> {
+        self.peer_lifecycle_call("sdk_peer_disconnect_v2", req, "peer_disconnect response")
+    }
+
+    pub fn peer_reconnect(
+        &self,
+        req: PeerConnectionRequest,
+    ) -> Result<PeerConnectionResult, SdkError> {
+        self.peer_lifecycle_call("sdk_peer_reconnect_v2", req, "peer_reconnect response")
+    }
+
+    fn peer_lifecycle_call(
+        &self,
+        method: &str,
+        req: PeerConnectionRequest,
+        context: &str,
+    ) -> Result<PeerConnectionResult, SdkError> {
+        let params = serde_json::to_value(req).map_err(|err| {
+            SdkError::new(code::INTERNAL, ErrorCategory::Internal, err.to_string())
+        })?;
+        let result = self.call_rpc(method, Some(params))?;
+        Self::decode_field_or_root(&result, "peer", context)
+    }
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/send.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/send.rs
@@ -75,14 +75,39 @@ fn batch_item_params(item: BatchSendItem) -> JsonValue {
         stamp_cost,
         include_ticket,
         try_propagation_on_fail,
+        idempotency_key,
+        ttl_ms,
+        correlation_id,
+        extensions,
     } = item;
     let content = message_content(&payload);
     let title =
         payload.get("title").and_then(JsonValue::as_str).map(str::to_owned).unwrap_or_default();
-    let fields = match payload {
+    let mut fields = match payload {
         JsonValue::Object(map) => JsonValue::Object(map),
         other => json!({ "payload": other }),
     };
+    if let JsonValue::Object(map) = &mut fields {
+        let mut sdk_meta = serde_json::Map::new();
+        if let Some(value) = idempotency_key {
+            sdk_meta.insert("idempotency_key".to_string(), JsonValue::String(value));
+        }
+        if let Some(value) = ttl_ms {
+            sdk_meta.insert("ttl_ms".to_string(), JsonValue::from(value));
+        }
+        if let Some(value) = correlation_id {
+            sdk_meta.insert("correlation_id".to_string(), JsonValue::String(value));
+        }
+        if !extensions.is_empty() {
+            sdk_meta.insert(
+                "extensions".to_string(),
+                JsonValue::Object(extensions.into_iter().collect()),
+            );
+        }
+        if !sdk_meta.is_empty() {
+            map.insert("_sdk".to_string(), JsonValue::Object(sdk_meta));
+        }
+    }
     json!({
         "id": id,
         "destination": destination,

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/batch.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/batch.rs
@@ -50,6 +50,10 @@ fn send_batch_uses_zmq_sdk_method_and_decodes_ordered_results() {
                     }),
                 )
                 .with_delivery_method("direct")
+                .with_idempotency_key("batch-msg-1-send-once")
+                .with_ttl_ms(30_000)
+                .with_correlation_id("batch-msg-1-corr")
+                .with_extension("burst_slot", json!(0))
                 .with_include_ticket(false),
                 crate::BatchSendItem::new(
                     "batch-msg-2",
@@ -90,6 +94,16 @@ fn send_batch_uses_zmq_sdk_method_and_decodes_ordered_results() {
         json!("payload a https://example.invalid/a")
     );
     assert_eq!(params["messages"][0]["fields"]["FIELD_THREAD"], json!("thread-a"));
+    assert_eq!(
+        params["messages"][0]["fields"]["_sdk"]["idempotency_key"],
+        json!("batch-msg-1-send-once")
+    );
+    assert_eq!(params["messages"][0]["fields"]["_sdk"]["ttl_ms"], json!(30_000));
+    assert_eq!(
+        params["messages"][0]["fields"]["_sdk"]["correlation_id"],
+        json!("batch-msg-1-corr")
+    );
+    assert_eq!(params["messages"][0]["fields"]["_sdk"]["extensions"]["burst_slot"], json!(0));
     assert_eq!(params["messages"][0]["method"], json!("direct"));
     assert_eq!(params["messages"][0]["include_ticket"], json!(false));
     assert_eq!(params["messages"][1]["fields"]["FIELD_GROUP"], json!("group-b"));

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/history.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/history.rs
@@ -82,3 +82,68 @@ fn list_message_history_uses_zmq_sdk_method_and_preserves_receipts_and_fields() 
     );
     server.join().expect("server joined");
 }
+
+#[test]
+fn list_message_history_accepts_direct_chat_message_id_and_body_aliases() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(None));
+    let server = spawn_single_response_zmq_server(
+        command_endpoint.clone(),
+        json!({
+            "response": {
+                "operation_id": "app.message.history.list",
+                "kind": "result",
+                "accepted": true,
+                "correlation_id": null,
+                "payload": {
+                    "messages": [{
+                        "message_id": "msg-history-legacy",
+                        "source": "peer-destination",
+                        "destination": "local-destination",
+                        "title": "legacy chat",
+                        "body": "legacy body https://example.invalid/recovery",
+                        "timestamp": 1_700_000_222,
+                        "direction": "inbound",
+                        "fields": {
+                            "body": "legacy body https://example.invalid/recovery",
+                            "FIELD_THREAD": "thread-recovered"
+                        },
+                        "receipt_status": "received"
+                    }],
+                    "next_cursor": null
+                }
+            }
+        }),
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let page = client
+        .list_message_history(crate::MessageHistoryListRequest {
+            peer_id: Some("peer-destination".to_string()),
+            conversation_id: None,
+            include_receipts: Some(true),
+            limit: Some(10),
+            before_ts: None,
+            cursor: None,
+        })
+        .expect("history page");
+
+    assert_eq!(page.messages.len(), 1);
+    let message = &page.messages[0];
+    assert_eq!(message.id, "msg-history-legacy");
+    assert_eq!(message.content, "legacy body https://example.invalid/recovery");
+    assert_eq!(message.receipt_status.as_deref(), Some("received"));
+    assert_eq!(message.fields.as_ref().expect("fields")["FIELD_THREAD"], json!("thread-recovered"));
+    let captured = captured.lock().expect("captured request");
+    let request = captured.as_ref().expect("zmq request");
+    assert_eq!(request.method, "sdk_envelope_execute_v2");
+    assert_eq!(
+        request.params.as_ref().expect("params")["payload"]["peer_id"],
+        json!("peer-destination")
+    );
+    server.join().expect("server joined");
+}

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/mod.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/mod.rs
@@ -780,6 +780,9 @@ fn operation_registry_uses_zmq_sdk_method_for_direct_chat_operations() {
     assert!(registry.supports("app.message.history.list"));
     assert!(registry.supports("app.delivery.destination_hash"));
     assert!(registry.supports("app.delivery.cancel"));
+    assert!(registry.supports("app.peer.connect"));
+    assert!(registry.supports("app.peer.disconnect"));
+    assert!(registry.supports("app.peer.reconnect"));
     let captured = captured.lock().expect("captured request");
     let request = captured.as_ref().expect("zmq request");
     assert_eq!(request.method, "sdk_operation_registry_v2");

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/workflow.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/workflow.rs
@@ -369,3 +369,108 @@ fn peer_directory_since_passes_presence_stale_cutoff_over_zmq_sdk_method() {
     assert_eq!(params["min_last_seen_ts_ms"], json!(1_700_000_500));
     server.join().expect("server joined");
 }
+
+#[test]
+fn peer_lifecycle_methods_use_zmq_sdk_methods_and_preserve_metadata() {
+    let command_endpoint = unused_loopback_endpoint();
+    let response_endpoint = unused_loopback_endpoint();
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let server = spawn_response_sequence_zmq_server(
+        command_endpoint.clone(),
+        vec![
+            json!({
+                "peer": {
+                    "identity": "peer-ready",
+                    "state": "connected",
+                    "display_name": "RCH Relay",
+                    "connected": true,
+                    "updated_ts_ms": 1700000600,
+                    "metadata": {
+                        "callsign": "RCH-1",
+                        "capability_flags": ["rem.direct_chat"],
+                        "announce_slots": ["rch.broadcast"]
+                    },
+                    "extensions": {
+                        "source": "connect"
+                    }
+                }
+            }),
+            json!({
+                "peer": {
+                    "identity": "peer-ready",
+                    "state": "disconnected",
+                    "display_name": "RCH Relay",
+                    "connected": false,
+                    "updated_ts_ms": 1700000610,
+                    "metadata": {
+                        "callsign": "RCH-1"
+                    },
+                    "extensions": {
+                        "source": "disconnect"
+                    }
+                }
+            }),
+            json!({
+                "peer": {
+                    "identity": "peer-ready",
+                    "state": "reconnected",
+                    "display_name": "RCH Relay",
+                    "connected": true,
+                    "updated_ts_ms": 1700000620,
+                    "metadata": {
+                        "callsign": "RCH-1"
+                    },
+                    "extensions": {
+                        "source": "reconnect"
+                    }
+                }
+            }),
+        ],
+        Arc::clone(&captured),
+    );
+    let mut config = ZmqPipelineBackendConfig::local_tcp(command_endpoint, response_endpoint);
+    config.request_timeout = std::time::Duration::from_secs(2);
+    let client = ZmqPipelineBackendClient::new(config).expect("zmq client");
+
+    let request = crate::PeerConnectionRequest {
+        identity: crate::IdentityRef("peer-ready".to_owned()),
+        display_name: Some("RCH Relay".to_owned()),
+        correlation_id: Some("peer-life-corr".to_owned()),
+        metadata: BTreeMap::from([
+            ("callsign".to_owned(), json!("RCH-1")),
+            ("capability_flags".to_owned(), json!(["rem.direct_chat"])),
+            ("announce_slots".to_owned(), json!(["rch.broadcast"])),
+        ]),
+        extensions: BTreeMap::from([("source".to_owned(), json!("rem-rch"))]),
+    };
+
+    let connected = client.peer_connect(request.clone()).expect("peer connect");
+    let disconnected = client.peer_disconnect(request.clone()).expect("peer disconnect");
+    let reconnected = client.peer_reconnect(request).expect("peer reconnect");
+
+    assert_eq!(connected.identity.0, "peer-ready");
+    assert_eq!(connected.state, crate::PeerConnectionState::Connected);
+    assert!(connected.connected);
+    assert_eq!(connected.metadata["announce_slots"][0], json!("rch.broadcast"));
+    assert_eq!(disconnected.state, crate::PeerConnectionState::Disconnected);
+    assert!(!disconnected.connected);
+    assert_eq!(reconnected.state, crate::PeerConnectionState::Reconnected);
+    assert!(reconnected.connected);
+
+    let captured = captured.lock().expect("captured requests");
+    assert_eq!(captured.len(), 3);
+    assert_eq!(captured[0].method, "sdk_peer_connect_v2");
+    assert_eq!(captured[1].method, "sdk_peer_disconnect_v2");
+    assert_eq!(captured[2].method, "sdk_peer_reconnect_v2");
+    for request in captured.iter() {
+        let params = request.params.as_ref().expect("params");
+        assert_eq!(params["identity"], json!("peer-ready"));
+        assert_eq!(params["display_name"], json!("RCH Relay"));
+        assert_eq!(params["correlation_id"], json!("peer-life-corr"));
+        assert_eq!(params["metadata"]["callsign"], json!("RCH-1"));
+        assert_eq!(params["metadata"]["capability_flags"][0], json!("rem.direct_chat"));
+        assert_eq!(params["metadata"]["announce_slots"][0], json!("rch.broadcast"));
+        assert_eq!(params["extensions"]["source"], json!("rem-rch"));
+    }
+    server.join().expect("server joined");
+}

--- a/crates/libs/lxmf-sdk/src/client.rs
+++ b/crates/libs/lxmf-sdk/src/client.rs
@@ -2,8 +2,8 @@
 use crate::api::LxmfSdkAsync;
 use crate::api::{
     LxmfSdk, LxmfSdkAttachments, LxmfSdkGroupDelivery, LxmfSdkIdentity, LxmfSdkManualTick,
-    LxmfSdkMarkers, LxmfSdkOperations, LxmfSdkPaper, LxmfSdkRemoteCommands, LxmfSdkTelemetry,
-    LxmfSdkTopics, LxmfSdkVoiceSignaling,
+    LxmfSdkMarkers, LxmfSdkOperations, LxmfSdkPaper, LxmfSdkPeerLifecycle, LxmfSdkRemoteCommands,
+    LxmfSdkTelemetry, LxmfSdkTopics, LxmfSdkVoiceSignaling,
 };
 use crate::backend::SdkBackend;
 #[cfg(feature = "sdk-async")]

--- a/crates/libs/lxmf-sdk/src/client/domains.rs
+++ b/crates/libs/lxmf-sdk/src/client/domains.rs
@@ -214,6 +214,29 @@ impl<B: SdkBackend> LxmfSdkIdentity for Client<B> {
     }
 }
 
+impl<B: SdkBackend> LxmfSdkPeerLifecycle for Client<B> {
+    fn peer_connect(
+        &self,
+        req: crate::domain::PeerConnectionRequest,
+    ) -> Result<crate::domain::PeerConnectionResult, SdkError> {
+        self.backend.peer_connect(req)
+    }
+
+    fn peer_disconnect(
+        &self,
+        req: crate::domain::PeerConnectionRequest,
+    ) -> Result<crate::domain::PeerConnectionResult, SdkError> {
+        self.backend.peer_disconnect(req)
+    }
+
+    fn peer_reconnect(
+        &self,
+        req: crate::domain::PeerConnectionRequest,
+    ) -> Result<crate::domain::PeerConnectionResult, SdkError> {
+        self.backend.peer_reconnect(req)
+    }
+}
+
 impl<B: SdkBackend> LxmfSdkPaper for Client<B> {
     fn paper_encode(
         &self,

--- a/crates/libs/lxmf-sdk/src/domain.rs
+++ b/crates/libs/lxmf-sdk/src/domain.rs
@@ -1,3 +1,5 @@
 include!("domain_parts/support_types.rs");
 
+include!("domain_parts/peerconnectionrequest.rs");
+
 include!("domain_parts/workflowpeerreadyrequest.rs");

--- a/crates/libs/lxmf-sdk/src/domain_parts/peerconnectionrequest.rs
+++ b/crates/libs/lxmf-sdk/src/domain_parts/peerconnectionrequest.rs
@@ -1,0 +1,34 @@
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct PeerConnectionRequest {
+    pub identity: IdentityRef,
+    pub display_name: Option<String>,
+    pub correlation_id: Option<String>,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, JsonValue>,
+    #[serde(default)]
+    pub extensions: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PeerConnectionState {
+    Connected,
+    Disconnected,
+    Reconnected,
+    Failed,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct PeerConnectionResult {
+    pub identity: IdentityRef,
+    pub state: PeerConnectionState,
+    pub display_name: Option<String>,
+    pub connected: bool,
+    pub updated_ts_ms: u64,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, JsonValue>,
+    #[serde(default)]
+    pub extensions: BTreeMap<String, JsonValue>,
+}

--- a/crates/libs/lxmf-sdk/src/lib.rs
+++ b/crates/libs/lxmf-sdk/src/lib.rs
@@ -19,7 +19,8 @@ pub use api::{LxmfSdk, LxmfSdkAsync, LxmfSdkManualTick};
 // Stability class: experimental (capability-gated extension traits)
 pub use api::{
     LxmfSdkAttachments, LxmfSdkGroupDelivery, LxmfSdkIdentity, LxmfSdkMarkers, LxmfSdkOperations,
-    LxmfSdkPaper, LxmfSdkRemoteCommands, LxmfSdkTelemetry, LxmfSdkTopics, LxmfSdkVoiceSignaling,
+    LxmfSdkPaper, LxmfSdkPeerLifecycle, LxmfSdkRemoteCommands, LxmfSdkTelemetry, LxmfSdkTopics,
+    LxmfSdkVoiceSignaling,
 };
 // Stability class: internal (backend composition surface)
 pub use backend::mobile_ble::{
@@ -60,8 +61,9 @@ pub use domain::{
     ContactRecord, ContactUpdateRequest, GeoPoint, IdentityBootstrapRequest, IdentityBundle,
     IdentityImportRequest, IdentityRef, IdentityResolveRequest, MarkerCreateRequest,
     MarkerDeleteRequest, MarkerId, MarkerListRequest, MarkerListResult, MarkerRecord,
-    MarkerUpdatePositionRequest, PaperMessageEnvelope, PresenceListRequest, PresenceListResult,
-    PresenceRecord, RemoteCommandRequest, RemoteCommandResponse, RemoteCommandSession,
+    MarkerUpdatePositionRequest, PaperMessageEnvelope, PeerConnectionRequest, PeerConnectionResult,
+    PeerConnectionState, PresenceListRequest, PresenceListResult, PresenceRecord,
+    RemoteCommandRequest, RemoteCommandResponse, RemoteCommandSession,
     RemoteCommandSessionListRequest, RemoteCommandSessionListResult, TelemetryPoint,
     TelemetryQuery, TopicCreateRequest, TopicId, TopicListRequest, TopicListResult, TopicPath,
     TopicPublishRequest, TopicRecord, TopicSubscriptionRequest, TrustLevel, VoiceSessionId,

--- a/crates/libs/lxmf-sdk/src/messaging.rs
+++ b/crates/libs/lxmf-sdk/src/messaging.rs
@@ -161,10 +161,12 @@ pub struct MessageHistoryPage {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MessageHistoryRecord {
+    #[serde(alias = "message_id")]
     pub id: String,
     pub source: String,
     pub destination: String,
     pub title: String,
+    #[serde(alias = "body")]
     pub content: String,
     pub timestamp: i64,
     pub direction: String,

--- a/crates/libs/lxmf-sdk/src/types/delivery.rs
+++ b/crates/libs/lxmf-sdk/src/types/delivery.rs
@@ -187,6 +187,11 @@ pub struct BatchSendItem {
     pub include_ticket: Option<bool>,
     #[serde(default)]
     pub try_propagation_on_fail: Option<bool>,
+    pub idempotency_key: Option<String>,
+    pub ttl_ms: Option<u64>,
+    pub correlation_id: Option<String>,
+    #[serde(default)]
+    pub extensions: BTreeMap<String, JsonValue>,
 }
 
 impl BatchSendItem {
@@ -199,7 +204,31 @@ impl BatchSendItem {
             stamp_cost: None,
             include_ticket: None,
             try_propagation_on_fail: None,
+            idempotency_key: None,
+            ttl_ms: None,
+            correlation_id: None,
+            extensions: BTreeMap::new(),
         }
+    }
+
+    pub fn with_idempotency_key(mut self, key: impl Into<String>) -> Self {
+        self.idempotency_key = Some(key.into());
+        self
+    }
+
+    pub fn with_ttl_ms(mut self, ttl_ms: u64) -> Self {
+        self.ttl_ms = Some(ttl_ms);
+        self
+    }
+
+    pub fn with_correlation_id(mut self, correlation_id: impl Into<String>) -> Self {
+        self.correlation_id = Some(correlation_id.into());
+        self
+    }
+
+    pub fn with_extension(mut self, key: impl Into<String>, value: JsonValue) -> Self {
+        self.extensions.insert(key.into(), value);
+        self
     }
 
     pub fn with_delivery_method(mut self, method: impl Into<String>) -> Self {

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -359,6 +359,9 @@ The project is best described by capability level:
   `app.delivery.send_batch` envelope calls to `sdk_send_batch_v2`, preserving
   ordered per-message acceptance and rejection results without raw RPC
   envelopes.
+- `BatchSendItem` now carries per-message idempotency keys, TTL, correlation
+  IDs, and SDK extensions into each batch message's `_sdk` field metadata, so
+  burst direct-chat retries can remain stable across client restarts.
 - The typed ZeroMQ SDK backend and operation registry now expose direct-chat
   cancellation through both `ZmqPipelineBackendClient::cancel` and
   `app.delivery.cancel` envelope execution, preserving daemon cancellation

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -341,6 +341,10 @@ The project is best described by capability level:
   `peer_id`/`conversation_id` filters, `include_receipts`, and restart
   pagination cursors through the daemon `app.message.history.list` SDK envelope
   path.
+- `ZmqPipelineBackendClient::list_message_history` now accepts both canonical
+  `id`/`content` records and legacy direct-chat `message_id`/`body` records
+  from `app.message.history.list`, keeping restart-recovered conversation
+  history readable without raw envelope decoding.
 - The typed ZeroMQ SDK backend now exposes the local runtime delivery
   destination through `ZmqPipelineBackendClient::local_delivery_destination_hash`,
   while still routing `app.delivery.destination_hash` through SDK envelope

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -330,6 +330,11 @@ The project is best described by capability level:
   `ZmqPipelineBackendClient::peer_directory_since` and a
   `min_last_seen_ts_ms` presence-list filter, so REM/RCH can suppress stale
   announce rows over the SDK path while keeping saved contacts visible offline.
+- The typed ZeroMQ SDK backend now exposes saved-peer lifecycle calls through
+  `ZmqPipelineBackendClient::peer_connect`, `peer_disconnect`, and
+  `peer_reconnect`, routing `sdk_peer_*_v2` methods while preserving identity,
+  display name, correlation ID, callsign, REM capability flags, RCH
+  announce-slot metadata, and per-call extensions.
 - The typed ZeroMQ SDK backend now also covers the operation registry and SDK
   envelope execution path, including `app.message.history.list` and
   `app.delivery.destination_hash`, so REM/RCH direct-chat history and runtime

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -349,6 +349,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   `peer_id`/`conversation_id` filters, `include_receipts`, and daemon
   pagination cursors for restart recovery through the
   `app.message.history.list` SDK envelope path.
+- `ZmqPipelineBackendClient::list_message_history` accepts canonical
+  `id`/`content` history rows and legacy direct-chat `message_id`/`body` rows,
+  so recovered history remains typed even when the daemon returns the older app
+  chat field names.
 - The typed ZeroMQ SDK backend exposes the local runtime delivery destination
   through `ZmqPipelineBackendClient::local_delivery_destination_hash` while
   retaining `app.delivery.destination_hash` envelope execution, so direct-chat

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -338,6 +338,12 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   `ZmqPipelineBackendClient::peer_directory_since` plus
   `min_last_seen_ts_ms` filtering on `sdk_identity_presence_list_v2`, allowing
   stale announce rows to be hidden without dropping saved offline contacts.
+- The typed ZeroMQ SDK backend exposes saved-peer lifecycle calls through
+  `ZmqPipelineBackendClient::peer_connect`, `peer_disconnect`, and
+  `peer_reconnect`, preserving identity, display name, correlation ID,
+  callsign, REM capability flags, RCH announce-slot metadata, and extensions
+  over `sdk_peer_connect_v2`, `sdk_peer_disconnect_v2`, and
+  `sdk_peer_reconnect_v2`.
 - The typed ZeroMQ SDK backend exposes the operation registry and envelope
   execution path, including the `app.message.history.list` and
   `app.delivery.destination_hash` operations used by direct-chat history and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -369,6 +369,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   `ZmqPipelineBackendClient::send_batch` and also supports
   `app.delivery.send_batch` envelope execution, preserving ordered per-message
   acceptance and rejection results without raw RPC envelopes.
+- `BatchSendItem` preserves per-message idempotency keys, TTL, correlation IDs,
+  and SDK extensions in each batch message's `_sdk` field metadata, keeping
+  burst direct-chat retry and restart recovery state on the typed SDK path.
 - The typed ZeroMQ SDK backend and operation registry expose direct-chat
   cancellation through both `ZmqPipelineBackendClient::cancel` and
   `app.delivery.cancel` envelope execution, preserving daemon cancellation


### PR DESCRIPTION
## Summary
- add typed peer lifecycle domain types and `LxmfSdkPeerLifecycle` extension methods
- route `ZmqPipelineBackendClient` peer connect/disconnect/reconnect through `sdk_peer_connect_v2`, `sdk_peer_disconnect_v2`, and `sdk_peer_reconnect_v2`
- register `app.peer.connect`, `app.peer.disconnect`, and `app.peer.reconnect` operations and update REM/RCH roadmap/parity notes

## Validation
- cargo test -p lxmf-sdk --features zmq-pipeline-backend peer_lifecycle_methods_use_zmq_sdk_methods_and_preserve_metadata -- --nocapture
- cargo test -p lxmf-sdk --features zmq-pipeline-backend zmq_pipeline -- --nocapture --test-threads=1
- cargo check -p lxmf-sdk --features zmq-pipeline-backend
- cargo clippy -p lxmf-sdk --features zmq-pipeline-backend --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- C:\Program Files\Git\bin\bash.exe tools/scripts/check-module-size.sh