### PR TITLE
[codex] Update 0.4.0 interop artifact baseline

### DIFF
--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -28,8 +28,8 @@
     },
     {
       "path": "docs/contracts/compatibility-contract.md",
-      "bytes": 2208,
-      "sha256": "0d493502286c8870bf3f02237f978425fcc739e1b236a95d39e4f13a7fb65f8f"
+      "bytes": 2303,
+      "sha256": "ddf1a8a080228ca5bf883b662703c1775c36f33bcb90f195e31029384faf5ae2"
     },
     {
       "path": "docs/contracts/compatibility-matrix.md",


### PR DESCRIPTION
## Summary
- refresh the interop artifact manifest for the v0.4.0 compatibility-contract metadata change

## Validation
- `cargo run -p xtask -- interop-artifacts --update`
- `cargo run -p xtask -- interop-artifacts`
- `git diff --check`
