### PR TITLE
Trim BLE setup from essential CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,6 @@ jobs:
       SDK_API_BREAK_TOOLCHAIN: nightly-2026-02-15
     steps:
       - uses: actions/checkout@v4
-      - name: Install Linux BLE build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libdbus-1-dev
       - uses: dtolnay/rust-toolchain@stable
       - name: Install pinned nightly toolchain (for cargo-public-api)
         run: rustup toolchain install nightly-2026-02-15 --profile minimal
@@ -127,10 +123,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Linux BLE build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libdbus-1-dev
       - uses: dtolnay/rust-toolchain@stable
       - name: Rust cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

- remove the Linux BLE system dependency install from `contracts`
- remove the same install from `peer-lifecycle-essential`
- keep BLE setup in build/test/quality jobs that still compile broader workspace targets

## Validation

- parsed `.github/workflows/ci.yml` with PyYAML
- `cargo xtask ci --stage doc`
- `cargo test -p reticulum-rs-rpc --lib`
- `cargo test -p reticulumd --lib`
- `cargo test -p reticulumd --test receipt_worker -- --nocapture`
- `cargo test -p reticulumd --test receipt_bridge -- --nocapture`