### PR TITLE
Persist announce identities for propagated delivery

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/announce_ingest.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/announce_ingest.rs
@@ -38,7 +38,7 @@ pub(super) async fn ingest_announce_event(
     let hops = Some(u32::from(event.hops));
     let interface = Some(hex::encode(event.interface.as_slice()));
     let _ = daemon.accept_announce_with_metadata(
-        peer,
+        peer.clone(),
         timestamp,
         peer_name,
         peer_name_source,
@@ -56,6 +56,12 @@ pub(super) async fn ingest_announce_event(
         None,
         None,
         None,
+    );
+    let _ = daemon.record_announce_identity(
+        peer.as_str(),
+        hex::encode(identity.public_key_bytes()).as_str(),
+        hex::encode(identity.verifying_key_bytes()).as_str(),
+        timestamp,
     );
 }
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_parts/module_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_parts/module_core.rs
@@ -9,7 +9,8 @@ use reticulum_daemon::config::{DaemonConfig, InterfaceConfig};
 use reticulum_daemon::identity_store::load_or_create_identity;
 
 use rns_rpc::{
-    AnnounceBridge, InterfaceRecord, MessagesStore, OutboundBridge, RemoteControlBridge, RpcDaemon,
+    AnnounceBridge, InterfaceRecord, MessagesStore, OutboundBridge, RemoteControlBridge,
+    RpcDaemon, RpcRequest,
 };
 
 use rns_transport::destination::SingleInputDestination;
@@ -20,7 +21,7 @@ use rns_transport::identity::Identity;
 
 use rns_transport::transport::Transport;
 
-use serde_json::{Map as JsonMap, Value as JsonValue};
+use serde_json::{json, Map as JsonMap, Value as JsonValue};
 
 use std::collections::{HashMap, HashSet};
 
@@ -282,6 +283,15 @@ pub(super) async fn bootstrap(args: Args) -> BootstrapContext {
         propagation_node_config.announce_config.peering_cost,
         propagation_node_config.allowed_control_identities.clone(),
     );
+    if propagation_node_config.enabled {
+        if let Some(peer) = propagation_destination_hash_hex.as_deref() {
+            let _ = daemon.handle_rpc(RpcRequest {
+                id: 0,
+                method: "set_outbound_propagation_node".to_string(),
+                params: Some(json!({ "peer": peer })),
+            });
+        }
+    }
 
     // Make the local delivery destination visible on startup when configured.
     if propagation_node_config.peer_announce_at_start {

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_identity.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_identity.rs
@@ -1,4 +1,5 @@
 use super::PeerCrypto;
+use rns_rpc::RpcDaemon;
 use rns_transport::destination::{DestinationName, SingleOutputDestination};
 use rns_transport::hash::AddressHash;
 use rns_transport::identity::Identity;
@@ -67,6 +68,41 @@ pub(super) fn cached_identity_for_destination(
     })
 }
 
+pub(super) fn persisted_identity_for_destination(
+    daemon: &RpcDaemon,
+    destination_hash: AddressHash,
+) -> Option<Identity> {
+    let destination_hex = hex::encode(destination_hash.as_slice());
+    let (public_key_hex, verifying_key_hex) =
+        daemon.announce_identity_keys(destination_hex.as_str()).ok().flatten()?;
+    let identity = identity_from_key_hex(public_key_hex.as_str(), verifying_key_hex.as_str())?;
+    identity_matches_destination(identity, destination_hash).then_some(identity)
+}
+
+fn identity_from_key_hex(public_key_hex: &str, verifying_key_hex: &str) -> Option<Identity> {
+    let public_key = hex::decode(public_key_hex).ok()?;
+    let verifying_key = hex::decode(verifying_key_hex).ok()?;
+    if public_key.len() != rns_transport::identity::PUBLIC_KEY_LENGTH
+        || verifying_key.len() != rns_transport::identity::PUBLIC_KEY_LENGTH
+    {
+        return None;
+    }
+    Some(Identity::new_from_slices(public_key.as_slice(), verifying_key.as_slice()))
+}
+
+fn identity_matches_destination(identity: Identity, destination_hash: AddressHash) -> bool {
+    const DESTINATION_NAMES: [(&str, &str); 4] = [
+        ("lxmf", "delivery"),
+        ("lxmf", "propagation"),
+        ("lxmf", "propagation.control"),
+        ("r3akt", "emergency"),
+    ];
+    DESTINATION_NAMES.iter().any(|(app, aspect)| {
+        SingleOutputDestination::new(identity, DestinationName::new(app, aspect)).desc.address_hash
+            == destination_hash
+    })
+}
+
 fn push_unique_identity(candidates: &mut Vec<Identity>, candidate: Option<Identity>) {
     let Some(candidate) = candidate else {
         return;
@@ -77,5 +113,57 @@ fn push_unique_identity(candidates: &mut Vec<Identity>, candidate: Option<Identi
     });
     if !already_present {
         candidates.push(candidate);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rns_rpc::{MessagesStore, RpcDaemon};
+
+    #[test]
+    fn persisted_identity_matches_lxmf_delivery_destination_after_restart() {
+        let store = MessagesStore::in_memory().expect("store");
+        let daemon = RpcDaemon::with_store(store, "test-node".to_string());
+        let remote = rns_transport::identity::PrivateIdentity::new_from_rand(rand_core::OsRng);
+        let delivery_hash = SingleOutputDestination::new(
+            *remote.as_identity(),
+            DestinationName::new("lxmf", "delivery"),
+        )
+        .desc
+        .address_hash;
+        let delivery_hex = hex::encode(delivery_hash.as_slice());
+        daemon
+            .record_announce_identity(
+                delivery_hex.as_str(),
+                hex::encode(remote.as_identity().public_key_bytes()).as_str(),
+                hex::encode(remote.as_identity().verifying_key_bytes()).as_str(),
+                1_781_964_554,
+            )
+            .expect("record announce identity");
+
+        let restored =
+            persisted_identity_for_destination(&daemon, delivery_hash).expect("restored identity");
+
+        assert_eq!(restored.public_key_bytes(), remote.as_identity().public_key_bytes());
+        assert_eq!(restored.verifying_key_bytes(), remote.as_identity().verifying_key_bytes());
+    }
+
+    #[test]
+    fn persisted_identity_rejects_mismatched_destination_hash() {
+        let store = MessagesStore::in_memory().expect("store");
+        let daemon = RpcDaemon::with_store(store, "test-node".to_string());
+        let remote = rns_transport::identity::PrivateIdentity::new_from_rand(rand_core::OsRng);
+        let wrong_hash = AddressHash::new([0x42; 16]);
+        daemon
+            .record_announce_identity(
+                hex::encode(wrong_hash.as_slice()).as_str(),
+                hex::encode(remote.as_identity().public_key_bytes()).as_str(),
+                hex::encode(remote.as_identity().verifying_key_bytes()).as_str(),
+                1_781_964_554,
+            )
+            .expect("record announce identity");
+
+        assert!(persisted_identity_for_destination(&daemon, wrong_hash).is_none());
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_outbound.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_outbound.rs
@@ -36,15 +36,18 @@ impl OutboundBridge for TransportBridge {
         options: &OutboundDeliveryOptions,
     ) -> Result<(), std::io::Error> {
         let destination = parse_destination_hash_required(&record.destination)?;
-        let peer_info =
-            self.peer_crypto.lock().expect("peer map").get(&record.destination).copied();
-        let peer_identity = peer_info.map(|info| info.identity);
         let daemon = self
             .daemon
             .lock()
             .expect("transport bridge daemon mutex poisoned")
             .clone()
             .ok_or_else(|| std::io::Error::other("daemon bridge unavailable"))?;
+        let peer_identity = outbound_peer_identity(
+            daemon.as_ref(),
+            &self.peer_crypto,
+            record.destination.as_str(),
+            destination,
+        );
 
         let include_ticket = if options.include_ticket {
             daemon
@@ -88,6 +91,15 @@ impl OutboundBridge for TransportBridge {
                 cached.or_else(|| {
                         let hash = parse_destination_hash_required(node_hex).ok()?;
                         let hash = AddressHash::new(hash);
+                        if let Some(identity) = identity_resolver::persisted_identity_for_destination(
+                            daemon.as_ref(),
+                            hash,
+                        ) {
+                            if let Ok(mut guard) = self.outbound_propagation_identities.lock() {
+                                guard.insert(node_hex.to_string(), identity);
+                            }
+                            return Some(identity);
+                        }
                         let identity = resolve_destination_identity_blocking(
                             self.transport.clone(),
                             hash,
@@ -144,5 +156,63 @@ impl OutboundBridge for TransportBridge {
 
     fn delivery_pipeline_status(&self) -> Option<serde_json::Value> {
         Some(self.delivery_scheduler.status_json())
+    }
+}
+
+fn outbound_peer_identity(
+    daemon: &RpcDaemon,
+    peer_crypto: &Mutex<HashMap<String, PeerCrypto>>,
+    destination_hex: &str,
+    destination: [u8; 16],
+) -> Option<Identity> {
+    peer_crypto
+        .lock()
+        .expect("peer map")
+        .get(destination_hex)
+        .copied()
+        .map(|info| info.identity)
+        .or_else(|| {
+            identity_resolver::persisted_identity_for_destination(
+                daemon,
+                AddressHash::new(destination),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rns_rpc::MessagesStore;
+
+    #[test]
+    fn outbound_peer_identity_uses_persisted_announce_identity_when_live_cache_is_empty() {
+        let store = MessagesStore::in_memory().expect("store");
+        let daemon = RpcDaemon::with_store(store, "test-node".to_string());
+        let remote = rns_transport::identity::PrivateIdentity::new_from_rand(rand_core::OsRng);
+        let delivery_hash = SingleOutputDestination::new(
+            *remote.as_identity(),
+            DestinationName::new("lxmf", "delivery"),
+        )
+        .desc
+        .address_hash;
+        let mut destination = [0u8; 16];
+        destination.copy_from_slice(delivery_hash.as_slice());
+        let destination_hex = hex::encode(destination);
+        daemon
+            .record_announce_identity(
+                destination_hex.as_str(),
+                hex::encode(remote.as_identity().public_key_bytes()).as_str(),
+                hex::encode(remote.as_identity().verifying_key_bytes()).as_str(),
+                1_781_964_554,
+            )
+            .expect("record announce identity");
+        let peer_crypto = Mutex::new(HashMap::new());
+
+        let identity =
+            outbound_peer_identity(&daemon, &peer_crypto, destination_hex.as_str(), destination)
+                .expect("persisted identity");
+
+        assert_eq!(identity.public_key_bytes(), remote.as_identity().public_key_bytes());
+        assert_eq!(identity.verifying_key_bytes(), remote.as_identity().verifying_key_bytes());
     }
 }

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_outbound.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_outbound.rs
@@ -77,7 +77,10 @@ impl OutboundBridge for TransportBridge {
 
         let requested_method = RequestedDeliveryMethod::parse(options.method.as_deref())?;
         let propagation_node_hex = daemon.outbound_propagation_node();
-        let propagation_node_identity = if requested_method == RequestedDeliveryMethod::Propagated {
+        let propagation_node_identity = if requested_method == RequestedDeliveryMethod::Propagated
+            || (requested_method == RequestedDeliveryMethod::Direct
+                && options.try_propagation_on_fail)
+        {
             propagation_node_hex.as_deref().and_then(|node_hex| {
                 let cached = match self.outbound_propagation_identities.lock() {
                     Ok(guard) => guard.get(node_hex).cloned(),

--- a/crates/apps/reticulumd/src/bin/reticulumd/tests_parts/bootstrap_reports_auto_interface_as.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests_parts/bootstrap_reports_auto_interface_as.rs
@@ -108,6 +108,62 @@ interfaces = [
 }
 
 #[test]
+fn bootstrap_selects_local_propagation_node_when_enabled_by_config() {
+    let temp = TempDir::new().expect("temp dir");
+    let db_path = temp.path().join("reticulum.db");
+    let config_path = temp.path().join("daemon.toml");
+    fs::write(
+        &config_path,
+        r#"
+[propagation_node]
+enabled = true
+node_announce_at_start = false
+peer_announce_at_start = false
+stamp_cost = 16
+stamp_cost_flexibility = 3
+peering_cost = 18
+"#,
+    )
+    .expect("write config");
+
+    let runtime =
+        tokio::runtime::Builder::new_current_thread().enable_all().build().expect("runtime");
+    let context = runtime.block_on(async {
+        bootstrap::bootstrap(test_args(
+            db_path.clone(),
+            Some(config_path.clone()),
+            Some("127.0.0.1:0".to_string()),
+            false,
+        ))
+        .await
+    });
+
+    let selected = context
+        .daemon
+        .handle_rpc(RpcRequest {
+            id: 1,
+            method: "get_outbound_propagation_node".to_string(),
+            params: None,
+        })
+        .expect("get selected propagation node")
+        .result
+        .expect("selected node result");
+    let peer = selected
+        .get("peer")
+        .and_then(|value| value.as_str())
+        .expect("config-enabled local propagation node should be selected");
+
+    let status = context
+        .daemon
+        .handle_rpc(RpcRequest { id: 2, method: "propagation_status".to_string(), params: None })
+        .expect("propagation status")
+        .result
+        .expect("status result");
+    assert_eq!(status["propagation"]["selected_node"].as_str(), Some(peer));
+    assert_eq!(status["propagation"]["propagation_node_enabled"].as_bool(), Some(true));
+}
+
+#[test]
 fn bootstrap_strict_mode_rejects_unbindable_udp_interface() {
     let runtime =
         tokio::runtime::Builder::new_current_thread().enable_all().build().expect("runtime");

--- a/crates/libs/rns-rpc/src/rpc/daemon/init_parts/rpcdaemon_sections/daemon_status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init_parts/rpcdaemon_sections/daemon_status_snapshot.rs
@@ -1,5 +1,24 @@
 impl RpcDaemon {
 
+    pub fn record_announce_identity(
+        &self,
+        peer: &str,
+        public_key_hex: &str,
+        verifying_key_hex: &str,
+        updated_at: i64,
+    ) -> Result<(), std::io::Error> {
+        self.store
+            .upsert_announce_identity(peer, public_key_hex, verifying_key_hex, updated_at)
+            .map_err(std::io::Error::other)
+    }
+
+    pub fn announce_identity_keys(
+        &self,
+        peer: &str,
+    ) -> Result<Option<(String, String)>, std::io::Error> {
+        self.store.announce_identity_keys(peer).map_err(std::io::Error::other)
+    }
+
     pub(super) fn daemon_status_snapshot(&self) -> DaemonStatusSnapshot {
         self.daemon_status_snapshot.read().expect("daemon_status_snapshot rwlock poisoned").clone()
     }

--- a/crates/libs/rns-rpc/src/storage/messages_parts/messagesstore_sections/list_announces.rs
+++ b/crates/libs/rns-rpc/src/storage/messages_parts/messagesstore_sections/list_announces.rs
@@ -62,6 +62,44 @@ impl MessagesStore {
         })
     }
 
+    pub fn upsert_announce_identity(
+        &self,
+        peer: &str,
+        public_key_hex: &str,
+        verifying_key_hex: &str,
+        updated_at: i64,
+    ) -> rusqlite::Result<()> {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.outbound_write_tx
+            .send(OutboundWriteCommand::UpsertAnnounceIdentity {
+                peer: normalize_peer_key(peer),
+                public_key_hex: normalize_hex_key(public_key_hex),
+                verifying_key_hex: normalize_hex_key(verifying_key_hex),
+                updated_at,
+                reply: reply_tx,
+            })
+            .map_err(|err| rusqlite::Error::ToSqlConversionFailure(Box::new(err)))?;
+        reply_rx.recv().map_err(|err| rusqlite::Error::ToSqlConversionFailure(Box::new(err)))?
+    }
+
+    pub fn announce_identity_keys(
+        &self,
+        peer: &str,
+    ) -> rusqlite::Result<Option<(String, String)>> {
+        let peer = normalize_peer_key(peer);
+        self.with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT public_key_hex, verifying_key_hex
+                 FROM announce_identities
+                 WHERE peer = ?1
+                 LIMIT 1",
+                params![peer],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()
+        })
+    }
+
     pub fn latest_announce_stamp_cost_for(&self, peer: &str) -> rusqlite::Result<Option<u32>> {
         self.with_read_conn(|conn| {
             conn.query_row(
@@ -285,6 +323,12 @@ impl MessagesStore {
                     stamp_cost INTEGER,
                     stamp_cost_flexibility INTEGER,
                     peering_cost INTEGER
+                );
+                CREATE TABLE IF NOT EXISTS announce_identities (
+                    peer TEXT PRIMARY KEY,
+                    public_key_hex TEXT NOT NULL,
+                    verifying_key_hex TEXT NOT NULL,
+                    updated_at INTEGER NOT NULL
                 );
                 CREATE TABLE IF NOT EXISTS sdk_domain_state (
                     domain TEXT PRIMARY KEY,

--- a/crates/libs/rns-rpc/src/storage/messages_parts/messagesstore_sections/list_announces.rs
+++ b/crates/libs/rns-rpc/src/storage/messages_parts/messagesstore_sections/list_announces.rs
@@ -227,6 +227,7 @@ impl MessagesStore {
     pub fn clear_announces(&self) -> rusqlite::Result<()> {
         self.with_write_conn(|conn| {
             conn.execute("DELETE FROM announces", [])?;
+            conn.execute("DELETE FROM announce_identities", [])?;
             Ok(())
         })
     }

--- a/crates/libs/rns-rpc/src/storage/messages_parts/messagesstore_sections/sdk_domain_snapshot_key.rs
+++ b/crates/libs/rns-rpc/src/storage/messages_parts/messagesstore_sections/sdk_domain_snapshot_key.rs
@@ -127,6 +127,21 @@ impl MessagesStore {
                                 fields_json.as_deref(),
                             ));
                         }
+                        OutboundWriteCommand::UpsertAnnounceIdentity {
+                            peer,
+                            public_key_hex,
+                            verifying_key_hex,
+                            updated_at,
+                            reply,
+                        } => {
+                            let _ = reply.send(Self::upsert_announce_identity_direct(
+                                write_state.as_ref(),
+                                peer.as_str(),
+                                public_key_hex.as_str(),
+                                verifying_key_hex.as_str(),
+                                updated_at,
+                            ));
+                        }
                         OutboundWriteCommand::InsertAnnounce { record, reply } => {
                             let _ = reply
                                 .send(Self::insert_announce_direct(write_state.as_ref(), &record));
@@ -372,6 +387,28 @@ impl MessagesStore {
                     record.stamp_cost_flexibility,
                     record.peering_cost,
                 ],
+            )?;
+            Ok(())
+        })
+    }
+
+    fn upsert_announce_identity_direct(
+        write_state: &WriteState,
+        peer: &str,
+        public_key_hex: &str,
+        verifying_key_hex: &str,
+        updated_at: i64,
+    ) -> rusqlite::Result<()> {
+        Self::write_lock_and_run(write_state, |conn| {
+            conn.execute(
+                "INSERT INTO announce_identities
+                    (peer, public_key_hex, verifying_key_hex, updated_at)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(peer) DO UPDATE SET
+                    public_key_hex = excluded.public_key_hex,
+                    verifying_key_hex = excluded.verifying_key_hex,
+                    updated_at = excluded.updated_at",
+                params![peer, public_key_hex, verifying_key_hex, updated_at],
             )?;
             Ok(())
         })

--- a/crates/libs/rns-rpc/src/storage/messages_parts/module_prelude.rs
+++ b/crates/libs/rns-rpc/src/storage/messages_parts/module_prelude.rs
@@ -74,6 +74,13 @@ enum OutboundWriteCommand {
         fields_json: Option<String>,
         reply: mpsc::Sender<rusqlite::Result<()>>,
     },
+    UpsertAnnounceIdentity {
+        peer: String,
+        public_key_hex: String,
+        verifying_key_hex: String,
+        updated_at: i64,
+        reply: mpsc::Sender<rusqlite::Result<()>>,
+    },
     InsertAnnounce {
         record: AnnounceRecord,
         reply: mpsc::Sender<rusqlite::Result<()>>,

--- a/crates/libs/rns-rpc/src/storage/messages_parts/outbound_message_sections/core_tests.rs
+++ b/crates/libs/rns-rpc/src/storage/messages_parts/outbound_message_sections/core_tests.rs
@@ -128,6 +128,30 @@
     }
 
     #[test]
+    fn announce_identity_keys_survive_store_restart() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("announce-identity.sqlite");
+        {
+            let store = MessagesStore::open(db_path.as_path()).expect("open store");
+            store
+                .upsert_announce_identity(
+                    "AA".repeat(16).as_str(),
+                    "BB".repeat(32).as_str(),
+                    "CC".repeat(32).as_str(),
+                    1_781_964_554,
+                )
+                .expect("upsert announce identity");
+        }
+
+        let reopened = MessagesStore::open(db_path.as_path()).expect("reopen store");
+        let keys = reopened
+            .announce_identity_keys("aa".repeat(16).as_str())
+            .expect("load announce identity");
+
+        assert_eq!(keys, Some(("bb".repeat(32), "cc".repeat(32))));
+    }
+
+    #[test]
     fn inbound_tickets_keep_multiple_generated_tickets_per_destination() {
         let store = MessagesStore::in_memory().expect("in-memory store");
         store.upsert_ticket("peer", "22", 200).expect("insert first ticket");

--- a/crates/libs/rns-rpc/src/storage/messages_parts/outbound_message_sections/core_tests.rs
+++ b/crates/libs/rns-rpc/src/storage/messages_parts/outbound_message_sections/core_tests.rs
@@ -152,6 +152,48 @@
     }
 
     #[test]
+    fn clear_announces_also_clears_persisted_identity_keys() {
+        let store = MessagesStore::in_memory().expect("in-memory store");
+        store
+            .insert_announce(&AnnounceRecord {
+                id: "ann-identity-clear".to_string(),
+                peer: "aa".repeat(16),
+                timestamp: 1_781_964_554,
+                name: None,
+                name_source: None,
+                first_seen: 1_781_964_554,
+                seen_count: 1,
+                app_data_hex: None,
+                capabilities: Vec::new(),
+                rssi: None,
+                snr: None,
+                q: None,
+                stamp_cost: None,
+                stamp_cost_flexibility: None,
+                peering_cost: None,
+            })
+            .expect("record announce");
+        store
+            .upsert_announce_identity(
+                "AA".repeat(16).as_str(),
+                "BB".repeat(32).as_str(),
+                "CC".repeat(32).as_str(),
+                1_781_964_554,
+            )
+            .expect("upsert announce identity");
+
+        store.clear_announces().expect("clear announces");
+
+        assert!(store.list_announces(10, None, None).expect("announces").is_empty());
+        assert_eq!(
+            store
+                .announce_identity_keys("aa".repeat(16).as_str())
+                .expect("load announce identity"),
+            None
+        );
+    }
+
+    #[test]
     fn inbound_tickets_keep_multiple_generated_tickets_per_destination() {
         let store = MessagesStore::in_memory().expect("in-memory store");
         store.upsert_ticket("peer", "22", 200).expect("insert first ticket");


### PR DESCRIPTION
## Summary
- persist announce public/verifying identity keys so reticulumd can resolve stale LXMF delivery/propagation destinations after restart or peer-cache loss
- validate reconstructed identities against the requested destination hash before use
- automatically select the local propagation node when reticulumd starts with propagation enabled, so daemon-originated propagated sends store locally instead of trying to link to itself

## Validation
- cargo test -p reticulumd bootstrap_selects_local_propagation_node_when_enabled_by_config -- --nocapture
- cargo test -p reticulumd outbound_peer_identity -- --nocapture
- cargo test -p reticulumd persisted_identity -- --nocapture
- cargo test -p reticulum-rs-rpc announce_identity_keys_survive_store_restart -- --nocapture
- cargo check -p reticulumd --bin reticulumd --features zmq-pipeline-rpc
- Live Pi/RCH check: propagated token hil-zmq-single-132646 reached reticulumd receipt_status="sent: propagated resource" with local propagation storage after RCH SDK2/ZMQ enqueue
