### PR TITLE
Close RNS channel parity

### DIFF
--- a/crates/apps/reticulumd/tests/python_channel_interop_parts/rust_to_python_raw_resource_roundtri.rs
+++ b/crates/apps/reticulumd/tests/python_channel_interop_parts/rust_to_python_raw_resource_roundtri.rs
@@ -153,6 +153,116 @@ async fn python_to_rust_channel_roundtrip() {
 
 #[tokio::test]
 #[ignore = "requires local Python Reticulum checkout"]
+async fn python_to_rust_channel_sequence_callbacks_are_ordered() {
+    let _interop_guard = python_interop_guard().await;
+    let paths = python_channel_interop_paths();
+
+    let server_port = free_tcp_port();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let py_config_dir = temp.path().join("python-rns-channel-sequence-client");
+    fs::create_dir_all(&py_config_dir).expect("python config dir");
+    write_python_client_config(&py_config_dir, server_port);
+
+    let rust_identity = PrivateIdentity::new_from_rand(OsRng);
+    let rust_identity = to_transport_private_identity(&rust_identity);
+    let mut config =
+        TransportConfig::new("python-channel-sequence-interop-rust-server", &rust_identity, true);
+    config.set_path_request_timeout_secs(2);
+    let mut transport = Transport::new(config);
+    let iface_manager = transport.iface_manager();
+    transport
+        .iface_manager()
+        .lock()
+        .await
+        .spawn(TcpServer::new(format!("127.0.0.1:{server_port}"), iface_manager), TcpServer::spawn);
+    wait_for_port(server_port, Duration::from_secs(5)).await;
+
+    let destination = transport
+        .add_destination(rust_identity.clone(), DestinationName::new("test", "channel"))
+        .await;
+    let destination_hash = {
+        let destination = destination.lock().await;
+        hex::encode(destination.desc.address_hash.as_slice())
+    };
+
+    let child = paths.spawn_channel_client(&py_config_dir, &destination_hash, "channel-sequence");
+    let mut guard = ChildGuard { child: Some(child) };
+
+    let mut in_events = transport.in_link_events();
+    let link_id = wait_for_in_link_active_with_announces(
+        &transport,
+        &destination,
+        &mut in_events,
+        Duration::from_secs(8),
+    )
+    .await;
+    sleep(Duration::from_millis(50)).await;
+
+    let channel = transport.channel(link_id);
+    let seen = Arc::new(StdMutex::new(Vec::<(String, String)>::new()));
+    let seen_clone = seen.clone();
+    channel
+        .register_handler(MSG_TYPE, move |envelope| {
+            if let Ok(decoded) = rmp_serde::from_slice::<(String, String)>(&envelope.payload) {
+                seen_clone.lock().expect("seen lock").push(decoded);
+                true
+            } else {
+                false
+            }
+        })
+        .await
+        .expect("register channel handler");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(8);
+    loop {
+        let ready = {
+            let seen = seen.lock().expect("seen lock");
+            seen.len() == 3
+        };
+        if ready {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for Python channel sequence"
+        );
+        sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        seen.lock().expect("seen lock").as_slice(),
+        &[
+            (String::from("python-seq-0"), String::from("hello-rust-0")),
+            (String::from("python-seq-1"), String::from("hello-rust-1")),
+            (String::from("python-seq-2"), String::from("hello-rust-2")),
+        ]
+    );
+
+    let payload =
+        rmp_serde::to_vec(&(String::from("sequence-ack"), String::from("reply:sequence-ok")))
+            .expect("encode channel ack");
+    channel.send(MSG_TYPE, payload).await.expect("send channel ack");
+
+    let child = guard.child.take().expect("python child");
+    let output = tokio::task::spawn_blocking(move || child.wait_with_output())
+        .await
+        .expect("join python client")
+        .expect("wait for python client");
+    if !output.status.success() {
+        panic!(
+            "python channel sequence client failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"sequence-ack\""),
+        "python client did not report sequence ack: {stdout}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires local Python Reticulum checkout"]
 async fn python_to_rust_link_data_roundtrip() {
     let _interop_guard = python_interop_guard().await;
     let paths = python_channel_interop_paths();

--- a/crates/apps/reticulumd/tests/support/python_channel_endpoint.py
+++ b/crates/apps/reticulumd/tests/support/python_channel_endpoint.py
@@ -314,6 +314,12 @@ class ChannelClient:
         if self.payload_kind == "buffer":
             self.buffer.write(message_data.encode("utf-8"))
             self.buffer.flush()
+        elif self.payload_kind == "channel-sequence":
+            time.sleep(1.0)
+            channel = active_link.get_channel()
+            for index in range(3):
+                channel.send(MessageTest(f"python-seq-{index}", f"hello-rust-{index}"))
+                time.sleep(0.25)
         elif self.payload_kind == "channel":
             active_link.get_channel().send(MessageTest(message_id, message_data))
         while True:
@@ -330,6 +336,13 @@ class ChannelClient:
                     self.payload_kind == "channel"
                     and reply["id"] == message_id
                     and reply["data"] == f"reply:{message_data}"
+                ):
+                    print(json.dumps({"received": reply}), flush=True)
+                    return 0
+                if (
+                    self.payload_kind == "channel-sequence"
+                    and reply["id"] == "sequence-ack"
+                    and reply["data"] == "reply:sequence-ok"
                 ):
                     print(json.dumps({"received": reply}), flush=True)
                     return 0
@@ -406,6 +419,7 @@ def main() -> int:
             "large-request",
             "file-response",
             "identify",
+            "channel-sequence",
         ),
         default="channel",
     )

--- a/crates/libs/rns-transport/src/channel.rs
+++ b/crates/libs/rns-transport/src/channel.rs
@@ -401,7 +401,7 @@ mod tests {
         let result = catch_unwind(AssertUnwindSafe(|| channel.receive(&first.pack())));
 
         assert!(result.is_ok(), "handler panic should not unwind channel receive");
-        assert_eq!(result.unwrap().expect("receive"), true);
+        assert!(result.unwrap().expect("receive"));
         assert_eq!(seen.lock().expect("lock").as_slice(), &[0]);
     }
 }

--- a/crates/libs/rns-transport/src/channel.rs
+++ b/crates/libs/rns-transport/src/channel.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::time::Duration;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -104,10 +105,12 @@ pub(crate) fn validate_typed_message_type<M: TypedMessage>() -> Result<(), Chann
 pub struct Channel<O: ChannelOutlet> {
     outlet: O,
     next_sequence: u16,
+    next_rx_sequence: u16,
     next_handler_id: u64,
     handlers: HashMap<u16, Vec<RegisteredHandler>>,
     pending: HashMap<u16, Envelope>,
     states: HashMap<u16, MessageState>,
+    rx_ring: HashMap<u16, Envelope>,
 }
 
 impl<O: ChannelOutlet> Channel<O> {
@@ -115,10 +118,12 @@ impl<O: ChannelOutlet> Channel<O> {
         Self {
             outlet,
             next_sequence: 0,
+            next_rx_sequence: 0,
             next_handler_id: 0,
             handlers: HashMap::new(),
             pending: HashMap::new(),
             states: HashMap::new(),
+            rx_ring: HashMap::new(),
         }
     }
 
@@ -204,15 +209,34 @@ impl<O: ChannelOutlet> Channel<O> {
 
     pub fn receive(&mut self, raw: &[u8]) -> Result<bool, ChannelError> {
         let envelope = Envelope::unpack(raw)?;
-        let Some(handlers) = self.handlers.get_mut(&envelope.msg_type) else {
-            return Err(ChannelError::NoHandler);
-        };
-        for registered in handlers {
-            if (registered.handler)(envelope.clone()) {
-                return Ok(true);
-            }
+        let distance = envelope.sequence.wrapping_sub(self.next_rx_sequence);
+        if distance >= 0x8000 || distance >= 48 {
+            return Ok(false);
         }
-        Ok(false)
+        if self.rx_ring.insert(envelope.sequence, envelope).is_some() {
+            return Ok(false);
+        }
+
+        let mut accepted = true;
+        while let Some(envelope) = self.rx_ring.remove(&self.next_rx_sequence) {
+            self.next_rx_sequence = self.next_rx_sequence.wrapping_add(1);
+            let Some(handlers) = self.handlers.get_mut(&envelope.msg_type) else {
+                return Err(ChannelError::NoHandler);
+            };
+            let mut handled = false;
+            for registered in handlers {
+                match catch_unwind(AssertUnwindSafe(|| (registered.handler)(envelope.clone()))) {
+                    Ok(true) => {
+                        handled = true;
+                        break;
+                    }
+                    Ok(false) => {}
+                    Err(_) => {}
+                }
+            }
+            accepted &= handled;
+        }
+        Ok(accepted)
     }
 
     pub fn mark_delivered(&mut self, sequence: u16) {
@@ -241,6 +265,8 @@ impl<O: ChannelOutlet> Channel<O> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::sync::{Arc, Mutex};
 
     struct MockOutlet;
 
@@ -314,5 +340,68 @@ mod tests {
         let _handler_id = channel
             .register_typed_handler::<SystemTypedMessage, _>(|_message| true)
             .expect("system message types should register");
+    }
+
+    #[test]
+    fn receive_buffers_out_of_order_messages_until_contiguous() {
+        let mut channel = Channel::new(MockOutlet);
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_clone = seen.clone();
+        channel.register_handler(0x1234, move |envelope| {
+            seen_clone.lock().expect("lock").push((envelope.sequence, envelope.payload));
+            true
+        });
+
+        let first = Envelope { msg_type: 0x1234, sequence: 0, payload: b"first".to_vec() };
+        let second = Envelope { msg_type: 0x1234, sequence: 1, payload: b"second".to_vec() };
+
+        assert!(channel.receive(&second.pack()).expect("buffer future sequence"));
+        assert!(seen.lock().expect("lock").is_empty());
+
+        assert!(channel.receive(&first.pack()).expect("release contiguous"));
+        let seen = seen.lock().expect("lock");
+        assert_eq!(seen.as_slice(), &[(0, b"first".to_vec()), (1, b"second".to_vec())]);
+    }
+
+    #[test]
+    fn receive_rejects_duplicate_old_and_outside_window_messages() {
+        let mut channel = Channel::new(MockOutlet);
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_clone = seen.clone();
+        channel.register_handler(0x1234, move |envelope| {
+            seen_clone.lock().expect("lock").push(envelope.sequence);
+            true
+        });
+
+        let first = Envelope { msg_type: 0x1234, sequence: 0, payload: b"first".to_vec() };
+        let duplicate_first = first.clone();
+        let far_future = Envelope { msg_type: 0x1234, sequence: 49, payload: b"future".to_vec() };
+        let old = Envelope { msg_type: 0x1234, sequence: u16::MAX, payload: b"old".to_vec() };
+
+        assert!(channel.receive(&first.pack()).expect("first"));
+        assert!(!channel.receive(&duplicate_first.pack()).expect("duplicate"));
+        assert!(!channel.receive(&far_future.pack()).expect("outside window"));
+        assert!(!channel.receive(&old.pack()).expect("old sequence"));
+
+        assert_eq!(seen.lock().expect("lock").as_slice(), &[0]);
+    }
+
+    #[test]
+    fn receive_contains_handler_panics_and_continues_to_later_handlers() {
+        let mut channel = Channel::new(MockOutlet);
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        channel.register_handler(0x1234, |_| -> bool { panic!("boom") });
+        let seen_clone = seen.clone();
+        channel.register_handler(0x1234, move |envelope| {
+            seen_clone.lock().expect("lock").push(envelope.sequence);
+            true
+        });
+
+        let first = Envelope { msg_type: 0x1234, sequence: 0, payload: b"first".to_vec() };
+        let result = catch_unwind(AssertUnwindSafe(|| channel.receive(&first.pack())));
+
+        assert!(result.is_ok(), "handler panic should not unwind channel receive");
+        assert_eq!(result.unwrap().expect("receive"), true);
+        assert_eq!(seen.lock().expect("lock").as_slice(), &[0]);
     }
 }

--- a/crates/libs/rns-transport/src/channel.rs
+++ b/crates/libs/rns-transport/src/channel.rs
@@ -217,8 +217,10 @@ impl<O: ChannelOutlet> Channel<O> {
             return Ok(false);
         }
 
+        let mut dispatched = false;
         let mut accepted = true;
         while let Some(envelope) = self.rx_ring.remove(&self.next_rx_sequence) {
+            dispatched = true;
             self.next_rx_sequence = self.next_rx_sequence.wrapping_add(1);
             let Some(handlers) = self.handlers.get_mut(&envelope.msg_type) else {
                 return Err(ChannelError::NoHandler);
@@ -236,7 +238,7 @@ impl<O: ChannelOutlet> Channel<O> {
             }
             accepted &= handled;
         }
-        Ok(accepted)
+        Ok(dispatched && accepted)
     }
 
     pub fn mark_delivered(&mut self, sequence: u16) {
@@ -355,7 +357,7 @@ mod tests {
         let first = Envelope { msg_type: 0x1234, sequence: 0, payload: b"first".to_vec() };
         let second = Envelope { msg_type: 0x1234, sequence: 1, payload: b"second".to_vec() };
 
-        assert!(channel.receive(&second.pack()).expect("buffer future sequence"));
+        assert!(!channel.receive(&second.pack()).expect("buffer future sequence"));
         assert!(seen.lock().expect("lock").is_empty());
 
         assert!(channel.receive(&first.pack()).expect("release contiguous"));

--- a/crates/libs/rns-transport/src/channel_buffer_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/channel_buffer_parts/module_prelude.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use std::io::{Read, Write};
 
@@ -118,7 +118,7 @@ impl TypedMessage for StreamDataMessage {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ReadyCallbackId(u64);
 
 impl ReadyCallbackId {
@@ -134,7 +134,7 @@ struct ReaderState {
     buffer: Vec<u8>,
     eof: bool,
     next_callback_id: u64,
-    callbacks: HashMap<ReadyCallbackId, ReadyCallback>,
+    callbacks: BTreeMap<ReadyCallbackId, ReadyCallback>,
 }
 
 fn dispatch_ready_callbacks(callbacks: Vec<ReadyCallback>, ready: usize) {

--- a/crates/libs/rns-transport/src/channel_buffer_parts/stream_data_message_roundtrips_compr.rs
+++ b/crates/libs/rns-transport/src/channel_buffer_parts/stream_data_message_roundtrips_compr.rs
@@ -161,6 +161,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn raw_channel_reader_ready_callbacks_run_in_registration_order() {
+        let transport = test_transport();
+        let (outbound, mut inbound, iface, channel) = linked_channel(&transport).await;
+        let reader = RawChannelReader::attach(27, channel).await.expect("reader");
+
+        let calls = Arc::new(StdMutex::new(Vec::new()));
+        let (tx, rx) = mpsc::channel();
+
+        for label in ["first", "second", "third"] {
+            let calls = calls.clone();
+            let tx = tx.clone();
+            reader.add_ready_callback(move |count| {
+                calls.lock().expect("lock").push((label, count));
+                tx.send(label).expect("callback signal");
+            });
+        }
+        drop(tx);
+
+        let message =
+            StreamDataMessage::new(27, b"ordered".to_vec(), false, false).expect("message");
+        let (_sequence, packet) = inbound
+            .send_channel_message(StreamDataMessage::MSG_TYPE, message.encode())
+            .expect("channel message");
+
+        let result = outbound.lock().await.handle_packet(&packet, iface);
+        assert!(matches!(result, LinkHandleResult::Proof(_)));
+
+        for _ in 0..3 {
+            rx.recv_timeout(Duration::from_secs(1)).expect("ready callback");
+        }
+        assert_eq!(
+            calls.lock().expect("lock").as_slice(),
+            &[("first", 7), ("second", 7), ("third", 7)]
+        );
+    }
+
+    #[tokio::test]
     async fn raw_channel_reader_close_unregisters_handler() {
         let transport = test_transport();
         let (outbound, mut inbound, iface, channel) = linked_channel(&transport).await;

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1,6 +1,6 @@
 # Current Roadmap Status
 
-Last reassessed: 2026-06-18
+Last reassessed: 2026-06-19
 
 This file is the repository-level source of truth for parity posture, release
 confidence, and execution order. Detailed row-level status lives in:
@@ -752,8 +752,8 @@ the implemented subset.
    - Capture release evidence for Sideband, MeshChatX, and Columba before making
      client-specific compatibility claims.
 3. **Reticulum behavioral breadth**
-   - Finish channel ordering, resolver/bootstrap, announce/path edge behavior,
-     and runtime mutation parity.
+   - Finish resolver/bootstrap, announce/path edge behavior, and runtime
+     mutation parity.
 4. **Operational breadth**
    - Add prepared-host hardware evidence for BLE/RNode paths.
    - Implement or explicitly defer missing Python interface families and
@@ -763,7 +763,7 @@ the implemented subset.
 
 1. Finish deferred stamp worker and retry lifecycle.
 2. Expand pinned Rust/Python interoperability gates with each completed row.
-3. Close RNS channel, discovery, resolver, and transport-policy gaps.
+3. Close RNS discovery, resolver, and transport-policy gaps.
 4. Collect hardware, soak, and external-client release evidence.
 5. Expand interface and utility breadth after protocol behavior stabilizes.
 

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -1,6 +1,6 @@
 # Reticulum Parity Matrix
 
-Last reassessed: 2026-06-07
+Last reassessed: 2026-06-19
 
 This is the maintained row-level status for Python Reticulum compatibility.
 Repository-level posture and execution order live in
@@ -27,7 +27,7 @@ Workspace paths are used for navigation. Published package names are
 | `RNS/Transport.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | Path and announce handling, link routing, resources, receipts, interface-aware sending, pacing, and duplicate suppression. | Remaining announce/path edge policy and full runtime behavior require live parity evidence. |
 | `RNS/Link.py` | `crates/libs/rns-transport` | done | Establishment, proof validation, bound-interface enforcement, RTT-derived liveness, protocol close, and cleanup. | Continue live regression coverage; no confirmed blocker. |
 | `RNS/Resource.py` | `crates/libs/rns-transport` | done | Bounded receive allocation, advertisement validation, retries, adaptive fragment scheduling, timeout/failure events, cancellation, and cleanup. | Split/segmented resources remain intentionally unsupported and rejected. |
-| `RNS/Channel.py` | `crates/libs/rns-transport` | partial | Channel packet handling, retry scheduling, buffering, and live Rust/Python channel tests. | Full Python sequential-delivery and callback behavior is not yet demonstrated. |
+| `RNS/Channel.py` | `crates/libs/rns-transport` | done | Channel packet handling, retry scheduling, buffering, ordered receive delivery, callback ordering/short-circuit/panic containment, delivery-on-proof, timeout retry, exhaustion cleanup, and live Rust/Python channel sequence tests. | No confirmed channel parity blocker. |
 | `RNS/Buffer.py` | `crates/libs/rns-core`, `crates/libs/rns-transport` | done | Packet buffers, readers/writers, and callback baseline. | No confirmed parity blocker. |
 | `RNS/Interfaces/*` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | TCP client/server, UDP, serial, KISS, AutoInterface, LoRa/RNode, feature-gated RNode BLE, and VR-N76 KISS-over-BLE. | AX.25, Backbone, I2P, Local, Pipe, Weave, full RNode management, and prepared-host hardware evidence remain. |
 | `RNS/Discovery.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | Announce/path discovery plus live AutoInterface discovery and peer runtime. | Public bootstrap/discovery breadth remains narrower than Python. |
@@ -63,17 +63,16 @@ instead of silently loading as inert unknown interface entries.
 
 ## Highest-Priority Gaps
 
-1. Prove complete channel ordering and callback behavior.
-2. Close remaining announce/path/discovery edge-policy differences.
-3. Complete resolver/bootstrap behavior.
-4. Capture prepared-host BLE/RNode lifecycle evidence.
-5. Decide and document support policy for missing interface families.
-6. Implement real utility equivalents only where product demand justifies them.
+1. Close remaining announce/path/discovery edge-policy differences.
+2. Complete resolver/bootstrap behavior.
+3. Capture prepared-host BLE/RNode lifecycle evidence.
+4. Decide and document support policy for missing interface families.
+5. Implement real utility equivalents only where product demand justifies them.
 
 ## Evidence
 
 - Workspace unit and integration tests cover core, transport, daemon, serial,
-  BLE, LoRa, AutoInterface, link, and resource behavior.
+  BLE, LoRa, AutoInterface, link, channel, buffer, and resource behavior.
 - `.github/workflows/python-interop.yml` runs pinned live Python channel and
   LXMF compatibility scenarios.
 - Nightly mesh, soak, and embedded HIL workflows provide additional operational


### PR DESCRIPTION
## Summary
- close the RNS/Channel.py parity gap by adding Python-style ordered receive buffering to the generic Channel surface
- make channel buffer ready callbacks deterministic in registration order
- add a live Rust/Python channel sequence interop case proving ordered Python-origin channel callbacks into Rust
- update the Reticulum parity docs and roadmap to remove Channel from the active RNS gap list

## Verification
- cargo fmt --check
- cargo test -p reticulum-rs-transport --lib -- --nocapture
- cargo test -p reticulumd --test python_channel_interop -- --ignored --nocapture
- cargo check -p reticulumd --bin reticulumd
- cargo test -p reticulumd --lib
- Git Bash: tools/scripts/check-module-size.sh

Note: did not add run-full-CI label to avoid runner overload while PR #365 still has it.