### PR TITLE
Test remote propagation success side effects

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_download_success_queue_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_download_success_queue_snapshot.rs
@@ -390,3 +390,5 @@ fn failed_propagation_remote_download_updates_source_peer_backoff_like_python() 
         Some("remote download failed")
     );
 }
+
+include!("propagation_remote_transfer_limit_matrix.rs");

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_import_success_matrix.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_import_success_matrix.rs
@@ -1,0 +1,136 @@
+fn run_propagation_remote_import_success_side_effect_case(method: &str, case_tag: &str) {
+    let payload = format!("{case_tag}-payload").into_bytes();
+    let payload_hex = hex::encode(payload.as_slice());
+    let transient_id = hex::encode(Sha256::digest(payload.as_slice()));
+    let source_peer = format!("{case_tag}-source");
+    let relay_peer = format!("{case_tag}-relay");
+    let remote = if method == "propagation_remote_sync" {
+        format!("{case_tag}-remote")
+    } else {
+        source_peer.clone()
+    };
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .handle_rpc(rpc_request(82, "peer_sync", json!({ "peer": source_peer })))
+        .expect("seed source peer");
+    daemon
+        .handle_rpc(rpc_request(83, "peer_sync", json!({ "peer": relay_peer })))
+        .expect("seed relay peer");
+    {
+        let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+        let peer = peers.get_mut(source_peer.as_str()).expect("source peer record");
+        peer.alive = false;
+        peer.last_sync_attempt = 111;
+        peer.sync_backoff = 12 * 60;
+        peer.next_sync_attempt = if method == "propagation_remote_sync" {
+            0
+        } else {
+            now_i64().saturating_add(12 * 60)
+        };
+    }
+    let messages = json!([
+        { "transient_id": transient_id, "payload_hex": payload_hex },
+        { "transient_id": transient_id, "payload_hex": payload_hex },
+    ]);
+    let bridge_result = match method {
+        "propagation_remote_sync" => json!({ "synced": true, "messages": messages }),
+        "propagation_remote_fetch" => {
+            json!({ "available_count": 2, "fetched_count": 2, "messages": messages })
+        }
+        "propagation_remote_download" => json!({ "downloaded_count": 2, "messages": messages }),
+        _ => unreachable!("remote import matrix method: {method}"),
+    };
+    daemon.set_remote_control_bridge(Arc::new(TestRemoteControlBridge {
+        result: Ok(bridge_result),
+    }));
+
+    let params = if method == "propagation_remote_sync" {
+        json!({ "remote": remote, "peer": source_peer })
+    } else {
+        json!({ "remote": remote })
+    };
+    let response = daemon
+        .handle_rpc(rpc_request(84, method, params))
+        .expect("remote propagation success")
+        .result
+        .expect("remote propagation result");
+    let result = &response["result"];
+    assert_eq!(result["imported_count"].as_u64(), Some(1), "{method}");
+    assert_eq!(result["duplicate_count"].as_u64(), Some(1), "{method}");
+    assert_eq!(result["imported_ids"], json!([transient_id.as_str()]), "{method}");
+    assert_eq!(result["transferred_bytes"].as_u64(), Some(payload.len() as u64), "{method}");
+    assert_eq!(response["propagation"]["sync_state"].as_u64(), Some(0x07), "{method}");
+    assert_eq!(response["propagation"]["state_name"].as_str(), Some("completed"), "{method}");
+    assert_eq!(response["propagation"]["last_sync_error"], JsonValue::Null, "{method}");
+
+    assert!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(source_peer.as_str())
+            .expect("source unhandled")
+            .is_empty(),
+        "{method} source should not retain unhandled work"
+    );
+    assert_eq!(
+        daemon
+            .store
+            .list_peer_handled_propagation_ids(source_peer.as_str())
+            .expect("source handled ids"),
+        vec![transient_id.clone()],
+        "{method}"
+    );
+    let relay_pending = daemon
+        .store
+        .list_peer_unhandled_propagation(relay_peer.as_str())
+        .expect("relay pending");
+    assert_eq!(relay_pending.len(), 1, "{method}");
+    assert_eq!(relay_pending[0].transient_id, transient_id, "{method}");
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 85, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    let source_row = peers["peers"]
+        .as_array()
+        .expect("peer rows")
+        .iter()
+        .find(|row| row["peer"].as_str() == Some(source_peer.as_str()))
+        .expect("source peer row");
+    assert_eq!(source_row["incoming"].as_u64(), Some(1), "{method}");
+    assert_eq!(source_row["messages"]["incoming"].as_u64(), Some(1), "{method}");
+    assert_eq!(source_row["rx_bytes"].as_u64(), Some(payload.len() as u64), "{method}");
+    assert_eq!(source_row["alive"].as_bool(), Some(true), "{method}");
+    assert_eq!(source_row["sync_backoff"].as_u64(), Some(0), "{method}");
+    assert_eq!(source_row["next_sync_attempt"].as_i64(), Some(0), "{method}");
+    assert!(
+        source_row["last_sync_attempt"].as_i64().is_some_and(|value| value > 111),
+        "{method} should refresh stale source backoff"
+    );
+
+    let peer_records = daemon.peers.lock().expect("peers mutex poisoned");
+    let relay_record = peer_records.get(relay_peer.as_str()).expect("relay record");
+    let relay_snapshot = serde_json::to_value(relay_record).expect("serialize relay");
+    assert_eq!(
+        relay_snapshot["unhandled_ids"]
+            .as_array()
+            .expect("relay snapshot unhandled ids"),
+        &[json!(transient_id.as_str())],
+        "{method}"
+    );
+}
+
+#[test]
+fn propagation_remote_import_success_matrix_covers_sync_fetch_and_download_side_effects() {
+    run_propagation_remote_import_success_side_effect_case(
+        "propagation_remote_sync",
+        "remote-import-matrix-sync",
+    );
+    run_propagation_remote_import_success_side_effect_case(
+        "propagation_remote_fetch",
+        "remote-import-matrix-fetch",
+    );
+    run_propagation_remote_import_success_side_effect_case(
+        "propagation_remote_download",
+        "remote-import-matrix-download",
+    );
+}

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_imports_match_sou.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_imports_match_sou.rs
@@ -412,3 +412,5 @@ fn propagation_remote_fetch_preserves_transfer_limited_peer_queue_mark_like_pyth
         vec![transient_id]
     );
 }
+
+include!("propagation_remote_import_success_matrix.rs");

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_transfer_limit_matrix.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_remote_transfer_limit_matrix.rs
@@ -1,0 +1,339 @@
+struct ExpectedRemoteTransferLimitBridge {
+    expected_sync_transfer_limit_kb: Option<f64>,
+    expected_fetch_transfer_limit_kb: Option<f64>,
+    expected_download_transfer_limit_kb: Option<f64>,
+    result: JsonValue,
+}
+
+impl RemoteControlBridge for ExpectedRemoteTransferLimitBridge {
+    fn propagation_remote_status(
+        &self,
+        remote: &str,
+        _identity_private_key_hex: Option<&str>,
+        _timeout_secs: f64,
+    ) -> Result<JsonValue, std::io::Error> {
+        Ok(json!({ "remote": remote, "status": "ok" }))
+    }
+
+    fn propagation_remote_sync(
+        &self,
+        remote: &str,
+        peer: &str,
+        _identity_private_key_hex: Option<&str>,
+        _timeout_secs: f64,
+        transfer_limit_kb: Option<f64>,
+    ) -> Result<JsonValue, std::io::Error> {
+        assert_eq!(transfer_limit_kb, self.expected_sync_transfer_limit_kb);
+        let mut result = self.result.clone();
+        result["remote"] = json!(remote);
+        result["peer"] = json!(peer);
+        Ok(result)
+    }
+
+    fn propagation_remote_download(
+        &self,
+        remote: &str,
+        _identity_private_key_hex: Option<&str>,
+        _timeout_secs: f64,
+        transfer_limit_kb: Option<f64>,
+    ) -> Result<JsonValue, std::io::Error> {
+        assert_eq!(transfer_limit_kb, self.expected_download_transfer_limit_kb);
+        let mut result = self.result.clone();
+        result["remote"] = json!(remote);
+        Ok(result)
+    }
+
+    fn propagation_remote_fetch(
+        &self,
+        remote: &str,
+        _identity_private_key_hex: Option<&str>,
+        _timeout_secs: f64,
+        transfer_limit_kb: Option<f64>,
+    ) -> Result<JsonValue, std::io::Error> {
+        assert_eq!(transfer_limit_kb, self.expected_fetch_transfer_limit_kb);
+        let mut result = self.result.clone();
+        result["remote"] = json!(remote);
+        Ok(result)
+    }
+
+    fn propagation_remote_unpeer(
+        &self,
+        remote: &str,
+        peer: &str,
+        _identity_private_key_hex: Option<&str>,
+        _timeout_secs: f64,
+    ) -> Result<JsonValue, std::io::Error> {
+        Ok(json!({ "remote": remote, "peer": peer, "unpeered": true }))
+    }
+}
+
+#[test]
+fn propagation_remote_fetch_forwards_request_transfer_limit_to_bridge() {
+    let daemon = RpcDaemon::test_instance();
+    daemon.set_remote_control_bridge(Arc::new(ExpectedRemoteTransferLimitBridge {
+        expected_sync_transfer_limit_kb: None,
+        expected_fetch_transfer_limit_kb: Some(42.5),
+        expected_download_transfer_limit_kb: None,
+        result: json!({ "available_count": 0, "fetched_count": 0, "messages": [] }),
+    }));
+
+    daemon
+        .handle_rpc(rpc_request(
+            86,
+            "propagation_remote_fetch",
+            json!({
+                "remote": "remote-node",
+                "transfer_limit_kb": 42.5,
+            }),
+        ))
+        .expect("remote fetch with transfer limit");
+}
+
+fn remote_transfer_limit_bridge_result(method: &str, messages: Vec<JsonValue>) -> JsonValue {
+    match method {
+        "propagation_remote_sync" => json!({ "synced": true, "messages": messages }),
+        "propagation_remote_fetch" => {
+            json!({ "available_count": messages.len(), "fetched_count": messages.len(), "messages": messages })
+        }
+        "propagation_remote_download" => {
+            json!({ "downloaded_count": messages.len(), "messages": messages })
+        }
+        _ => unreachable!("remote transfer-limit method: {method}"),
+    }
+}
+
+fn invoke_remote_transfer_limit_import(
+    daemon: &RpcDaemon,
+    method: &str,
+    remote: &str,
+    source_peer: &str,
+    messages: Vec<JsonValue>,
+) {
+    daemon.set_remote_control_bridge(Arc::new(ExpectedRemoteTransferLimitBridge {
+        expected_sync_transfer_limit_kb: None,
+        expected_fetch_transfer_limit_kb: None,
+        expected_download_transfer_limit_kb: None,
+        result: remote_transfer_limit_bridge_result(method, messages),
+    }));
+    let params = if method == "propagation_remote_sync" {
+        json!({ "remote": remote, "peer": source_peer })
+    } else {
+        json!({ "remote": source_peer })
+    };
+    daemon
+        .handle_rpc(rpc_request(90, method, params))
+        .expect("remote import for transfer-limit matrix");
+}
+
+#[test]
+fn propagation_remote_download_transfer_limit_matrix_completes_individually_oversized_imports() {
+    for (method, byte) in [
+        ("propagation_remote_sync", 0x41_u8),
+        ("propagation_remote_fetch", 0x42_u8),
+        ("propagation_remote_download", 0x43_u8),
+    ] {
+        let payload = vec![byte; 100];
+        let payload_hex = hex::encode(payload.as_slice());
+        let transient_id = hex::encode(Sha256::digest(payload.as_slice()));
+        let source_peer = format!("remote-transfer-limit-oversized-source-{byte}");
+        let relay_peer = format!("remote-transfer-limit-oversized-relay-{byte}");
+        let daemon = RpcDaemon::test_instance();
+        daemon
+            .handle_rpc(rpc_request(91, "peer_sync", json!({ "peer": source_peer })))
+            .expect("seed source peer");
+        daemon
+            .handle_rpc(rpc_request(92, "peer_sync", json!({ "peer": relay_peer })))
+            .expect("seed relay peer");
+        {
+            let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+            let relay = peers.get_mut(relay_peer.as_str()).expect("relay peer");
+            relay.propagation_transfer_limit = Some(80);
+            relay.propagation_sync_limit = Some(1_000);
+            relay.propagation_stamp_cost = Some(0);
+        }
+        invoke_remote_transfer_limit_import(
+            &daemon,
+            method,
+            "remote-transfer-limit-oversized-node",
+            source_peer.as_str(),
+            vec![json!({ "transient_id": transient_id, "payload_hex": payload_hex })],
+        );
+
+        let limited = daemon
+            .handle_rpc(rpc_request(93, "peer_sync", json!({ "peer": relay_peer })))
+            .expect("relay peer sync transfer-limits oversized payload")
+            .result
+            .expect("relay peer sync result");
+        assert_eq!(limited["synced"].as_bool(), Some(true), "{method}");
+        assert_eq!(limited["propagation"]["transfer_limited"].as_u64(), Some(1), "{method}");
+        assert_eq!(limited["propagation"]["skipped"].as_u64(), Some(0), "{method}");
+        assert_eq!(
+            limited["propagation"]["transfer_limited_ids"]
+                .as_array()
+                .expect("transfer-limited ids"),
+            &[json!(transient_id.as_str())],
+            "{method}"
+        );
+        assert_eq!(
+            daemon
+                .store
+                .list_peer_handled_propagation_ids(relay_peer.as_str())
+                .expect("handled ids"),
+            vec![transient_id.clone()],
+            "{method}"
+        );
+        assert!(
+            daemon
+                .store
+                .list_peer_unhandled_propagation(relay_peer.as_str())
+                .expect("pending relay entries")
+                .is_empty(),
+            "{method} oversized entry should not remain retryable"
+        );
+
+        {
+            let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+            let relay = peers.get_mut(relay_peer.as_str()).expect("relay peer");
+            relay.propagation_transfer_limit = Some(1_000);
+            relay.propagation_sync_limit = Some(1_000);
+        }
+        let retry = daemon
+            .handle_rpc(rpc_request(
+                94,
+                "peer_sync",
+                json!({
+                    "peer": relay_peer,
+                    "transfer_limit_kb": 1.0,
+                }),
+            ))
+            .expect("relay peer sync after larger limit")
+            .result
+            .expect("retry result");
+        assert_eq!(retry["propagation"]["transferred"].as_u64(), Some(0), "{method}");
+        assert_eq!(retry["propagation"]["transfer_limited"].as_u64(), Some(0), "{method}");
+        assert!(
+            retry["propagation"]["transferred_ids"]
+                .as_array()
+                .expect("transferred ids")
+                .is_empty(),
+            "{method}"
+        );
+    }
+}
+
+#[test]
+fn propagation_remote_download_transfer_limit_matrix_keeps_cumulative_budget_skips_retryable() {
+    for (method, byte) in [
+        ("propagation_remote_sync", 0x51_u8),
+        ("propagation_remote_fetch", 0x52_u8),
+        ("propagation_remote_download", 0x53_u8),
+    ] {
+        let first_payload = vec![byte; 10];
+        let second_payload = vec![byte.saturating_add(1); 40];
+        let first_hex = hex::encode(first_payload.as_slice());
+        let second_hex = hex::encode(second_payload.as_slice());
+        let first_id = hex::encode(Sha256::digest(first_payload.as_slice()));
+        let second_id = hex::encode(Sha256::digest(second_payload.as_slice()));
+        let source_peer = format!("remote-transfer-limit-budget-source-{byte}");
+        let relay_peer = format!("remote-transfer-limit-budget-relay-{byte}");
+        let daemon = RpcDaemon::test_instance();
+        daemon
+            .handle_rpc(rpc_request(95, "peer_sync", json!({ "peer": source_peer })))
+            .expect("seed source peer");
+        daemon
+            .handle_rpc(rpc_request(96, "peer_sync", json!({ "peer": relay_peer })))
+            .expect("seed relay peer");
+        {
+            let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+            let relay = peers.get_mut(relay_peer.as_str()).expect("relay peer");
+            relay.propagation_transfer_limit = Some(1_000);
+            relay.propagation_sync_limit = Some(80);
+            relay.propagation_stamp_cost = Some(0);
+            relay.sync_strategy = 0;
+        }
+        invoke_remote_transfer_limit_import(
+            &daemon,
+            method,
+            "remote-transfer-limit-budget-node",
+            source_peer.as_str(),
+            vec![
+                json!({ "transient_id": first_id, "payload_hex": first_hex }),
+                json!({ "transient_id": second_id, "payload_hex": second_hex }),
+            ],
+        );
+
+        let limited = daemon
+            .handle_rpc(rpc_request(
+                97,
+                "peer_sync",
+                json!({
+                    "peer": relay_peer,
+                    "transfer_limit_kb": 1.0,
+                }),
+            ))
+            .expect("relay peer sync with cumulative budget")
+            .result
+            .expect("limited result");
+        assert_eq!(limited["propagation"]["transferred"].as_u64(), Some(1), "{method}");
+        assert_eq!(limited["propagation"]["skipped"].as_u64(), Some(1), "{method}");
+        assert_eq!(limited["propagation"]["transfer_limited"].as_u64(), Some(0), "{method}");
+        assert_eq!(
+            limited["propagation"]["transferred_ids"]
+                .as_array()
+                .expect("transferred ids"),
+            &[json!(first_id.as_str())],
+            "{method}"
+        );
+        assert_eq!(
+            limited["propagation"]["skipped_ids"].as_array().expect("skipped ids"),
+            &[json!(second_id.as_str())],
+            "{method}"
+        );
+        assert_eq!(
+            daemon
+                .store
+                .list_peer_unhandled_propagation(relay_peer.as_str())
+                .expect("pending relay entries")
+                .into_iter()
+                .map(|entry| entry.transient_id)
+                .collect::<Vec<_>>(),
+            vec![second_id.clone()],
+            "{method}"
+        );
+
+        {
+            let mut peers = daemon.peers.lock().expect("peers mutex poisoned");
+            let relay = peers.get_mut(relay_peer.as_str()).expect("relay peer");
+            relay.propagation_sync_limit = Some(1_000);
+        }
+        let retry = daemon
+            .handle_rpc(rpc_request(
+                98,
+                "peer_sync",
+                json!({
+                    "peer": relay_peer,
+                    "transfer_limit_kb": 1.0,
+                }),
+            ))
+            .expect("relay peer sync retries skipped payload")
+            .result
+            .expect("retry result");
+        assert_eq!(retry["propagation"]["transferred"].as_u64(), Some(1), "{method}");
+        assert_eq!(retry["propagation"]["skipped"].as_u64(), Some(0), "{method}");
+        assert_eq!(
+            retry["propagation"]["transferred_ids"]
+                .as_array()
+                .expect("retry transferred ids"),
+            &[json!(second_id.as_str())],
+            "{method}"
+        );
+        assert!(
+            daemon
+                .store
+                .list_peer_unhandled_propagation(relay_peer.as_str())
+                .expect("pending relay entries")
+                .is_empty(),
+            "{method} cumulative skip should clear after later successful request"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a remote propagation success matrix for sync, fetch, and download visible side effects
- add transfer-limit matrix coverage for request forwarding, oversized completed marks, and cumulative retryable skips
- keep changes test-only; no daemon production delta was required

## Tests
- `cargo test -p reticulum-rs-rpc --lib propagation_remote_import -- --nocapture`
- `cargo test -p reticulum-rs-rpc --lib propagation_remote_download -- --nocapture`
- `cargo test -p reticulum-rs-rpc --lib transfer_limit -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

Note: the requested `--test status_snapshot` form is not available in this crate; these status snapshot tests are included under the library unit-test target.