### PR TITLE
[codex] Accept tcp RPC endpoint scheme

### DIFF
--- a/crates/libs/lxmf-sdk/src/backend/rpc/transport_parts/rpcbackendclient_sections/call_rpc.rs
+++ b/crates/libs/lxmf-sdk/src/backend/rpc/transport_parts/rpcbackendclient_sections/call_rpc.rs
@@ -366,6 +366,7 @@ impl RpcBackendClient {
             .strip_prefix("http://")
             .or_else(|| endpoint.strip_prefix("https://"))
             .or_else(|| endpoint.strip_prefix("tls://"))
+            .or_else(|| endpoint.strip_prefix("tcp://"))
             .unwrap_or(endpoint);
         let authority = without_scheme.split('/').next().unwrap_or(without_scheme).trim();
         if authority.is_empty() {

--- a/crates/libs/lxmf-sdk/src/backend/rpc/transport_parts/test_sdk_event_sections/core_tests.rs
+++ b/crates/libs/lxmf-sdk/src/backend/rpc/transport_parts/test_sdk_event_sections/core_tests.rs
@@ -79,6 +79,17 @@
         request.lines().find_map(|line| line.strip_prefix(prefix.as_str()).map(str::trim))
     }
 
+    #[test]
+    fn rpc_endpoint_accepts_tcp_scheme_for_http_rpc_compatibility() {
+        let endpoint = RpcBackendClient::parse_endpoint("tcp://127.0.0.1:37428/rpc")
+            .expect("tcp scheme should be accepted");
+
+        match endpoint {
+            RpcEndpoint::Tcp(authority) => assert_eq!(authority, "127.0.0.1:37428"),
+            RpcEndpoint::Unix(_) => panic!("tcp scheme must not parse as unix endpoint"),
+        }
+    }
+
     #[cfg(feature = "sdk-async")]
     #[tokio::test]
     async fn call_rpc_async_uses_async_http_post_transport() {


### PR DESCRIPTION
## Summary
- Accept `tcp://` as an HTTP RPC endpoint scheme in `RpcBackendClient`.
- Add a regression test covering `tcp://127.0.0.1:<port>/rpc` authority normalization.

## Root Cause
The RPC endpoint parser stripped `http://`, `https://`, and `tls://`, but not `tcp://`. A `tcp://host:port` endpoint was therefore split at `/` into `tcp:`, causing event polling and RPC connection attempts to fail with address lookup errors instead of connecting to the intended daemon endpoint.

## Validation
- `cargo test -p lxmf-sdk rpc_endpoint_accepts_tcp_scheme_for_http_rpc_compatibility`
- `cargo test -p lxmf-sdk backend::rpc::transport::tests`
- `cargo fmt --all -- --check`
- `git diff --check`