### PR TITLE
[codex] Fix phone HIL propagation self storage

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge.rs
@@ -47,7 +47,9 @@ use super::outbound_resources::{
 };
 use reticulum_daemon::receipt_bridge::{track_receipt_mapping, ReceiptEvent};
 use rns_core::identity::PrivateIdentity;
-use rns_rpc::{RpcDaemon, RpcRequest};
+use rns_rpc::RpcDaemon;
+#[cfg(test)]
+use rns_rpc::RpcRequest;
 use rns_transport::delivery::await_link_activation;
 use rns_transport::delivery::{
     send_on_link_observed, send_outcome_is_sent, send_outcome_status, LinkSendResult,

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_propagation.rs
@@ -149,21 +149,29 @@ impl DeliveryTask {
             "propagation",
             "local propagation node selected",
         );
-        let response = self.daemon.handle_rpc(RpcRequest {
-            id: 0,
-            method: "propagation_ingest".to_string(),
-            params: Some(json!({
-                "payload_hex": hex::encode(payload.bytes.as_slice()),
-            })),
-        })?;
-        if let Some(error) = response.error {
-            return Err(std::io::Error::other(error.message));
+        let (_timestamp, messages): (f64, Vec<Vec<u8>>) =
+            rmp_serde::from_slice(payload.bytes.as_slice()).map_err(|err| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("invalid local propagation envelope: {err}"),
+                )
+            })?;
+        let accepted_stamp_cost = self.daemon.propagation_min_accepted_stamp_cost();
+        for message in messages.iter() {
+            let transient_id = self
+                .daemon
+                .canonical_propagation_payload_bytes_at_cost(message, accepted_stamp_cost)?;
+            self.daemon.ingest_propagation_payload_bytes_at_cost(
+                message,
+                Some(transient_id.as_str()),
+                accepted_stamp_cost,
+            )?;
         }
         log_delivery_trace(
             &self.message_id,
             propagation_node_hex,
             "propagation",
-            "propagation stored locally",
+            format!("propagation stored locally messages={}", messages.len()).as_str(),
         );
         Ok(())
     }

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests_parts/record_propagation_payload_metadata.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests_parts/record_propagation_payload_metadata.rs
@@ -218,7 +218,8 @@ async fn self_selected_propagation_node_stores_locally_without_link_activation()
             method: "propagation_enable".to_string(),
             params: Some(json!({
                 "enabled": true,
-                "target_cost": 0,
+                "target_cost": 1,
+                "stamp_cost_flexibility": 0,
                 "autopeer": true,
             })),
         })
@@ -229,7 +230,7 @@ async fn self_selected_propagation_node_stores_locally_without_link_activation()
         rmpv::Value::Boolean(true),
         rmpv::Value::from(256),
         rmpv::Value::from(2048),
-        rmpv::Value::Array(vec![rmpv::Value::from(0), rmpv::Value::from(0), rmpv::Value::from(0)]),
+        rmpv::Value::Array(vec![rmpv::Value::from(1), rmpv::Value::from(0), rmpv::Value::from(0)]),
         rmpv::Value::Map(Vec::new()),
     ]))
     .expect("encode app data");

--- a/crates/libs/lxmf-sdk/src/backend/rpc.rs
+++ b/crates/libs/lxmf-sdk/src/backend/rpc.rs
@@ -48,12 +48,15 @@ mod transport;
 
 pub struct RpcBackendClient {
     endpoint: String,
+    client_instance_id: String,
     next_request_id: AtomicU64,
     negotiated_capabilities: RwLock<Vec<String>>,
     negotiated_limits: RwLock<Option<EffectiveLimits>>,
     manual_tick_cursor: RwLock<Option<EventCursor>>,
     session_auth: RwLock<SessionAuth>,
 }
+
+static NEXT_CLIENT_INSTANCE_ID: AtomicU64 = AtomicU64::new(1);
 
 enum SessionAuth {
     LocalTrusted,
@@ -81,6 +84,7 @@ impl RpcBackendClient {
     pub fn new(endpoint: impl Into<String>) -> Self {
         Self {
             endpoint: endpoint.into(),
+            client_instance_id: new_client_instance_id(),
             next_request_id: AtomicU64::new(1),
             negotiated_capabilities: RwLock::new(Vec::new()),
             negotiated_limits: RwLock::new(None),
@@ -91,6 +95,10 @@ impl RpcBackendClient {
 
     fn next_request_id(&self) -> u64 {
         self.next_request_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn next_message_id(&self) -> String {
+        format!("sdk-{}-{}", self.client_instance_id, self.next_request_id())
     }
 
     fn now_seconds() -> u64 {
@@ -113,6 +121,15 @@ impl RpcBackendClient {
             .map(|limits| limits.max_poll_events.max(1))
             .unwrap_or(256)
     }
+}
+
+fn new_client_instance_id() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let serial = NEXT_CLIENT_INSTANCE_ID.fetch_add(1, Ordering::Relaxed);
+    format!("{:032x}-{:x}-{:x}", now, std::process::id(), serial)
 }
 
 impl SdkBackend for RpcBackendClient {

--- a/crates/libs/lxmf-sdk/src/backend/rpc/core_impl_parts/rpcbackendclient_sections/default_idle_tick_delay_ms.rs
+++ b/crates/libs/lxmf-sdk/src/backend/rpc/core_impl_parts/rpcbackendclient_sections/default_idle_tick_delay_ms.rs
@@ -265,7 +265,7 @@ impl RpcBackendClient {
             correlation_id: _,
             extensions: _,
         } = req;
-        let rpc_message_id = format!("sdk-{}", self.next_request_id());
+        let rpc_message_id = self.next_message_id();
         let content = payload
             .get("content")
             .and_then(JsonValue::as_str)

--- a/crates/libs/lxmf-sdk/src/backend/rpc/core_impl_parts/support_types.rs
+++ b/crates/libs/lxmf-sdk/src/backend/rpc/core_impl_parts/support_types.rs
@@ -128,6 +128,24 @@ mod tests {
     }
 
     #[test]
+    fn send_params_message_ids_do_not_collide_across_fresh_clients() {
+        let first_backend = RpcBackendClient::new("127.0.0.1:65530");
+        let second_backend = RpcBackendClient::new("127.0.0.1:65530");
+        let first = first_backend.send_params(SendRequest::new(
+            "source-destination",
+            "first-target",
+            json!({ "title": "ops", "content": "first" }),
+        ));
+        let second = second_backend.send_params(SendRequest::new(
+            "source-destination",
+            "second-target",
+            json!({ "title": "ops", "content": "second" }),
+        ));
+
+        assert_ne!(first["id"], second["id"]);
+    }
+
+    #[test]
     fn manual_tick_loop_is_deterministic_for_fixed_budget() {
         let expected_batches = vec![
             test_batch(1, 2, "cursor-1"),

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
@@ -88,6 +88,9 @@ impl ZmqPipelineBackendClient {
     fn next_request_id(&self) -> u64 {
         self.next_request_id.fetch_add(1, Ordering::Relaxed)
     }
+    fn next_message_id(&self) -> String {
+        format!("sdk-zmq-{}-{}", self.session_id, self.next_request_id())
+    }
     fn has_capability(&self, capability_id: &str) -> bool {
         self.negotiated_capabilities
             .read()
@@ -201,10 +204,8 @@ impl SdkBackend for ZmqPipelineBackendClient {
     }
 
     fn send(&self, req: SendRequest) -> Result<MessageId, SdkError> {
-        let value = self.call_rpc(
-            "sdk_send_v2",
-            Some(send::send_params(req, format!("sdk-zmq-{}", self.next_request_id()))),
-        )?;
+        let value =
+            self.call_rpc("sdk_send_v2", Some(send::send_params(req, self.next_message_id())))?;
         Ok(MessageId(Self::parse_required_string(&value, "message_id")?))
     }
 

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/mod.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/mod.rs
@@ -769,6 +769,74 @@ fn send_uses_zmq_sdk_method_and_preserves_delivery_options() {
 }
 
 #[test]
+fn send_message_ids_do_not_collide_across_fresh_zmq_clients() {
+    let first_command_endpoint = unused_loopback_endpoint();
+    let first_response_endpoint = unused_loopback_endpoint();
+    let first_captured = Arc::new(Mutex::new(None));
+    let first_server = spawn_single_response_zmq_server(
+        first_command_endpoint.clone(),
+        json!({ "message_id": "first" }),
+        Arc::clone(&first_captured),
+    );
+    let mut first_config =
+        ZmqPipelineBackendConfig::local_tcp(first_command_endpoint, first_response_endpoint);
+    first_config.request_timeout = std::time::Duration::from_secs(2);
+    let first_client = ZmqPipelineBackendClient::new(first_config).expect("first zmq client");
+
+    first_client
+        .send(SendRequest::new(
+            "source-destination",
+            "first-target",
+            json!({ "title": "RCH", "content": "first" }),
+        ))
+        .expect("first send");
+
+    let second_command_endpoint = unused_loopback_endpoint();
+    let second_response_endpoint = unused_loopback_endpoint();
+    let second_captured = Arc::new(Mutex::new(None));
+    let second_server = spawn_single_response_zmq_server(
+        second_command_endpoint.clone(),
+        json!({ "message_id": "second" }),
+        Arc::clone(&second_captured),
+    );
+    let mut second_config =
+        ZmqPipelineBackendConfig::local_tcp(second_command_endpoint, second_response_endpoint);
+    second_config.request_timeout = std::time::Duration::from_secs(2);
+    let second_client = ZmqPipelineBackendClient::new(second_config).expect("second zmq client");
+
+    second_client
+        .send(SendRequest::new(
+            "source-destination",
+            "second-target",
+            json!({ "title": "RCH", "content": "second" }),
+        ))
+        .expect("second send");
+
+    let first_id = first_captured
+        .lock()
+        .expect("first captured")
+        .as_ref()
+        .expect("first request")
+        .params
+        .as_ref()
+        .expect("first params")["id"]
+        .clone();
+    let second_id = second_captured
+        .lock()
+        .expect("second captured")
+        .as_ref()
+        .expect("second request")
+        .params
+        .as_ref()
+        .expect("second params")["id"]
+        .clone();
+
+    assert_ne!(first_id, second_id);
+    first_server.join().expect("first server joined");
+    second_server.join().expect("second server joined");
+}
+
+#[test]
 fn send_preserves_documented_lxmf_field_keys_over_zmq_sdk_method() {
     let command_endpoint = unused_loopback_endpoint();
     let response_endpoint = unused_loopback_endpoint();

--- a/tools/scripts/phone-reticulumd-hil.sh
+++ b/tools/scripts/phone-reticulumd-hil.sh
@@ -43,6 +43,7 @@ Environment:
   LARGE_BYTES                default 4096
   PHONE_PEER_WAIT_SECS       default 180
   MANUAL_WAIT_SECS           default 120
+  PHONE_HIL_IDENTITY_PATH    default target/phone-hil/reticulumd.identity
   KEEP_DAEMON                default 0
 EOF
 }
@@ -60,6 +61,7 @@ ARTIFACT_ROOT="${LOG_DIR:-${REPO_ROOT}/target/phone-hil/${RUN_ID}}"
 REPORT_PATH="${REPORT_PATH:-${ARTIFACT_ROOT}/report.json}"
 RESULTS_JSONL="${ARTIFACT_ROOT}/results.jsonl"
 DB_PATH="${ARTIFACT_ROOT}/reticulum.db"
+IDENTITY_PATH="${PHONE_HIL_IDENTITY_PATH:-${REPO_ROOT}/target/phone-hil/reticulumd.identity}"
 RETICULUMD_LOG="${ARTIFACT_ROOT}/reticulumd.log"
 CONFIG_PATH="${ARTIFACT_ROOT}/reticulumd-phone-hil.toml"
 ADB_DEVICES_LOG="${ARTIFACT_ROOT}/adb-devices.txt"
@@ -202,6 +204,7 @@ write_report() {
     "${COLUMBA_HASH}" \
     "${ADB_DEVICES_LOG}" \
     "${RETICULUMD_LOG}" \
+    "${IDENTITY_PATH}" \
     "${SIDE_BAND_LOGCAT}" \
     "${COLUMBA_LOGCAT}" <<'PY'
 import json
@@ -225,9 +228,10 @@ import sys
     columba_hash,
     adb_devices_log,
     reticulumd_log,
+    identity_path,
     sideband_logcat,
     columba_logcat,
-) = sys.argv[1:19]
+) = sys.argv[1:20]
 
 tests = []
 if os.path.exists(results_path):
@@ -257,6 +261,7 @@ payload = {
         "delivery_hash": daemon_hash or None,
         "propagation_hash": daemon_propagation_hash or None,
         "log": reticulumd_log,
+        "identity": identity_path,
     },
     "artifacts": {
         "adb_devices": adb_devices_log,
@@ -337,10 +342,11 @@ run_capture() {
   local out="$2"
   shift 2
   log_cmd "$*"
-  if "$@" >"${out}" 2>&1; then
+  "$@" >"${out}" 2>&1
+  local status=$?
+  if [[ "${status}" -eq 0 ]]; then
     return 0
   fi
-  local status=$?
   record_result "${label}" "fail" "command exited with ${status}" "log=${out}"
   return "${status}"
 }
@@ -696,12 +702,14 @@ configure_adb_reverse() {
 
 start_daemon() {
   write_config
+  mkdir -p "$(dirname "${IDENTITY_PATH}")"
   (
     RETICULUMD_DIAGNOSTICS=1 \
       LXMD_DELIVERY_PER_PEER_IN_FLIGHT="${PER_PEER_IN_FLIGHT}" \
       "${REPO_ROOT}/target/debug/reticulumd" \
       --rpc "${RPC_ADDR}" \
       --db "${DB_PATH}" \
+      --identity "${IDENTITY_PATH}" \
       --transport "${TRANSPORT_ADDR}" \
       --announce-interval-secs 2 \
       --config "${CONFIG_PATH}" >"${RETICULUMD_LOG}" 2>&1
@@ -722,6 +730,7 @@ start_daemon() {
   record_result "reticulumd_start" "pass" "reticulumd started with diagnostics and propagation enabled" \
     "log=${RETICULUMD_LOG}" \
     "config=${CONFIG_PATH}" \
+    "identity=${IDENTITY_PATH}" \
     "delivery_hash=${DAEMON_HASH}" \
     "propagation_hash=${DAEMON_PROPAGATION_HASH}"
 }
@@ -752,12 +761,12 @@ discover_phone_hashes() {
   while true; do
     rpc_call "list_peers" "{}" "${peers_path}" || true
     local discovered
-    discovered="$("${PYTHON_BIN}" - "${peers_path}" "${DAEMON_HASH}" <<'PY'
+    discovered="$("${PYTHON_BIN}" - "${peers_path}" "${DAEMON_HASH}" "${DAEMON_PROPAGATION_HASH}" <<'PY'
 import json
 import sys
 
-path, daemon_hash = sys.argv[1:3]
-daemon_hash = daemon_hash.lower()
+path, *daemon_hashes = sys.argv[1:]
+excluded_hashes = {value.lower() for value in daemon_hashes if len(value) == 32}
 try:
     with open(path, "r", encoding="utf-8") as handle:
         payload = json.load(handle)
@@ -785,7 +794,7 @@ for peer in peers:
         if not isinstance(value, str):
             continue
         value = value.lower()
-        if len(value) == 32 and value != daemon_hash and value not in seen:
+        if len(value) == 32 and value not in excluded_hashes and value not in seen:
             seen.append(value)
             ranked.append((distance_rank, last_seen_rank, value))
 direct = [value for distance, _, value in sorted(ranked) if distance <= 1]
@@ -1157,12 +1166,12 @@ PY
   rpc_call "propagation_status" "{}" "${dir}/propagation_status.after-set.json" || true
   local propagated_id
   propagated_id="$(send_daemon_message "daemon-to-s8-propagated" "${SIDE_BAND_HASH}" "phone-hil propagated to S8 ${RUN_ID}" "propagated")" || true
-  if wait_trace_contains "daemon-to-s8-propagated" "${propagated_id}" "propagated|failed" 90; then
-    record_result "propagation_node_delivery_attempt" "pass" "propagated delivery produced inspectable terminal or handoff state" \
+  if wait_trace_contains "daemon-to-s8-propagated" "${propagated_id}" "sent: propagated resource" 90; then
+    record_result "propagation_node_delivery_attempt" "pass" "propagated delivery reached local propagation storage handoff" \
       "trace=${ARTIFACT_ROOT}/daemon-to-s8-propagated/message_delivery_trace.json" \
       "status=${dir}/propagation_status.after-set.json"
   else
-    record_result "propagation_node_delivery_attempt" "fail" "propagated delivery did not produce inspectable state" \
+    record_result "propagation_node_delivery_attempt" "fail" "propagated delivery did not reach local propagation storage handoff" \
       "trace=${ARTIFACT_ROOT}/daemon-to-s8-propagated/message_delivery_trace.json" \
       "status=${dir}/propagation_status.after-set.json"
   fi


### PR DESCRIPTION
﻿## Summary

This PR fixes the daemon-side propagation self-storage failure found during the two-phone Sideband HIL run and a follow-up SDK2/ZMQ generated message-id collision found while collecting fresh evidence.

## What Changed

- Fixed self-selected propagation-node delivery so `reticulumd` decodes the propagation envelope and ingests transient payloads locally instead of handing the full envelope to `propagation_ingest`.
- Preserved local propagation handoff evidence as `sent: propagated resource` instead of timing out on a self-link activation path.
- Added persistent HIL identity support in `tools/scripts/phone-reticulumd-hil.sh` so daemon delivery and propagation hashes stay stable across clean-DB test runs.
- Tightened the phone HIL harness so it does not confuse the daemon propagation hash with a phone delivery hash, and so propagation no longer passes on a failed trace.
- Fixed SDK-generated outbound message IDs for both HTTP RPC and SDK2/ZMQ backends. Fresh clients now include a client/session component in generated IDs, preventing short-lived clients from reusing IDs like `sdk-2` or `sdk-zmq-1`.

## Current Evidence

Local validation run:

- `cargo fmt`
- `cargo test -p lxmf-sdk send_params_message_ids_do_not_collide_across_fresh_clients -- --nocapture`
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend send_message_ids_do_not_collide_across_fresh_zmq_clients -- --nocapture`
- `cargo test -p lxmf-sdk --lib backend::rpc::core_impl::tests -- --nocapture`
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend backend::zmq_pipeline::tests::send -- --nocapture`
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend --lib`
- `cargo check -p lxmf-sdk --features zmq-pipeline-backend`
- `cargo check -p lxmf-cli --bin lxmf-cli`
- `cargo check -p reticulumd --bin reticulumd`
- `cargo test -p reticulumd --test phone_hil_harness_contract -- --nocapture`
- `cargo test -p reticulumd self_selected_propagation_node_stores_locally_without_link_activation -- --nocapture`
- `C:\Program Files\Git\bin\bash.exe -n tools/scripts/phone-reticulumd-hil.sh`
- `git diff --check`

Phone HIL evidence retained under `target/phone-hil/`:

- Automated run `target/phone-hil/20260619T145810Z/report.json` shows both Sideband phones visible, both phone LXMF hashes discovered, daemon-to-phone direct delivery reached `delivered`, resource handoff passed for both phones, burst/retry/failure-recovery checks passed, and local propagation reached `sent: propagated resource`.
- Manual live daemon run `target/phone-hil/manual-20260619T150454Z/explicit-live-sends.json` sent explicit daemon-originated messages to both phones:
  - Pixel: `explicit-live-pixel7-20260619T151649Z`, trace `queued -> sending -> sent: link -> delivered`.
  - POCO: `explicit-live-poco-20260619T151649Z`, trace `queued -> sending -> sent: link -> delivered`.

Stable daemon hashes from the manual run:

- Delivery: `b080fc882ca6f837fc5d8a9ea8c16274`
- Propagation: `d4555d7a11368e3d0f568b013286c142`
- Control: `87d6e8a064d11d57e749e0eb86e631fe`

## Remaining HIL Notes

This remains draft because final phone-visible and phone-originated Sideband evidence still needs manual confirmation. Sideband exposes its Kivy UI to ADB only as a surface/view, so ADB cannot reliably read message text from the app UI. Pixel Sideband is still logging propagation stamp-cost unavailable, which likely means the phone-side propagation-node preference is stale or not applied to `d4555d7a11368e3d0f568b013286c142`.
