### PR TITLE
Fix propagation stamp round encoding

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker_parts/inbound_propagation_payload_is_inges_sections/duplicate_direct_delivery_packet_doe.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker_parts/inbound_propagation_payload_is_inges_sections/duplicate_direct_delivery_packet_doe.rs
@@ -185,8 +185,7 @@
         for round in 0..PROPAGATION_STAMP_ROUNDS {
             let mut salt_data = Vec::with_capacity(transient_id.len() + 8);
             salt_data.extend_from_slice(transient_id.as_slice());
-            let packed =
-                rmp_serde::to_vec(&(round as u32)).expect("msgpack encode propagation stamp round");
+            let packed = rmp_serde::to_vec(&round).expect("msgpack encode propagation stamp round");
             salt_data.extend_from_slice(&packed);
             let salt_hash = Sha256::digest(&salt_data);
             let hk = Hkdf::<Sha256>::new(Some(salt_hash.as_slice()), transient_id.as_slice());

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/propagation_sync_state_name.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/propagation_sync_state_name.rs
@@ -277,8 +277,7 @@ pub(super) fn propagation_stamp_workblock(material: &[u8]) -> Vec<u8> {
     for round in 0..PROPAGATION_STAMP_WORKBLOCK_ROUNDS {
         let mut salt_data = Vec::with_capacity(material.len() + 8);
         salt_data.extend_from_slice(material);
-        let packed =
-            rmp_serde::to_vec(&(round as u32)).expect("msgpack encode propagation stamp round");
+        let packed = rmp_serde::to_vec(&round).expect("msgpack encode propagation stamp round");
         salt_data.extend_from_slice(&packed);
         let salt_hash = Sha256::digest(&salt_data);
         let hk = hkdf::Hkdf::<Sha256>::new(Some(salt_hash.as_slice()), material);

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_propagation_ingest_parts/propagation_destination_fetch_dedupl.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_propagation_ingest_parts/propagation_destination_fetch_dedupl.rs
@@ -32,6 +32,25 @@ fn propagation_destination_fetch_deduplicates_repeated_wanted_ids_like_python() 
 }
 
 #[test]
+fn propagation_ingest_accepts_reference_cost_16_stamp() {
+    use sha2::{Digest, Sha256};
+
+    let daemon = RpcDaemon::test_instance();
+    let destination = [0xa2_u8; 16];
+    let mut lxm_data = destination.to_vec();
+    lxm_data.extend(std::iter::repeat_n(0x42_u8, 180));
+    let transient_id = hex::encode(Sha256::digest(&lxm_data));
+    let payload = stamped_propagation_payload(&lxm_data, 16);
+
+    let result = daemon
+        .ingest_propagation_payload_bytes_at_cost(&payload, Some(&transient_id), 16)
+        .expect("cost-16 reference propagation stamp should ingest");
+
+    assert_eq!(result, transient_id);
+    assert!(daemon.has_propagation_payload(&result));
+}
+
+#[test]
 fn propagation_ingest_rejects_ignored_destination_before_queueing() {
     use sha2::{Digest, Sha256};
 
@@ -386,8 +405,7 @@ fn stamped_propagation_payload(lxm_data: &[u8], target_cost: u32) -> Vec<u8> {
     for round in 0..PROPAGATION_STAMP_ROUNDS {
         let mut salt_data = Vec::with_capacity(transient_id.len() + 8);
         salt_data.extend_from_slice(transient_id.as_slice());
-        let packed =
-            rmp_serde::to_vec(&(round as u32)).expect("msgpack encode propagation stamp round");
+        let packed = rmp_serde::to_vec(&round).expect("msgpack encode propagation stamp round");
         salt_data.extend_from_slice(&packed);
         let salt_hash = Sha256::digest(&salt_data);
         let hk = Hkdf::<Sha256>::new(Some(salt_hash.as_slice()), transient_id.as_slice());


### PR DESCRIPTION
## Summary
- align propagation stamp workblock round encoding with the Rust stamp generator/reference behavior
- update the duplicate local-propagation validation helper to use the same round encoding
- add a cost-16 propagation ingest regression that matches the Sideband/RCH HIL failure mode

## Live validation
- Deployed the patched current-source `reticulumd` on the RCH Pi with `--features zmq-pipeline-rpc`.
- Confirmed the service listens on TCP transport `0.0.0.0:4242`, RPC `127.0.0.1:4243`, and ZMQ command `127.0.0.1:9100`.
- Selected local propagation node `f9db6e71264d81c2bf74b2f96a0eb2e3` with cached stamp cost `16`.
- Sent daemon-originated propagated message `codex-propstamp-live-1781899490` to POCO; daemon trace reached:
  - `propagation using propagation stamp cost=16 source=cached_announce`
  - `propagation local propagation node selected`
  - `propagation propagation stored locally messages=1`
  - `receipt-update status=sent: propagated resource`
- The previous HIL failure `failed: invalid propagation stamp` did not recur.

## Test plan
- `cargo test -p reticulum-rs-rpc propagation_ingest_accepts_reference_cost_16_stamp -- --nocapture`
- `cargo test -p reticulumd self_selected_propagation_node_stores_locally_without_link_activation -- --nocapture`
- `cargo check -p reticulumd --bin reticulumd --features zmq-pipeline-rpc`