### PR TITLE
[codex] Fix Windows release artifact lookup

### DIFF
--- a/xtask/src/main_parts/capture_platform_descriptor.rs
+++ b/xtask/src/main_parts/capture_platform_descriptor.rs
@@ -91,7 +91,8 @@ fn run_supply_chain_check() -> Result<()> {
 
     let mut artifacts = Vec::with_capacity(RELEASE_BINARIES.len());
     for name in RELEASE_BINARIES {
-        let path = Path::new("target/release").join(name);
+        let binary_name = executable_name(name);
+        let path = Path::new("target/release").join(&binary_name);
         if !path.exists() {
             bail!("release artifact missing: {}", path.display());
         }


### PR DESCRIPTION
## Summary
- resolve release supply-chain artifact paths with the existing platform executable-name helper
- fixes Windows release-check failures looking for extensionless release binaries

## Verification
- cargo fmt --check -p xtask
- cargo test -p xtask
- cargo run -p xtask -- supply-chain-check
- git diff --check