### PR TITLE
[codex] Align remote transfer failure classification

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/propagation_sync_state_name.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/propagation_sync_state_name.rs
@@ -105,6 +105,11 @@ fn is_retryable_remote_peer_sync_error(err: &std::io::Error) -> bool {
             | (std::io::ErrorKind::InvalidData, "unexpected propagation control response")
             | (std::io::ErrorKind::NotFound, "propagation peer not found")
             | (std::io::ErrorKind::TimedOut, "propagation peer timed out")
+            | (std::io::ErrorKind::BrokenPipe, "propagation link closed")
+            | (std::io::ErrorKind::ConnectionAborted, "propagation link closed")
+            | (std::io::ErrorKind::ConnectionReset, "propagation link closed")
+            | (std::io::ErrorKind::NotConnected, "propagation link closed")
+            | (std::io::ErrorKind::UnexpectedEof, "propagation link closed")
     )
 }
 
@@ -123,7 +128,9 @@ fn remote_peer_sync_failure_kind(error: &str, postpone_reason: Option<&str>) -> 
             "invalid_data"
         }
         "propagation peer not found" => "not_found",
-        "propagation peer timed out" | "remote sync failed" => "timeout",
+        "propagation peer timed out" | "propagation link closed" | "remote sync failed" => {
+            "timeout"
+        }
         "propagation node denied access" => "no_access",
         _ => "failed",
     }

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/record_remote_unpeer_failure.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/record_remote_unpeer_failure.rs
@@ -219,6 +219,24 @@ impl RpcDaemon {
         remote: &str,
         error: &std::io::Error,
     ) -> Result<bool, std::io::Error> {
+        if is_retryable_remote_peer_sync_error(error) {
+            let source_peer_key = self
+                .active_peer_ids()
+                .into_iter()
+                .find(|peer| peer.eq_ignore_ascii_case(source_peer));
+            let Some(source_peer_key) = source_peer_key else {
+                return Ok(false);
+            };
+            self.record_retryable_remote_peer_sync_error(
+                source_peer_key.as_str(),
+                remote,
+                error.to_string().as_str(),
+                None,
+                None,
+            )?;
+            return Ok(true);
+        }
+
         if !is_remote_transfer_attempt_error(error) {
             return Ok(false);
         }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/assert_local_remote_transfer_error_d.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/assert_local_remote_transfer_error_d.rs
@@ -275,6 +275,288 @@ fn denied_access_propagation_remote_fetch_reports_stored_peer_case_like_python()
     assert_eq!(event.payload["reason"].as_str(), Some("access_denied"));
 }
 
+struct RemoteTransferFailureCase {
+    suffix: &'static str,
+    kind: std::io::ErrorKind,
+    message: &'static str,
+    failure_kind: &'static str,
+}
+
+fn assert_retryable_remote_transfer_failure_matches_sync_path(
+    method: &str,
+    case: &RemoteTransferFailureCase,
+) {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(RemoteTransferErrorBridge {
+        kind: case.kind,
+        message: case.message,
+        fail_download: method == "propagation_remote_download",
+        fail_fetch: method == "propagation_remote_fetch",
+    }));
+    let method_suffix = method.strip_prefix("propagation_remote_").expect("remote method suffix");
+    let peer = format!("peer-{method_suffix}-{}", case.suffix);
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.alive = true;
+        record.sync_backoff = 0;
+        record.next_sync_attempt = 0;
+        record.acceptance_rate = 0.62;
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let transient_id = format!("{:02x}", 0xd0 + (case.suffix.len() % 16)).repeat(32);
+    let pending = PropagationEntryRecord {
+        transient_id,
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_700 + i64::try_from(case.suffix.len()).expect("case suffix len"),
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer.as_str(), pending.transient_id.as_str())
+        .expect("mark peer unhandled");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            81,
+            method,
+            json!({
+                "remote": peer,
+            }),
+        ))
+        .expect_err("retryable remote transfer failure should return the bridge error");
+    assert_eq!(err.kind(), case.kind);
+    assert_eq!(err.to_string(), case.message);
+
+    let status = daemon
+        .handle_rpc(RpcRequest { id: 82, method: "propagation_status".to_string(), params: None })
+        .expect("propagation status")
+        .result
+        .expect("propagation status result");
+    let propagation = &status["propagation"];
+    assert_eq!(propagation["sync_state"].as_u64(), Some(0xfe));
+    assert_eq!(propagation["state_name"].as_str(), Some("failed"));
+    assert_eq!(propagation["sync_progress"].as_f64(), Some(0.0));
+    assert!(propagation["last_sync_started"].as_i64().is_some());
+    assert!(propagation["last_sync_completed"].is_null());
+    assert_eq!(propagation["last_sync_error"].as_str(), Some(case.message));
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 83, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(peer.as_str()))
+        .expect("peer should remain queued for retry");
+    assert_eq!(row["alive"].as_bool(), Some(true));
+    assert_eq!(row["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(row["acceptance_rate"].as_f64(), Some(0.62));
+    let last_sync_attempt = row["last_sync_attempt"].as_i64().expect("last sync attempt");
+    assert!(last_sync_attempt > 0);
+    assert_eq!(row["next_sync_attempt"].as_i64(), Some(last_sync_attempt + 12 * 60));
+    assert_eq!(
+        row["messages"]["unhandled_ids"].as_array().expect("unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+
+    let events = daemon.event_queue.lock().expect("event_queue mutex poisoned");
+    assert!(
+        events.iter().all(|event| event.event_type != "peer_unpeer"),
+        "retryable remote transfer failure should not break peering"
+    );
+    let event = events
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "peer_sync")
+        .expect("failed remote transfer peer sync event");
+    assert_eq!(event.payload["peer"].as_str(), Some(peer.as_str()));
+    assert_eq!(event.payload["remote"].as_str(), Some(peer.as_str()));
+    assert_eq!(event.payload["remote_sync"].as_bool(), Some(true));
+    assert_eq!(event.payload["synced"].as_bool(), Some(false));
+    assert_eq!(event.payload["alive"].as_bool(), Some(true));
+    assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(event.payload["failure_kind"].as_str(), Some(case.failure_kind));
+    assert_eq!(
+        event.payload["propagation"]["failure_kind"].as_str(),
+        Some(case.failure_kind)
+    );
+    assert_eq!(event.payload["last_sync_attempt"].as_i64(), Some(last_sync_attempt));
+    assert_eq!(
+        event.payload["next_sync_attempt"].as_i64(),
+        Some(last_sync_attempt + 12 * 60)
+    );
+    assert_eq!(event.payload["propagation"]["error"].as_str(), Some(case.message));
+}
+
+fn assert_retryable_remote_transfer_failures_match_sync_paths(method: &str) {
+    for case in [
+        RemoteTransferFailureCase {
+            suffix: "timeout",
+            kind: std::io::ErrorKind::TimedOut,
+            message: "propagation peer timed out",
+            failure_kind: "timeout",
+        },
+        RemoteTransferFailureCase {
+            suffix: "closed-link",
+            kind: std::io::ErrorKind::BrokenPipe,
+            message: "propagation link closed",
+            failure_kind: "timeout",
+        },
+        RemoteTransferFailureCase {
+            suffix: "needs-id",
+            kind: std::io::ErrorKind::PermissionDenied,
+            message: "propagation node requires identity",
+            failure_kind: "no_identity",
+        },
+        RemoteTransferFailureCase {
+            suffix: "invalid-key",
+            kind: std::io::ErrorKind::PermissionDenied,
+            message: "propagation peer invalid peering key",
+            failure_kind: "invalid_key",
+        },
+        RemoteTransferFailureCase {
+            suffix: "invalid-stamp",
+            kind: std::io::ErrorKind::PermissionDenied,
+            message: "propagation peer invalid stamp",
+            failure_kind: "invalid_stamp",
+        },
+        RemoteTransferFailureCase {
+            suffix: "invalid-data",
+            kind: std::io::ErrorKind::InvalidInput,
+            message: "propagation node rejected the request",
+            failure_kind: "invalid_data",
+        },
+        RemoteTransferFailureCase {
+            suffix: "not-found",
+            kind: std::io::ErrorKind::NotFound,
+            message: "propagation peer not found",
+            failure_kind: "not_found",
+        },
+    ] {
+        assert_retryable_remote_transfer_failure_matches_sync_path(method, &case);
+    }
+}
+
+#[test]
+fn propagation_remote_download_classifies_retryable_bridge_failures_like_sync_paths() {
+    assert_retryable_remote_transfer_failures_match_sync_paths("propagation_remote_download");
+}
+
+#[test]
+fn propagation_remote_fetch_classifies_retryable_bridge_failures_like_sync_paths() {
+    assert_retryable_remote_transfer_failures_match_sync_paths("propagation_remote_fetch");
+}
+
+fn assert_remote_transfer_bridge_unavailable_preserves_failed_lifecycle(method: &str) {
+    let daemon = RpcDaemon::test_instance();
+    let method_suffix = method.strip_prefix("propagation_remote_").expect("remote method suffix");
+    let peer = format!("peer-{method_suffix}-bridge-unavailable");
+    daemon
+        .handle_rpc(rpc_request(80, "peer_sync", json!({ "peer": peer })))
+        .expect("initial peer sync");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let record = peers.get_mut(peer.as_str()).expect("peer record");
+        record.restored_handled_ids.clear();
+        record.restored_unhandled_ids.clear();
+    }
+    let pending = PropagationEntryRecord {
+        transient_id: if method == "propagation_remote_download" {
+            "e0".repeat(32)
+        } else {
+            "e1".repeat(32)
+        },
+        destination: "12".repeat(16),
+        payload_hex: "12".repeat(24),
+        received_at: 1_700_000_740,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&pending).expect("store propagation entry");
+    daemon
+        .store
+        .mark_peer_unhandled_propagation(peer.as_str(), pending.transient_id.as_str())
+        .expect("mark peer unhandled");
+    daemon.event_queue.lock().expect("event_queue mutex poisoned").clear();
+
+    let err = daemon
+        .handle_rpc(rpc_request(
+            81,
+            method,
+            json!({
+                "remote": peer,
+            }),
+        ))
+        .expect_err("missing bridge should return unavailable error");
+    assert_eq!(err.kind(), std::io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "remote control bridge unavailable");
+
+    let status = daemon
+        .handle_rpc(RpcRequest { id: 82, method: "propagation_status".to_string(), params: None })
+        .expect("propagation status")
+        .result
+        .expect("propagation status result");
+    let propagation = &status["propagation"];
+    assert_eq!(propagation["sync_state"].as_u64(), Some(0xfe));
+    assert_eq!(propagation["state_name"].as_str(), Some("failed"));
+    assert_eq!(propagation["sync_progress"].as_f64(), Some(0.0));
+    assert!(propagation["last_sync_started"].as_i64().is_some());
+    assert!(propagation["last_sync_completed"].is_null());
+    assert_eq!(
+        propagation["last_sync_error"].as_str(),
+        Some("remote control bridge unavailable")
+    );
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 83, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(peer.as_str()))
+        .expect("peer should remain listed");
+    assert_eq!(
+        row["messages"]["unhandled_ids"].as_array().expect("unhandled ids"),
+        &[json!(pending.transient_id.as_str())]
+    );
+    assert!(
+        daemon
+            .event_queue
+            .lock()
+            .expect("event_queue mutex poisoned")
+            .iter()
+            .all(|event| event.event_type != "peer_unpeer"),
+        "bridge unavailable should not break peering"
+    );
+}
+
+#[test]
+fn propagation_remote_download_bridge_unavailable_preserves_failed_lifecycle_and_queue() {
+    assert_remote_transfer_bridge_unavailable_preserves_failed_lifecycle(
+        "propagation_remote_download",
+    );
+}
+
+#[test]
+fn propagation_remote_fetch_bridge_unavailable_preserves_failed_lifecycle_and_queue() {
+    assert_remote_transfer_bridge_unavailable_preserves_failed_lifecycle("propagation_remote_fetch");
+}
+
 #[test]
 fn failed_propagation_remote_sync_updates_lifecycle_error() {
     let daemon = RpcDaemon::test_instance();

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/failed_propagation_remote_download_i.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/failed_propagation_remote_download_i.rs
@@ -87,6 +87,8 @@ fn failed_propagation_remote_download_import_updates_source_peer_backoff_like_py
     assert_eq!(event.payload["synced"].as_bool(), Some(false));
     assert_eq!(event.payload["alive"].as_bool(), Some(false));
     assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(event.payload["failure_kind"].as_str(), Some("invalid_data"));
+    assert_eq!(event.payload["propagation"]["failure_kind"].as_str(), Some("invalid_data"));
     assert!(event.payload["propagation"]["error"]
         .as_str()
         .is_some_and(|value| value.contains("invalid remote propagation payload hex")));
@@ -249,6 +251,8 @@ fn failed_propagation_remote_fetch_import_updates_source_peer_backoff_like_pytho
     assert_eq!(event.payload["synced"].as_bool(), Some(false));
     assert_eq!(event.payload["alive"].as_bool(), Some(false));
     assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(event.payload["failure_kind"].as_str(), Some("invalid_data"));
+    assert_eq!(event.payload["propagation"]["failure_kind"].as_str(), Some("invalid_data"));
     assert!(event.payload["propagation"]["error"]
         .as_str()
         .is_some_and(|value| value.contains("invalid remote propagation payload hex")));
@@ -397,6 +401,8 @@ fn failed_propagation_remote_fetch_updates_source_peer_backoff_like_python() {
     assert_eq!(event.payload["synced"].as_bool(), Some(false));
     assert_eq!(event.payload["alive"].as_bool(), Some(false));
     assert_eq!(event.payload["sync_backoff"].as_u64(), Some(12 * 60));
+    assert_eq!(event.payload["failure_kind"].as_str(), Some("failed"));
+    assert_eq!(event.payload["propagation"]["failure_kind"].as_str(), Some("failed"));
     assert_eq!(
         event.payload["propagation"]["error"].as_str(),
         Some("remote fetch failed")


### PR DESCRIPTION
## Summary
- add fetch/download failure parity coverage for timeout, closed-link, identity-required, invalid key/stamp/data, not-found, access-denied, and bridge-unavailable cases
- route retryable remote fetch/download bridge failures through the same peer retry classification path as remote sync
- assert RPC error details, propagation lifecycle state, peer queue/backoff preservation, and peer-sync failure_kind payloads

## Verification
- cargo test -p reticulum-rs-rpc --lib propagation_remote_fetch -- --nocapture
- cargo test -p reticulum-rs-rpc --lib propagation_remote_download -- --nocapture
- cargo test -p reticulum-rs-rpc --lib
- git diff --check
- C:\Program Files\Git\bin\bash.exe tools/scripts/check-module-size.sh

Note: `cargo test -p reticulum-rs-rpc --test status_snapshot ...` is not runnable on this branch because `status_snapshot.rs` is included in the library test module, not exposed as an integration-test target.