### PR TITLE
LXMF peer retry unpeer parity

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/enriched_peer_status_row.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/enriched_peer_status_row.rs
@@ -300,6 +300,7 @@ impl RpcDaemon {
         let peer_type_value = peer.peer_type.clone();
         let peer_status_type =
             if self.is_static_peer(peer.peer.as_str()) { "static" } else { "discovered" };
+        let failure_kind = local_retryable_peer_offer_failure_kind(offer_response);
         let propagation_sync = json!({
             "synced": false,
             "postponed": false,
@@ -377,8 +378,22 @@ impl RpcDaemon {
         });
         payload["state"] = json!(PEER_SYNC_STATE_FAILED);
         payload["state_name"] = json!("failed");
+        payload["failure_kind"] = json!(failure_kind);
+        payload["propagation"]["failure_kind"] = json!(failure_kind);
         self.publish_event(RpcEvent { event_type: "peer_sync".into(), payload: payload.clone() });
 
         RpcResponse { id: request_id, result: Some(payload), error: None }
+    }
+}
+
+fn local_retryable_peer_offer_failure_kind(offer_error: u8) -> &'static str {
+    match offer_error {
+        LXMF_PEER_ERROR_NO_IDENTITY => "no_identity",
+        LXMF_PEER_ERROR_INVALID_KEY => "invalid_key",
+        LXMF_PEER_ERROR_INVALID_DATA => "invalid_data",
+        LXMF_PEER_ERROR_INVALID_STAMP => "invalid_stamp",
+        LXMF_PEER_ERROR_NOT_FOUND => "not_found",
+        LXMF_PEER_ERROR_TIMEOUT => "timeout",
+        _ => "failed",
     }
 }

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/peer_sync_offer_error.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/peer_sync_offer_error.rs
@@ -64,7 +64,10 @@ impl RpcDaemon {
                     let mut peers = self.peers.lock().expect("peers mutex poisoned");
                     if let Some(peer) = peers.get_mut(record.peer.as_str()) {
                         peer.last_sync_attempt = timestamp;
-                        peer.next_sync_attempt = 0;
+                        peer.sync_backoff =
+                            peer.sync_backoff.saturating_add(LXMF_PEER_SYNC_BACKOFF_STEP_SECS);
+                        peer.next_sync_attempt =
+                            timestamp.saturating_add(i64::from(peer.sync_backoff));
                     }
                 }
                 Ok(self.local_peer_offer_error_response(

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/peer_sync_no_access_offer_response_b.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/peer_sync_no_access_offer_response_b.rs
@@ -236,10 +236,18 @@ fn peer_sync_no_identity_offer_response_preserves_peer_for_immediate_retry_like_
     assert_eq!(result["peer"].as_str(), Some("peer-local-needs-id"));
     assert_eq!(result["synced"].as_bool(), Some(false));
     assert_eq!(result["reason"].as_str(), Some("identity_required"));
+    assert_eq!(result["failure_kind"].as_str(), Some("no_identity"));
+    assert_eq!(result["propagation"]["failure_kind"].as_str(), Some("no_identity"));
     assert_eq!(result["offer_response"].as_u64(), Some(0xf0));
     assert_eq!(result["alive"].as_bool(), Some(true));
-    assert_eq!(result["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(result["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(result["sync_backoff"].as_u64(), Some(12 * 60));
+    let result_last_sync_attempt =
+        result["last_sync_attempt"].as_i64().expect("result last sync attempt");
+    assert!(result_last_sync_attempt > 0);
+    assert_eq!(
+        result["next_sync_attempt"].as_i64(),
+        Some(result_last_sync_attempt + 12 * 60)
+    );
     assert_eq!(result["acceptance_rate"].as_f64(), Some(0.8));
     assert_eq!(result["propagation"]["handled"].as_u64(), Some(0));
     assert_eq!(result["propagation"]["postponed"].as_bool(), Some(false));
@@ -273,8 +281,8 @@ fn peer_sync_no_identity_offer_response_preserves_peer_for_immediate_retry_like_
     let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
     assert!(last_sync_attempt > 0);
     assert_eq!(row["alive"].as_bool(), Some(true));
-    assert_eq!(row["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(row["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
 
     let events = daemon.event_queue.lock().expect("event_queue mutex poisoned");
     assert!(
@@ -290,21 +298,113 @@ fn peer_sync_no_identity_offer_response_preserves_peer_for_immediate_retry_like_
     assert_eq!(event.payload["peer"].as_str(), Some("peer-local-needs-id"));
     assert_eq!(event.payload["synced"].as_bool(), Some(false));
     assert_eq!(event.payload["reason"].as_str(), Some("identity_required"));
+    assert_eq!(event.payload["failure_kind"].as_str(), Some("no_identity"));
+    assert_eq!(event.payload["propagation"]["failure_kind"].as_str(), Some("no_identity"));
     assert_eq!(event.payload["offer_response"].as_u64(), Some(0xf0));
     assert_eq!(event.payload["alive"].as_bool(), Some(true));
-    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(0));
-    assert_eq!(event.payload["next_sync_attempt"].as_i64(), Some(0));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(
+        event.payload["next_sync_attempt"].as_i64(),
+        Some(last_sync_attempt + 12 * 60)
+    );
+}
+
+#[test]
+fn peer_sync_retryable_offer_response_advances_backoff_and_reports_failure_kind_like_python() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-local-offer-error-backoff";
+    daemon
+        .handle_rpc(rpc_request(52, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer).expect("peer record");
+        record.alive = true;
+        record.sync_backoff = 0;
+        record.next_sync_attempt = 0;
+        record.acceptance_rate = 0.55;
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: "bf".repeat(32),
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_620,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer, pending.transient_id.as_str())
+        .expect("mark unhandled");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let result = daemon
+        .handle_rpc(rpc_request(
+            55,
+            "peer_sync",
+            json!({
+                "peer": peer,
+                "wanted_ids": 0xf5,
+            }),
+        ))
+        .expect("invalid-stamp response should preserve peer queue for retry")
+        .result
+        .expect("peer sync result");
+
+    assert_eq!(result["reason"].as_str(), Some("invalid_stamp"));
+    assert_eq!(result["failure_kind"].as_str(), Some("invalid_stamp"));
+    assert_eq!(result["propagation"]["failure_kind"].as_str(), Some("invalid_stamp"));
+    assert_eq!(result["sync_backoff"].as_u64(), Some(12 * 60));
+    let last_sync_attempt = result["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(result["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer)
+            .expect("pending propagation"),
+        vec![pending.clone()]
+    );
+    assert!(
+        daemon
+            .store
+            .list_peer_handled_propagation_ids(peer)
+            .expect("handled ids")
+            .is_empty()
+    );
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_sync")
+        .cloned()
+        .expect("retryable peer sync event");
+    assert_eq!(event.payload["failure_kind"].as_str(), Some("invalid_stamp"));
+    assert_eq!(event.payload["propagation"]["failure_kind"].as_str(), Some("invalid_stamp"));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(
+        event.payload["next_sync_attempt"].as_i64(),
+        Some(last_sync_attempt + 12 * 60)
+    );
+    assert_eq!(
+        event.payload["messages"]["unhandled_ids"].as_array().expect("event unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
 }
 
 #[test]
 fn peer_sync_retryable_offer_responses_preserve_peer_queue_like_python() {
-    for (suffix, offer_response, reason) in [
-        ("invalid-key", 0xf3, "invalid_key"),
-        ("invalid-data", 0xf4, "invalid_data"),
-        ("invalid-stamp", 0xf5, "invalid_stamp"),
-        ("unknown", 0xf2, "peer_offer_error"),
-        ("not-found", 0xfd, "not_found"),
-        ("timeout", 0xfe, "timeout"),
+    for (suffix, offer_response, reason, failure_kind) in [
+        ("invalid-key", 0xf3, "invalid_key", "invalid_key"),
+        ("invalid-data", 0xf4, "invalid_data", "invalid_data"),
+        ("invalid-stamp", 0xf5, "invalid_stamp", "invalid_stamp"),
+        ("unknown", 0xf2, "peer_offer_error", "failed"),
+        ("not-found", 0xfd, "not_found", "not_found"),
+        ("timeout", 0xfe, "timeout", "timeout"),
     ] {
         let daemon = RpcDaemon::test_instance();
         let peer_id = format!("peer-local-{suffix}");
@@ -352,10 +452,18 @@ fn peer_sync_retryable_offer_responses_preserve_peer_queue_like_python() {
         assert_eq!(result["state"].as_u64(), Some(0xfe));
         assert_eq!(result["state_name"].as_str(), Some("failed"));
         assert_eq!(result["reason"].as_str(), Some(reason));
+        assert_eq!(result["failure_kind"].as_str(), Some(failure_kind));
+        assert_eq!(result["propagation"]["failure_kind"].as_str(), Some(failure_kind));
         assert_eq!(result["offer_response"].as_u64(), Some(offer_response));
         assert_eq!(result["alive"].as_bool(), Some(true));
-        assert_eq!(result["sync_backoff"].as_u64(), Some(0));
-        assert_eq!(result["next_sync_attempt"].as_i64(), Some(0));
+        assert_eq!(result["sync_backoff"].as_u64(), Some(12 * 60));
+        let result_last_sync_attempt =
+            result["last_sync_attempt"].as_i64().expect("result last sync attempt");
+        assert!(result_last_sync_attempt > 0);
+        assert_eq!(
+            result["next_sync_attempt"].as_i64(),
+            Some(result_last_sync_attempt + 12 * 60)
+        );
         assert_eq!(result["acceptance_rate"].as_f64(), Some(0.6));
         assert_eq!(result["propagation"]["handled"].as_u64(), Some(0));
         assert_eq!(result["propagation"]["postponed"].as_bool(), Some(false));
@@ -391,8 +499,8 @@ fn peer_sync_retryable_offer_responses_preserve_peer_queue_like_python() {
         let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
         assert!(last_sync_attempt > 0);
         assert_eq!(row["alive"].as_bool(), Some(true));
-        assert_eq!(row["sync_backoff"].as_u64(), Some(0));
-        assert_eq!(row["next_sync_attempt"].as_i64(), Some(0));
+        assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
+        assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
 
         let events = daemon.event_queue.lock().expect("event_queue mutex poisoned");
         assert!(
@@ -410,10 +518,15 @@ fn peer_sync_retryable_offer_responses_preserve_peer_queue_like_python() {
         assert_eq!(event.payload["state"].as_u64(), Some(0xfe));
         assert_eq!(event.payload["state_name"].as_str(), Some("failed"));
         assert_eq!(event.payload["reason"].as_str(), Some(reason));
+        assert_eq!(event.payload["failure_kind"].as_str(), Some(failure_kind));
+        assert_eq!(event.payload["propagation"]["failure_kind"].as_str(), Some(failure_kind));
         assert_eq!(event.payload["offer_response"].as_u64(), Some(offer_response));
         assert_eq!(event.payload["alive"].as_bool(), Some(true));
-        assert_eq!(event.payload["sync_backoff"].as_u64(), Some(0));
-        assert_eq!(event.payload["next_sync_attempt"].as_i64(), Some(0));
+        assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+        assert_eq!(
+            event.payload["next_sync_attempt"].as_i64(),
+            Some(last_sync_attempt + 12 * 60)
+        );
         assert_eq!(event.payload["propagation"]["state"].as_u64(), Some(0xfe));
         assert_eq!(event.payload["propagation"]["state_name"].as_str(), Some("failed"));
     }

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -782,6 +782,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Local peer offer-error responses now expose failed peer-sync state fields at
   both the top-level event/result and nested propagation result while keeping
   retryable queue marks intact.
+- Retryable local peer offer-error responses now advance the ordinary peer
+  sync backoff window and expose structured `failure_kind` fields at both the
+  top-level event/result and nested propagation result while preserving queued
+  work for retry.
 - Inbound propagation distinguishes clients, validated peers, unpeered
   identified senders, and local delivery; source peers are accounted and not
   re-offered their own payloads.


### PR DESCRIPTION
## Summary
- Advance retryable local peer offer-error outcomes through the ordinary peer sync backoff window.
- Expose structured local offer-error failure_kind fields on the top-level peer sync result/event and nested propagation payload.
- Extend focused peer lifecycle tests and update the parity matrix for the proven behavior.

## Validation
- cargo test -p reticulum-rs-rpc --lib
- cargo test -p reticulumd --lib
- cargo test -p reticulumd --test receipt_worker -- --nocapture
- cargo test -p reticulumd --test receipt_bridge -- --nocapture
- Focused added test: peer_sync_retryable_offer_response_advances_backoff_and_reports_failure_kind_like_python
- Skipped: cargo test -p reticulumd --test python_compat_matrix -- --ignored --nocapture --test-threads=1 because LXMF_PY_COMPAT_HARNESS is not set