### PR TITLE
Close deferred stamp lifecycle parity

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_scheduler.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_scheduler.rs
@@ -1,4 +1,5 @@
-use super::delivery_task::DeliveryTask;
+use super::delivery_task::{DeliveryTask, PreparedDeliveryPayload, PreparedPropagationPayload};
+use super::{log_delivery_trace, propagation, RequestedDeliveryMethod};
 use serde_json::{json, Value as JsonValue};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -50,8 +51,14 @@ pub(super) struct DeliverySchedulerSnapshot {
     pub(super) queued_current: u64,
     pub(super) in_flight_current: u64,
     pub(super) completed_total: u64,
+    pub(super) stamp_queued_current: u64,
+    pub(super) stamp_in_flight_current: u64,
+    pub(super) stamp_completed_total: u64,
+    pub(super) stamp_retried_total: u64,
     pub(super) queued_by_peer: BTreeMap<String, u64>,
     pub(super) in_flight_by_peer: BTreeMap<String, u64>,
+    pub(super) stamp_queued_by_peer: BTreeMap<String, u64>,
+    pub(super) stamp_in_flight_by_peer: BTreeMap<String, u64>,
 }
 
 #[derive(Debug, Default)]
@@ -61,6 +68,10 @@ pub(super) struct DeliverySchedulerMetrics {
     queued_current: AtomicU64,
     in_flight_current: AtomicU64,
     completed_total: AtomicU64,
+    stamp_queued_current: AtomicU64,
+    stamp_in_flight_current: AtomicU64,
+    stamp_completed_total: AtomicU64,
+    stamp_retried_total: AtomicU64,
     peers: Mutex<HashMap<String, PeerDeliveryCounters>>,
 }
 
@@ -68,6 +79,8 @@ pub(super) struct DeliverySchedulerMetrics {
 struct PeerDeliveryCounters {
     queued: u64,
     in_flight: u64,
+    stamp_queued: u64,
+    stamp_in_flight: u64,
 }
 
 impl DeliverySchedulerMetrics {
@@ -101,16 +114,64 @@ impl DeliverySchedulerMetrics {
         });
     }
 
+    fn record_finished_before_delivery_for_peer(&self, peer: &str) {
+        self.queued_current.fetch_sub(1, Ordering::Relaxed);
+        self.completed_total.fetch_add(1, Ordering::Relaxed);
+        self.update_peer(peer, |counters| {
+            counters.queued = counters.queued.saturating_sub(1);
+        });
+    }
+
+    pub(super) fn record_stamp_queued_for_peer(&self, peer: &str) {
+        self.stamp_queued_current.fetch_add(1, Ordering::Relaxed);
+        self.update_peer(peer, |counters| {
+            counters.stamp_queued = counters.stamp_queued.saturating_add(1);
+        });
+    }
+
+    pub(super) fn record_stamp_started_for_peer(&self, peer: &str) {
+        self.stamp_queued_current.fetch_sub(1, Ordering::Relaxed);
+        self.stamp_in_flight_current.fetch_add(1, Ordering::Relaxed);
+        self.update_peer(peer, |counters| {
+            counters.stamp_queued = counters.stamp_queued.saturating_sub(1);
+            counters.stamp_in_flight = counters.stamp_in_flight.saturating_add(1);
+        });
+    }
+
+    pub(super) fn record_stamp_retry_for_peer(&self, peer: &str) {
+        self.stamp_retried_total.fetch_add(1, Ordering::Relaxed);
+        self.stamp_queued_current.fetch_add(1, Ordering::Relaxed);
+        self.update_peer(peer, |counters| {
+            counters.stamp_queued = counters.stamp_queued.saturating_add(1);
+        });
+    }
+
+    pub(super) fn record_stamp_completed_for_peer(&self, peer: &str) {
+        self.stamp_in_flight_current.fetch_sub(1, Ordering::Relaxed);
+        self.stamp_completed_total.fetch_add(1, Ordering::Relaxed);
+        self.update_peer(peer, |counters| {
+            counters.stamp_in_flight = counters.stamp_in_flight.saturating_sub(1);
+        });
+    }
+
     pub(super) fn snapshot(&self) -> DeliverySchedulerSnapshot {
         let peers = self.peers.lock().expect("delivery scheduler peer metrics mutex poisoned");
         let mut queued_by_peer = BTreeMap::new();
         let mut in_flight_by_peer = BTreeMap::new();
+        let mut stamp_queued_by_peer = BTreeMap::new();
+        let mut stamp_in_flight_by_peer = BTreeMap::new();
         for (peer, counters) in peers.iter() {
             if counters.queued > 0 {
                 queued_by_peer.insert(peer.clone(), counters.queued);
             }
             if counters.in_flight > 0 {
                 in_flight_by_peer.insert(peer.clone(), counters.in_flight);
+            }
+            if counters.stamp_queued > 0 {
+                stamp_queued_by_peer.insert(peer.clone(), counters.stamp_queued);
+            }
+            if counters.stamp_in_flight > 0 {
+                stamp_in_flight_by_peer.insert(peer.clone(), counters.stamp_in_flight);
             }
         }
         DeliverySchedulerSnapshot {
@@ -119,8 +180,14 @@ impl DeliverySchedulerMetrics {
             queued_current: self.queued_current.load(Ordering::Relaxed),
             in_flight_current: self.in_flight_current.load(Ordering::Relaxed),
             completed_total: self.completed_total.load(Ordering::Relaxed),
+            stamp_queued_current: self.stamp_queued_current.load(Ordering::Relaxed),
+            stamp_in_flight_current: self.stamp_in_flight_current.load(Ordering::Relaxed),
+            stamp_completed_total: self.stamp_completed_total.load(Ordering::Relaxed),
+            stamp_retried_total: self.stamp_retried_total.load(Ordering::Relaxed),
             queued_by_peer,
             in_flight_by_peer,
+            stamp_queued_by_peer,
+            stamp_in_flight_by_peer,
         }
     }
 
@@ -196,8 +263,14 @@ impl DeliveryScheduler {
             "queued_total": snapshot.queued_current,
             "in_flight_total": snapshot.in_flight_current,
             "completed_total": snapshot.completed_total,
+            "stamp_queued_total": snapshot.stamp_queued_current,
+            "stamp_in_flight_total": snapshot.stamp_in_flight_current,
+            "stamp_completed_total": snapshot.stamp_completed_total,
+            "stamp_retried_total": snapshot.stamp_retried_total,
             "queued_by_peer": snapshot.queued_by_peer,
             "in_flight_by_peer": snapshot.in_flight_by_peer,
+            "stamp_queued_by_peer": snapshot.stamp_queued_by_peer,
+            "stamp_in_flight_by_peer": snapshot.stamp_in_flight_by_peer,
         })
     }
 }
@@ -213,17 +286,28 @@ async fn run_scheduler(
     metrics: Arc<DeliverySchedulerMetrics>,
 ) {
     let global_limit = Arc::new(Semaphore::new(config.global_concurrency));
+    let stamp_limit = Arc::new(Semaphore::new(1));
     let mut peer_limits: HashMap<String, Arc<Semaphore>> = HashMap::new();
 
     while let Some(delivery) = rx.recv().await {
         let peer = delivery.task.destination_hex.clone();
+        if delivery.task.requires_deferred_stamp_work() {
+            delivery.task.record_deferred_stamp_queued_metadata();
+            metrics.record_stamp_queued_for_peer(&peer);
+        }
         let peer_limit = peer_limits
             .entry(peer.clone())
             .or_insert_with(|| Arc::new(Semaphore::new(config.per_peer_in_flight)))
             .clone();
         let global_limit = Arc::clone(&global_limit);
+        let stamp_limit = Arc::clone(&stamp_limit);
         let metrics = Arc::clone(&metrics);
         tokio::task::spawn_local(async move {
+            let prepared = prepare_payload(&delivery.task, &stamp_limit, &metrics, &peer).await;
+            let Some(prepared) = prepared else {
+                metrics.record_finished_before_delivery_for_peer(&peer);
+                return;
+            };
             let Ok(_global_permit) = global_limit.acquire_owned().await else {
                 return;
             };
@@ -232,10 +316,165 @@ async fn run_scheduler(
             };
             metrics.record_dequeued_for_peer(&peer);
             metrics.record_started_for_peer(&peer);
-            delivery.task.run().await;
+            delivery.task.run_prepared(prepared, stamp_limit).await;
             metrics.record_completed_for_peer(&peer);
         });
     }
+}
+
+async fn prepare_payload(
+    task: &DeliveryTask,
+    stamp_limit: &Arc<Semaphore>,
+    metrics: &Arc<DeliverySchedulerMetrics>,
+    peer: &str,
+) -> Option<PreparedDeliveryPayload> {
+    task.start_delivery_trace();
+    if task.abort_if_cancelled("start") {
+        task.record_deferred_stamp_cancelled_metadata();
+        if task.requires_deferred_stamp_work() {
+            metrics.record_stamp_started_for_peer(peer);
+            metrics.record_stamp_completed_for_peer(peer);
+        }
+        return None;
+    }
+
+    let lxmf_payload = prepare_lxmf_payload(task, stamp_limit, metrics, peer).await?;
+    let propagation = if task.requested_method == RequestedDeliveryMethod::Propagated {
+        if task.requires_normal_deferred_stamp_work() {
+            metrics.record_stamp_queued_for_peer(peer);
+        }
+        Some(prepare_propagation_payload(task, &lxmf_payload, stamp_limit, metrics, peer).await?)
+    } else {
+        None
+    };
+    Some(PreparedDeliveryPayload { lxmf_payload, propagation })
+}
+
+async fn prepare_lxmf_payload(
+    task: &DeliveryTask,
+    stamp_limit: &Arc<Semaphore>,
+    metrics: &Arc<DeliverySchedulerMetrics>,
+    peer: &str,
+) -> Option<Vec<u8>> {
+    let normal_stamp_work = task.requires_normal_deferred_stamp_work();
+    let attempts = if normal_stamp_work { 2 } else { 1 };
+    for attempt in 1..=attempts {
+        let _stamp_permit = if normal_stamp_work {
+            metrics.record_stamp_started_for_peer(peer);
+            Some(stamp_limit.clone().acquire_owned().await.ok()?)
+        } else {
+            None
+        };
+        task.record_deferred_stamp_attempt_metadata(attempt);
+        let result = task.build_payload().await;
+        drop(_stamp_permit);
+        if normal_stamp_work {
+            metrics.record_stamp_completed_for_peer(peer);
+        }
+        match result {
+            Ok(payload) => return Some(payload),
+            Err(err) => {
+                if task.abort_if_cancelled("payload") {
+                    task.record_deferred_stamp_cancelled_metadata();
+                    return None;
+                }
+                if attempt < attempts {
+                    task.record_deferred_stamp_retry_metadata(attempt, err.to_string());
+                    metrics.record_stamp_retry_for_peer(peer);
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    continue;
+                }
+                task.record_deferred_stamp_failed_metadata(attempt, err.to_string());
+                task.fail_payload_build(err);
+                return None;
+            }
+        }
+    }
+    None
+}
+
+async fn prepare_propagation_payload(
+    task: &DeliveryTask,
+    lxmf_payload: &[u8],
+    stamp_limit: &Arc<Semaphore>,
+    metrics: &Arc<DeliverySchedulerMetrics>,
+    peer: &str,
+) -> Option<PreparedPropagationPayload> {
+    let context = task.propagation_preparation_context().await?;
+    log_delivery_trace(
+        &task.message_id,
+        &task.destination_hex,
+        "propagation",
+        "building propagation payload",
+    );
+    task.record_propagation_stamp_work_metadata("queued", context.target_cost, None);
+    for attempt in 1..=2u32 {
+        let _stamp_permit = {
+            metrics.record_stamp_started_for_peer(peer);
+            stamp_limit.clone().acquire_owned().await.ok()?
+        };
+        task.record_propagation_stamp_attempt_metadata(context.target_cost, attempt);
+        if task.abort_if_cancelled("propagation") {
+            task.record_propagation_stamp_work_metadata("cancelled", context.target_cost, None);
+            metrics.record_stamp_completed_for_peer(peer);
+            return None;
+        }
+        let result = propagation::build_propagation_payload_until_cancelled(
+            lxmf_payload,
+            &context.destination_identity,
+            context.target_cost,
+            || {
+                let status = task.daemon.message_receipt_status(&task.message_id).ok().flatten();
+                DeliveryTask::is_cancelled_status(status.as_deref())
+            },
+        );
+        drop(_stamp_permit);
+        metrics.record_stamp_completed_for_peer(peer);
+        match result {
+            Ok(payload) => {
+                task.record_propagation_stamp_work_metadata(
+                    "ready",
+                    context.target_cost,
+                    Some(payload.stamp_value.to_string()),
+                );
+                task.record_propagation_payload_metadata(&payload, context.target_cost);
+                return Some(PreparedPropagationPayload {
+                    propagation_node_hex: context.propagation_node_hex,
+                    propagation_hash: context.propagation_hash,
+                    target_cost: context.target_cost,
+                    payload,
+                });
+            }
+            Err(err) => {
+                if task.abort_if_cancelled("propagation") {
+                    task.record_propagation_stamp_work_metadata(
+                        "cancelled",
+                        context.target_cost,
+                        None,
+                    );
+                    return None;
+                }
+                if attempt < 2 {
+                    task.record_propagation_stamp_retry_metadata(
+                        context.target_cost,
+                        attempt,
+                        err.to_string(),
+                    );
+                    metrics.record_stamp_retry_for_peer(peer);
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    continue;
+                }
+                task.record_propagation_stamp_work_metadata(
+                    "failed",
+                    context.target_cost,
+                    Some(err.to_string()),
+                );
+                task.fail_payload_build(err);
+                return None;
+            }
+        }
+    }
+    None
 }
 
 fn env_usize(name: &str) -> Option<usize> {
@@ -243,20 +482,5 @@ fn env_usize(name: &str) -> Option<usize> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn scheduler_metrics_record_admission_and_queue_pressure() {
-        let metrics = DeliverySchedulerMetrics::default();
-
-        metrics.record_admitted_for_peer("peer-a");
-        metrics.record_admitted_for_peer("peer-a");
-        metrics.record_queue_full();
-
-        let snapshot = metrics.snapshot();
-        assert_eq!(snapshot.accepted_total, 2);
-        assert_eq!(snapshot.rejected_queue_full_total, 1);
-        assert_eq!(snapshot.queued_current, 2);
-    }
-}
+#[path = "bridge_delivery_scheduler_tests.rs"]
+mod tests;

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_scheduler.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_scheduler.rs
@@ -138,6 +138,13 @@ impl DeliverySchedulerMetrics {
         });
     }
 
+    pub(super) fn record_stamp_unqueued_for_peer(&self, peer: &str) {
+        self.stamp_queued_current.fetch_sub(1, Ordering::Relaxed);
+        self.update_peer(peer, |counters| {
+            counters.stamp_queued = counters.stamp_queued.saturating_sub(1);
+        });
+    }
+
     pub(super) fn record_stamp_retry_for_peer(&self, peer: &str) {
         self.stamp_retried_total.fetch_add(1, Ordering::Relaxed);
         self.stamp_queued_current.fetch_add(1, Ordering::Relaxed);
@@ -360,8 +367,9 @@ async fn prepare_lxmf_payload(
     let attempts = if normal_stamp_work { 2 } else { 1 };
     for attempt in 1..=attempts {
         let _stamp_permit = if normal_stamp_work {
+            let permit = stamp_limit.clone().acquire_owned().await.ok()?;
             metrics.record_stamp_started_for_peer(peer);
-            Some(stamp_limit.clone().acquire_owned().await.ok()?)
+            Some(permit)
         } else {
             None
         };
@@ -400,7 +408,10 @@ async fn prepare_propagation_payload(
     metrics: &Arc<DeliverySchedulerMetrics>,
     peer: &str,
 ) -> Option<PreparedPropagationPayload> {
-    let context = task.propagation_preparation_context().await?;
+    let Some(context) = task.propagation_preparation_context().await else {
+        metrics.record_stamp_unqueued_for_peer(peer);
+        return None;
+    };
     log_delivery_trace(
         &task.message_id,
         &task.destination_hex,
@@ -409,10 +420,8 @@ async fn prepare_propagation_payload(
     );
     task.record_propagation_stamp_work_metadata("queued", context.target_cost, None);
     for attempt in 1..=2u32 {
-        let _stamp_permit = {
-            metrics.record_stamp_started_for_peer(peer);
-            stamp_limit.clone().acquire_owned().await.ok()?
-        };
+        let _stamp_permit = stamp_limit.clone().acquire_owned().await.ok()?;
+        metrics.record_stamp_started_for_peer(peer);
         task.record_propagation_stamp_attempt_metadata(context.target_cost, attempt);
         if task.abort_if_cancelled("propagation") {
             task.record_propagation_stamp_work_metadata("cancelled", context.target_cost, None);

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_scheduler_tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_scheduler_tests.rs
@@ -30,6 +30,8 @@ fn scheduler_metrics_track_deferred_stamp_worker_ownership() {
     metrics.record_stamp_completed_for_peer("peer-a");
     metrics.record_stamp_started_for_peer("peer-a");
     metrics.record_stamp_completed_for_peer("peer-a");
+    metrics.record_stamp_queued_for_peer("peer-a");
+    metrics.record_stamp_unqueued_for_peer("peer-a");
 
     let snapshot = metrics.snapshot();
     assert_eq!(snapshot.stamp_queued_current, 0);

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_scheduler_tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_scheduler_tests.rs
@@ -1,0 +1,171 @@
+use super::super::*;
+use super::*;
+use rand_core::OsRng;
+use rns_core::identity::PrivateIdentity;
+use rns_rpc::{MessageRecord, MessagesStore, RpcDaemon, RpcRequest};
+use rns_transport::identity_bridge::to_transport_private_identity;
+use rns_transport::transport::{Transport, TransportConfig};
+
+#[test]
+fn scheduler_metrics_record_admission_and_queue_pressure() {
+    let metrics = DeliverySchedulerMetrics::default();
+
+    metrics.record_admitted_for_peer("peer-a");
+    metrics.record_admitted_for_peer("peer-a");
+    metrics.record_queue_full();
+
+    let snapshot = metrics.snapshot();
+    assert_eq!(snapshot.accepted_total, 2);
+    assert_eq!(snapshot.rejected_queue_full_total, 1);
+    assert_eq!(snapshot.queued_current, 2);
+}
+
+#[test]
+fn scheduler_metrics_track_deferred_stamp_worker_ownership() {
+    let metrics = DeliverySchedulerMetrics::default();
+
+    metrics.record_stamp_queued_for_peer("peer-a");
+    metrics.record_stamp_started_for_peer("peer-a");
+    metrics.record_stamp_retry_for_peer("peer-a");
+    metrics.record_stamp_completed_for_peer("peer-a");
+    metrics.record_stamp_started_for_peer("peer-a");
+    metrics.record_stamp_completed_for_peer("peer-a");
+
+    let snapshot = metrics.snapshot();
+    assert_eq!(snapshot.stamp_queued_current, 0);
+    assert_eq!(snapshot.stamp_in_flight_current, 0);
+    assert_eq!(snapshot.stamp_retried_total, 1);
+    assert_eq!(snapshot.stamp_completed_total, 2);
+}
+
+#[tokio::test]
+async fn prepare_payload_builds_propagation_stamp_before_delivery_lane() {
+    let message_id = "deferred-propagation-prepare";
+    let store = MessagesStore::in_memory().expect("store");
+    let destination_identity = rns_transport::identity::PrivateIdentity::new_from_rand(OsRng);
+    let destination_hash = destination_identity.as_identity().address_hash;
+    let destination_hex = hex::encode(destination_hash.as_slice());
+    store
+        .insert_message(&MessageRecord {
+            id: message_id.to_string(),
+            source: "source".to_string(),
+            destination: destination_hex.clone(),
+            title: String::new(),
+            content: "propagated before delivery".to_string(),
+            timestamp: 0,
+            direction: "out".to_string(),
+            fields: None,
+            receipt_status: Some("queued".to_string()),
+        })
+        .expect("insert message");
+    let daemon = Arc::new(RpcDaemon::with_store(store, "deferred-propagation-node".to_string()));
+    let local_propagation_hash = hex::encode([0x77u8; 16]);
+    daemon.set_propagation_destination_hash(Some(local_propagation_hash.clone()));
+    daemon
+        .handle_rpc(RpcRequest {
+            id: 901,
+            method: "propagation_enable".to_string(),
+            params: Some(json!({
+                "enabled": true,
+                "target_cost": 0,
+                "autopeer": true,
+            })),
+        })
+        .expect("enable propagation");
+    let app_data = rmp_serde::to_vec_named(&rmpv::Value::Array(vec![
+        rmpv::Value::Boolean(false),
+        rmpv::Value::from(1_700_000_901i64),
+        rmpv::Value::Boolean(true),
+        rmpv::Value::from(256),
+        rmpv::Value::from(2048),
+        rmpv::Value::Array(vec![rmpv::Value::from(0), rmpv::Value::from(0), rmpv::Value::from(0)]),
+        rmpv::Value::Map(Vec::new()),
+    ]))
+    .expect("encode app data");
+    daemon
+        .handle_rpc(RpcRequest {
+            id: 902,
+            method: "announce_received".to_string(),
+            params: Some(json!({
+                "peer": local_propagation_hash,
+                "timestamp": 1_700_000_901i64,
+                "app_data_hex": hex::encode(app_data),
+                "aspect": "lxmf.propagation",
+                "hops": 0,
+            })),
+        })
+        .expect("local propagation announce");
+    daemon
+        .handle_rpc(RpcRequest {
+            id: 903,
+            method: "set_outbound_propagation_node".to_string(),
+            params: Some(json!({ "peer": local_propagation_hash.clone() })),
+        })
+        .expect("select local propagation node");
+
+    let signer = PrivateIdentity::new_from_name("deferred-propagation-prepare");
+    let transport_identity = to_transport_private_identity(&signer);
+    let transport = Arc::new(Transport::new(TransportConfig::new(
+        "deferred-propagation-prepare",
+        &transport_identity,
+        true,
+    )));
+    let (receipt_tx, _receipt_rx) = tokio::sync::mpsc::channel(16);
+    let mut destination = [0u8; 16];
+    destination.copy_from_slice(destination_hash.as_slice());
+    let task = DeliveryTask {
+        daemon: daemon.clone(),
+        transport,
+        peer_crypto: Arc::new(Mutex::new(HashMap::new())),
+        outbound_propagation_identities: Arc::new(Mutex::new(HashMap::new())),
+        receipt_map: Arc::new(Mutex::new(HashMap::new())),
+        outbound_resource_map: Arc::new(Mutex::new(HashMap::new())),
+        outbound_propagation_link: Arc::new(tokio::sync::Mutex::new(None)),
+        receipt_tx,
+        message_id: message_id.to_string(),
+        source_hash: [1u8; 16],
+        destination,
+        destination_hash,
+        destination_hex: destination_hex.clone(),
+        title: String::new(),
+        content: "propagated before delivery".to_string(),
+        fields: None,
+        signer,
+        stamp_cost: None,
+        outbound_ticket: None,
+        include_ticket: None,
+        peer_identity: Some(*destination_identity.as_identity()),
+        propagation_node_identity: Some(*transport_identity.as_identity()),
+        requested_method: RequestedDeliveryMethod::Propagated,
+        try_propagation_on_fail: false,
+        propagation_node_hex: Some(local_propagation_hash),
+    };
+    let metrics = Arc::new(DeliverySchedulerMetrics::default());
+    let stamp_limit = Arc::new(Semaphore::new(1));
+    task.record_deferred_stamp_queued_metadata();
+    metrics.record_stamp_queued_for_peer(&destination_hex);
+
+    let _payload = prepare_payload(&task, &stamp_limit, &metrics, &destination_hex)
+        .await
+        .expect("prepared propagated payload");
+
+    let result = daemon
+        .handle_rpc(RpcRequest { id: 904, method: "list_messages".to_string(), params: None })
+        .expect("list messages")
+        .result
+        .expect("result");
+    let message = result["messages"]
+        .as_array()
+        .expect("messages")
+        .iter()
+        .find(|message| message["id"].as_str() == Some(message_id))
+        .expect("message");
+    let lxmf = &message["fields"]["_lxmf"];
+    assert_eq!(lxmf["propagation_stamp_state"], json!("ready"));
+    assert_eq!(lxmf["propagation_packed"], json!(true));
+    assert!(lxmf["propagation_packed_size"].as_u64().unwrap_or_default() > 0);
+    let snapshot = metrics.snapshot();
+    assert_eq!(snapshot.stamp_queued_current, 0);
+    assert_eq!(snapshot.stamp_in_flight_current, 0);
+    assert_eq!(snapshot.in_flight_current, 0);
+}

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_parts/deliverytask_sections/cached_identity_for_destination.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_parts/deliverytask_sections/cached_identity_for_destination.rs
@@ -10,8 +10,13 @@ impl DeliveryTask {
         )
     }
 
-    pub(super) async fn run(self) {
+    pub(super) fn start_delivery_trace(&self) {
         log_delivery_trace(&self.message_id, &self.destination_hex, "start", "delivery requested");
+    }
+
+    #[cfg(test)]
+    pub(super) async fn run(self) {
+        self.start_delivery_trace();
         if self.abort_if_cancelled("start") {
             return;
         }
@@ -21,25 +26,52 @@ impl DeliveryTask {
                 if self.abort_if_cancelled("payload") {
                     return;
                 }
-                let _ = self.receipt_tx.try_send(ReceiptEvent {
-                    message_id: self.message_id,
-                    status: format!("failed: {err}"),
-                });
+                self.fail_payload_build(err);
                 return;
             }
         };
+        self.run_prepared(
+            PreparedDeliveryPayload {
+                lxmf_payload: payload,
+                propagation: None,
+            },
+            Arc::new(tokio::sync::Semaphore::new(1)),
+        )
+        .await;
+    }
+
+    pub(super) async fn run_prepared(
+        self,
+        prepared: PreparedDeliveryPayload,
+        stamp_limit: Arc<tokio::sync::Semaphore>,
+    ) {
         if self.abort_if_cancelled("payload") {
             return;
         }
         match self.requested_method {
-            RequestedDeliveryMethod::Direct => self.run_direct(payload).await,
-            RequestedDeliveryMethod::Opportunistic => self.run_opportunistic(payload).await,
-            RequestedDeliveryMethod::Propagated => self.run_propagated(payload).await,
+            RequestedDeliveryMethod::Direct => self.run_direct(prepared.lxmf_payload, stamp_limit).await,
+            RequestedDeliveryMethod::Opportunistic => {
+                self.run_opportunistic(prepared.lxmf_payload).await;
+            }
+            RequestedDeliveryMethod::Propagated => {
+                if let Some(propagation) = prepared.propagation {
+                    self.send_prepared_propagated(propagation).await;
+                } else {
+                    self.run_propagated(prepared.lxmf_payload, stamp_limit).await;
+                }
+            }
             RequestedDeliveryMethod::Paper => {}
         }
     }
 
-    async fn run_direct(self, payload: Vec<u8>) {
+    pub(super) fn fail_payload_build(&self, err: std::io::Error) {
+        let _ = self.receipt_tx.try_send(ReceiptEvent {
+            message_id: self.message_id.clone(),
+            status: format!("failed: {err}"),
+        });
+    }
+
+    async fn run_direct(self, payload: Vec<u8>, stamp_limit: Arc<tokio::sync::Semaphore>) {
         if self.abort_if_cancelled("link") {
             return;
         }
@@ -77,7 +109,7 @@ impl DeliveryTask {
                     message_id: self.message_id.clone(),
                     status: format!("link failed: {err}; trying propagated"),
                 });
-                self.run_propagated(payload).await;
+                self.run_propagated(payload, stamp_limit).await;
             }
             Err(err) => {
                 let detail = format!("direct failed err={err}");
@@ -90,110 +122,107 @@ impl DeliveryTask {
         }
     }
 
-    async fn run_propagated(self, payload: Vec<u8>) {
+    async fn run_propagated(self, payload: Vec<u8>, stamp_limit: Arc<tokio::sync::Semaphore>) {
         if self.abort_if_cancelled("propagation") {
             return;
         }
-        let Some(destination_identity) = self.resolve_destination_identity().await else {
+        let Some(context) = self.propagation_preparation_context().await else {
             return;
         };
-        if self.abort_if_cancelled("propagation") {
-            return;
-        }
-        log_delivery_trace(
-            &self.message_id,
-            &self.destination_hex,
-            "propagation",
-            "recipient identity ready",
-        );
-        let Some(propagation_node_hex) = self.propagation_node_hex.clone() else {
-            let _ = self.receipt_tx.try_send(ReceiptEvent {
-                message_id: self.message_id,
-                status: "failed: no outbound propagation node selected".to_string(),
-            });
-            return;
-        };
-
-        let propagation_hash = match parse_destination_hash_required(&propagation_node_hex) {
-            Ok(hash) => AddressHash::new(hash),
-            Err(err) => {
-                let _ = self.receipt_tx.try_send(ReceiptEvent {
-                    message_id: self.message_id,
-                    status: format!("failed: {err}"),
-                });
-                return;
-            }
-        };
-        log_delivery_trace(
-            &self.message_id,
-            &self.destination_hex,
-            "propagation",
-            "selected propagation node parsed",
-        );
-        log_delivery_trace(
-            &self.message_id,
-            &self.destination_hex,
-            "propagation",
-            "looking up propagation stamp cost",
-        );
-        let (target_cost, cost_source) = self
-            .propagation_target_cost_reference_style(propagation_node_hex.as_str(), propagation_hash)
-            .await;
-        let target_cost = target_cost.unwrap_or(propagation::DEFAULT_PROPAGATION_STAMP_COST);
-        log_delivery_trace(
-            &self.message_id,
-            &self.destination_hex,
-            "propagation",
-            format!("using propagation stamp cost={target_cost} source={cost_source}").as_str(),
-        );
         log_delivery_trace(
             &self.message_id,
             &self.destination_hex,
             "propagation",
             "building propagation payload",
         );
-        self.record_propagation_stamp_work_metadata("generating", target_cost, None);
-        if self.abort_if_cancelled("propagation") {
-            self.record_propagation_stamp_work_metadata("cancelled", target_cost, None);
-            return;
-        }
-        let propagation_payload = match propagation::build_propagation_payload_until_cancelled(
-            &payload,
-            &destination_identity,
-            target_cost,
-            || {
-                let status = self.daemon.message_receipt_status(&self.message_id).ok().flatten();
-                Self::is_cancelled_status(status.as_deref())
-            },
-        ) {
-            Ok(payload) => payload,
-            Err(err) => {
-                if self.abort_if_cancelled("propagation") {
-                    self.record_propagation_stamp_work_metadata("cancelled", target_cost, None);
+        self.record_propagation_stamp_work_metadata("queued", context.target_cost, None);
+        let mut propagation_payload = None;
+        for attempt in 1..=2u32 {
+            let _stamp_permit = match stamp_limit.clone().acquire_owned().await {
+                Ok(permit) => permit,
+                Err(_) => {
+                    let _ = self.receipt_tx.try_send(ReceiptEvent {
+                        message_id: self.message_id,
+                        status: "failed: stamp worker stopped".to_string(),
+                    });
                     return;
                 }
-                self.record_propagation_stamp_work_metadata(
-                    "failed",
-                    target_cost,
-                    Some(err.to_string()),
-                );
-                let _ = self.receipt_tx.try_send(ReceiptEvent {
-                    message_id: self.message_id,
-                    status: format!("failed: {err}"),
-                });
+            };
+            self.record_propagation_stamp_attempt_metadata(context.target_cost, attempt);
+            if self.abort_if_cancelled("propagation") {
+                self.record_propagation_stamp_work_metadata("cancelled", context.target_cost, None);
                 return;
             }
+            let result = propagation::build_propagation_payload_until_cancelled(
+                &payload,
+                &context.destination_identity,
+                context.target_cost,
+                || {
+                    let status = self.daemon.message_receipt_status(&self.message_id).ok().flatten();
+                    Self::is_cancelled_status(status.as_deref())
+                },
+            );
+            drop(_stamp_permit);
+            match result {
+                Ok(payload) => {
+                    propagation_payload = Some(payload);
+                    break;
+                }
+                Err(err) => {
+                    if self.abort_if_cancelled("propagation") {
+                        self.record_propagation_stamp_work_metadata(
+                            "cancelled",
+                            context.target_cost,
+                            None,
+                        );
+                        return;
+                    }
+                    if attempt < 2 {
+                        self.record_propagation_stamp_retry_metadata(
+                            context.target_cost,
+                            attempt,
+                            err.to_string(),
+                        );
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        continue;
+                    }
+                    self.record_propagation_stamp_work_metadata(
+                        "failed",
+                        context.target_cost,
+                        Some(err.to_string()),
+                    );
+                    let _ = self.receipt_tx.try_send(ReceiptEvent {
+                        message_id: self.message_id,
+                        status: format!("failed: {err}"),
+                    });
+                    return;
+                }
+            }
+        }
+        let Some(propagation_payload) = propagation_payload else {
+            return;
         };
         self.record_propagation_stamp_work_metadata(
             "ready",
-            target_cost,
+            context.target_cost,
             Some(propagation_payload.stamp_value.to_string()),
         );
-        self.record_propagation_payload_metadata(&propagation_payload, target_cost);
-        if self.selected_propagation_node_is_local(propagation_node_hex.as_str()) {
+        self.record_propagation_payload_metadata(&propagation_payload, context.target_cost);
+        self
+            .send_prepared_propagated(PreparedPropagationPayload {
+                propagation_node_hex: context.propagation_node_hex,
+                propagation_hash: context.propagation_hash,
+                target_cost: context.target_cost,
+                payload: propagation_payload,
+            })
+            .await;
+    }
+
+    async fn send_prepared_propagated(self, prepared: PreparedPropagationPayload) {
+        if self.selected_propagation_node_is_local(prepared.propagation_node_hex.as_str()) {
             match self.store_local_propagation_payload(
-                propagation_node_hex.as_str(),
-                &propagation_payload,
+                prepared.propagation_node_hex.as_str(),
+                &prepared.payload,
             ) {
                 Ok(()) => {
                     let _ = self.receipt_tx.try_send(ReceiptEvent {
@@ -210,12 +239,17 @@ impl DeliveryTask {
             }
             return;
         }
-        let payload = propagation_payload.bytes;
+        let payload = prepared.payload.bytes;
         log_delivery_trace(
             &self.message_id,
             &self.destination_hex,
             "propagation",
-            format!("propagation payload ready bytes={}", payload.len()).as_str(),
+            format!(
+                "propagation payload ready bytes={} target_cost={}",
+                payload.len(),
+                prepared.target_cost
+            )
+            .as_str(),
         );
         if self.abort_if_cancelled("propagation") {
             return;
@@ -228,7 +262,10 @@ impl DeliveryTask {
             "resolving propagation link",
         );
         let propagation_link = match self
-            .resolve_or_create_propagation_link(&propagation_node_hex, propagation_hash)
+            .resolve_or_create_propagation_link(
+                &prepared.propagation_node_hex,
+                prepared.propagation_hash,
+            )
             .await
         {
             Ok(link) => link,
@@ -253,7 +290,7 @@ impl DeliveryTask {
         if let Err(err) = self
             .send_via_existing_link_mode(
                 "propagation",
-                propagation_node_hex.as_str(),
+                prepared.propagation_node_hex.as_str(),
                 propagation_link,
                 &payload,
                 LinkModeStatuses {
@@ -420,7 +457,7 @@ impl DeliveryTask {
         }
     }
 
-    async fn resolve_destination_identity(&self) -> Option<Identity> {
+    pub(super) async fn resolve_destination_identity(&self) -> Option<Identity> {
         let identity = self
             .resolve_identity(
                 Some(self.destination_hex.as_str()),

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_parts/module_prelude.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_parts/module_prelude.rs
@@ -39,3 +39,22 @@ pub(super) struct DeliveryTask {
     pub(super) try_propagation_on_fail: bool,
     pub(super) propagation_node_hex: Option<String>,
 }
+
+pub(super) struct PreparedDeliveryPayload {
+    pub(super) lxmf_payload: Vec<u8>,
+    pub(super) propagation: Option<PreparedPropagationPayload>,
+}
+
+pub(super) struct PreparedPropagationPayload {
+    pub(super) propagation_node_hex: String,
+    pub(super) propagation_hash: AddressHash,
+    pub(super) target_cost: u32,
+    pub(super) payload: propagation::PropagationPayload,
+}
+
+pub(super) struct PropagationPreparationContext {
+    pub(super) destination_identity: Identity,
+    pub(super) propagation_node_hex: String,
+    pub(super) propagation_hash: AddressHash,
+    pub(super) target_cost: u32,
+}

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_payload.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_payload.rs
@@ -50,6 +50,99 @@ impl DeliveryTask {
         result
     }
 
+    pub(super) fn requires_deferred_stamp_work(&self) -> bool {
+        self.requires_normal_deferred_stamp_work()
+            || self.requested_method == RequestedDeliveryMethod::Propagated
+    }
+
+    pub(super) fn requires_normal_deferred_stamp_work(&self) -> bool {
+        self.normal_stamp_work().is_some()
+    }
+
+    pub(super) fn record_deferred_stamp_queued_metadata(&self) {
+        if let Some(work) = self.normal_stamp_work() {
+            let mut entries = self.stamp_work_entries("queued", work);
+            entries.push(("stamp_attempts".to_string(), JsonValue::Number(0.into())));
+            entries.push(("progress".to_string(), JsonValue::Number(0.into())));
+            let _ = self.daemon.record_message_lxmf_metadata_entries(&self.message_id, entries);
+        }
+        if self.requested_method == RequestedDeliveryMethod::Propagated {
+            let _ = self.daemon.record_message_lxmf_metadata_entries(
+                &self.message_id,
+                [
+                    (
+                        "propagation_stamp_state".to_string(),
+                        JsonValue::String("queued".to_string()),
+                    ),
+                    ("propagation_stamp_attempts".to_string(), JsonValue::Number(0.into())),
+                    ("progress".to_string(), JsonValue::Number(0.into())),
+                    ("propagation_stamp_error".to_string(), JsonValue::Null),
+                ],
+            );
+        }
+    }
+
+    pub(super) fn record_deferred_stamp_attempt_metadata(&self, attempt: u32) {
+        if let Some(work) = self.normal_stamp_work() {
+            let mut entries = self.stamp_work_entries("generating", work);
+            entries.push((
+                "stamp_attempts".to_string(),
+                JsonValue::Number(serde_json::Number::from(attempt)),
+            ));
+            entries.push(("progress".to_string(), JsonValue::Number(0.into())));
+            let _ = self.daemon.record_message_lxmf_metadata_entries(&self.message_id, entries);
+        }
+    }
+
+    pub(super) fn record_deferred_stamp_retry_metadata(&self, attempt: u32, error: String) {
+        if let Some(work) = self.normal_stamp_work() {
+            let mut entries = self.stamp_work_entries("queued", work);
+            entries.push((
+                "stamp_attempts".to_string(),
+                JsonValue::Number(serde_json::Number::from(attempt)),
+            ));
+            entries.push(("stamp_error".to_string(), JsonValue::String(error)));
+            entries.push((
+                "stamp_next_retry_at".to_string(),
+                JsonValue::Number(serde_json::Number::from(now_secs_i64() + 1)),
+            ));
+            entries.push(("progress".to_string(), JsonValue::Number(0.into())));
+            let _ = self.daemon.record_message_lxmf_metadata_entries(&self.message_id, entries);
+        }
+    }
+
+    pub(super) fn record_deferred_stamp_failed_metadata(&self, attempt: u32, error: String) {
+        if let Some(work) = self.normal_stamp_work() {
+            let mut entries = self.stamp_work_entries("failed", work);
+            entries.push((
+                "stamp_attempts".to_string(),
+                JsonValue::Number(serde_json::Number::from(attempt)),
+            ));
+            entries.push(("stamp_error".to_string(), JsonValue::String(error)));
+            let _ = self.daemon.record_message_lxmf_metadata_entries(&self.message_id, entries);
+        }
+    }
+
+    pub(super) fn record_deferred_stamp_cancelled_metadata(&self) {
+        if let Some(work) = self.normal_stamp_work() {
+            let mut entries = self.stamp_work_entries("cancelled", work);
+            entries.push(("stamp_error".to_string(), JsonValue::Null));
+            let _ = self.daemon.record_message_lxmf_metadata_entries(&self.message_id, entries);
+        }
+        if self.requested_method == RequestedDeliveryMethod::Propagated {
+            let _ = self.daemon.record_message_lxmf_metadata_entries(
+                &self.message_id,
+                [
+                    (
+                        "propagation_stamp_state".to_string(),
+                        JsonValue::String("cancelled".to_string()),
+                    ),
+                    ("propagation_stamp_error".to_string(), JsonValue::Null),
+                ],
+            );
+        }
+    }
+
     fn normal_stamp_work(&self) -> Option<StampWorkMetadata<'_>> {
         if let Some(ticket) = self.outbound_ticket.as_ref() {
             return Some(StampWorkMetadata {
@@ -66,6 +159,15 @@ impl DeliveryTask {
     }
 
     fn record_stamp_work_metadata(&self, state: &str, work: StampWorkMetadata<'_>) {
+        let entries = self.stamp_work_entries(state, work);
+        let _ = self.daemon.record_message_lxmf_metadata_entries(&self.message_id, entries);
+    }
+
+    fn stamp_work_entries(
+        &self,
+        state: &str,
+        work: StampWorkMetadata<'_>,
+    ) -> Vec<(String, JsonValue)> {
         let mut entries = vec![
             ("stamp_state".to_string(), JsonValue::String(state.to_string())),
             ("stamp_kind".to_string(), JsonValue::String(work.kind.to_string())),
@@ -83,7 +185,7 @@ impl DeliveryTask {
         if state != "failed" {
             entries.push(("stamp_error".to_string(), JsonValue::Null));
         }
-        let _ = self.daemon.record_message_lxmf_metadata_entries(&self.message_id, entries);
+        entries
     }
 }
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_propagation.rs
@@ -1,8 +1,73 @@
+use super::delivery_task::PropagationPreparationContext;
 use super::*;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
 
 impl DeliveryTask {
+    pub(super) async fn propagation_preparation_context(
+        &self,
+    ) -> Option<PropagationPreparationContext> {
+        let destination_identity = self.resolve_destination_identity().await?;
+        if self.abort_if_cancelled("propagation") {
+            return None;
+        }
+        log_delivery_trace(
+            &self.message_id,
+            &self.destination_hex,
+            "propagation",
+            "recipient identity ready",
+        );
+        let Some(propagation_node_hex) = self.propagation_node_hex.clone() else {
+            let _ = self.receipt_tx.try_send(ReceiptEvent {
+                message_id: self.message_id.clone(),
+                status: "failed: no outbound propagation node selected".to_string(),
+            });
+            return None;
+        };
+
+        let propagation_hash = match parse_destination_hash_required(&propagation_node_hex) {
+            Ok(hash) => AddressHash::new(hash),
+            Err(err) => {
+                let _ = self.receipt_tx.try_send(ReceiptEvent {
+                    message_id: self.message_id.clone(),
+                    status: format!("failed: {err}"),
+                });
+                return None;
+            }
+        };
+        log_delivery_trace(
+            &self.message_id,
+            &self.destination_hex,
+            "propagation",
+            "selected propagation node parsed",
+        );
+        log_delivery_trace(
+            &self.message_id,
+            &self.destination_hex,
+            "propagation",
+            "looking up propagation stamp cost",
+        );
+        let (target_cost, cost_source) = self
+            .propagation_target_cost_reference_style(
+                propagation_node_hex.as_str(),
+                propagation_hash,
+            )
+            .await;
+        let target_cost = target_cost.unwrap_or(propagation::DEFAULT_PROPAGATION_STAMP_COST);
+        log_delivery_trace(
+            &self.message_id,
+            &self.destination_hex,
+            "propagation",
+            format!("using propagation stamp cost={target_cost} source={cost_source}").as_str(),
+        );
+        Some(PropagationPreparationContext {
+            destination_identity,
+            propagation_node_hex,
+            propagation_hash,
+            target_cost,
+        })
+    }
+
     pub(super) async fn propagation_target_cost_reference_style(
         &self,
         propagation_node_hex: &str,
@@ -137,5 +202,55 @@ impl DeliveryTask {
             entries.push(("propagation_stamp_error".to_string(), JsonValue::Null));
         }
         let _ = self.daemon.record_message_lxmf_metadata_entries(&self.message_id, entries);
+    }
+
+    pub(super) fn record_propagation_stamp_attempt_metadata(&self, target_cost: u32, attempt: u32) {
+        let _ = self.daemon.record_message_lxmf_metadata_entries(
+            &self.message_id,
+            [
+                (
+                    "propagation_stamp_state".to_string(),
+                    JsonValue::String("generating".to_string()),
+                ),
+                (
+                    "propagation_target_cost".to_string(),
+                    JsonValue::Number(serde_json::Number::from(target_cost)),
+                ),
+                (
+                    "propagation_stamp_attempts".to_string(),
+                    JsonValue::Number(serde_json::Number::from(attempt)),
+                ),
+                ("propagation_stamp_error".to_string(), JsonValue::Null),
+                ("progress".to_string(), JsonValue::Number(0.into())),
+            ],
+        );
+    }
+
+    pub(super) fn record_propagation_stamp_retry_metadata(
+        &self,
+        target_cost: u32,
+        attempt: u32,
+        error: String,
+    ) {
+        let _ = self.daemon.record_message_lxmf_metadata_entries(
+            &self.message_id,
+            [
+                ("propagation_stamp_state".to_string(), JsonValue::String("queued".to_string())),
+                (
+                    "propagation_target_cost".to_string(),
+                    JsonValue::Number(serde_json::Number::from(target_cost)),
+                ),
+                (
+                    "propagation_stamp_attempts".to_string(),
+                    JsonValue::Number(serde_json::Number::from(attempt)),
+                ),
+                ("propagation_stamp_error".to_string(), JsonValue::String(error)),
+                (
+                    "propagation_stamp_next_retry_at".to_string(),
+                    JsonValue::Number(serde_json::Number::from(now_secs_i64() + 1)),
+                ),
+                ("progress".to_string(), JsonValue::Number(0.into())),
+            ],
+        );
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests_parts/record_propagation_payload_metadata.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests_parts/record_propagation_payload_metadata.rs
@@ -105,7 +105,26 @@ async fn propagation_stamp_retry_clears_stale_error_metadata() {
     let mut task = delivery_task_for_propagation_cost_lookup(daemon.clone());
     task.message_id = message_id.to_string();
 
-    task.record_propagation_stamp_work_metadata("generating", 5, None);
+    task.record_propagation_stamp_retry_metadata(5, 1, "transient propagation stamp failure".into());
+    let retry_result = daemon
+        .handle_rpc(RpcRequest { id: 78, method: "list_messages".to_string(), params: None })
+        .expect("list messages")
+        .result
+        .expect("result");
+    let retry_message = retry_result["messages"]
+        .as_array()
+        .expect("messages")
+        .iter()
+        .find(|message| message["id"].as_str() == Some(message_id))
+        .expect("message");
+    assert_eq!(retry_message["fields"]["_lxmf"]["propagation_stamp_state"], json!("queued"));
+    assert_eq!(retry_message["fields"]["_lxmf"]["propagation_stamp_attempts"], json!(1));
+    assert_eq!(
+        retry_message["fields"]["_lxmf"]["propagation_stamp_error"],
+        json!("transient propagation stamp failure")
+    );
+
+    task.record_propagation_stamp_attempt_metadata(5, 2);
 
     let result = daemon
         .handle_rpc(RpcRequest { id: 79, method: "list_messages".to_string(), params: None })
@@ -119,6 +138,7 @@ async fn propagation_stamp_retry_clears_stale_error_metadata() {
         .find(|message| message["id"].as_str() == Some(message_id))
         .expect("message");
     assert_eq!(message["fields"]["_lxmf"]["propagation_stamp_state"], json!("generating"));
+    assert_eq!(message["fields"]["_lxmf"]["propagation_stamp_attempts"], json!(2));
     assert_eq!(message["fields"]["_lxmf"]["propagation_stamp_error"], JsonValue::Null);
 }
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests.rs
@@ -1,5 +1,7 @@
 include!("tests_parts/module_prelude.rs");
 
+include!("tests_parts/transport_bridge_reports_deferred_stamp_queue.rs");
+
 include!("tests_parts/propagation_link_cache_reuses_same_s.rs");
 
 include!("tests_parts/vrn76_builder_rejects_missing_periph.rs");

--- a/crates/apps/reticulumd/src/bin/reticulumd/tests_parts/transport_bridge_reports_deferred_stamp_queue.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests_parts/transport_bridge_reports_deferred_stamp_queue.rs
@@ -1,0 +1,90 @@
+#[tokio::test]
+async fn transport_bridge_reports_deferred_stamp_queue_and_cancels_work() {
+    let (daemon, _bridge, _recipient, recipient_hex) =
+        test_transport_bridge_fixture_with_peer().await;
+
+    let send = daemon
+        .handle_rpc(RpcRequest {
+            id: 240,
+            method: "send_message_v2".into(),
+            params: Some(json!({
+                "id": "deferred-stamp-queue-1",
+                "source": "src",
+                "destination": recipient_hex,
+                "title": "deferred stamp",
+                "content": "body",
+                "stamp_cost": 255
+            })),
+        })
+        .expect("send");
+    assert!(send.error.is_none(), "deferred stamped send should enqueue");
+
+    let mut saw_stamp_worker = false;
+    for _ in 0..40 {
+        let status = daemon
+            .handle_rpc(RpcRequest {
+                id: 241,
+                method: "sdk_status_v2".into(),
+                params: Some(json!({ "message_id": "deferred-stamp-queue-1" })),
+            })
+            .expect("status")
+            .result
+            .expect("status result");
+        let pipeline = &status["delivery_pipeline"];
+        let stamp_queued = pipeline["stamp_queued_total"].as_u64().unwrap_or_default();
+        let stamp_in_flight = pipeline["stamp_in_flight_total"].as_u64().unwrap_or_default();
+        if stamp_queued + stamp_in_flight > 0 {
+            saw_stamp_worker = true;
+            assert_eq!(pipeline["in_flight_total"].as_u64().unwrap_or_default(), 0);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(saw_stamp_worker, "deferred stamp work should be visible before delivery starts");
+
+    let progress = daemon
+        .handle_rpc(RpcRequest {
+            id: 242,
+            method: "get_outbound_progress".into(),
+            params: Some(json!({ "message_id": "deferred-stamp-queue-1" })),
+        })
+        .expect("progress")
+        .result
+        .expect("progress result");
+    assert_eq!(progress["progress"].as_f64(), Some(0.0));
+
+    let cancel = daemon
+        .handle_rpc(RpcRequest {
+            id: 243,
+            method: "sdk_cancel_message_v2".into(),
+            params: Some(json!({ "message_id": "deferred-stamp-queue-1" })),
+        })
+        .expect("cancel");
+    assert!(cancel.error.is_none(), "cancel should be accepted while stamp is active");
+
+    let mut cancelled = false;
+    for _ in 0..80 {
+        let status = daemon
+            .handle_rpc(RpcRequest {
+                id: 244,
+                method: "sdk_status_v2".into(),
+                params: Some(json!({ "message_id": "deferred-stamp-queue-1" })),
+            })
+            .expect("status")
+            .result
+            .expect("status result");
+        let lxmf = &status["message"]["fields"]["_lxmf"];
+        if status["message"]["receipt_status"] == json!("cancelled")
+            && lxmf["stamp_state"] == json!("cancelled")
+        {
+            let pipeline = &status["delivery_pipeline"];
+            assert_eq!(pipeline["queued_total"].as_u64().unwrap_or_default(), 0);
+            assert_eq!(pipeline["stamp_queued_total"].as_u64().unwrap_or_default(), 0);
+            assert_eq!(pipeline["stamp_in_flight_total"].as_u64().unwrap_or_default(), 0);
+            cancelled = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(cancelled, "deferred stamp cancellation should terminalize the queued work");
+}

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1,6 +1,6 @@
 # Current Roadmap Status
 
-Last reassessed: 2026-06-18
+Last reassessed: 2026-06-19
 
 This file is the repository-level source of truth for parity posture, release
 confidence, and execution order. Detailed row-level status lives in:
@@ -219,6 +219,12 @@ The project is best described by capability level:
 - Active outbound normal and propagation stamp generation now reports stored
   generation progress through `get_outbound_progress`, while terminal failed or
   cancelled stamp states continue to suppress stale progress values.
+- Deferred normal and requested propagated sends now run expensive stamp work
+  in the outbound background worker before delivery handoff. The worker exposes
+  queued and in-flight stamp ownership through `delivery_pipeline`, serializes
+  normal and propagation stamp generation, records retry/cancellation metadata,
+  and prepares propagated resource payloads before link/resource delivery
+  semaphores are acquired.
 - Inbound reticulumd `/pn/peer/sync` and `/pn/peer/unpeer` control commands now
   resolve stored peer IDs case-insensitively before dispatching to daemon RPCs,
   so binary peer-control requests do not report not-found for restored or
@@ -742,30 +748,26 @@ The project is best described by capability level:
 These are blockers to a broad "Python replacement" claim, not blockers to using
 the implemented subset.
 
-1. **Deferred stamp lifecycle**
-   - Add Python-style background work ownership, queueing, retry, cancellation,
-     and progress behavior for expensive normal and propagation stamps.
-2. **Interop breadth**
+1. **Interop breadth**
    - Propagation router lifecycle now has dispatchable Python-reference cases
      for remote status, Rust-to-Python fetch/download/sync, Python-origin
      `/get` haves acknowledgement, and Python-origin `/offer` side effects.
    - Capture release evidence for Sideband, MeshChatX, and Columba before making
      client-specific compatibility claims.
-3. **Reticulum behavioral breadth**
+2. **Reticulum behavioral breadth**
    - Finish channel ordering, resolver/bootstrap, announce/path edge behavior,
      and runtime mutation parity.
-4. **Operational breadth**
+3. **Operational breadth**
    - Add prepared-host hardware evidence for BLE/RNode paths.
    - Implement or explicitly defer missing Python interface families and
      utility commands.
 
 ## Active Execution Order
 
-1. Finish deferred stamp worker and retry lifecycle.
-2. Expand pinned Rust/Python interoperability gates with each completed row.
-3. Close RNS channel, discovery, resolver, and transport-policy gaps.
-4. Collect hardware, soak, and external-client release evidence.
-5. Expand interface and utility breadth after protocol behavior stabilizes.
+1. Expand pinned Rust/Python interoperability gates with each completed row.
+2. Close RNS channel, discovery, resolver, and transport-policy gaps.
+3. Collect hardware, soak, and external-client release evidence.
+4. Expand interface and utility breadth after protocol behavior stabilizes.
 
 ## Verification Baseline
 

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -1,6 +1,6 @@
 # LXMF Parity Matrix
 
-Last reassessed: 2026-06-18
+Last reassessed: 2026-06-19
 
 This is the maintained row-level status for Python LXMF compatibility.
 Repository-level posture and execution order live in
@@ -25,7 +25,7 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 | `LXMF/LXMPeer.py` | `crates/libs/rns-rpc`, `crates/apps/reticulumd` | done | Persistent peers, queue marks, offer selection, policy gates, peering keys, throttling, maintenance, source accounting, cumulative acceptance, serialized restored queue snapshots, boolean/list/numeric offer responses, transfer/retry/restart recovery, and unpeer cleanup. | No confirmed `LXMPeer.py` blocker in the pinned Python-only coverage. |
 | `LXMF/LXMRouter.py` | `crates/libs/rns-rpc`, `crates/apps/reticulumd` | partial | Outbound modes, selected propagation nodes, direct/propagated resources, cancellation, fetch/download/sync RPCs, receipts, persistence, propagation-node side effects, retry/failure handling, and Python live remote lifecycle coverage. | No confirmed propagation-router lifecycle blocker remains; broader non-propagation router convenience surface remains narrower than Python. |
 | `LXMF/Handlers.py` | `crates/apps/reticulumd`, `crates/libs/rns-rpc` | partial | Delivery, announce, propagation app-data, receipt, and inbound bridge handling. | Some router-coupled side effects and negative/drop observability remain narrower. |
-| `LXMF/LXStamper.py` | `crates/libs/lxmf-core`, `crates/libs/rns-rpc`, `crates/apps/reticulumd` | partial | Validation, generation, ticket-derived stamps, cancellation-aware task work, and lifecycle metadata. | Python-style deferred worker queue, retry ownership, and continuous progress remain. |
+| `LXMF/LXStamper.py` | `crates/libs/lxmf-core`, `crates/libs/rns-rpc`, `crates/apps/reticulumd` | done | Validation, generation, ticket-derived stamps, cancellation-aware task work, background deferred worker queue ownership, retry state, cancellation, propagation-stamp pre-handoff preparation, and progress metadata. | No confirmed deferred-stamp lifecycle blocker. |
 
 ## Method Checklist
 
@@ -38,10 +38,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - PARITY_ITEM id=message.file_unpack_helpers status=done
 - PARITY_ITEM id=message.signature_verify status=done
 - PARITY_ITEM id=message.object_accessors status=done
-- PARITY_ITEM id=stamper.validate_pn_stamp status=partial
-- PARITY_ITEM id=stamper.generate_stamp status=partial
-- PARITY_ITEM id=stamper.cancel_work status=partial
-- PARITY_ITEM id=stamper.outbound_progress_queries status=partial
+- PARITY_ITEM id=stamper.validate_pn_stamp status=done
+- PARITY_ITEM id=stamper.generate_stamp status=done
+- PARITY_ITEM id=stamper.cancel_work status=done
+- PARITY_ITEM id=stamper.outbound_progress_queries status=done
 - PARITY_ITEM id=ticket.validity_with_grace status=done
 - PARITY_ITEM id=ticket.renewal_window status=done
 - PARITY_ITEM id=ticket.derived_stamp status=done
@@ -103,8 +103,12 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Active outbound normal and propagation stamp generation reports stored
   continuous progress through `get_outbound_progress`; failed or cancelled
   stamp states still suppress stale progress.
-- The remaining gap is background queue/worker/retry behavior, not basic stamp
-  cryptography or ticket semantics.
+- Expensive normal and requested propagated sends now enter a background
+  deferred-stamp worker before delivery handoff. The worker exposes queue and
+  in-flight ownership in `delivery_pipeline`, serializes stamp generation,
+  retries failed generation attempts with retry metadata, accepts cancellation
+  while stamp work is active, and prebuilds propagation resource payloads before
+  delivery/link semaphores are acquired.
 
 ### Peers and propagation
 
@@ -811,9 +815,8 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 
 ## Highest-Priority Gaps
 
-1. Add deferred stamp queue ownership and retry semantics.
-2. Validate external clients before making client-specific claims.
-3. Continue widening non-propagation router convenience coverage only where it
+1. Validate external clients before making client-specific claims.
+2. Continue widening non-propagation router convenience coverage only where it
    affects supported clients.
 
 ## Evidence
@@ -836,5 +839,8 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Focused daemon/RPC tests cover delivery modes, propagation offers, peer
   maintenance, queue policy, source accounting, stamps, tickets, receipts, and
   cancellation.
+- Focused daemon bridge tests cover deferred normal-stamp queue ownership,
+  cancellation, retry metadata, and propagation-stamp preparation before
+  delivery handoff.
 - `interop.python_live_gate` means the configured scenarios run successfully;
   it does not imply every partial row is complete.


### PR DESCRIPTION
## Summary
- adds deferred stamp worker ownership metrics to the reticulumd delivery pipeline
- prepares expensive normal stamps and requested propagated resource stamps before delivery handoff
- records queued/generating/retry/ready/failed/cancelled metadata for normal and propagation stamp work
- updates LXMF parity docs to remove deferred stamp lifecycle as a remaining communication blocker

## Verification
- cargo fmt --check
- cargo check -p reticulumd --bin reticulumd
- cargo test -p reticulumd --lib
- cargo test -p reticulumd --bin reticulumd -- --nocapture
- cargo test -p reticulum-rs-rpc --lib
- cargo test -p reticulumd --test receipt_worker -- --nocapture
- cargo test -p reticulumd --test receipt_bridge -- --nocapture
- Git Bash: tools/scripts/check-module-size.sh

## Notes
- Local ignored Python compatibility tests could not run because `LXMF_PY_COMPAT_HARNESS` is not set in this shell; every ignored case failed immediately on that missing environment variable.