### PR TITLE
[codex] Improve issue 369 diagnostics and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ cargo run -p rns-tools --bin rnx -- e2e --timeout-secs 20
 - Payload contract: `docs/contracts/payload-contract.md`
 - Historical performance comparison report: `docs/PerformancesComparison.html`
 - reticulumd operational deployment: `docs/runbooks/reticulumd-operational-deployment.md`
+- Logging and diagnostics: `docs/runbooks/logging-and-diagnostics.md`
 - crates.io publish plan: `docs/runbooks/crates-io-publish-plan.md`
 - Release readiness: `docs/runbooks/release-readiness.md`
 

--- a/crates/apps/lxmf-cli/src/bin/lxmd/rpc_client.rs
+++ b/crates/apps/lxmf-cli/src/bin/lxmd/rpc_client.rs
@@ -131,7 +131,10 @@ fn http_status_code(response: &[u8]) -> Option<u16> {
     let header_end = response.windows(2).position(|window| window == b"\r\n")?;
     let status_line = match std::str::from_utf8(&response[..header_end]) {
         Ok(value) => value,
-        Err(_) => return None,
+        Err(err) => {
+            log::debug!("invalid UTF-8 in RPC HTTP status line: {err}");
+            return None;
+        }
     };
     let mut parts = status_line.split_whitespace();
     let _http = parts.next()?;

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_parts/deliverytask_sections/resolve_or_create_propagation_link.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_parts/deliverytask_sections/resolve_or_create_propagation_link.rs
@@ -17,10 +17,15 @@ impl DeliveryTask {
         let cached_identity = self
             .propagation_node_identity
             .or_else(|| {
-                self.outbound_propagation_identities
-                    .lock()
-                    .ok()
-                    .and_then(|guard| guard.get(propagation_node_hex).cloned())
+                match self.outbound_propagation_identities.lock() {
+                    Ok(guard) => guard.get(propagation_node_hex).cloned(),
+                    Err(err) => {
+                        log::warn!(
+                            "[daemon] failed to read propagation identity cache for {propagation_node_hex}: {err}"
+                        );
+                        None
+                    }
+                }
             })
             .or_else(|| {
                 resolve_destination_identity_blocking(

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_link_send.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_link_send.rs
@@ -45,11 +45,16 @@ pub(super) fn spawn_tracked_resource_cancel_monitor(monitor: ResourceCancelMonit
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         for _ in 0..(30 * 60 * 4) {
             interval.tick().await;
-            let still_tracked = monitor
-                .outbound_resource_map
-                .lock()
-                .ok()
-                .is_some_and(|guard| guard.contains_key(&resource_hash_hex));
+            let still_tracked = match monitor.outbound_resource_map.lock() {
+                Ok(guard) => guard.contains_key(&resource_hash_hex),
+                Err(err) => {
+                    log::warn!(
+                        "[daemon] failed to read outbound resource map for cancel monitor message_id={} hash={resource_hash_hex}: {err}",
+                        monitor.message_id
+                    );
+                    false
+                }
+            };
             if !still_tracked {
                 return;
             }

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_outbound.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_outbound.rs
@@ -76,11 +76,16 @@ impl OutboundBridge for TransportBridge {
         let propagation_node_hex = daemon.outbound_propagation_node();
         let propagation_node_identity = if requested_method == RequestedDeliveryMethod::Propagated {
             propagation_node_hex.as_deref().and_then(|node_hex| {
-                self.outbound_propagation_identities
-                    .lock()
-                    .ok()
-                    .and_then(|guard| guard.get(node_hex).cloned())
-                    .or_else(|| {
+                let cached = match self.outbound_propagation_identities.lock() {
+                    Ok(guard) => guard.get(node_hex).cloned(),
+                    Err(err) => {
+                        log::warn!(
+                            "[daemon] failed to read propagation identity cache for {node_hex}: {err}"
+                        );
+                        None
+                    }
+                };
+                cached.or_else(|| {
                         let hash = parse_destination_hash_required(node_hex).ok()?;
                         let hash = AddressHash::new(hash);
                         let identity = resolve_destination_identity_blocking(

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control.rs
@@ -214,12 +214,14 @@ impl RemoteControlBridge for TransportBridge {
             ]),
         )?;
         let payloads = rmpv_binary_array(&fetched)?;
-        let daemon = self
-            .daemon
-            .lock()
-            .ok()
-            .and_then(|guard| guard.clone())
-            .ok_or_else(|| std::io::Error::other("daemon unavailable"))?;
+        let daemon = match self.daemon.lock() {
+            Ok(guard) => guard.clone(),
+            Err(err) => {
+                log::warn!("[daemon-control] failed to read daemon for remote fetch: {err}");
+                None
+            }
+        }
+        .ok_or_else(|| std::io::Error::other("daemon unavailable"))?;
 
         let mut imported_count = 0usize;
         let mut duplicate_count = 0usize;
@@ -296,12 +298,14 @@ impl RemoteControlBridge for TransportBridge {
         let timeout = Duration::from_secs_f64(timeout_secs.max(0.1));
         let transport = self.transport.clone();
         let identity_cache = self.outbound_propagation_identities.clone();
-        let daemon = self
-            .daemon
-            .lock()
-            .ok()
-            .and_then(|guard| guard.clone())
-            .ok_or_else(|| std::io::Error::other("rpc daemon unavailable"))?;
+        let daemon = match self.daemon.lock() {
+            Ok(guard) => guard.clone(),
+            Err(err) => {
+                log::warn!("[daemon-control] failed to read daemon for remote download: {err}");
+                None
+            }
+        }
+        .ok_or_else(|| std::io::Error::other("rpc daemon unavailable"))?;
         let delivery_destination = self.announce_destination.clone();
 
         std::thread::spawn(move || {

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_link.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_link.rs
@@ -253,6 +253,15 @@ pub(super) async fn wait_for_link_request_response_with_terminal_policy(
                                     ));
                                 }
                             }
+                            rns_transport::resource::ResourceEventKind::InboundFailed(failure) => {
+                                if fail_on_terminal_resource_events {
+                                    let msg = format!(
+                                        "propagation control inbound resource transfer failed: {}",
+                                        failure.reason
+                                    );
+                                    return Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, msg));
+                                }
+                            }
                             rns_transport::resource::ResourceEventKind::OutboundComplete
                             | rns_transport::resource::ResourceEventKind::Progress(_) => {}
                         }
@@ -336,165 +345,5 @@ fn value_to_bytes(value: &rmpv::Value) -> Option<Vec<u8>> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use rns_transport::hash::Hash;
-    use rns_transport::packet::PacketDataBuffer;
-    use rns_transport::resource::{ResourceEvent, ResourceEventKind};
-    use rns_transport::transport::{ReceivedData, ReceivedPayloadMode};
-
-    #[test]
-    fn build_link_request_payload_encodes_peer_sync_data_as_msgpack_binary() {
-        let peer_hash = vec![0xab; 16];
-        let payload =
-            build_link_request_payload("/pn/peer/sync", rmpv::Value::Binary(peer_hash.clone()))
-                .expect("encode peer sync request");
-
-        assert_eq!(payload.first(), Some(&0x93), "request frame must be a 3-item array");
-        assert_eq!(
-            payload.get(10..12),
-            Some(&[0xc4, 0x10][..]),
-            "path hash must be MessagePack bin8 bytes"
-        );
-        assert_eq!(
-            payload.get(28..30),
-            Some(&[0xc4, 0x10][..]),
-            "peer sync data must be MessagePack bin8 bytes for Python LXMF"
-        );
-        assert_eq!(payload.get(30..46), Some(peer_hash.as_slice()));
-    }
-
-    async fn resource_terminal_error(kind: ResourceEventKind) -> std::io::Error {
-        let (_data_tx, mut data_rx) = tokio::sync::broadcast::channel(4);
-        let (resource_tx, mut resource_rx) = tokio::sync::broadcast::channel(4);
-        let destination = AddressHash::new([0x11; 16]);
-        let link_id = AddressHash::new([0x22; 16]);
-        let request_id = [0x33; 16];
-
-        resource_tx
-            .send(ResourceEvent {
-                hash: Hash::new_from_slice(b"terminal propagation control resource"),
-                link_id,
-                kind,
-            })
-            .expect("send terminal resource event");
-
-        wait_for_link_request_response_with_terminal_policy(
-            &mut data_rx,
-            &mut resource_rx,
-            destination,
-            link_id,
-            request_id,
-            true,
-            Duration::from_millis(50),
-        )
-        .await
-        .expect_err("terminal resource event should fail immediately")
-    }
-
-    #[tokio::test]
-    async fn wait_for_link_request_response_fails_on_resource_failure() {
-        let err = resource_terminal_error(ResourceEventKind::OutboundFailed).await;
-
-        assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
-        assert_eq!(err.to_string(), "propagation control resource transfer failed");
-    }
-
-    #[tokio::test]
-    async fn wait_for_link_request_response_fails_on_resource_cancel() {
-        let err = resource_terminal_error(ResourceEventKind::OutboundCancelled).await;
-
-        assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
-        assert_eq!(err.to_string(), "propagation control resource transfer cancelled");
-    }
-
-    #[tokio::test]
-    async fn wait_for_link_request_response_ignores_terminal_resource_without_policy() {
-        let (data_tx, mut data_rx) = tokio::sync::broadcast::channel(4);
-        let (resource_tx, mut resource_rx) = tokio::sync::broadcast::channel(4);
-        let destination = AddressHash::new([0x11; 16]);
-        let link_id = AddressHash::new([0x22; 16]);
-        let stale_request_id = [0x33; 16];
-        let request_id = [0x44; 16];
-        let response_payload = rmpv::Value::Array(vec![
-            rmpv::Value::Binary(request_id.to_vec()),
-            rmpv::Value::String("ok".into()),
-        ]);
-        let response_frame = rmp_serde::to_vec(&response_payload).expect("encode response frame");
-
-        resource_tx
-            .send(ResourceEvent {
-                hash: Hash::new_from_slice(b"stale propagation control resource"),
-                link_id,
-                kind: ResourceEventKind::OutboundFailed,
-            })
-            .expect("send stale terminal resource event");
-        assert!(data_tx
-            .send(ReceivedData {
-                destination: link_id,
-                data: PacketDataBuffer::new_from_slice(&response_frame),
-                payload_mode: ReceivedPayloadMode::FullWire,
-                ratchet_used: false,
-                context: Some(PacketContext::None),
-                request_id: None,
-                hops: None,
-                interface: None,
-            })
-            .is_ok());
-
-        let response = wait_for_link_request_response_with_terminal_policy(
-            &mut data_rx,
-            &mut resource_rx,
-            destination,
-            link_id,
-            request_id,
-            false,
-            Duration::from_millis(50),
-        )
-        .await
-        .expect("stale terminal event should not fail the current request");
-
-        assert_eq!(response.as_str(), Some("ok"));
-        assert_ne!(stale_request_id, request_id);
-    }
-
-    #[tokio::test]
-    async fn wait_for_link_request_response_fails_on_link_close_signal() {
-        let (data_tx, mut data_rx) = tokio::sync::broadcast::channel(4);
-        let (_resource_tx, mut resource_rx) = tokio::sync::broadcast::channel::<ResourceEvent>(4);
-        let expected_destination = AddressHash::new_from_slice(&[0x11; 16]);
-        let expected_link_id = AddressHash::new_from_slice(&[0x22; 16]);
-        let request_id = [0x33; 16];
-        let signal_payload = rmp_serde::to_vec(&vec![0xf1u8]).expect("signal msgpack");
-
-        assert!(
-            data_tx
-                .send(ReceivedData {
-                    destination: expected_link_id,
-                    data: PacketDataBuffer::new_from_slice(&signal_payload),
-                    payload_mode: ReceivedPayloadMode::FullWire,
-                    ratchet_used: false,
-                    context: Some(PacketContext::LinkClose),
-                    request_id: None,
-                    hops: None,
-                    interface: None,
-                })
-                .is_ok(),
-            "send link-close signal"
-        );
-
-        let err = wait_for_link_request_response(
-            &mut data_rx,
-            &mut resource_rx,
-            expected_destination,
-            expected_link_id,
-            request_id,
-            Duration::from_secs(10),
-        )
-        .await
-        .expect_err("link-close signal should fail the active request");
-
-        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
-        assert!(err.to_string().contains("propagation node denied access"));
-    }
-}
+#[path = "bridge_remote_control_link_tests.rs"]
+mod tests;

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_link_tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_remote_control_link_tests.rs
@@ -1,0 +1,160 @@
+use super::*;
+use rns_transport::hash::Hash;
+use rns_transport::packet::PacketDataBuffer;
+use rns_transport::resource::{ResourceEvent, ResourceEventKind};
+use rns_transport::transport::{ReceivedData, ReceivedPayloadMode};
+
+#[test]
+fn build_link_request_payload_encodes_peer_sync_data_as_msgpack_binary() {
+    let peer_hash = vec![0xab; 16];
+    let payload =
+        build_link_request_payload("/pn/peer/sync", rmpv::Value::Binary(peer_hash.clone()))
+            .expect("encode peer sync request");
+
+    assert_eq!(payload.first(), Some(&0x93), "request frame must be a 3-item array");
+    assert_eq!(
+        payload.get(10..12),
+        Some(&[0xc4, 0x10][..]),
+        "path hash must be MessagePack bin8 bytes"
+    );
+    assert_eq!(
+        payload.get(28..30),
+        Some(&[0xc4, 0x10][..]),
+        "peer sync data must be MessagePack bin8 bytes for Python LXMF"
+    );
+    assert_eq!(payload.get(30..46), Some(peer_hash.as_slice()));
+}
+
+async fn resource_terminal_error(kind: ResourceEventKind) -> std::io::Error {
+    let (_data_tx, mut data_rx) = tokio::sync::broadcast::channel(4);
+    let (resource_tx, mut resource_rx) = tokio::sync::broadcast::channel(4);
+    let destination = AddressHash::new([0x11; 16]);
+    let link_id = AddressHash::new([0x22; 16]);
+    let request_id = [0x33; 16];
+
+    resource_tx
+        .send(ResourceEvent {
+            hash: Hash::new_from_slice(b"terminal propagation control resource"),
+            link_id,
+            kind,
+        })
+        .expect("send terminal resource event");
+
+    wait_for_link_request_response_with_terminal_policy(
+        &mut data_rx,
+        &mut resource_rx,
+        destination,
+        link_id,
+        request_id,
+        true,
+        Duration::from_millis(50),
+    )
+    .await
+    .expect_err("terminal resource event should fail immediately")
+}
+
+#[tokio::test]
+async fn wait_for_link_request_response_fails_on_resource_failure() {
+    let err = resource_terminal_error(ResourceEventKind::OutboundFailed).await;
+
+    assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
+    assert_eq!(err.to_string(), "propagation control resource transfer failed");
+}
+
+#[tokio::test]
+async fn wait_for_link_request_response_fails_on_resource_cancel() {
+    let err = resource_terminal_error(ResourceEventKind::OutboundCancelled).await;
+
+    assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
+    assert_eq!(err.to_string(), "propagation control resource transfer cancelled");
+}
+
+#[tokio::test]
+async fn wait_for_link_request_response_ignores_terminal_resource_without_policy() {
+    let (data_tx, mut data_rx) = tokio::sync::broadcast::channel(4);
+    let (resource_tx, mut resource_rx) = tokio::sync::broadcast::channel(4);
+    let destination = AddressHash::new([0x11; 16]);
+    let link_id = AddressHash::new([0x22; 16]);
+    let stale_request_id = [0x33; 16];
+    let request_id = [0x44; 16];
+    let response_payload = rmpv::Value::Array(vec![
+        rmpv::Value::Binary(request_id.to_vec()),
+        rmpv::Value::String("ok".into()),
+    ]);
+    let response_frame = rmp_serde::to_vec(&response_payload).expect("encode response frame");
+
+    resource_tx
+        .send(ResourceEvent {
+            hash: Hash::new_from_slice(b"stale propagation control resource"),
+            link_id,
+            kind: ResourceEventKind::OutboundFailed,
+        })
+        .expect("send stale terminal resource event");
+    assert!(data_tx
+        .send(ReceivedData {
+            destination: link_id,
+            data: PacketDataBuffer::new_from_slice(&response_frame),
+            payload_mode: ReceivedPayloadMode::FullWire,
+            ratchet_used: false,
+            context: Some(PacketContext::None),
+            request_id: None,
+            hops: None,
+            interface: None,
+        })
+        .is_ok());
+
+    let response = wait_for_link_request_response_with_terminal_policy(
+        &mut data_rx,
+        &mut resource_rx,
+        destination,
+        link_id,
+        request_id,
+        false,
+        Duration::from_millis(50),
+    )
+    .await
+    .expect("stale terminal event should not fail the current request");
+
+    assert_eq!(response.as_str(), Some("ok"));
+    assert_ne!(stale_request_id, request_id);
+}
+
+#[tokio::test]
+async fn wait_for_link_request_response_fails_on_link_close_signal() {
+    let (data_tx, mut data_rx) = tokio::sync::broadcast::channel(4);
+    let (_resource_tx, mut resource_rx) = tokio::sync::broadcast::channel::<ResourceEvent>(4);
+    let expected_destination = AddressHash::new_from_slice(&[0x11; 16]);
+    let expected_link_id = AddressHash::new_from_slice(&[0x22; 16]);
+    let request_id = [0x33; 16];
+    let signal_payload = rmp_serde::to_vec(&vec![0xf1u8]).expect("signal msgpack");
+
+    assert!(
+        data_tx
+            .send(ReceivedData {
+                destination: expected_link_id,
+                data: PacketDataBuffer::new_from_slice(&signal_payload),
+                payload_mode: ReceivedPayloadMode::FullWire,
+                ratchet_used: false,
+                context: Some(PacketContext::LinkClose),
+                request_id: None,
+                hops: None,
+                interface: None,
+            })
+            .is_ok(),
+        "send link-close signal"
+    );
+
+    let err = wait_for_link_request_response(
+        &mut data_rx,
+        &mut resource_rx,
+        expected_destination,
+        expected_link_id,
+        request_id,
+        Duration::from_secs(10),
+    )
+    .await
+    .expect_err("link-close signal should fail the active request");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    assert!(err.to_string().contains("propagation node denied access"));
+}

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker_parts/module_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker_parts/module_core.rs
@@ -118,6 +118,16 @@ pub(super) fn spawn_inbound_worker(
                             resource_hash_hex.as_str(),
                         );
                     }
+                    ResourceEventKind::InboundFailed(failure) => {
+                        log::warn!(
+                            "[daemon-rx] inbound resource failed link={} hash={} reason={} received={}/{}",
+                            event.link_id,
+                            event.hash,
+                            failure.reason,
+                            failure.progress.received_parts,
+                            failure.progress.total_parts
+                        );
+                    }
                     ResourceEventKind::Progress(_) => {}
                 }
             }

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker_parts/module_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker_parts/module_core.rs
@@ -69,11 +69,17 @@ pub(super) fn spawn_inbound_worker(
                                         &event.link_id,
                                     )
                                     .await;
-                                    let peer_link_validated = resource_control
-                                        .validated_peer_links
-                                        .lock()
-                                        .ok()
-                                        .is_some_and(|guard| guard.contains(&event.link_id));
+                                    let peer_link_validated =
+                                        match resource_control.validated_peer_links.lock() {
+                                            Ok(guard) => guard.contains(&event.link_id),
+                                            Err(err) => {
+                                                log::warn!(
+                                                    "[daemon-rx] failed to read validated peer links for link={}: {err}",
+                                                    hex::encode(event.link_id.as_slice())
+                                                );
+                                                false
+                                            }
+                                        };
                                     if let Err(error) =
                                         propagation::ingest_propagation_resource_from_peer(
                                             daemon.as_ref(),

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_access_log.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_access_log.rs
@@ -1,5 +1,5 @@
 use rns_rpc::rpc::codec;
-use rns_rpc::{http, RpcRequest};
+use rns_rpc::{http, RpcRequest, RpcResponse};
 use serde_json::json;
 use std::io::IsTerminal;
 use std::net::SocketAddr;
@@ -61,6 +61,10 @@ pub(super) fn emit_rpc_access_log(
     error_text: Option<&str>,
 ) {
     let status_code = parse_status_code(response).unwrap_or(0);
+    let rpc_error = parse_rpc_response_error(response);
+    let effective_error = error_text
+        .map(str::to_string)
+        .or_else(|| rpc_error.as_ref().map(|(_, message)| message.clone()));
     if pretty_console_logs_enabled() {
         log::info!(
             "{} {} {} {} {}{}{}",
@@ -73,10 +77,15 @@ pub(super) fn emit_rpc_access_log(
                 .as_ref()
                 .map(|method| format!(" {}", pretty_secondary(&format!("rpc={method}"))))
                 .unwrap_or_default(),
-            error_text.map(|error| format!(" {}", pretty_error(error))).unwrap_or_default()
+            effective_error
+                .as_deref()
+                .map(|error| format!(" {}", pretty_error(error)))
+                .unwrap_or_default()
         );
         return;
     }
+    let (rpc_error_code, rpc_error_message) =
+        rpc_error.map_or((None, None), |(code, message)| (Some(code), Some(message)));
     let payload = json!({
         "event": "rpc_request",
         "peer": peer_addr.to_string(),
@@ -86,9 +95,11 @@ pub(super) fn emit_rpc_access_log(
         "rpc_request_id": meta.rpc_request_id,
         "trace_ref": meta.trace_ref,
         "status_code": status_code,
+        "rpc_error_code": rpc_error_code,
+        "rpc_error_message": rpc_error_message,
         "elapsed_ms": elapsed_ms,
-        "ok": error_text.is_none(),
-        "error": error_text,
+        "ok": (200..=299).contains(&status_code) && effective_error.is_none(),
+        "error": effective_error,
     });
     log::info!("{}", payload);
 }
@@ -109,6 +120,23 @@ fn parse_status_code(response: &[u8]) -> Option<u16> {
     let _http_version = parts.next()?;
     let code = parts.next()?;
     code.parse::<u16>().ok()
+}
+
+fn parse_rpc_response_error(response: &[u8]) -> Option<(String, String)> {
+    let header_end = http::find_header_end(response)?;
+    let headers = &response[..header_end];
+    let content_length = http::parse_content_length(headers)?;
+    if content_length > codec::MAX_FRAME_PAYLOAD_LEN + 4 {
+        return None;
+    }
+    let body_start = header_end.checked_add(4)?;
+    let body_end = body_start.checked_add(content_length)?;
+    if response.len() < body_end {
+        return None;
+    }
+    let rpc_response = codec::decode_frame::<RpcResponse>(&response[body_start..body_end]).ok()?;
+    let error = rpc_response.error?;
+    Some((error.code, error.message))
 }
 
 fn decode_utf8<'a>(data: &'a [u8], context: &str) -> Option<&'a str> {
@@ -258,5 +286,23 @@ mod tests {
     fn parse_status_code_extracts_numeric_status() {
         let response = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
         assert_eq!(parse_status_code(response), Some(200));
+    }
+
+    #[test]
+    fn parse_rpc_response_error_extracts_json_rpc_error_from_http_ok() {
+        let rpc_body = codec::encode_frame(&RpcResponse {
+            id: 44,
+            result: None,
+            error: Some(rns_rpc::RpcError::new("SDK_INTERNAL", "boom")),
+        })
+        .expect("encode rpc body");
+        let response = format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n", rpc_body.len());
+        let mut raw = response.into_bytes();
+        raw.extend_from_slice(&rpc_body);
+
+        assert_eq!(
+            parse_rpc_response_error(&raw),
+            Some(("SDK_INTERNAL".to_string(), "boom".to_string()))
+        );
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
@@ -120,13 +120,30 @@ fn handle_zmq_command_message(
 ) -> Option<ZmqOutboundResponse> {
     let bytes = match Vec::<u8>::try_from(message) {
         Ok(bytes) => bytes,
-        Err(_) => return None,
+        Err(err) => {
+            log::warn!(
+                "[daemon] zmq rpc command rejected reason=message_conversion_failed err={err}"
+            );
+            return None;
+        }
     };
     let envelope = match zmq::decode_envelope(&bytes) {
         Ok(envelope) => envelope,
-        Err(_) => return None,
+        Err(err) => {
+            log::warn!("[daemon] zmq rpc command rejected reason=envelope_decode_failed err={err}");
+            return None;
+        }
     };
-    let response_endpoint = envelope.response_endpoint.clone()?;
+    let response_endpoint = match envelope.response_endpoint.clone() {
+        Some(endpoint) => endpoint,
+        None => {
+            log::warn!(
+                "[daemon] zmq rpc command rejected request_id={} reason=missing_response_endpoint",
+                envelope.request_id
+            );
+            return None;
+        }
+    };
     let response_endpoint_is_local = is_local_zmq_endpoint(response_endpoint.as_str());
     if let Err(error) = authorize_zmq_envelope(
         daemon,
@@ -140,6 +157,11 @@ fn handle_zmq_command_message(
                 envelope: rpc_error_envelope(envelope.session_id, envelope.request_id, error),
             });
         }
+        log::warn!(
+            "[daemon] zmq rpc command rejected request_id={} code={} reason=remote_response_auth_failed",
+            envelope.request_id,
+            error.code
+        );
         return None;
     }
     if envelope.kind != ZmqRpcEnvelopeKind::Request {

--- a/crates/apps/reticulumd/tests/code_quality_issue_369.rs
+++ b/crates/apps/reticulumd/tests/code_quality_issue_369.rs
@@ -11,6 +11,9 @@ fn production_code_does_not_silently_discard_issue_369_failures() {
         }
         let source = fs::read_to_string(path).expect("read Rust source");
         let display = path.strip_prefix(&root).unwrap_or(path).display();
+        for line_no in multiline_lock_ok_lines(&source) {
+            findings.push(format!("{display}:{line_no}: mutex lock poison is discarded"));
+        }
         for (line, text) in source.lines().enumerate() {
             let line_no = line + 1;
             if text.contains(".lock().ok()") {
@@ -62,6 +65,31 @@ fn production_code_does_not_silently_discard_issue_369_failures() {
         "issue #369 silent failure patterns remain:\n{}",
         findings.join("\n")
     );
+}
+
+fn multiline_lock_ok_lines(source: &str) -> Vec<usize> {
+    let mut findings = Vec::new();
+    let mut pending_lock_line = None;
+    for (index, text) in source.lines().enumerate() {
+        let line_no = index + 1;
+        if text.contains(".lock()") || text.contains(".try_lock()") {
+            if !text.contains(".expect(") && !text.contains(".ok()") {
+                pending_lock_line = Some(line_no);
+            }
+            continue;
+        }
+        if let Some(lock_line) = pending_lock_line {
+            if text.contains(".ok()") {
+                findings.push(lock_line);
+                pending_lock_line = None;
+                continue;
+            }
+            if text.contains(';') || text.contains(".expect(") || text.contains("match ") {
+                pending_lock_line = None;
+            }
+        }
+    }
+    findings
 }
 
 fn workspace_root() -> PathBuf {

--- a/crates/libs/rns-rpc/src/rpc/daemon/init_parts/rpcdaemon_sections/issue_ticket.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init_parts/rpcdaemon_sections/issue_ticket.rs
@@ -298,14 +298,16 @@ impl RpcDaemon {
         let stats = self.store.peer_message_stats(peer).map_err(std::io::Error::other)?;
         let propagation =
             self.store.peer_propagation_message_stats(peer).map_err(std::io::Error::other)?;
-        let (record_offered, record_outgoing, record_incoming) = self
-            .peers
-            .lock()
-            .ok()
-            .and_then(|guard| {
+        let (record_offered, record_outgoing, record_incoming) = match self.peers.lock() {
+            Ok(guard) => {
                 guard.get(peer).map(|record| (record.offered, record.outgoing, record.incoming))
-            })
-            .unwrap_or((0, 0, 0));
+            }
+            Err(err) => {
+                log::warn!("[rpc-daemon] failed to read peer message stats cache for {peer}: {err}");
+                None
+            }
+        }
+        .unwrap_or((0, 0, 0));
         Ok((
             stats.outgoing.saturating_add(record_outgoing.max(propagation.outgoing)),
             stats.incoming.saturating_add(record_incoming.max(propagation.incoming)),

--- a/crates/libs/rns-rpc/src/rpc/daemon/init_parts/rpcdaemon_sections/propagation_destination_cost.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init_parts/rpcdaemon_sections/propagation_destination_cost.rs
@@ -26,17 +26,19 @@ impl RpcDaemon {
         let Some(peer) = selected else {
             return (None, None, "unavailable");
         };
-        let cost = self
-            .peers
-            .lock()
-            .ok()
-            .and_then(|guard| {
+        let cost = match self.peers.lock() {
+            Ok(guard) => {
                 guard
                     .values()
                     .find(|record| record.peer.eq_ignore_ascii_case(peer.as_str()))
                     .and_then(|record| record.propagation_stamp_cost)
-            })
-            .or_else(|| self.store.latest_announce_stamp_cost_for(peer.as_str()).ok().flatten());
+            }
+            Err(err) => {
+                log::warn!("[rpc-daemon] failed to read peer cost cache for {peer}: {err}");
+                None
+            }
+        }
+        .or_else(|| self.store.latest_announce_stamp_cost_for(peer.as_str()).ok().flatten());
         let source = if cost.is_some() { "cached_announce" } else { "unavailable" };
         (Some(peer), cost, source)
     }

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_capabilities.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_capabilities.rs
@@ -76,7 +76,8 @@ impl RpcDaemon {
     }
 
     pub(super) fn token_signature(secret: &str, payload: &str) -> Option<String> {
-        let mut mac = hmac::Hmac::<sha2::Sha256>::new_from_slice(secret.as_bytes()).ok()?;
+        let mut mac = hmac::Hmac::<sha2::Sha256>::new_from_slice(secret.as_bytes())
+            .expect("HMAC key length is valid for HMAC-SHA256");
         mac.update(payload.as_bytes());
         Some(hex::encode(mac.finalize().into_bytes()))
     }

--- a/crates/libs/rns-rpc/src/rpc/helpers_parts/merge_fields_with_options.rs
+++ b/crates/libs/rns-rpc/src/rpc/helpers_parts/merge_fields_with_options.rs
@@ -148,7 +148,10 @@ fn parse_capabilities_from_app_data_hex(app_data_hex: Option<&str>) -> Vec<Strin
 fn parse_rch_capabilities_from_lxmf_announce(app_data: &[u8]) -> Option<Vec<String>> {
     let value = match rmp_serde::from_slice::<MsgPackValue>(app_data) {
         Ok(value) => value,
-        Err(_) => return None,
+        Err(err) => {
+            log::debug!("failed to decode LXMF announce app_data for capabilities: {err}");
+            return None;
+        }
     };
     let entries = value.as_array()?;
     let capability_payload = match entries.get(2) {
@@ -428,7 +431,10 @@ fn parse_propagation_timebase_from_app_data_hex(app_data_hex: Option<&str>) -> O
     let app_data = hex::decode(raw_hex).ok()?;
     let value = match rmp_serde::from_slice::<MsgPackValue>(&app_data) {
         Ok(value) => value,
-        Err(_) => return None,
+        Err(err) => {
+            log::debug!("failed to decode propagation app_data for timebase: {err}");
+            return None;
+        }
     };
     let entries = value.as_array()?;
     entries.get(1).and_then(parse_fuzzy_i64)
@@ -439,7 +445,10 @@ fn parse_propagation_enabled_from_app_data_hex(app_data_hex: Option<&str>) -> Op
     let app_data = hex::decode(raw_hex).ok()?;
     let value = match rmp_serde::from_slice::<MsgPackValue>(&app_data) {
         Ok(value) => value,
-        Err(_) => return None,
+        Err(err) => {
+            log::debug!("failed to decode propagation app_data for enabled flag: {err}");
+            return None;
+        }
     };
     let entries = value.as_array()?;
     if entries.len() < 6 {
@@ -469,7 +478,10 @@ fn parse_peer_name_from_app_data_hex(app_data_hex: Option<&str>) -> Option<(Stri
     let app_data = hex::decode(raw_hex).ok()?;
     let value = match rmp_serde::from_slice::<MsgPackValue>(&app_data) {
         Ok(value) => value,
-        Err(_) => return None,
+        Err(err) => {
+            log::debug!("failed to decode app_data for peer name: {err}");
+            return None;
+        }
     };
     let entries = value.as_array()?;
 
@@ -481,8 +493,8 @@ fn parse_peer_name_from_app_data_hex(app_data_hex: Option<&str>) -> Option<(Stri
     }
     None
 }
-
 fn decode_utf8_field(bytes: &[u8]) -> Option<&str> {
-    let decoded = std::str::from_utf8(bytes);
+    let decoded = std::str::from_utf8(bytes)
+        .inspect_err(|err| log::debug!("invalid UTF-8 in app_data field: {err}"));
     decoded.ok()
 }

--- a/crates/libs/rns-rpc/src/rpc/helpers_parts/pn_metadata_to_json.rs
+++ b/crates/libs/rns-rpc/src/rpc/helpers_parts/pn_metadata_to_json.rs
@@ -88,7 +88,10 @@ fn parse_delivery_stamp_cost_from_app_data_hex(app_data_hex: Option<&str>) -> Op
     let app_data = hex::decode(raw_hex).ok()?;
     let value = match rmp_serde::from_slice::<MsgPackValue>(&app_data) {
         Ok(value) => value,
-        Err(_) => return None,
+        Err(err) => {
+            log::debug!("failed to decode delivery app_data for stamp cost: {err}");
+            return None;
+        }
     };
     let entries = value.as_array()?;
     entries.get(1).and_then(parse_fuzzy_u32).filter(|cost| (1..255).contains(cost))

--- a/crates/libs/rns-transport/src/ratchets.rs
+++ b/crates/libs/rns-transport/src/ratchets.rs
@@ -68,9 +68,15 @@ impl RatchetStore {
             self.remove_record(destination);
             return None;
         }
-        let ratchet = record.ratchet.as_ref().try_into().ok();
+        let ratchet = match ratchet_bytes(destination, &record) {
+            Some(ratchet) => ratchet,
+            None => {
+                self.remove_record(destination);
+                return None;
+            }
+        };
         self.cache.insert(*destination, record);
-        ratchet
+        Some(ratchet)
     }
 
     pub(crate) fn clean_expired(&mut self, now: f64) {
@@ -132,6 +138,24 @@ impl RatchetStore {
 
     fn path_for(&self, destination: &AddressHash) -> PathBuf {
         self.ratchet_dir.join(destination.to_hex_string())
+    }
+}
+
+fn ratchet_bytes(
+    destination: &AddressHash,
+    record: &RatchetRecord,
+) -> Option<[u8; PUBLIC_KEY_LENGTH]> {
+    match record.ratchet.as_ref().try_into() {
+        Ok(ratchet) => Some(ratchet),
+        Err(_) => {
+            log::warn!(
+                "invalid ratchet length destination={} len={} expected={}",
+                destination,
+                record.ratchet.as_ref().len(),
+                PUBLIC_KEY_LENGTH
+            );
+            None
+        }
     }
 }
 
@@ -254,5 +278,20 @@ mod tests {
         fs::write(temp.path().join(dest.to_hex_string()), encoded).expect("write");
         let ratchet = store.get(&dest);
         assert!(ratchet.is_none(), "expired ratchet should be ignored");
+    }
+
+    #[test]
+    fn ratchet_store_removes_malformed_length_without_caching() {
+        let temp = TempDir::new().expect("temp dir");
+        let mut store = RatchetStore::new(temp.path().to_path_buf());
+        let dest = AddressHash::new_from_rand(rand_core::OsRng);
+        let path = temp.path().join(dest.to_hex_string());
+        let record = RatchetRecord { ratchet: ByteBuf::from(vec![2u8; 3]), received: now_secs() };
+        let encoded = rmp_serde::to_vec_named(&record).expect("encode");
+        fs::write(&path, encoded).expect("write malformed ratchet");
+
+        assert!(store.get(&dest).is_none());
+        assert!(!store.cache.contains_key(&dest));
+        assert!(!path.exists(), "malformed ratchet file should be removed");
     }
 }

--- a/crates/libs/rns-transport/src/resource.rs
+++ b/crates/libs/rns-transport/src/resource.rs
@@ -156,10 +156,18 @@ pub struct ResourceEvent {
     pub kind: ResourceEventKind,
 }
 
+/// Resource transfer event emitted by `ResourceManager`.
+///
+/// Downstream consumers should include a catch-all match arm. New terminal
+/// variants may be added when previously silent failure classes become
+/// operator-visible.
 #[derive(Debug, Clone)]
 pub enum ResourceEventKind {
     Progress(ResourceProgress),
     Complete(ResourceComplete),
+    /// Inbound transfer failed before completion. This variant was added for
+    /// issue #369 diagnostics and is an intentional public event surface change.
+    InboundFailed(ResourceFailure),
     OutboundComplete,
     OutboundFailed,
     OutboundCancelled,
@@ -171,6 +179,12 @@ pub struct ResourceProgress {
     pub total_bytes: u64,
     pub received_parts: usize,
     pub total_parts: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResourceFailure {
+    pub reason: String,
+    pub progress: ResourceProgress,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/libs/rns-transport/src/resource/manager.rs
+++ b/crates/libs/rns-transport/src/resource/manager.rs
@@ -92,11 +92,20 @@ impl ResourceManager {
                 }
             }
             if receiver.retry_count >= self.retry_limit {
-                failed.push(*hash);
+                failed.push((*hash, receiver.link_id, receiver.progress()));
             }
         }
-        for hash in failed {
+        for (hash, link_id, progress) in failed {
+            log::warn!("resource transfer failed link={link_id} hash={hash} reason=retry_limit_exhausted");
             self.incoming.remove(&hash);
+            self.events.push(ResourceEvent {
+                hash,
+                link_id,
+                kind: ResourceEventKind::InboundFailed(ResourceFailure {
+                    reason: "retry_limit_exhausted".to_string(),
+                    progress,
+                }),
+            });
         }
         requests
     }
@@ -308,13 +317,13 @@ impl ResourceManager {
         let mut proof_packet: Option<Packet> = None;
         let mut request_packet: Option<Packet> = None;
         let mut payload: Option<ResourcePayload> = None;
-        let mut failed: Option<Hash> = None;
+        let mut failed: Option<(Hash, AddressHash, ResourceProgress, &'static str)> = None;
         for (hash, receiver) in self.incoming.iter_mut() {
             let before_received = receiver.received;
             match receiver.handle_part(packet.data.as_slice(), link) {
                 PartOutcome::NoMatch => continue,
-                PartOutcome::Failed => {
-                    failed = Some(*hash);
+                PartOutcome::Failed(reason) => {
+                    failed = Some((*hash, receiver.link_id, receiver.progress(), reason));
                     break;
                 }
                 PartOutcome::Complete(packet, data_payload) => {
@@ -378,8 +387,17 @@ impl ResourceManager {
                 }
             }
         }
-        if let Some(hash) = failed {
+        if let Some((hash, link_id, progress, reason)) = failed {
+            log::warn!("resource transfer failed link={link_id} hash={hash} reason={reason}");
             self.incoming.remove(&hash);
+            self.events.push(ResourceEvent {
+                hash,
+                link_id,
+                kind: ResourceEventKind::InboundFailed(ResourceFailure {
+                    reason: reason.to_string(),
+                    progress,
+                }),
+            });
             // Reset so the inter-resource gap doesn't skew the arrival EWMA.
             // TODO: a better approach is to schedule a delayed reset — wait
             // arrival_interval * 2, and only reset if no new part has arrived by

--- a/crates/libs/rns-transport/src/resource/receiver.rs
+++ b/crates/libs/rns-transport/src/resource/receiver.rs
@@ -44,7 +44,7 @@ struct ResourcePayload {
 enum PartOutcome {
     NoMatch,
     Incomplete,
-    Failed,
+    Failed(&'static str),
     Complete(Packet, ResourcePayload),
 }
 
@@ -189,8 +189,7 @@ impl ResourceReceiver {
 
     fn handle_part(&mut self, part: &[u8], link: &Link) -> PartOutcome {
         if self.split {
-            self.status = ResourceStatus::Failed;
-            return PartOutcome::Failed;
+            return self.fail("split_resource_unsupported");
         }
 
         let hash = map_hash(part, &self.random_hash);
@@ -226,8 +225,7 @@ impl ResourceReceiver {
                 let decrypted = match link.decrypt(&stream, &mut out) {
                     Ok(value) => value,
                     Err(_) => {
-                        self.status = ResourceStatus::Failed;
-                        return PartOutcome::Failed;
+                        return self.fail("decrypt_failed");
                     }
                 };
                 decrypted.to_vec()
@@ -249,13 +247,11 @@ impl ResourceReceiver {
                 ) {
                     Ok(decompressed) => decompressed,
                     Err(()) => {
-                        self.status = ResourceStatus::Failed;
-                        return PartOutcome::Failed;
+                        return self.fail("decompress_failed");
                     }
                 };
                 if decompressed.len() > max_decompressed_size {
-                    self.status = ResourceStatus::Failed;
-                    return PartOutcome::Failed;
+                    return self.fail("decompressed_size_exceeded");
                 }
                 payload = decompressed;
             }
@@ -265,8 +261,7 @@ impl ResourceReceiver {
                     | ((payload[1] as usize) << 8)
                     | payload[2] as usize;
                 if size > METADATA_MAX_SIZE {
-                    self.status = ResourceStatus::Failed;
-                    return PartOutcome::Failed;
+                    return self.fail("metadata_size_exceeded");
                 }
                 if payload.len() >= 3 + size {
                     let meta = payload[3..3 + size].to_vec();
@@ -285,8 +280,7 @@ impl ResourceReceiver {
             let computed = match copy_hash(&hasher.finalize()) {
                 Ok(hash) => Hash::new(hash),
                 Err(_) => {
-                    self.status = ResourceStatus::Failed;
-                    return PartOutcome::Failed;
+                    return self.fail("resource_hash_copy_failed");
                 }
             };
 
@@ -297,8 +291,7 @@ impl ResourceReceiver {
                 let proof = match copy_hash(&proof_hasher.finalize()) {
                     Ok(hash) => Hash::new(hash),
                     Err(_) => {
-                        self.status = ResourceStatus::Failed;
-                        return PartOutcome::Failed;
+                        return self.fail("proof_hash_copy_failed");
                     }
                 };
                 let proof_payload = ResourceProof { resource_hash: self.resource_hash, proof };
@@ -312,8 +305,7 @@ impl ResourceReceiver {
                     Ok(packet) => packet,
                     Err(_) => {
                         log::warn!("failed to build proof packet");
-                        self.status = ResourceStatus::Failed;
-                        return PartOutcome::Failed;
+                        return self.fail("proof_packet_build_failed");
                     }
                 };
                 return PartOutcome::Complete(
@@ -327,12 +319,16 @@ impl ResourceReceiver {
                     },
                 );
             } else {
-                self.status = ResourceStatus::Failed;
-                return PartOutcome::Failed;
+                return self.fail("resource_hash_mismatch");
             }
         }
 
         PartOutcome::Incomplete
+    }
+
+    fn fail(&mut self, reason: &'static str) -> PartOutcome {
+        self.status = ResourceStatus::Failed;
+        PartOutcome::Failed(reason)
     }
 
     fn is_active(&self) -> bool {

--- a/crates/libs/rns-transport/src/resource/tests.rs
+++ b/crates/libs/rns-transport/src/resource/tests.rs
@@ -315,6 +315,53 @@ mod tests {
         let responses = manager.handle_packet(&part_packet, &mut link);
         assert!(responses.is_empty());
         assert!(manager.incoming.is_empty());
+        let events = manager.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].hash, resource_hash);
+        assert_eq!(events[0].link_id, *link.id());
+        let ResourceEventKind::InboundFailed(failure) = &events[0].kind else {
+            panic!("expected inbound failure event");
+        };
+        assert_eq!(failure.reason, "decompress_failed");
+        assert_eq!(failure.progress.received_parts, 1);
+    }
+
+    #[test]
+    fn resource_receiver_reports_failure_reason() {
+        let signer = PrivateIdentity::new_from_rand(OsRng);
+        let identity = *signer.as_identity();
+        let destination = DestinationDesc {
+            identity,
+            address_hash: identity.address_hash,
+            name: DestinationName::new("lxmf", "resource"),
+        };
+        let (tx, _) = tokio::sync::broadcast::channel(1);
+        let mut link = Link::new(destination, tx);
+        link.request();
+
+        let part = b"not-bzip";
+        let random_hash = [5u8; RANDOM_HASH_SIZE];
+        let mut hashmap = Vec::with_capacity(MAPHASH_LEN);
+        hashmap.extend_from_slice(&map_hash(part, &random_hash));
+        let adv = ResourceAdvertisement {
+            transfer_size: part.len() as u64,
+            data_size: part.len() as u64,
+            parts: 1,
+            hash: Hash::new_from_slice(&[8u8; 32]),
+            random_hash,
+            original_hash: Hash::new_from_slice(&[8u8; 32]),
+            segment_index: 1,
+            total_segments: 1,
+            request_id: None,
+            flags: FLAG_COMPRESSED,
+            hashmap,
+        };
+        let mut receiver = ResourceReceiver::new(&adv, *link.id()).expect("resource receiver");
+
+        assert!(matches!(
+            receiver.handle_part(part, &link),
+            PartOutcome::Failed("decompress_failed")
+        ));
     }
 
     #[test]
@@ -371,6 +418,7 @@ mod tests {
     }
 
     include!("tests_mtu.rs");
+    include!("tests_retry_failures.rs");
     include!("tests_timeouts.rs");
     include!("tests_timeouts_lifecycle.rs");
 

--- a/crates/libs/rns-transport/src/resource/tests_retry_failures.rs
+++ b/crates/libs/rns-transport/src/resource/tests_retry_failures.rs
@@ -1,0 +1,52 @@
+#[test]
+fn resource_manager_emits_inbound_failed_when_retry_budget_exhausts() {
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination = DestinationDesc {
+        identity,
+        address_hash: identity.address_hash,
+        name: DestinationName::new("lxmf", "resource"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(1);
+    let mut link = Link::new(destination, tx);
+    link.request();
+
+    let part = b"never-arrives";
+    let random_hash = [0xAB; RANDOM_HASH_SIZE];
+    let mut hashmap = Vec::with_capacity(MAPHASH_LEN);
+    hashmap.extend_from_slice(&map_hash(part, &random_hash));
+    let resource_hash = Hash::new_from_slice(&[0xCC; 32]);
+    let adv = ResourceAdvertisement {
+        transfer_size: part.len() as u64,
+        data_size: part.len() as u64,
+        parts: 1,
+        hash: resource_hash,
+        random_hash,
+        original_hash: resource_hash,
+        segment_index: 1,
+        total_segments: 1,
+        request_id: None,
+        flags: 0,
+        hashmap,
+    };
+
+    let adv_packet = resource_packet(
+        PacketContext::ResourceAdvrtisement,
+        &adv.pack().expect("pack advertisement"),
+        *link.id(),
+    );
+    let mut manager = ResourceManager::new_with_config(Duration::from_secs(1), 1);
+    let _ = manager.handle_packet(&adv_packet, &mut link);
+
+    manager.retry_requests(Instant::now() + Duration::from_secs(2));
+
+    assert!(!manager.incoming.contains_key(&resource_hash));
+    let events = manager.drain_events();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].hash, resource_hash);
+    let ResourceEventKind::InboundFailed(failure) = &events[0].kind else {
+        panic!("expected inbound failure event");
+    };
+    assert_eq!(failure.reason, "retry_limit_exhausted");
+    assert_eq!(failure.progress.received_parts, 0);
+}

--- a/crates/libs/rns-transport/src/transport/core.rs
+++ b/crates/libs/rns-transport/src/transport/core.rs
@@ -297,8 +297,13 @@ impl Transport {
     }
 
     pub fn emit_receipt_for_test(&self, receipt: DeliveryReceipt) {
-        let receipt_handler =
-            self.handler.try_lock().ok().and_then(|handler| handler.receipt_handler.clone());
+        let receipt_handler = match self.handler.try_lock() {
+            Ok(handler) => handler.receipt_handler.clone(),
+            Err(err) => {
+                log::warn!("[transport] failed to read receipt handler for test receipt: {err}");
+                None
+            }
+        };
 
         if let Some(handler) = receipt_handler {
             handler.on_receipt(&receipt);

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,8 @@ are kept in Git history instead of the live documentation tree.
 - `docs/PerformancesComparison.html`: retained performance comparison snapshot;
   use the benchmarking runbook for current measurements
 - `docs/runbooks/release-readiness.md`: release gate checklist
+- `docs/runbooks/logging-and-diagnostics.md`: operator logging knobs and
+  contributor failure-visibility rules
 - `docs/release-notes-v0.5.0.md`: current project release notes
 - `docs/runbooks/reticulumd-operational-deployment.md`: daemon deployment,
   probes, shutdown, and service manager examples

--- a/docs/architecture/module-size-allowlist.txt
+++ b/docs/architecture/module-size-allowlist.txt
@@ -5,3 +5,5 @@ crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sect
 # Baseline SDK backend exceptions present before issue #369 cleanup; split backend state/tests.
 crates/libs/lxmf-sdk/src/backend/zmq_pipeline.rs
 crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/mod.rs
+# Baseline transport test helper exception present before issue #369 cleanup; split shared packet helpers.
+crates/libs/rns-transport/src/transport/tests_parts/encrypted_resource_control_packet.rs

--- a/docs/release-notes-v0.5.0.md
+++ b/docs/release-notes-v0.5.0.md
@@ -31,6 +31,9 @@ replacement parity. The maintained parity source of truth remains
 
 - Closed the propagation router lifecycle gate with live Python-reference
   remote lifecycle coverage.
+- Added issue #369 diagnostics for previously silent inbound resource failures,
+  malformed ratchet records, malformed ZMQ/RPC ingress, and JSON-RPC errors
+  returned inside HTTP 200 responses.
 - Closed the peer lifecycle parity gate across restart replay, offers,
   transfer limits, retry/failure classes, unpeer cleanup, haves, and source
   accounting.
@@ -57,6 +60,14 @@ blanket workspace version:
 - `reticulum-rs-core`: `0.2.0`
 - `reticulum-rs-transport`: `0.2.0`
 - app/tool crates remain unpublished and are distributed through GitHub bundles
+
+## API Notes
+
+- `reticulum-rs-transport` now emits
+  `ResourceEventKind::InboundFailed(ResourceFailure)` when inbound resource
+  transfer failure or retry exhaustion is terminal. Downstream exhaustive
+  matches on `ResourceEventKind` should add this variant or include a catch-all
+  arm.
 
 ## Validation Record
 

--- a/docs/runbooks/logging-and-diagnostics.md
+++ b/docs/runbooks/logging-and-diagnostics.md
@@ -1,0 +1,72 @@
+# Logging and Diagnostics
+
+This runbook defines the default logging posture for operators and the failure
+visibility rules for contributors.
+
+## Operator Defaults
+
+Use `RUST_LOG=info` for normal daemon operation. Increase selected modules to
+`debug` only while investigating a concrete failure.
+
+```bash
+RUST_LOG=info reticulumd --config /etc/lxmf/reticulumd/config.toml
+RUST_LOG=reticulumd=debug,reticulum_rs_transport=debug,lxmf_sdk=debug lxmd --config /etc/lxmf/lxmd/config
+```
+
+Set `LXMF_LOG_PRETTY=1` for local terminal sessions where compact human-readable
+RPC access logs are more useful than JSON-shaped log lines. Keep service units
+on structured logs so journald and collectors can index fields.
+
+Set `RETICULUMD_DIAGNOSTICS=1` only during focused transport, resource, or
+interop debugging. It enables extra diagnostic lines in hot paths and may add
+noise on busy nodes.
+
+## What Logs Must Include
+
+Failure logs should include:
+
+- component or operation name
+- stable reason or error code
+- retryability or terminal state when known
+- redacted peer, link, resource, message, or request identifier when available
+- short operator action when the failure is user-actionable
+
+Do not log bearer tokens, shared secrets, private keys, ticket material, full
+message payloads, or unredacted message bodies. Prefer existing redaction
+helpers for JSON event/error payloads.
+
+## Contributor Rules
+
+`ResourceEventKind` is public. Consumers should avoid exhaustive matches
+without a catch-all arm because new terminal event variants may be added when a
+previously silent failure class becomes visible to operators. Issue #369 added
+`InboundFailed(ResourceFailure)` for this reason.
+
+Do not turn expected errors into absence unless absence is the real domain
+meaning. Use `Result<T, E>` or `Result<Option<T>, E>` when malformed input,
+serialization failure, IO failure, or crypto failure must be distinguishable
+from "not present".
+
+Avoid silent `let _ = ...` on fallible operations. If a send, write,
+serialization, or persistence trigger can fail in production, either propagate
+the error or log a warning with context. Teardown best-effort operations may
+remain quiet when the caller cannot use the result.
+
+Avoid `.ok()` on production decode paths unless the error is intentionally
+non-actionable. When lossy behavior is acceptable, make it explicit with
+`from_utf8_lossy` or a named helper that logs or documents the downgrade.
+
+## Useful Checks
+
+Run the issue-369 regression scan after changing error handling:
+
+```bash
+cargo test -p reticulumd --test code_quality_issue_369
+```
+
+Run focused runtime checks for touched components:
+
+```bash
+cargo test -p reticulum-rs-transport resource::
+cargo test -p reticulumd
+```


### PR DESCRIPTION
﻿## Summary
- surfaces inbound resource failures with stable reasons, progress, daemon warnings, and terminal events
- adds diagnostics for retry exhaustion, malformed ratchet records, malformed ZMQ ingress, and JSON-RPC errors inside HTTP 200 responses
- documents operator logging defaults, contributor no-silent-discard rules, and the public `ResourceEventKind::InboundFailed` API note

## Context
Follow-up to issue #369 and PR #371. The previous cleanup removed several silent-error patterns; this PR makes the remaining user-visible failure paths produce actionable logs/events instead of disappearing as absence.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `tools/scripts/check-module-size.sh`
- `cargo test -p reticulumd --test code_quality_issue_369`
- `cargo test -p reticulum-rs-transport resource::`
- `cargo test -p reticulum-rs-transport ratchets`
- `cargo test -p reticulumd`
- `cargo test -p reticulum-rs-rpc`
- `cargo clippy -p reticulumd -p reticulum-rs-transport --all-targets --all-features --no-deps -- -D warnings`

## Notes
- `ResourceEventKind::InboundFailed(ResourceFailure)` is an intentional public event surface change; downstream exhaustive matches should add the variant or use a catch-all arm.
- Cargo still emits the existing `lxmf-cli/src/main.rs` multiple-target warning.
