### PR TITLE
[codex] Finalize LXMF-rs 0.4.0 release note ref

### DIFF
--- a/docs/release-notes-v0.4.0.md
+++ b/docs/release-notes-v0.4.0.md
@@ -1,7 +1,7 @@
 # LXMF-rs v0.4.0 Release Notes
 
 Date: 2026-06-14
-Release commit: pending release tag
+Release ref: `v0.4.0`
 
 This is the ZeroMQ SDK integration release for REM 1.1.1 and RCH pre-3.0
 Rust consumers. It promotes the typed `lxmf-sdk` ZeroMQ path through


### PR DESCRIPTION
## Summary
- replace the v0.4.0 release-note placeholder with the actual release ref wording

## Validation
- `rg -n "pending release tag|Release commit" docs\release-notes-v0.4.0.md` returned no matches
- `cargo fmt --all -- --check`
- `git diff --check`
