### PR TITLE
Close LXMF peer lifecycle parity status

### DIFF
--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1,6 +1,6 @@
 # Current Roadmap Status
 
-Last reassessed: 2026-06-13
+Last reassessed: 2026-06-18
 
 This file is the repository-level source of truth for parity posture, release
 confidence, and execution order. Detailed row-level status lives in:
@@ -24,7 +24,7 @@ The project is best described by capability level:
 | --- | --- | --- |
 | Wire compatible | achieved | Core Reticulum packet/identity primitives and LXMF message encodings are implemented and tested. |
 | Direct-message interoperable | achieved | Selected bidirectional Rust/Python direct, link, channel, paper, and daemon paths are exercised in CI. |
-| Propagation interoperable | partial | Propagated delivery and substantial peer/node behavior exist, but the complete Python router and peer lifecycle is not yet reproduced. |
+| Propagation interoperable | partial | Propagated delivery and complete Python-only `LXMPeer.py` lifecycle coverage exist, but the complete Python router lifecycle is not yet reproduced. |
 | Operationally substitutable | partial | `reticulumd` is deployable and supports several production interfaces, but runtime, interface, and utility breadth remains narrower than Python. |
 | Full Python surface parity | not achieved | Remaining gaps are tracked in the two parity matrices. |
 
@@ -743,19 +743,20 @@ These are blockers to a broad "Python replacement" claim, not blockers to using
 the implemented subset.
 
 1. **Propagation router lifecycle**
-   - Complete peer offer, transfer, retry, fetch, download, and synchronization
-     behavior across success, denial, timeout, identity, and restart paths.
+   - Complete remaining router fetch, download, synchronization, and
+     propagation-node side effects across success, denial, timeout, identity,
+     and restart paths.
    - Close remaining `LXMRouter` side effects and persistent queue semantics.
 2. **Deferred stamp lifecycle**
    - Add Python-style background work ownership, queueing, retry, cancellation,
      and progress behavior for expensive normal and propagation stamps.
 3. **Interop breadth**
    - Add bidirectional live Python cases for every claimed delivery mode and
-     newly completed peer/router row.
+     newly completed router row.
    - Propagation remote-status/control now has dispatchable compatibility cases
      for Python control-path discovery, Rust-to-Python remote status, and
      Python-origin `/get` haves acknowledgement and `/offer` side effects;
-     broader peer/router row coverage still needs additional live scenarios.
+     broader router row coverage still needs additional live scenarios.
    - Capture release evidence for Sideband, MeshChatX, and Columba before making
      client-specific compatibility claims.
 4. **Reticulum behavioral breadth**
@@ -768,7 +769,7 @@ the implemented subset.
 
 ## Active Execution Order
 
-1. Finish propagation peer/router state machines.
+1. Finish propagation router state machines.
 2. Finish deferred stamp worker and retry lifecycle.
 3. Expand pinned Rust/Python interoperability gates with each completed row.
 4. Close RNS channel, discovery, resolver, and transport-policy gaps.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -1,6 +1,6 @@
 # LXMF Parity Matrix
 
-Last reassessed: 2026-06-13
+Last reassessed: 2026-06-18
 
 This is the maintained row-level status for Python LXMF compatibility.
 Repository-level posture and execution order live in
@@ -22,7 +22,7 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 | --- | --- | --- | --- | --- |
 | `LXMF/LXMF.py` | `crates/libs/lxmf-core` | partial | Constants, payload fields, message identity, inbound decoding, and wire helpers. | The complete convenience/module surface is not mirrored. |
 | `LXMF/LXMessage.py` | `crates/libs/lxmf-core` | done | Wire, storage, propagation, paper, signatures, message IDs, binary fidelity, and timestamp precision metadata. | No confirmed base-message blocker. |
-| `LXMF/LXMPeer.py` | `crates/libs/rns-rpc`, `crates/apps/reticulumd` | partial | Persistent peers, queue marks, offer selection, policy gates, peering keys, throttling, maintenance, source accounting, cumulative acceptance, serialized restored queue snapshots, and boolean/list/numeric offer responses. | Complete transfer/retry/restart lifecycle and broad live peer interop remain. |
+| `LXMF/LXMPeer.py` | `crates/libs/rns-rpc`, `crates/apps/reticulumd` | done | Persistent peers, queue marks, offer selection, policy gates, peering keys, throttling, maintenance, source accounting, cumulative acceptance, serialized restored queue snapshots, boolean/list/numeric offer responses, transfer/retry/restart recovery, and unpeer cleanup. | No confirmed `LXMPeer.py` blocker in the pinned Python-only coverage. |
 | `LXMF/LXMRouter.py` | `crates/libs/rns-rpc`, `crates/apps/reticulumd` | partial | Outbound modes, selected propagation nodes, direct/propagated resources, cancellation, fetch/download/sync RPCs, receipts, persistence, and status. | Full Python queue, retry, propagation-node, and command side effects remain. |
 | `LXMF/Handlers.py` | `crates/apps/reticulumd`, `crates/libs/rns-rpc` | partial | Delivery, announce, propagation app-data, receipt, and inbound bridge handling. | Some router-coupled side effects and negative/drop observability remain narrower. |
 | `LXMF/LXStamper.py` | `crates/libs/lxmf-core`, `crates/libs/rns-rpc`, `crates/apps/reticulumd` | partial | Validation, generation, ticket-derived stamps, cancellation-aware task work, and lifecycle metadata. | Python-style deferred worker queue, retry ownership, and continuous progress remain. |
@@ -45,10 +45,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - PARITY_ITEM id=ticket.validity_with_grace status=done
 - PARITY_ITEM id=ticket.renewal_window status=done
 - PARITY_ITEM id=ticket.derived_stamp status=done
-- PARITY_ITEM id=peer.serialize_roundtrip status=partial
-- PARITY_ITEM id=peer.queue_accounting status=partial
-- PARITY_ITEM id=peer.acceptance_rate status=partial
-- PARITY_ITEM id=peer.peering_key status=partial
+- PARITY_ITEM id=peer.serialize_roundtrip status=done
+- PARITY_ITEM id=peer.queue_accounting status=done
+- PARITY_ITEM id=peer.acceptance_rate status=done
+- PARITY_ITEM id=peer.peering_key status=done
 - PARITY_ITEM id=router.outbound_queue status=partial
 - PARITY_ITEM id=router.handle_outbound_policy status=partial
 - PARITY_ITEM id=router.adapter_transport status=partial
@@ -797,16 +797,15 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Inbound propagation distinguishes clients, validated peers, unpeered
   identified senders, and local delivery; source peers are accounted and not
   re-offered their own payloads.
-- These behaviors materially narrow the gap, but complete Python peer transfer,
-  restart recovery, and router queue lifecycle remain unproven.
+- These behaviors close the pinned Python-only `LXMPeer.py` lifecycle row.
+  Broader `LXMRouter.py` propagation queue lifecycle remains partial.
 
 ## Highest-Priority Gaps
 
-1. Complete peer transfer, retry, restart, and persistent queue lifecycle.
-2. Complete propagation-node fetch/download/sync and router side effects.
-3. Add deferred stamp queue ownership and retry semantics.
-4. Expand live bidirectional Python interop for propagation and peer rows.
-5. Validate external clients before making client-specific claims.
+1. Complete propagation-node fetch/download/sync and router side effects.
+2. Add deferred stamp queue ownership and retry semantics.
+3. Expand live bidirectional Python interop for remaining propagation/router rows.
+4. Validate external clients before making client-specific claims.
 
 ## Evidence
 


### PR DESCRIPTION
## Summary

- marks `LXMF/LXMPeer.py` as done after the four peer-lifecycle slices merged
- updates peer method checklist rows from partial to done
- narrows remaining roadmap blockers to router/stamp/client gaps instead of peer lifecycle

## Validation

- `cargo test -p reticulum-rs-rpc --lib`
- `cargo test -p reticulumd --lib`
- `cargo test -p reticulumd --test receipt_worker -- --nocapture`
- `cargo test -p reticulumd --test receipt_bridge -- --nocapture`
- `git diff --check`

## Notes

The ignored Python compatibility matrix needs the pinned reference checkout and `LXMF_PY_COMPAT_HARNESS`; this PR carries `run-peer-lifecycle-CI` so GitHub runs that oracle.