### PR TITLE
Fix Sideband phone HIL ACK and resource transfer

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_parts/deliverytask_sections/cached_identity_for_destination.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_parts/deliverytask_sections/cached_identity_for_destination.rs
@@ -277,11 +277,15 @@ impl DeliveryTask {
                 return;
             }
         };
+        let (link_id, link_status) = {
+            let guard = propagation_link.lock().await;
+            (*guard.id(), guard.status())
+        };
         log_delivery_trace(
             &self.message_id,
             &self.destination_hex,
             "propagation",
-            "propagation link ready",
+            format!("propagation link ready link={link_id} status={link_status:?}").as_str(),
         );
         if self.abort_if_cancelled("propagation") {
             return;

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_parts/deliverytask_sections/cached_identity_for_destination.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_parts/deliverytask_sections/cached_identity_for_destination.rs
@@ -321,6 +321,21 @@ impl DeliveryTask {
         // without the destination prefix. Receivers prepend the
         // packet destination hash before unpacking.
         let opportunistic_payload = opportunistic_payload(&payload, &self.destination);
+        if opportunistic_payload.len() > rns_transport::packet::PACKET_MDU {
+            log_delivery_trace(
+                &self.message_id,
+                &self.destination_hex,
+                "opportunistic",
+                "payload too large for single packet",
+            );
+            self.run_opportunistic_link_fallback(
+                payload,
+                identity,
+                "payload too large for single packet",
+            )
+            .await;
+            return;
+        }
         let mut data = PacketDataBuffer::new();
         if data.write(opportunistic_payload).is_err() {
             log_delivery_trace(

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_link_send.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_link_send.rs
@@ -234,7 +234,38 @@ impl DeliveryTask {
         payload: &[u8],
         statuses: LinkModeStatuses,
     ) -> Result<(), std::io::Error> {
-        await_link_activation(self.transport.as_ref(), &link, Duration::from_secs(20)).await?;
+        let (activation_link_id, activation_status) = {
+            let guard = link.lock().await;
+            (*guard.id(), guard.status())
+        };
+        log_delivery_trace(
+            &self.message_id,
+            &self.destination_hex,
+            trace_stage,
+            format!(
+                "waiting for link activation link={activation_link_id} status={activation_status:?}"
+            )
+            .as_str(),
+        );
+        if let Err(err) =
+            await_link_activation(self.transport.as_ref(), &link, Duration::from_secs(20)).await
+        {
+            log_delivery_trace(
+                &self.message_id,
+                &self.destination_hex,
+                trace_stage,
+                format!("link activation wait failed link={activation_link_id} err={err}").as_str(),
+            );
+            return Err(err);
+        }
+        let active_status = link.lock().await.status();
+        log_delivery_trace(
+            &self.message_id,
+            &self.destination_hex,
+            trace_stage,
+            format!("link activation ready link={activation_link_id} status={active_status:?}")
+                .as_str(),
+        );
         if self.abort_if_cancelled(trace_stage) {
             return Ok(());
         }

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/auto_parts/auto_iface_sections/auto_peer_data_transport_bridge_regi.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/auto_parts/auto_iface_sections/auto_peer_data_transport_bridge_regi.rs
@@ -87,7 +87,7 @@
             .await
             .send(TxMessage {
                 tx_type: TxMessageType::Direct(rx_message.address),
-                packet: outbound_packet,
+                packet: outbound_packet.clone(),
             })
             .await;
         let mut outbound_payload = [0u8; 512];

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/auto_parts/module_prelude.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/auto_parts/module_prelude.rs
@@ -353,7 +353,7 @@ impl AutoInterfaceTransportBridge {
             TxMessageType::Broadcast(_) => {
                 let routes = self.outbound_routes.lock().await.clone();
                 for (iface, _) in routes {
-                    self.send_to_route(iface, message.packet).await;
+                    self.send_to_route(iface, message.packet.clone()).await;
                 }
             }
         }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/selected_propagation_node_matches_ex.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/selected_propagation_node_matches_ex.rs
@@ -146,6 +146,49 @@ fn outbound_propagation_cost_reads_selected_node_app_data_like_python() {
 }
 
 #[test]
+fn outbound_propagation_cost_accepts_destination_hash_alias() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "d4555d7a11368e3d0f568b013286c142";
+    let app_data = rmp_serde::to_vec_named(&rmpv::Value::Array(vec![
+        rmpv::Value::Boolean(false),
+        rmpv::Value::from(1_700_000_702i64),
+        rmpv::Value::Boolean(true),
+        rmpv::Value::from(256),
+        rmpv::Value::from(10240),
+        rmpv::Value::Array(vec![rmpv::Value::from(8), rmpv::Value::from(3), rmpv::Value::from(8)]),
+        rmpv::Value::Map(Vec::new()),
+    ]))
+    .expect("encode propagation app data");
+    daemon
+        .handle_rpc(rpc_request(
+            97,
+            "announce_received",
+            json!({
+                "peer": peer,
+                "timestamp": 1_700_000_702i64,
+                "app_data_hex": hex::encode(app_data),
+                "aspect": "lxmf.propagation",
+                "hops": 1,
+            }),
+        ))
+        .expect("propagation announce");
+
+    let result = daemon
+        .handle_rpc(rpc_request(
+            98,
+            "get_outbound_propagation_cost",
+            json!({ "destination_hash": peer }),
+        ))
+        .expect("get outbound propagation cost")
+        .result
+        .expect("cost result");
+
+    assert_eq!(result["peer"].as_str(), Some(peer));
+    assert_eq!(result["target_cost"].as_u64(), Some(8));
+    assert_eq!(result["source"].as_str(), Some("cached_announce"));
+}
+
+#[test]
 fn outbound_propagation_cost_reports_unavailable_without_silent_default() {
     let daemon = RpcDaemon::test_instance();
     let missing_peer = "11223344556677889900aabbccddeeff";

--- a/crates/libs/rns-rpc/src/rpc/params/core.rs
+++ b/crates/libs/rns-rpc/src/rpc/params/core.rs
@@ -192,7 +192,7 @@ struct ListAnnouncesParams {
 
 #[derive(Debug, Deserialize)]
 struct SetOutboundPropagationNodeParams {
-    #[serde(default)]
+    #[serde(default, alias = "destination_hash", alias = "destination", alias = "hash")]
     peer: Option<String>,
 }
 

--- a/crates/libs/rns-transport/benches/link_hotpaths.rs
+++ b/crates/libs/rns-transport/benches/link_hotpaths.rs
@@ -57,7 +57,7 @@ fn resource_request_fixture() -> (Link, Vec<u8>, ResourceRequest) {
 }
 
 fn decrypt_resource_packet(link: &Link, packet: &Packet) -> Packet {
-    let mut plain_packet = *packet;
+    let mut plain_packet = packet.clone();
     let mut buffer = PacketDataBuffer::new();
     let plain_len = {
         let plaintext = link

--- a/crates/libs/rns-transport/src/delivery.rs
+++ b/crates/libs/rns-transport/src/delivery.rs
@@ -88,7 +88,7 @@ pub async fn send_on_link_observed(
     match packet {
         Ok(packet) => {
             observe_packet(&packet);
-            let outcome = transport.send_link_packet_on_bound_iface(link, packet).await;
+            let outcome = transport.send_link_packet_on_bound_iface(link, packet.clone()).await;
             if !send_outcome_is_sent(outcome) {
                 return Err(io::Error::other(format!(
                     "link packet not sent: {}",

--- a/crates/libs/rns-transport/src/destination/link_parts/link_sections/next_watchdog_deadline.rs
+++ b/crates/libs/rns-transport/src/destination/link_parts/link_sections/next_watchdog_deadline.rs
@@ -75,6 +75,9 @@ impl Link {
             let cipher_text = self.encrypt(data, packet_data.accuire_buf_max())?;
             cipher_text.len()
         };
+        if cipher_text_len > crate::packet::PACKET_MDU {
+            return Err(RnsError::OutOfMemory);
+        }
         packet_data.resize(cipher_text_len);
         Ok(())
     }

--- a/crates/libs/rns-transport/src/destination/link_parts/link_sections/remove_channel_handler.rs
+++ b/crates/libs/rns-transport/src/destination/link_parts/link_sections/remove_channel_handler.rs
@@ -44,14 +44,14 @@ impl Link {
             packet.hash(),
             PendingChannelPacket {
                 sequence,
-                packet,
+                packet: packet.clone(),
                 tries: 1,
                 next_retry_at: Instant::now()
                     + Self::channel_retry_timeout_for(self.rtt, 1, self.channel_pending.len() + 1),
             },
         );
         self.channel_states.insert(sequence, ChannelMessageState::Sent);
-        Ok((sequence, packet))
+        Ok((sequence, packet.clone()))
     }
 
     pub fn channel_state(&self, sequence: u16) -> ChannelMessageState {
@@ -109,7 +109,7 @@ impl Link {
                 let tries = pending.tries;
                 let retry_timeout = Self::channel_retry_timeout_for(rtt, tries, outstanding);
                 pending.next_retry_at = now + retry_timeout;
-                resend_packets.push(pending.packet);
+                resend_packets.push(pending.packet.clone());
             }
         }
 

--- a/crates/libs/rns-transport/src/destination/link_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/destination/link_parts/module_prelude.rs
@@ -79,7 +79,7 @@ const CHANNEL_WINDOW_FLEXIBILITY: u8 = 4;
 #[allow(dead_code)]
 const CHANNEL_MAX_TRIES: u8 = 5;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 struct PendingChannelPacket {
     sequence: u16,
     #[allow(dead_code)]

--- a/crates/libs/rns-transport/src/destination_parts/destination.rs
+++ b/crates/libs/rns-transport/src/destination_parts/destination.rs
@@ -183,7 +183,7 @@ impl Destination<PrivateIdentity, Input, Single> {
 
         if let Some(tag) = tag {
             if let Some((_, cached)) = self.path_responses.get(tag) {
-                return Ok(*cached);
+                return Ok(cached.clone());
             }
         }
 
@@ -193,7 +193,7 @@ impl Destination<PrivateIdentity, Input, Single> {
         if let Some(tag) = tag {
             let expires_at = now + std::time::Duration::from_secs(PATH_RESPONSE_TAG_WINDOW);
             let tag = tag.to_vec();
-            self.path_responses.insert(tag.clone(), (expires_at, announce));
+            self.path_responses.insert(tag.clone(), (expires_at, announce.clone()));
             self.path_response_queue.push_back((tag, expires_at));
             self.prune_path_responses(now);
         }

--- a/crates/libs/rns-transport/src/iface/tcp_client.rs
+++ b/crates/libs/rns-transport/src/iface/tcp_client.rs
@@ -49,7 +49,7 @@ pub struct TcpClient {
 }
 
 impl TcpClient {
-    pub const DEFAULT_MTU: usize = 2048;
+    pub const DEFAULT_MTU: usize = 262_144;
 
     pub fn new<T: Into<String>>(addr: T) -> Self {
         Self { addr: addr.into(), stream: None, mtu: Self::DEFAULT_MTU }
@@ -328,6 +328,7 @@ mod tests {
     #[test]
     fn tcp_client_default_and_configured_mtu_are_exposed() {
         assert_eq!(TcpClient::new("rmap.world:4242").mtu_value(), TcpClient::DEFAULT_MTU);
+        assert_eq!(TcpClient::DEFAULT_MTU, 262_144);
         assert_eq!(TcpClient::new("rmap.world:4242").with_mtu(4096).mtu_value(), 4096);
         assert_eq!(TcpClient::new("rmap.world:4242").with_mtu(64).mtu_value(), 256);
     }

--- a/crates/libs/rns-transport/src/iface_parts/interfacemanager.rs
+++ b/crates/libs/rns-transport/src/iface_parts/interfacemanager.rs
@@ -282,9 +282,10 @@ impl InterfaceManager {
     }
 
     async fn send_to_iface(iface: &LocalInterface, message: TxMessage) -> bool {
+        let tx_type = message.tx_type;
         match iface.tx_send.try_send(message) {
             Ok(()) => true,
-            Err(mpsc::error::TrySendError::Full(_)) => {
+            Err(mpsc::error::TrySendError::Full(message)) => {
                 match tokio::time::timeout(
                     Duration::from_millis(IFACE_TX_ENQUEUE_TIMEOUT_MS),
                     iface.tx_send.send(message),
@@ -296,7 +297,7 @@ impl InterfaceManager {
                             log::warn!(
                                 "recovered from full tx queue on {} for {:?}",
                                 iface.address,
-                                message.tx_type
+                                tx_type
                             );
                         }
                         true
@@ -305,7 +306,7 @@ impl InterfaceManager {
                         log::warn!(
                             "tx queue closed on {} for {:?}",
                             iface.address,
-                            message.tx_type
+                            tx_type
                         );
                         false
                     }
@@ -313,14 +314,14 @@ impl InterfaceManager {
                         log::warn!(
                             "tx queue full timeout on {} for {:?}",
                             iface.address,
-                            message.tx_type
+                            tx_type
                         );
                         false
                     }
                 }
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
-                log::warn!("tx queue closed on {} for {:?}", iface.address, message.tx_type);
+                log::warn!("tx queue closed on {} for {:?}", iface.address, tx_type);
                 false
             }
         }
@@ -451,7 +452,7 @@ impl InterfaceManager {
                 if is_paced_announce
                     && (!iface.announce_queue.is_empty() || now < iface.announce_allowed_at)
                 {
-                    if Self::queue_announce(iface, message, now) {
+                    if Self::queue_announce(iface, message.clone(), now) {
                         trace.queued_ifaces += 1;
                     } else {
                         trace.failed_ifaces += 1;
@@ -468,7 +469,7 @@ impl InterfaceManager {
                         );
                 }
 
-                if Self::send_to_iface(iface, message).await {
+                if Self::send_to_iface(iface, message.clone()).await {
                     trace.sent_ifaces += 1;
                 } else {
                     trace.failed_ifaces += 1;

--- a/crates/libs/rns-transport/src/iface_parts/txmessagetype.rs
+++ b/crates/libs/rns-transport/src/iface_parts/txmessagetype.rs
@@ -4,7 +4,7 @@ pub enum TxMessageType {
     Direct(AddressHash),
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TxMessage {
     pub tx_type: TxMessageType,
     pub packet: Packet,
@@ -97,7 +97,7 @@ pub enum IfaceRole {
     VirtualUnicast,
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RxMessage {
     pub address: AddressHash,
     pub packet: Packet,
@@ -161,7 +161,7 @@ struct LocalInterface {
     announce_cap_percent: u64,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 struct QueuedAnnounce {
     message: TxMessage,
     queued_at: Instant,

--- a/crates/libs/rns-transport/src/iface_tests.rs
+++ b/crates/libs/rns-transport/src/iface_tests.rs
@@ -185,7 +185,7 @@ mod tests {
         let packet = announce_packet();
         let trace = mgr
             .send_with_announce_policy(
-                TxMessage { tx_type: TxMessageType::Broadcast(None), packet },
+                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: packet.clone() },
                 Some(AnnounceBroadcastPolicy {
                     local_destination: false,
                     next_hop_iface_mode: Some(InterfaceMode::Full),
@@ -236,7 +236,7 @@ mod tests {
         let packet = announce_packet();
         let trace = mgr
             .send_with_announce_policy(
-                TxMessage { tx_type: TxMessageType::Broadcast(None), packet },
+                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: packet.clone() },
                 Some(AnnounceBroadcastPolicy {
                     local_destination: false,
                     next_hop_iface_mode: Some(InterfaceMode::Boundary),
@@ -256,7 +256,7 @@ mod tests {
         let packet = announce_packet();
         let trace = mgr
             .send_with_announce_policy(
-                TxMessage { tx_type: TxMessageType::Broadcast(None), packet },
+                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: packet.clone() },
                 Some(AnnounceBroadcastPolicy {
                     local_destination: true,
                     next_hop_iface_mode: None,
@@ -276,7 +276,7 @@ mod tests {
         let packet = announce_packet();
         let trace = mgr
             .send_with_announce_policy(
-                TxMessage { tx_type: TxMessageType::Broadcast(None), packet },
+                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: packet.clone() },
                 Some(AnnounceBroadcastPolicy {
                     local_destination: false,
                     next_hop_iface_mode: Some(InterfaceMode::Roaming),
@@ -296,7 +296,7 @@ mod tests {
         let packet = announce_packet();
         let trace = mgr
             .send_with_announce_policy(
-                TxMessage { tx_type: TxMessageType::Broadcast(None), packet },
+                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: packet.clone() },
                 Some(AnnounceBroadcastPolicy {
                     local_destination: false,
                     next_hop_iface_mode: Some(InterfaceMode::Boundary),
@@ -316,7 +316,7 @@ mod tests {
         let first = announce_packet_with(1, b"first-destination", 1);
         let trace = mgr
             .send_with_announce_policy(
-                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: first },
+                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: first.clone() },
                 Some(AnnounceBroadcastPolicy {
                     local_destination: false,
                     next_hop_iface_mode: Some(InterfaceMode::Full),
@@ -339,7 +339,7 @@ mod tests {
             .await;
         let nearer_trace = mgr
             .send_with_announce_policy(
-                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: nearer },
+                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: nearer.clone() },
                 Some(AnnounceBroadcastPolicy {
                     local_destination: false,
                     next_hop_iface_mode: Some(InterfaceMode::Full),

--- a/crates/libs/rns-transport/src/packet.rs
+++ b/crates/libs/rns-transport/src/packet.rs
@@ -1,8 +1,8 @@
 use core::fmt;
 
+use alloc::vec::Vec;
 use sha2::Digest;
 
-use crate::buffer::StaticBuffer;
 use crate::crypt::fernet::{FERNET_MAX_PADDING_SIZE, FERNET_OVERHEAD_SIZE};
 use crate::error::RnsError;
 use crate::hash::AddressHash;
@@ -14,6 +14,7 @@ use crate::hash::ADDRESS_HASH_SIZE;
 pub const PACKET_MDU: usize = 464usize;
 pub const LXMF_MAX_PAYLOAD: usize = PACKET_MDU - FERNET_OVERHEAD_SIZE - FERNET_MAX_PADDING_SIZE;
 pub const PACKET_IFAC_MAX_LENGTH: usize = 64usize;
+pub const PACKET_DATA_MAX: usize = 262_144usize;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum IfacFlag {
@@ -236,7 +237,91 @@ impl fmt::Display for Header {
     }
 }
 
-pub type PacketDataBuffer = StaticBuffer<PACKET_MDU>;
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct PacketDataBuffer {
+    buffer: Vec<u8>,
+}
+
+impl PacketDataBuffer {
+    pub fn new() -> Self {
+        Self { buffer: Vec::new() }
+    }
+
+    pub fn new_from_slice(data: &[u8]) -> Self {
+        let mut buffer = Self::new();
+        buffer.safe_write(data);
+        buffer
+    }
+
+    pub fn reset(&mut self) {
+        self.buffer.clear();
+    }
+
+    pub fn resize(&mut self, len: usize) {
+        self.buffer.resize(len.min(PACKET_DATA_MAX), 0);
+    }
+
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    pub fn chain_write(&mut self, data: &[u8]) -> Result<&mut Self, RnsError> {
+        self.write(data)?;
+        Ok(self)
+    }
+
+    pub fn finalize(self) -> Self {
+        self
+    }
+
+    pub fn safe_write(&mut self, data: &[u8]) -> usize {
+        let available = PACKET_DATA_MAX.saturating_sub(self.buffer.len());
+        let write_len = data.len().min(available);
+        self.buffer.extend_from_slice(&data[..write_len]);
+        write_len
+    }
+
+    pub fn chain_safe_write(&mut self, data: &[u8]) -> &mut Self {
+        self.safe_write(data);
+        self
+    }
+
+    pub fn write(&mut self, data: &[u8]) -> Result<usize, RnsError> {
+        if self.buffer.len().saturating_add(data.len()) > PACKET_DATA_MAX {
+            return Err(RnsError::OutOfMemory);
+        }
+        self.buffer.extend_from_slice(data);
+        Ok(data.len())
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buffer
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.buffer
+    }
+
+    pub fn accuire_buf(&mut self, len: usize) -> &mut [u8] {
+        self.buffer.resize(len.min(PACKET_DATA_MAX), 0);
+        &mut self.buffer
+    }
+
+    pub fn accuire_buf_max(&mut self) -> &mut [u8] {
+        self.buffer.resize(PACKET_DATA_MAX, 0);
+        &mut self.buffer
+    }
+}
+
+impl Default for PacketDataBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct PacketIfac {
@@ -256,7 +341,7 @@ impl PacketIfac {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Packet {
     pub header: Header,
     pub ifac: Option<PacketIfac>,
@@ -307,6 +392,9 @@ impl Packet {
         let context = PacketContext::from(bytes[idx]);
         idx += 1;
 
+        if bytes.len() - idx > PACKET_DATA_MAX {
+            return Err(RnsError::OutOfMemory);
+        }
         let data = PacketDataBuffer::new_from_slice(&bytes[idx..]);
 
         Ok(Self { header, ifac: None, destination, transport, context, data })
@@ -345,7 +433,8 @@ impl Packet {
     pub fn fragment_for_lxmf(data: &[u8]) -> Result<Vec<Packet>, RnsError> {
         let mut out = Vec::new();
         for chunk in data.chunks(Self::LXMF_MAX_PAYLOAD) {
-            let packet = Packet { data: StaticBuffer::new_from_slice(chunk), ..Default::default() };
+            let packet =
+                Packet { data: PacketDataBuffer::new_from_slice(chunk), ..Default::default() };
             out.push(packet);
         }
         Ok(out)

--- a/crates/libs/rns-transport/src/resource/manager.rs
+++ b/crates/libs/rns-transport/src/resource/manager.rs
@@ -108,7 +108,7 @@ impl ResourceManager {
         for (hash, sender) in self.outgoing.iter_mut() {
             match sender.poll(now, self.retry_interval) {
                 OutboundResourcePoll::Send(packet) => {
-                    packets.push((sender.link_id, *packet));
+                    packets.push((sender.link_id, (*packet).clone()));
                 }
                 OutboundResourcePoll::Failed => {
                     self.events.push(ResourceEvent {

--- a/crates/libs/rns-transport/src/resource/sender.rs
+++ b/crates/libs/rns-transport/src/resource/sender.rs
@@ -160,7 +160,7 @@ impl ResourceSender {
     }
 
     fn advertisement_packet(&self) -> Packet {
-        self.advertisement_packet
+        self.advertisement_packet.clone()
     }
 
     fn mark_advertised(&mut self, retry_limit: u8) {
@@ -240,7 +240,7 @@ impl ResourceSender {
                     {
                         self.sent_parts[index] = true;
                         sent_any = true;
-                        packets.push(scratch_packet);
+                        packets.push(scratch_packet.clone());
                     } else {
                         self.status = ResourceStatus::Failed;
                         return;

--- a/crates/libs/rns-transport/src/serde.rs
+++ b/crates/libs/rns-transport/src/serde.rs
@@ -1,8 +1,8 @@
 use crate::{
-    buffer::{InputBuffer, OutputBuffer, StaticBuffer},
+    buffer::{InputBuffer, OutputBuffer},
     error::RnsError,
     hash::AddressHash,
-    packet::{Header, HeaderType, Packet, PacketContext, PACKET_MDU},
+    packet::{Header, HeaderType, Packet, PacketContext, PacketDataBuffer, PACKET_DATA_MAX},
 };
 
 pub trait Serialize {
@@ -88,11 +88,11 @@ impl Packet {
             destination,
             transport,
             context,
-            data: StaticBuffer::new(),
+            data: PacketDataBuffer::new(),
         };
 
         let remaining = buffer.bytes_left();
-        if remaining > PACKET_MDU {
+        if remaining > PACKET_DATA_MAX {
             return Err(RnsError::OutOfMemory);
         }
         buffer.read(packet.data.accuire_buf(remaining))?;
@@ -106,11 +106,11 @@ mod tests {
     use rand_core::OsRng;
 
     use crate::{
-        buffer::{InputBuffer, OutputBuffer, StaticBuffer},
+        buffer::{InputBuffer, OutputBuffer},
         hash::AddressHash,
         packet::{
             ContextFlag, DestinationType, Header, HeaderType, IfacFlag, Packet, PacketContext,
-            PacketType, PropagationType,
+            PacketDataBuffer, PacketType, PropagationType, PACKET_DATA_MAX, PACKET_MDU,
         },
     };
 
@@ -136,7 +136,7 @@ mod tests {
             destination: AddressHash::new_from_rand(OsRng),
             transport: None,
             context: PacketContext::None,
-            data: StaticBuffer::new(),
+            data: PacketDataBuffer::new(),
         };
 
         packet.serialize(&mut buffer).expect("serialized packet");
@@ -164,7 +164,7 @@ mod tests {
             destination: AddressHash::new_from_rand(OsRng),
             transport: None,
             context: PacketContext::None,
-            data: StaticBuffer::new(),
+            data: PacketDataBuffer::new(),
         };
 
         packet.data.safe_write(b"Hello, world!");
@@ -180,5 +180,61 @@ mod tests {
         assert_eq!(packet.transport, new_packet.transport);
         assert_eq!(packet.context, new_packet.context);
         assert_eq!(packet.data.as_slice(), new_packet.data.as_slice());
+    }
+
+    #[test]
+    fn deserialize_allows_large_tcp_resource_packet_data() {
+        let payload_len = PACKET_MDU + 128;
+        let packet = Packet {
+            header: Header {
+                ifac_flag: IfacFlag::Open,
+                header_type: HeaderType::Type1,
+                context_flag: ContextFlag::Set,
+                propagation_type: PropagationType::Broadcast,
+                destination_type: DestinationType::Link,
+                packet_type: PacketType::Data,
+                hops: 0,
+            },
+            ifac: None,
+            destination: AddressHash::new([0x42; crate::hash::ADDRESS_HASH_SIZE]),
+            transport: None,
+            context: PacketContext::Resource,
+            data: PacketDataBuffer::new_from_slice(&vec![0xA5; payload_len]),
+        };
+
+        let mut wire = vec![0u8; payload_len + 64];
+        let mut output = OutputBuffer::new(&mut wire);
+        packet.serialize(&mut output).expect("serialize large resource packet");
+
+        let mut input = InputBuffer::new(output.as_slice());
+        let decoded = Packet::deserialize(&mut input).expect("deserialize large resource packet");
+
+        assert_eq!(decoded.context, PacketContext::Resource);
+        assert_eq!(decoded.data.len(), payload_len);
+        assert!(decoded.data.as_slice().iter().all(|byte| *byte == 0xA5));
+    }
+
+    #[test]
+    fn deserialize_rejects_packet_data_beyond_tcp_cap() {
+        let mut wire = Vec::with_capacity(PACKET_DATA_MAX + 64);
+        wire.push(
+            Header {
+                ifac_flag: IfacFlag::Open,
+                header_type: HeaderType::Type1,
+                context_flag: ContextFlag::Set,
+                propagation_type: PropagationType::Broadcast,
+                destination_type: DestinationType::Link,
+                packet_type: PacketType::Data,
+                hops: 0,
+            }
+            .to_meta(),
+        );
+        wire.push(0);
+        wire.extend_from_slice(&[0x24; crate::hash::ADDRESS_HASH_SIZE]);
+        wire.push(PacketContext::Resource as u8);
+        wire.resize(wire.len() + PACKET_DATA_MAX + 1, 0x11);
+
+        let mut input = InputBuffer::new(&wire);
+        assert!(Packet::deserialize(&mut input).is_err());
     }
 }

--- a/crates/libs/rns-transport/src/transport/announce_limits.rs
+++ b/crates/libs/rns-transport/src/transport/announce_limits.rs
@@ -45,7 +45,7 @@ pub enum AnnounceLimitAction {
     Hold(Duration),
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct HeldAnnounce {
     packet: Packet,
     source: IfaceSource,
@@ -153,7 +153,7 @@ impl AnnounceLimitEntry {
         rate_limit: &AnnounceRateLimit,
     ) -> bool {
         if let Entry::Occupied(mut entry) = self.held_announces.entry(packet.destination) {
-            entry.insert(HeldAnnounce { packet: *packet, source, held_at: now });
+            entry.insert(HeldAnnounce { packet: packet.clone(), source, held_at: now });
             return true;
         }
 
@@ -173,8 +173,10 @@ impl AnnounceLimitEntry {
             }
         }
 
-        self.held_announces
-            .insert(packet.destination, HeldAnnounce { packet: *packet, source, held_at: now });
+        self.held_announces.insert(
+            packet.destination,
+            HeldAnnounce { packet: packet.clone(), source, held_at: now },
+        );
         true
     }
 
@@ -208,7 +210,7 @@ impl AnnounceLimitEntry {
             .held_announces
             .iter()
             .min_by_key(|(_, held)| (held.packet.header.hops, held.held_at))
-            .map(|(destination, held)| (*destination, held.packet, held.source));
+            .map(|(destination, held)| (*destination, held.packet.clone(), held.source));
 
         let (destination, packet, source) = selected?;
 

--- a/crates/libs/rns-transport/src/transport/announce_table.rs
+++ b/crates/libs/rns-transport/src/transport/announce_table.rs
@@ -44,7 +44,7 @@ impl AnnounceEntry {
             destination: self.packet.destination,
             transport: Some(*transport_id),
             context: self.packet.context,
-            data: self.packet.data,
+            data: self.packet.data.clone(),
         };
 
         let tx_type = match self.response_to_iface {
@@ -149,7 +149,7 @@ impl AnnounceTable {
         let hops = announce.header.hops;
 
         let entry = AnnounceEntry {
-            packet: *announce,
+            packet: announce.clone(),
             timeout: now + retry_window(),
             received_from,
             retries: 0,
@@ -198,7 +198,7 @@ impl AnnounceTable {
         self.map
             .get(destination)
             .or_else(|| self.responses.get(destination))
-            .map(|entry| entry.packet)
+            .map(|entry| entry.packet.clone())
             .or_else(|| self.cache.get(destination).map(|entry| entry.packet))
     }
 

--- a/crates/libs/rns-transport/src/transport/core.rs
+++ b/crates/libs/rns-transport/src/transport/core.rs
@@ -161,21 +161,17 @@ impl Transport {
         };
         let packet = decision.packet;
         let maybe_iface = decision.next_iface;
+        let destination = packet.destination;
 
         if let Some(iface) = maybe_iface {
             self.send_direct(iface, packet).await;
             log::trace!("Sent outbound packet to {}", iface);
-        }
-        if maybe_iface.is_none() {
+        } else {
             let handler = self.handler.lock().await;
             if handler.config.broadcast {
                 handler.send(TxMessage { tx_type: TxMessageType::Broadcast(None), packet }).await;
             } else {
-                log::trace!(
-                    "tp({}): no route for outbound packet dst={}",
-                    self.name,
-                    packet.destination
-                );
+                log::trace!("tp({}): no route for outbound packet dst={}", self.name, destination);
             }
         }
     }

--- a/crates/libs/rns-transport/src/transport/handler.rs
+++ b/crates/libs/rns-transport/src/transport/handler.rs
@@ -152,7 +152,7 @@ impl TransportHandler {
     }
 
     pub(super) async fn send(&self, message: TxMessage) -> TxDispatchTrace {
-        let packet = message.packet;
+        let packet = message.packet.clone();
         self.packet_cache.lock().await.update(&packet);
         let announce_policy = if packet.header.packet_type == PacketType::Announce
             && matches!(message.tx_type, TxMessageType::Broadcast(_))

--- a/crates/libs/rns-transport/src/transport/jobs.rs
+++ b/crates/libs/rns-transport/src/transport/jobs.rs
@@ -208,7 +208,7 @@ pub(super) async fn manage_transport(
                         break;
                     },
                     Some(message) = rx_receiver.recv() => {
-                        let _ = iface_messages_tx.send(message);
+                        let _ = iface_messages_tx.send(message.clone());
 
                         let packet = message.packet;
 

--- a/crates/libs/rns-transport/src/transport/link_table.rs
+++ b/crates/libs/rns-transport/src/transport/link_table.rs
@@ -25,7 +25,7 @@ fn send_backwards(packet: &Packet, entry: &LinkEntry) -> (Packet, AddressHash) {
         destination: packet.destination,
         transport: packet.transport,
         context: packet.context,
-        data: packet.data,
+        data: packet.data.clone(),
     };
 
     (propagated, entry.received_from)

--- a/crates/libs/rns-transport/src/transport/packet_cache.rs
+++ b/crates/libs/rns-transport/src/transport/packet_cache.rs
@@ -4,21 +4,24 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{hash::Hash, packet::Packet};
+use crate::{hash::AddressHash, hash::Hash, packet::Packet};
 
 pub struct PacketTrack {
     pub time: Instant,
     pub min_hops: u8,
+    pub source_iface: Option<AddressHash>,
+    pub destination: AddressHash,
 }
 
 pub struct PacketCache {
     map: HashMap<Hash, PacketTrack>,
+    by_proof_destination: HashMap<AddressHash, Hash>,
     remove_cache: Vec<Hash>,
 }
 
 impl PacketCache {
     pub fn new() -> Self {
-        Self { map: HashMap::new(), remove_cache: Vec::new() }
+        Self { map: HashMap::new(), by_proof_destination: HashMap::new(), remove_cache: Vec::new() }
     }
 
     pub fn release(&mut self, duration: Duration) {
@@ -29,7 +32,9 @@ impl PacketCache {
         }
 
         for hash in &self.remove_cache {
-            self.map.remove(hash);
+            if self.map.remove(hash).is_some() {
+                self.by_proof_destination.remove(&AddressHash::new_from_hash(hash));
+            }
         }
 
         self.remove_cache.clear();
@@ -47,10 +52,64 @@ impl PacketCache {
         } else {
             is_new_packet = true;
 
-            self.map
-                .insert(hash, PacketTrack { time: Instant::now(), min_hops: packet.header.hops });
+            self.map.insert(
+                hash,
+                PacketTrack {
+                    time: Instant::now(),
+                    min_hops: packet.header.hops,
+                    source_iface: None,
+                    destination: packet.destination,
+                },
+            );
         }
 
         is_new_packet
+    }
+
+    pub fn note_source(&mut self, packet: &Packet, iface: AddressHash) {
+        let hash = packet.hash();
+        let now = Instant::now();
+        self.by_proof_destination.insert(AddressHash::new_from_hash(&hash), hash);
+
+        if let Some(track) = self.map.get_mut(&hash) {
+            if packet.header.hops <= track.min_hops || track.source_iface.is_none() {
+                track.source_iface = Some(iface);
+                track.destination = packet.destination;
+            }
+            track.time = now;
+            track.min_hops = min(packet.header.hops, track.min_hops);
+        } else {
+            self.map.insert(
+                hash,
+                PacketTrack {
+                    time: now,
+                    min_hops: packet.header.hops,
+                    source_iface: Some(iface),
+                    destination: packet.destination,
+                },
+            );
+        }
+    }
+
+    pub fn source_iface_for_hash(&self, hash: &Hash) -> Option<AddressHash> {
+        self.map.get(hash).and_then(|track| track.source_iface)
+    }
+
+    pub fn source_iface_for_proof_destination(
+        &self,
+        destination: &AddressHash,
+    ) -> Option<(Hash, AddressHash)> {
+        let hash = self.by_proof_destination.get(destination)?;
+        let source_iface = self.source_iface_for_hash(hash)?;
+        Some((*hash, source_iface))
+    }
+
+    pub fn proof_context_for_destination(
+        &self,
+        destination: &AddressHash,
+    ) -> Option<(Hash, AddressHash, Option<AddressHash>)> {
+        let hash = *self.by_proof_destination.get(destination)?;
+        let track = self.map.get(&hash)?;
+        Some((hash, track.destination, track.source_iface))
     }
 }

--- a/crates/libs/rns-transport/src/transport/path.rs
+++ b/crates/libs/rns-transport/src/transport/path.rs
@@ -2,7 +2,7 @@ use super::diag;
 use super::*;
 use crate::packet::{DestinationType, Header, HeaderType, PacketType, PropagationType};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct RouteDecision {
     pub packet: Packet,
     pub next_iface: Option<AddressHash>,
@@ -16,7 +16,7 @@ pub(super) fn route_inbound_packet(
     let lookup = lookup.unwrap_or(original_packet.destination);
 
     let Some(entry) = path_table.get(&lookup) else {
-        return RouteDecision { packet: *original_packet, next_iface: None };
+        return RouteDecision { packet: original_packet.clone(), next_iface: None };
     };
 
     let is_direct_hop = entry.hops <= 1 && entry.received_from == lookup;
@@ -35,7 +35,7 @@ pub(super) fn route_inbound_packet(
             destination: original_packet.destination,
             transport: None,
             context: original_packet.context,
-            data: original_packet.data,
+            data: original_packet.data.clone(),
         }
     } else {
         Packet {
@@ -52,7 +52,7 @@ pub(super) fn route_inbound_packet(
             destination: original_packet.destination,
             transport: Some(entry.received_from),
             context: original_packet.context,
-            data: original_packet.data,
+            data: original_packet.data.clone(),
         }
     };
 
@@ -64,25 +64,25 @@ pub(super) fn route_outbound_packet(
     original_packet: &Packet,
 ) -> RouteDecision {
     if original_packet.header.header_type == HeaderType::Type2 {
-        return RouteDecision { packet: *original_packet, next_iface: None };
+        return RouteDecision { packet: original_packet.clone(), next_iface: None };
     }
 
     if original_packet.header.packet_type == PacketType::Announce {
-        return RouteDecision { packet: *original_packet, next_iface: None };
+        return RouteDecision { packet: original_packet.clone(), next_iface: None };
     }
 
     if original_packet.header.destination_type == DestinationType::Plain
         || original_packet.header.destination_type == DestinationType::Group
     {
-        return RouteDecision { packet: *original_packet, next_iface: None };
+        return RouteDecision { packet: original_packet.clone(), next_iface: None };
     }
 
     let Some(entry) = path_table.get(&original_packet.destination) else {
-        return RouteDecision { packet: *original_packet, next_iface: None };
+        return RouteDecision { packet: original_packet.clone(), next_iface: None };
     };
 
     if entry.hops <= 1 && entry.received_from == original_packet.destination {
-        return RouteDecision { packet: *original_packet, next_iface: Some(entry.iface) };
+        return RouteDecision { packet: original_packet.clone(), next_iface: Some(entry.iface) };
     }
 
     RouteDecision {
@@ -100,7 +100,7 @@ pub(super) fn route_outbound_packet(
             destination: original_packet.destination,
             transport: Some(entry.received_from),
             context: original_packet.context,
-            data: original_packet.data,
+            data: original_packet.data.clone(),
         },
         next_iface: Some(entry.iface),
     }

--- a/crates/libs/rns-transport/src/transport/path_tests.rs
+++ b/crates/libs/rns-transport/src/transport/path_tests.rs
@@ -3,8 +3,7 @@ mod tests {
     use super::*;
     use std::time::Instant;
 
-    use crate::buffer::StaticBuffer;
-    use crate::packet::{ContextFlag, IfacFlag};
+    use crate::packet::{ContextFlag, IfacFlag, PacketDataBuffer};
 
     fn path_table_with_route(
         destination: AddressHash,
@@ -46,7 +45,7 @@ mod tests {
             destination,
             transport,
             context: crate::packet::PacketContext::None,
-            data: StaticBuffer::new(),
+            data: PacketDataBuffer::new(),
         }
     }
 

--- a/crates/libs/rns-transport/src/transport/resource_wire.rs
+++ b/crates/libs/rns-transport/src/transport/resource_wire.rs
@@ -151,7 +151,7 @@ fn packet_for_resource_manager(packet: &Packet, link: &mut Link) -> Option<Packe
             | PacketContext::ResourceReceiverCancel
     );
     if !needs_decrypt {
-        return Some(*packet);
+        return Some(packet.clone());
     }
 
     let mut buffer = PacketDataBuffer::new();
@@ -171,7 +171,7 @@ fn packet_for_resource_manager(packet: &Packet, link: &mut Link) -> Option<Packe
         }
     };
     buffer.resize(plain_len);
-    let mut plain_packet = *packet;
+    let mut plain_packet = packet.clone();
     plain_packet.data = buffer;
     Some(plain_packet)
 }

--- a/crates/libs/rns-transport/src/transport/reticulum_announce_cache.rs
+++ b/crates/libs/rns-transport/src/transport/reticulum_announce_cache.rs
@@ -36,7 +36,8 @@ impl ReticulumAnnounceCache {
         let Ok(announce) = DestinationAnnounce::validate(&packet) else {
             return Ok(None);
         };
-        Ok(Some(CachedAnnounce { packet, destination: announce.destination }))
+        let destination = announce.destination;
+        Ok(Some(CachedAnnounce { packet, destination }))
     }
 
     async fn read_packet(&self, packet_hash: Hash) -> io::Result<Option<Packet>> {

--- a/crates/libs/rns-transport/src/transport/tests_parts/encrypted_resource_control_packet.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/encrypted_resource_control_packet.rs
@@ -144,6 +144,126 @@ async fn handle_inbound_for_test_accepts_valid_destination_proof() {
 }
 
 #[tokio::test]
+async fn routed_destination_proof_forwards_back_to_packet_source() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let config = TransportConfig::new("test", &local_identity, true);
+    let transport = Transport::new(config);
+    let handler = transport.get_handler();
+    let mut source_iface = transport.iface_manager.lock().await.new_channel(8);
+    let mut recipient_iface = transport.iface_manager.lock().await.new_channel(8);
+
+    let recipient_identity = PrivateIdentity::new_from_rand(OsRng);
+    let mut recipient_destination =
+        SingleInputDestination::new(recipient_identity, DestinationName::new("lxmf", "delivery"));
+    let announce = recipient_destination.announce(OsRng, None).expect("valid announce packet");
+    handle_announce(
+        &announce,
+        handler.lock().await,
+        recipient_iface.address,
+        crate::iface::IfaceSource::None,
+    )
+    .await;
+
+    let original_packet = Packet {
+        header: Header { packet_type: PacketType::Data, ..Default::default() },
+        destination: announce.destination,
+        context: PacketContext::None,
+        data: PacketDataBuffer::new_from_slice(b"opportunistic lxmf body"),
+        ..Default::default()
+    };
+
+    assert!(handler.lock().await.filter_duplicate_packets(&original_packet).await);
+    handle_data(&original_packet, source_iface.address, handler.lock().await).await;
+    let forwarded = timeout(Duration::from_millis(200), recipient_iface.tx_channel.recv())
+        .await
+        .expect("data should be forwarded to recipient iface")
+        .expect("tx channel open");
+    assert_eq!(forwarded.tx_type, TxMessageType::Direct(recipient_iface.address));
+
+    let packet_hash = original_packet.hash().to_bytes();
+    let signature = recipient_destination.identity.sign(&packet_hash).to_bytes();
+    let mut data = PacketDataBuffer::new();
+    data.safe_write(&packet_hash);
+    data.safe_write(&signature);
+    let proof = Packet {
+        header: Header { packet_type: PacketType::Proof, ..Default::default() },
+        destination: announce.destination,
+        context: PacketContext::None,
+        data,
+        ..Default::default()
+    };
+
+    handle_proof(proof, handler, recipient_iface.address).await;
+
+    let sent = timeout(Duration::from_millis(200), source_iface.tx_channel.recv())
+        .await
+        .expect("destination proof should be forwarded back to packet source")
+        .expect("tx channel open");
+    assert_eq!(sent.tx_type, TxMessageType::Direct(source_iface.address));
+    assert_eq!(sent.packet.header.packet_type, PacketType::Proof);
+    assert_eq!(sent.packet.destination, announce.destination);
+}
+
+#[tokio::test]
+async fn routed_implicit_destination_proof_forwards_back_to_packet_source() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let config = TransportConfig::new("test", &local_identity, true);
+    let transport = Transport::new(config);
+    let handler = transport.get_handler();
+    let mut source_iface = transport.iface_manager.lock().await.new_channel(8);
+    let mut recipient_iface = transport.iface_manager.lock().await.new_channel(8);
+
+    let recipient_identity = PrivateIdentity::new_from_rand(OsRng);
+    let mut recipient_destination =
+        SingleInputDestination::new(recipient_identity, DestinationName::new("lxmf", "delivery"));
+    let announce = recipient_destination.announce(OsRng, None).expect("valid announce packet");
+    handle_announce(
+        &announce,
+        handler.lock().await,
+        recipient_iface.address,
+        crate::iface::IfaceSource::None,
+    )
+    .await;
+
+    let original_packet = Packet {
+        header: Header { packet_type: PacketType::Data, ..Default::default() },
+        destination: announce.destination,
+        context: PacketContext::None,
+        data: PacketDataBuffer::new_from_slice(b"sideband implicit lxmf body"),
+        ..Default::default()
+    };
+
+    assert!(handler.lock().await.filter_duplicate_packets(&original_packet).await);
+    handle_data(&original_packet, source_iface.address, handler.lock().await).await;
+    let forwarded = timeout(Duration::from_millis(200), recipient_iface.tx_channel.recv())
+        .await
+        .expect("data should be forwarded to recipient iface")
+        .expect("tx channel open");
+    assert_eq!(forwarded.tx_type, TxMessageType::Direct(recipient_iface.address));
+
+    let packet_hash = original_packet.hash();
+    let signature = recipient_destination.identity.sign(packet_hash.as_slice()).to_bytes();
+    let proof = Packet {
+        header: Header { packet_type: PacketType::Proof, ..Default::default() },
+        destination: AddressHash::new_from_hash(&packet_hash),
+        context: PacketContext::None,
+        data: PacketDataBuffer::new_from_slice(&signature),
+        ..Default::default()
+    };
+
+    handle_proof(proof, handler, recipient_iface.address).await;
+
+    let sent = timeout(Duration::from_millis(200), source_iface.tx_channel.recv())
+        .await
+        .expect("implicit destination proof should be forwarded back to packet source")
+        .expect("tx channel open");
+    assert_eq!(sent.tx_type, TxMessageType::Direct(source_iface.address));
+    assert_eq!(sent.packet.header.packet_type, PacketType::Proof);
+    assert_eq!(sent.packet.destination, AddressHash::new_from_hash(&packet_hash));
+    assert_eq!(sent.packet.data.as_slice(), signature.as_slice());
+}
+
+#[tokio::test]
 async fn handle_inbound_for_test_accepts_python_style_link_proof_with_none_context() {
     let local_identity = PrivateIdentity::new_from_rand(OsRng);
     let config = TransportConfig::new("test", &local_identity, true);
@@ -397,6 +517,10 @@ async fn routed_link_resource_proof_forwards_back_to_link_requester() {
     )
     .expect("link from request");
     let link_request_proof = inbound.prove();
+    assert!(matches!(
+        outbound_link.handle_packet(&link_request_proof, next_hop_iface),
+        LinkHandleResult::Activated
+    ));
 
     {
         let mut guard = handler.lock().await;
@@ -436,4 +560,59 @@ async fn routed_link_resource_proof_forwards_back_to_link_requester() {
     assert_eq!(sent.packet.destination, *outbound_link.id());
     assert_eq!(sent.packet.header.packet_type, PacketType::Proof);
     assert_eq!(sent.packet.context, PacketContext::ResourceProof);
+}
+
+#[tokio::test]
+async fn routed_link_packet_proof_forwards_back_to_link_requester() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let config = TransportConfig::new("test", &local_identity, true);
+    let transport = Transport::new(config);
+    let handler = transport.get_handler();
+    let mut requester_iface = transport.iface_manager.lock().await.new_channel(8);
+    let received_from = requester_iface.address;
+
+    let remote_identity = PrivateIdentity::new_from_rand(OsRng);
+    let remote_destination =
+        SingleInputDestination::new(remote_identity, DestinationName::new("lxmf", "delivery"));
+
+    let next_hop = AddressHash::new_from_slice(&[2u8; 16]);
+    let next_hop_iface = AddressHash::new_from_slice(&[3u8; 16]);
+
+    let (tx, _) = tokio::sync::broadcast::channel(4);
+    let mut outbound_link = Link::new(remote_destination.desc, tx.clone());
+    let request = outbound_link.request();
+    let mut inbound = Link::new_from_request(
+        &request,
+        remote_destination.sign_key().clone(),
+        remote_destination.desc,
+        tx,
+    )
+    .expect("link from request");
+    let link_request_proof = inbound.prove();
+
+    {
+        let mut guard = handler.lock().await;
+        guard.link_table.add(
+            &request,
+            request.destination,
+            received_from,
+            next_hop,
+            next_hop_iface,
+        );
+        assert!(guard.link_table.handle_proof(&link_request_proof).is_some());
+    }
+
+    let data_packet = outbound_link.data_packet(b"needs receipt proof").expect("data packet");
+    let packet_proof = inbound.prove_packet(&data_packet);
+
+    handle_proof(packet_proof, handler, next_hop_iface).await;
+
+    let sent = timeout(Duration::from_millis(200), requester_iface.tx_channel.recv())
+        .await
+        .expect("packet proof should be forwarded back to requester iface")
+        .expect("tx channel open");
+    assert_eq!(sent.tx_type, TxMessageType::Direct(received_from));
+    assert_eq!(sent.packet.destination, *outbound_link.id());
+    assert_eq!(sent.packet.header.packet_type, PacketType::Proof);
+    assert!(matches!(sent.packet.context, PacketContext::None | PacketContext::LinkProof));
 }

--- a/crates/libs/rns-transport/src/transport/tests_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/module_prelude.rs
@@ -129,9 +129,9 @@ async fn drop_duplicates() {
         destination,
         ..Default::default()
     };
-    let duplicate: Packet = data_packet;
+    let duplicate: Packet = data_packet.clone();
 
-    let mut different_packet = data_packet;
+    let mut different_packet = data_packet.clone();
     different_packet.data = PacketDataBuffer::new_from_slice(b"bar");
 
     assert!(handler.lock().await.filter_duplicate_packets(&data_packet).await);

--- a/crates/libs/rns-transport/src/transport/wire.rs
+++ b/crates/libs/rns-transport/src/transport/wire.rs
@@ -25,6 +25,21 @@ fn validate_destination_receipt_proof(
     Ok(Hash::new(hash))
 }
 
+fn validate_destination_receipt_signature(
+    identity: &Identity,
+    receipt_hash: &Hash,
+    signature_bytes: &[u8],
+) -> Result<Hash, RnsError> {
+    if signature_bytes.len() < SIGNATURE_LENGTH {
+        return Err(RnsError::PacketError);
+    }
+    let signature = Signature::from_slice(&signature_bytes[..SIGNATURE_LENGTH])
+        .map_err(|_| RnsError::CryptoError)?;
+    identity.verify(receipt_hash.as_slice(), &signature)?;
+
+    Ok(*receipt_hash)
+}
+
 pub(super) async fn validated_receipt_hash(
     packet: &Packet,
     handler: &TransportHandler,
@@ -56,6 +71,39 @@ pub(super) async fn validated_receipt_hash(
             }
         }
         return None;
+    }
+
+    if packet.data.len() == SIGNATURE_LENGTH {
+        let proof_context = {
+            let packet_cache = handler.packet_cache.lock().await;
+            packet_cache.proof_context_for_destination(&packet.destination)
+        };
+        if let Some((receipt_hash, proved_destination, _)) = proof_context {
+            if let Some(destination) =
+                handler.single_out_destinations.get(&proved_destination).cloned()
+            {
+                let destination = destination.lock().await;
+                if let Ok(hash) = validate_destination_receipt_signature(
+                    &destination.identity,
+                    &receipt_hash,
+                    packet.data.as_slice(),
+                ) {
+                    return Some(hash.to_bytes());
+                }
+            }
+            if let Some(destination) =
+                handler.single_in_destinations.get(&proved_destination).cloned()
+            {
+                let destination = destination.lock().await;
+                if let Ok(hash) = validate_destination_receipt_signature(
+                    destination.identity.as_identity(),
+                    &receipt_hash,
+                    packet.data.as_slice(),
+                ) {
+                    return Some(hash.to_bytes());
+                }
+            }
+        }
     }
 
     if let Some(destination) = handler.single_out_destinations.get(&packet.destination).cloned() {
@@ -173,6 +221,40 @@ pub(super) async fn handle_proof(
 
     let mut handler = handler.lock().await;
 
+    if packet.header.destination_type != DestinationType::Link {
+        let source_iface = {
+            let packet_cache = handler.packet_cache.lock().await;
+            if packet.data.len() == SIGNATURE_LENGTH {
+                packet_cache
+                    .source_iface_for_proof_destination(&packet.destination)
+                    .map(|(_, source_iface)| source_iface)
+            } else if packet.data.len() >= HASH_SIZE {
+                let mut proof_hash = [0u8; HASH_SIZE];
+                proof_hash.copy_from_slice(&packet.data.as_slice()[..HASH_SIZE]);
+                packet_cache.source_iface_for_hash(&Hash::new(proof_hash))
+            } else {
+                None
+            }
+        };
+        if let Some(source_iface) = source_iface {
+            if source_iface != iface {
+                if diag::enabled() {
+                    log::debug!(
+                        "[tp-diag] destination_proof_reverse_forward node={} proof_dst={} source_iface={} ingress_iface={}",
+                        handler.config.name,
+                        packet.destination,
+                        source_iface,
+                        iface
+                    );
+                }
+                handler
+                    .send(TxMessage { tx_type: TxMessageType::Direct(source_iface), packet })
+                    .await;
+                return;
+            }
+        }
+    }
+
     let mut rtt_messages = Vec::new();
     for link in handler.out_links.values() {
         let mut link = link.lock().await;
@@ -268,6 +350,7 @@ pub(super) async fn handle_data<'a>(
     iface: AddressHash,
     mut handler: MutexGuard<'a, TransportHandler>,
 ) {
+    handler.packet_cache.lock().await.note_source(packet, iface);
     let mut data_handled = false;
 
     if packet.header.destination_type == DestinationType::Link {

--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -14,7 +14,7 @@
     {
       "path": "docs/contracts/baselines/schema-client-generation-baseline.json",
       "bytes": 373,
-      "sha256": "100d2c1e16cfc53e7d889ffa05f2b172ac863cf45a98912ffa251805237f1ddd"
+      "sha256": "e966db1c4a77d568bbb6a46c7f12f73caa024d76cf277b03d34117ea657c298b"
     },
     {
       "path": "docs/contracts/ble-camera-wire-v1.md",

--- a/docs/contracts/baselines/schema-client-generation-baseline.json
+++ b/docs/contracts/baselines/schema-client-generation-baseline.json
@@ -2,8 +2,8 @@
   "version": 1,
   "spec_hash": "9fecb139e1ef7686ebd7f33caca39fac42eea951aa44ae7af67bc0360f34f61f",
   "target_hashes": {
-    "go": "87863403fff9a1b0a52ea7f9e578be6c8dbea8c6de45c3d00eb6d568b2883c22",
-    "javascript": "74c758d9a439fcee5e70b3665b4161497f04dc17b7eb5672836fdf09bada4122",
-    "python": "52bc292d5ba171ca94aabdc5e54ba97726cdb5f057bc903426a09a2d3cb86279"
+    "go": "d4cd47819e1230c78e32664b2b677754e9020d224f0cfb711a442851f421817d",
+    "javascript": "a3f73ebb3de3ba7c759e6b9368d952c1e390de72bbbcfda921eba08a96964978",
+    "python": "bf51b5fb12e2e91ba38154eec470fcd59e6fa067326523e9c855b6132776e1c3"
   }
 }

--- a/xtask/src/main_parts/run_rust_python_impl_benchmark.rs
+++ b/xtask/src/main_parts/run_rust_python_impl_benchmark.rs
@@ -284,7 +284,7 @@ fn rust_active_link_pair() -> Result<(Link, Link, Vec<u8>)> {
 }
 
 fn rust_decrypt_resource_packet(link: &Link, packet: &Packet) -> Result<Packet> {
-    let mut plain_packet = *packet;
+    let mut plain_packet = packet.clone();
     let mut buffer = PacketDataBuffer::new();
     let plain_len = {
         let plaintext = link


### PR DESCRIPTION
## Summary
- Accept and reverse-forward Sideband/Python implicit destination proofs so phone-originated LXMF messages reach delivered instead of sender-side failed.
- Raise TCP client MTU and packet data capacity to match Reticulum TCP resource behavior, allowing large Sideband resource/image frames through instead of rejecting them at decode time.
- Preserve packet/resource proof correlation through sent handoff, add resource/proof regression coverage, and accept `destination_hash` aliases for propagation stamp-cost RPC lookups.

## HIL evidence so far
- Two Sideband phones were connected over ADB reverse to host `reticulumd`.
- Direct text ACK was verified both directions after the proof fix: Pixel -> POCO and POCO -> Pixel reached Delivered in Sideband.
- Daemon propagation announce advertises the active propagation hash `d4555d7a11368e3d0f568b013286c142` with stamp cost 8 / flexibility 3 / peering cost 8.
- Remaining live HIL blocker is phone-side propagation configuration/state: after daemon restart, both Sideband phones still report propagation stamp cost unavailable and issue path requests for stale propagation hash `4fa9359ec3ea68185d4dd03b23073244`. Both phones must be manually corrected/restarted to use `d4555d7a11368e3d0f568b013286c142` before final propagation/image retest.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p reticulum-rs-transport routed_ -- --nocapture`
- `cargo test -p reticulum-rs-transport deserialize_ -- --nocapture`
- `cargo test -p reticulum-rs-rpc outbound_propagation_cost_ -- --nocapture`
- `cargo test -p reticulum-rs-transport --lib`
- `cargo test -p reticulum-rs-rpc --lib`
- `cargo test -p reticulumd --lib`
- `cargo test -p reticulumd --test receipt_worker -- --nocapture`
- `cargo test -p reticulumd --test receipt_bridge -- --nocapture`
- `cargo check -p reticulumd --bin reticulumd`