### PR TITLE
Fix Sideband propagation resource request handling

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_parts/module_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_parts/module_core.rs
@@ -16,6 +16,8 @@ use rns_transport::destination::SingleInputDestination;
 
 use rns_transport::hash::AddressHash;
 
+use rns_transport::identity::Identity;
+
 use rns_transport::transport::Transport;
 
 use serde_json::{Map as JsonMap, Value as JsonValue};
@@ -64,6 +66,7 @@ pub(super) struct PropagationControlContext {
         Option<Arc<tokio::sync::Mutex<rns_transport::destination::SingleInputDestination>>>,
     pub(super) allowed_control_identities: Vec<String>,
     pub(super) validated_peer_links: Arc<Mutex<HashSet<AddressHash>>>,
+    pub(super) identified_peer_links: Arc<Mutex<HashMap<AddressHash, Identity>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -366,6 +369,7 @@ pub(super) async fn bootstrap(args: Args) -> BootstrapContext {
                 delivery_destination: announce_destination.clone(),
                 allowed_control_identities: configured_control_identities,
                 validated_peer_links: Arc::new(Mutex::new(HashSet::new())),
+                identified_peer_links: Arc::new(Mutex::new(HashMap::new())),
             },
             receipt_tx.clone(),
             outbound_resource_map,

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_propagation.rs
@@ -163,31 +163,15 @@ impl DeliveryTask {
                 )
             })?;
         let accepted_stamp_cost = self.daemon.propagation_min_accepted_stamp_cost();
-        let mut transient_ids = Vec::with_capacity(messages.len());
         for message in messages.iter() {
             let transient_id = self
                 .daemon
                 .canonical_propagation_payload_bytes_at_cost(message, accepted_stamp_cost)?;
-            let transient_id = self.daemon.ingest_client_propagation_payload_bytes_at_cost(
+            self.daemon.ingest_client_propagation_payload_bytes_at_cost(
                 message,
                 Some(transient_id.as_str()),
                 accepted_stamp_cost,
             )?;
-            transient_ids.push(transient_id);
-        }
-        if !transient_ids.is_empty() {
-            let daemon = Arc::clone(&self.daemon);
-            tokio::task::spawn_blocking(move || {
-                for transient_id in transient_ids {
-                    if let Err(err) = daemon
-                        .queue_stored_propagation_entry_for_active_peers(transient_id.as_str())
-                    {
-                        log::warn!(
-                            "[daemon] failed to queue local propagation payload for peers: {err}"
-                        );
-                    }
-                }
-            });
         }
         log_delivery_trace(
             &self.message_id,

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_propagation.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_propagation.rs
@@ -163,15 +163,31 @@ impl DeliveryTask {
                 )
             })?;
         let accepted_stamp_cost = self.daemon.propagation_min_accepted_stamp_cost();
+        let mut transient_ids = Vec::with_capacity(messages.len());
         for message in messages.iter() {
             let transient_id = self
                 .daemon
                 .canonical_propagation_payload_bytes_at_cost(message, accepted_stamp_cost)?;
-            self.daemon.ingest_propagation_payload_bytes_at_cost(
+            let transient_id = self.daemon.ingest_client_propagation_payload_bytes_at_cost(
                 message,
                 Some(transient_id.as_str()),
                 accepted_stamp_cost,
             )?;
+            transient_ids.push(transient_id);
+        }
+        if !transient_ids.is_empty() {
+            let daemon = Arc::clone(&self.daemon);
+            tokio::task::spawn_blocking(move || {
+                for transient_id in transient_ids {
+                    if let Err(err) = daemon
+                        .queue_stored_propagation_entry_for_active_peers(transient_id.as_str())
+                    {
+                        log::warn!(
+                            "[daemon] failed to queue local propagation payload for peers: {err}"
+                        );
+                    }
+                }
+            });
         }
         log_delivery_trace(
             &self.message_id,

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_parts/module_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_parts/module_core.rs
@@ -1,7 +1,6 @@
 use response::ControlResponse;
 
-use std::collections::HashMap;
-
+#[cfg(test)]
 use std::sync::Mutex;
 
 pub(super) fn spawn_control_worker(
@@ -11,7 +10,6 @@ pub(super) fn spawn_control_worker(
 ) {
     tokio::spawn(async move {
         let mut rx = transport.in_link_events();
-        let identified = Arc::new(Mutex::new(HashMap::<AddressHash, Identity>::new()));
         loop {
             let Ok(event) = rx.recv().await else {
                 break;
@@ -55,7 +53,7 @@ pub(super) fn spawn_control_worker(
                     if let Some(identity) =
                         parse_link_identify_payload(payload.as_slice(), &event.id)
                     {
-                        if let Ok(mut guard) = identified.lock() {
+                        if let Ok(mut guard) = control.identified_peer_links.lock() {
                             guard.insert(event.id, identity);
                         }
                     }
@@ -64,7 +62,7 @@ pub(super) fn spawn_control_worker(
                     let Some(request_id) = payload.request_id() else {
                         continue;
                     };
-                    let remote_identity = match identified.lock() {
+                    let remote_identity = match control.identified_peer_links.lock() {
                         Ok(guard) => guard.get(&event.id).cloned(),
                         Err(err) => {
                             log::warn!(
@@ -105,6 +103,9 @@ pub(super) fn spawn_control_worker(
 
 fn clear_validated_peer_link(control: &PropagationControlContext, link_id: &AddressHash) {
     if let Ok(mut guard) = control.validated_peer_links.lock() {
+        guard.remove(link_id);
+    }
+    if let Ok(mut guard) = control.identified_peer_links.lock() {
         guard.remove(link_id);
     }
 }
@@ -222,7 +223,7 @@ pub(super) async fn handle_resource_control_request(
     request_id: [u8; 16],
     propagation_destination: bool,
 ) -> Result<(), std::io::Error> {
-    let remote_identity = remote_identity_for_resource_link(transport, link_id).await;
+    let remote_identity = remote_identity_for_resource_link(control, transport, link_id).await;
     let response = resource_control_response(
         daemon,
         control,
@@ -235,12 +236,19 @@ pub(super) async fn handle_resource_control_request(
 }
 
 async fn remote_identity_for_resource_link(
+    control: &PropagationControlContext,
     transport: &Transport,
     link_id: &AddressHash,
 ) -> Option<Identity> {
-    if let Some(link) = transport.find_in_link(link_id).await {
-        let guard = link.lock().await;
-        return Some(*guard.peer_identity());
+    match control.identified_peer_links.lock() {
+        Ok(guard) => {
+            if let Some(identity) = guard.get(link_id) {
+                return Some(*identity);
+            }
+        }
+        Err(err) => {
+            log::warn!("[daemon-control] failed to lock identified peer map: {err}");
+        }
     }
     if let Some(link) = transport.find_out_link(link_id).await {
         let guard = link.lock().await;

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_parts/module_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_parts/module_core.rs
@@ -195,6 +195,60 @@ fn handle_control_request(
     ControlResponse::Code(ERROR_INVALID_DATA)
 }
 
+fn resource_control_response(
+    daemon: &RpcDaemon,
+    control: &PropagationControlContext,
+    link_id: &AddressHash,
+    payload: &[u8],
+    remote_identity: Option<&Identity>,
+    propagation_destination: bool,
+) -> ControlResponse {
+    handle_control_request(
+        daemon,
+        control,
+        link_id,
+        payload,
+        remote_identity,
+        propagation_destination,
+    )
+}
+
+pub(super) async fn handle_resource_control_request(
+    daemon: &RpcDaemon,
+    transport: &Transport,
+    control: &PropagationControlContext,
+    link_id: &AddressHash,
+    payload: &[u8],
+    request_id: [u8; 16],
+    propagation_destination: bool,
+) -> Result<(), std::io::Error> {
+    let remote_identity = remote_identity_for_resource_link(transport, link_id).await;
+    let response = resource_control_response(
+        daemon,
+        control,
+        link_id,
+        payload,
+        remote_identity.as_ref(),
+        propagation_destination,
+    );
+    response::send_control_response(transport, link_id, request_id, response).await
+}
+
+async fn remote_identity_for_resource_link(
+    transport: &Transport,
+    link_id: &AddressHash,
+) -> Option<Identity> {
+    if let Some(link) = transport.find_in_link(link_id).await {
+        let guard = link.lock().await;
+        return Some(*guard.peer_identity());
+    }
+    if let Some(link) = transport.find_out_link(link_id).await {
+        let guard = link.lock().await;
+        return Some(*guard.peer_identity());
+    }
+    None
+}
+
 fn control_identity_allowed(control: &PropagationControlContext, remote_hash: &str) -> bool {
     if control.allowed_control_identities.is_empty() {
         return true;

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_parts/test_validated_peer_links_sections/core_tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_parts/test_validated_peer_links_sections/core_tests.rs
@@ -25,6 +25,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         }
     }
 
@@ -215,6 +216,7 @@
             delivery_destination: None,
             allowed_control_identities: vec!["not-the-remote".to_string()],
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
         let response = handle_control_request(
             &daemon,
@@ -271,6 +273,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 
@@ -291,6 +294,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 
@@ -326,6 +330,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 
@@ -358,6 +363,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 
@@ -386,6 +392,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 
@@ -433,6 +440,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_parts/test_validated_peer_links_sections/core_tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_parts/test_validated_peer_links_sections/core_tests.rs
@@ -103,6 +103,32 @@
     }
 
     #[test]
+    fn resource_carried_get_request_uses_control_dispatch() {
+        let daemon = ready_propagation_daemon();
+        let remote_private =
+            rns_transport::identity::PrivateIdentity::new_from_rand(rand_core::OsRng);
+        let remote_identity = *remote_private.as_identity();
+        let payload = control_request(
+            "/get",
+            rmpv::Value::Array(vec![rmpv::Value::Nil, rmpv::Value::Nil]),
+        );
+
+        let response = resource_control_response(
+            &daemon,
+            &test_control_context(),
+            &test_link_id(),
+            payload.as_slice(),
+            Some(&remote_identity),
+            true,
+        );
+
+        let ControlResponse::Rmpv(rmpv::Value::Array(entries)) = response else {
+            panic!("expected propagation /get response array");
+        };
+        assert!(entries.is_empty());
+    }
+
+    #[test]
     fn stats_request_returns_status_when_propagation_node_is_enabled() {
         let daemon = RpcDaemon::test_instance();
         daemon

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_parts/test_validated_peer_links_sections/python_status_exposes_peer_peering_k.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_parts/test_validated_peer_links_sections/python_status_exposes_peer_peering_k.rs
@@ -68,6 +68,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 
@@ -149,6 +150,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_parts/test_validated_peer_links_sections/python_status_reports_peer_propagati.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_parts/test_validated_peer_links_sections/python_status_reports_peer_propagati.rs
@@ -44,6 +44,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 
@@ -114,6 +115,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 
@@ -156,6 +158,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 
@@ -197,6 +200,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 
@@ -240,6 +244,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 
@@ -287,6 +292,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 
@@ -355,6 +361,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 
@@ -407,6 +414,7 @@
                 delivery_destination: None,
                 allowed_control_identities: Vec::new(),
                 validated_peer_links: test_validated_peer_links(),
+                identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
             },
         );
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation_parts/test_validated_peer_links_sections/core_tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation_parts/test_validated_peer_links_sections/core_tests.rs
@@ -69,6 +69,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let link_id = test_link_id();
@@ -154,6 +155,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let link_id = test_link_id();
@@ -230,6 +232,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let link_id = test_link_id();
@@ -326,6 +329,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let response = handle_offer_request(
@@ -377,6 +381,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let first = handle_offer_request(

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation_parts/test_validated_peer_links_sections/offer_request_defers_capacity_limite.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation_parts/test_validated_peer_links_sections/offer_request_defers_capacity_limite.rs
@@ -39,6 +39,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
         let link_id = test_link_id();
 
@@ -118,6 +119,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let offer_data = || {
@@ -186,6 +188,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let response = handle_offer_request(
@@ -239,6 +242,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let response = handle_offer_request(
@@ -285,6 +289,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let response = handle_offer_request(

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation_parts/test_validated_peer_links_sections/offer_request_invalid_peering_key_st.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation_parts/test_validated_peer_links_sections/offer_request_invalid_peering_key_st.rs
@@ -26,6 +26,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let first = handle_offer_request(
@@ -120,6 +121,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let response = handle_offer_request(
@@ -186,6 +188,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let response = handle_offer_request(
@@ -260,6 +263,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let response = handle_offer_request(
@@ -340,6 +344,7 @@
             delivery_destination: None,
             allowed_control_identities: Vec::new(),
             validated_peer_links: test_validated_peer_links(),
+            identified_peer_links: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
 
         let response = handle_offer_request(

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_response.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_response.rs
@@ -34,7 +34,7 @@ pub(super) async fn send_control_response(
             Ok(())
         }
         LinkResponsePacket::Resource(payload) => transport
-            .send_resource_direct(link_id, ingress_iface, payload, None)
+            .send_response_resource(link_id, request_id.to_vec(), payload, None)
             .await
             .map(|_| ())
             .map_err(|err| std::io::Error::other(format!("{err:?}"))),

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_routing.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_routing.rs
@@ -90,6 +90,17 @@ pub(super) fn should_skip_control_payload(
     )
 }
 
+pub(super) fn should_skip_resolved_control_payload(
+    destination: InboundLxmfDestination,
+    context: Option<PacketContext>,
+) -> bool {
+    matches!(destination, InboundLxmfDestination::Propagation)
+        && matches!(
+            context,
+            Some(PacketContext::Request | PacketContext::Response | PacketContext::LinkIdentify)
+        )
+}
+
 fn lxmf_destination_from_desc(destination: &DestinationDesc) -> Option<InboundLxmfDestination> {
     if is_lxmf_delivery_destination(destination) {
         return Some(InboundLxmfDestination::Delivery(destination_hash(&destination.address_hash)));
@@ -116,10 +127,14 @@ fn is_lxmf_propagation_link_destination(destination: &DestinationDesc) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_lxmf_delivery_destination, is_lxmf_propagation_link_destination};
+    use super::{
+        is_lxmf_delivery_destination, is_lxmf_propagation_link_destination,
+        should_skip_resolved_control_payload, InboundLxmfDestination,
+    };
     use rand_core::OsRng;
     use rns_transport::destination::{DestinationDesc, DestinationName};
     use rns_transport::identity::PrivateIdentity;
+    use rns_transport::packet::PacketContext;
 
     #[test]
     fn lxmf_delivery_destination_is_accepted_for_resource_decode() {
@@ -155,5 +170,17 @@ mod tests {
         };
 
         assert!(is_lxmf_propagation_link_destination(&destination));
+    }
+
+    #[test]
+    fn propagation_link_control_context_is_skipped_from_payload_ingest() {
+        assert!(should_skip_resolved_control_payload(
+            InboundLxmfDestination::Propagation,
+            Some(PacketContext::LinkIdentify)
+        ));
+        assert!(should_skip_resolved_control_payload(
+            InboundLxmfDestination::Propagation,
+            Some(PacketContext::Request)
+        ));
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker_parts/module_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker_parts/module_core.rs
@@ -64,6 +64,40 @@ pub(super) fn spawn_inbound_worker(
                                     .await;
                                 }
                                 InboundLxmfDestination::Propagation => {
+                                    if complete.is_request {
+                                        match resource_request_id(&complete.request_id) {
+                                            Some(request_id) => {
+                                                if let Err(error) =
+                                                    control::handle_resource_control_request(
+                                                        daemon.as_ref(),
+                                                        transport.as_ref(),
+                                                        &resource_control,
+                                                        &event.link_id,
+                                                        &complete.data,
+                                                        request_id,
+                                                        true,
+                                                    )
+                                                    .await
+                                                {
+                                                    log::error!(
+                                                        "[daemon-control] failed to handle propagation resource request link={} error={}",
+                                                        event.link_id,
+                                                        error
+                                                    );
+                                                }
+                                            }
+                                            None => {
+                                                log::warn!(
+                                                    "[daemon-control] ignoring propagation resource request with invalid request id link={}",
+                                                    event.link_id
+                                                );
+                                            }
+                                        }
+                                        continue;
+                                    }
+                                    if complete.is_response {
+                                        continue;
+                                    }
                                     let remote_peer = remote_propagation_peer_for_link(
                                         transport.as_ref(),
                                         &event.link_id,
@@ -123,6 +157,16 @@ pub(super) fn spawn_inbound_worker(
             }
         }
     });
+}
+
+fn resource_request_id(request_id: &Option<Vec<u8>>) -> Option<[u8; 16]> {
+    let bytes = request_id.as_ref()?;
+    if bytes.len() != 16 {
+        return None;
+    }
+    let mut out = [0u8; 16];
+    out.copy_from_slice(bytes.as_slice());
+    Some(out)
 }
 
 async fn remote_propagation_peer_for_link(
@@ -223,6 +267,13 @@ fn spawn_packet_inbound_worker(
                         }
                         continue;
                     };
+
+                    if routing::should_skip_resolved_control_payload(
+                        resolved_destination,
+                        event.context,
+                    ) {
+                        continue;
+                    }
 
                     delivery_events::log_resolved_packet(
                         &raw_destination_hex,

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/ingest_propagation_payload_hex_at_co.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/ingest_propagation_payload_hex_at_co.rs
@@ -96,6 +96,61 @@ impl RpcDaemon {
         self.ingest_propagation_payload_hex_at_cost(payload_hex.as_str(), transient_id, stamp_cost)
     }
 
+    pub fn ingest_client_propagation_payload_bytes_at_cost(
+        &self,
+        payload: &[u8],
+        transient_id: Option<&str>,
+        stamp_cost: u32,
+    ) -> Result<String, std::io::Error> {
+        let (canonical_transient_id, normalized_payload) =
+            normalize_propagation_payload_bytes(payload, stamp_cost)?;
+        let canonical_transient_id = hex::encode(canonical_transient_id);
+        if let Some(provided_transient_id) = transient_id {
+            if !provided_transient_id.eq_ignore_ascii_case(canonical_transient_id.as_str()) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "transient_id does not match propagation payload",
+                ));
+            }
+        }
+        let transient_id =
+            transient_id.map(normalize_propagation_transient_key).unwrap_or(canonical_transient_id);
+        if self.propagation_payload_destination_is_ignored(normalized_payload) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "ignored propagation destination",
+            ));
+        }
+        let already_known = self
+            .store
+            .get_propagation_entry(transient_id.as_str())
+            .map_err(std::io::Error::other)?
+            .is_some()
+            || self
+                .store
+                .local_propagation_processed_mark_exists(transient_id.as_str())
+                .map_err(std::io::Error::other)?;
+        let payload_hex = hex::encode(normalized_payload);
+        self.store_propagation_payload_hex(transient_id.as_str(), payload_hex.as_str())?;
+        self.propagation_payloads
+            .lock()
+            .expect("propagation payload mutex poisoned")
+            .insert(transient_id.clone(), payload_hex);
+        self.store
+            .mark_local_propagation_processed(transient_id.as_str())
+            .map_err(std::io::Error::other)?;
+        self.prune_propagation_payloads_to_storage_limit()?;
+        self.note_client_propagation_messages_received(usize::from(!already_known));
+        Ok(transient_id)
+    }
+
+    pub fn queue_stored_propagation_entry_for_active_peers(
+        &self,
+        transient_id: &str,
+    ) -> Result<(), std::io::Error> {
+        self.queue_propagation_entry_for_active_peers(transient_id)
+    }
+
     fn propagation_payload_destination_is_ignored(&self, payload: &[u8]) -> bool {
         if payload.len() < 16 {
             return false;

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/ingest_propagation_payload_hex_at_co.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_propagation_parts/rpcdaemon_sections/ingest_propagation_payload_hex_at_co.rs
@@ -144,13 +144,6 @@ impl RpcDaemon {
         Ok(transient_id)
     }
 
-    pub fn queue_stored_propagation_entry_for_active_peers(
-        &self,
-        transient_id: &str,
-    ) -> Result<(), std::io::Error> {
-        self.queue_propagation_entry_for_active_peers(transient_id)
-    }
-
     fn propagation_payload_destination_is_ignored(&self, payload: &[u8]) -> bool {
         if payload.len() < 16 {
             return false;

--- a/crates/libs/rns-transport/src/iface_parts/interfacemanager.rs
+++ b/crates/libs/rns-transport/src/iface_parts/interfacemanager.rs
@@ -286,6 +286,12 @@ impl InterfaceManager {
         match iface.tx_send.try_send(message) {
             Ok(()) => true,
             Err(mpsc::error::TrySendError::Full(message)) => {
+                if matches!(tx_type, TxMessageType::Broadcast(_)) {
+                    if tx_diag_enabled() {
+                        log::warn!("tx queue full dropping broadcast on {} for {:?}", iface.address, tx_type);
+                    }
+                    return false;
+                }
                 match tokio::time::timeout(
                     Duration::from_millis(IFACE_TX_ENQUEUE_TIMEOUT_MS),
                     iface.tx_send.send(message),

--- a/crates/libs/rns-transport/src/iface_tests.rs
+++ b/crates/libs/rns-transport/src/iface_tests.rs
@@ -228,6 +228,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn saturated_broadcast_queue_returns_without_enqueue_timeout() {
+        let mut mgr = InterfaceManager::new(16);
+        let mut rx = mgr.new_channel(1).tx_channel;
+        let iface = mgr.ifaces[0].address;
+        let first = Packet::default();
+        let second = Packet::default();
+
+        let fill =
+            mgr.send(TxMessage { tx_type: TxMessageType::Direct(iface), packet: first }).await;
+        assert_eq!(fill.sent_ifaces, 1);
+
+        let started = Instant::now();
+        let trace = mgr
+            .send(TxMessage { tx_type: TxMessageType::Broadcast(None), packet: second })
+            .await;
+
+        assert!(
+            started.elapsed() < Duration::from_millis(50),
+            "broadcast dispatch must not wait for the enqueue timeout on saturated queues"
+        );
+        assert_eq!(trace.matched_ifaces, 1);
+        assert_eq!(trace.sent_ifaces, 0);
+        assert_eq!(trace.failed_ifaces, 1);
+        assert!(rx.try_recv().is_ok());
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
     async fn roaming_blocks_remote_announce_without_allowed_next_hop() {
         let mut mgr = InterfaceManager::new(16);
         let mut rx = mgr


### PR DESCRIPTION
## Summary
- route Sideband/RNS resource-backed `Link.request()` payloads on the LXMF propagation destination through the propagation control request handler instead of the propagation message-envelope ingester
- ignore resource-backed control responses in the inbound propagation ingester; request waiters already consume the resource event stream
- avoid inbound payload parsing for propagation link control packets and avoid blocking transport receive on saturated broadcast queues

## Root Cause
RCH/Sideband field testing showed Pixel could complete an RNS Resource transfer to the daemon, but `reticulumd` then logged `invalid propagation envelope: invalid type: integer 148, expected a sequence`. The completed resource advertisement had `flags=0x09 request=true`, so it was a `Link.request()` resource, not an LXMF propagation message envelope. The resource completion worker was treating every completed resource on the propagation destination as message-ingest data.

## Validation
- `cargo fmt --check`
- `cargo check -p reticulumd --bin reticulumd --features zmq-pipeline-rpc`
- `cargo test -p reticulumd resource_carried_get_request_uses_control_dispatch -- --nocapture`
- `cargo test -p reticulumd propagation_link_control_context_is_skipped_from_payload_ingest -- --nocapture`
- `cargo test -p reticulum-rs-transport saturated_broadcast_queue_returns_without_enqueue_timeout -- --nocapture`
- `cargo test -p reticulumd --lib`

## Field Evidence
Deployed the rebuilt daemon to the RCH Pi and restarted `rch3-reticulumd`. Pixel Sideband remained connected over the TCP server. After the fix, multiple Sideband `request=true` propagation resources completed without the prior `invalid propagation envelope` error. A fresh Pixel-to-RCH message `pixonly1844` was stored in both `reticulum.db.messages` and RCH `rch_messages`, and Sideband displayed `State Delivered`.