### PR TITLE
Preserve valid announce costs when siblings are malformed

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/helpers_parts/merge_fields_with_options.rs
+++ b/crates/libs/rns-rpc/src/rpc/helpers_parts/merge_fields_with_options.rs
@@ -420,9 +420,9 @@ fn parse_announce_costs_from_app_data_hex(
     };
     if let MsgPackValue::Array(values) = costs {
         return Ok((
-            values.first().map(parse_fuzzy_u32).transpose()?,
-            values.get(1).map(parse_fuzzy_u32).transpose()?,
-            values.get(2).map(parse_fuzzy_u32).transpose()?,
+            parse_announce_cost_slot(values.first(), "stamp_cost"),
+            parse_announce_cost_slot(values.get(1), "stamp_cost_flexibility"),
+            parse_announce_cost_slot(values.get(2), "peering_cost"),
         ));
     }
     let MsgPackValue::Map(entries) = costs else {
@@ -436,16 +436,28 @@ fn parse_announce_costs_from_app_data_hex(
             continue;
         };
         if key == "stamp_cost" {
-            stamp_cost = Some(parse_fuzzy_u32(value)?);
+            stamp_cost = parse_announce_cost_slot(Some(value), "stamp_cost");
         }
         if key == "stamp_cost_flexibility" {
-            stamp_cost_flexibility = Some(parse_fuzzy_u32(value)?);
+            stamp_cost_flexibility =
+                parse_announce_cost_slot(Some(value), "stamp_cost_flexibility");
         }
         if key == "peering_cost" {
-            peering_cost = Some(parse_fuzzy_u32(value)?);
+            peering_cost = parse_announce_cost_slot(Some(value), "peering_cost");
         }
     }
     Ok((stamp_cost, stamp_cost_flexibility, peering_cost))
+}
+
+fn parse_announce_cost_slot(slot: Option<&MsgPackValue>, label: &str) -> Option<u32> {
+    let raw = slot?;
+    match parse_fuzzy_u32(raw) {
+        Ok(cost) => Some(cost),
+        Err(err) => {
+            log::warn!("[daemon] ignoring malformed announce {label}: {err}");
+            None
+        }
+    }
 }
 
 fn parse_propagation_limits_from_app_data_hex(

--- a/crates/libs/rns-rpc/src/rpc/helpers_tests.rs
+++ b/crates/libs/rns-rpc/src/rpc/helpers_tests.rs
@@ -209,6 +209,60 @@ fn parse_propagation_limits_keep_transfer_when_sync_slot_malformed() {
 }
 
 #[test]
+fn parse_announce_costs_keep_valid_siblings_when_array_slot_malformed() {
+    // index 5 = propagation costs. A bad optional cost slot must not erase valid
+    // sibling slots because the legacy caller collapses any Err to all None.
+    let announce = rmp_serde::to_vec_named(&rmpv::Value::Array(vec![
+        rmpv::Value::Nil,
+        rmpv::Value::Nil,
+        rmpv::Value::Nil,
+        rmpv::Value::Nil,
+        rmpv::Value::Nil,
+        rmpv::Value::Array(vec![
+            rmpv::Value::String("not-a-cost".into()),
+            rmpv::Value::from(2),
+            rmpv::Value::from(5),
+        ]),
+    ]))
+    .expect("encode announce");
+
+    assert_eq!(
+        parse_announce_costs_from_app_data_hex(Some(hex::encode(announce).as_str()))
+            .expect("structural decode succeeds"),
+        (None, Some(2), Some(5))
+    );
+}
+
+#[test]
+fn parse_announce_costs_keep_valid_siblings_when_map_slot_malformed() {
+    let announce = rmp_serde::to_vec_named(&rmpv::Value::Array(vec![
+        rmpv::Value::Nil,
+        rmpv::Value::Nil,
+        rmpv::Value::Nil,
+        rmpv::Value::Nil,
+        rmpv::Value::Nil,
+        rmpv::Value::Map(vec![
+            (
+                rmpv::Value::String("stamp_cost".into()),
+                rmpv::Value::String("not-a-cost".into()),
+            ),
+            (
+                rmpv::Value::String("stamp_cost_flexibility".into()),
+                rmpv::Value::from(3),
+            ),
+            (rmpv::Value::String("peering_cost".into()), rmpv::Value::from(7)),
+        ]),
+    ]))
+    .expect("encode announce");
+
+    assert_eq!(
+        parse_announce_costs_from_app_data_hex(Some(hex::encode(announce).as_str()))
+            .expect("structural decode succeeds"),
+        (None, Some(3), Some(7))
+    );
+}
+
+#[test]
 fn parse_propagation_enabled_preserved_for_minimal_array() {
     // A minimal `[flag, timebase, enabled]` announce still carries the enabled flag at
     // index 2; it must not be discarded for lacking later cost/metadata slots.


### PR DESCRIPTION
## Summary

Contributor guide: `CONTRIBUTING.md`

## Type
- [ ] breaking
- [ ] refactor
- [ ] reliability
- [ ] chore/governance

## Validation
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `make test`
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [ ] `cargo doc --workspace --no-deps`
- [ ] `cargo deny check`
- [ ] `cargo audit`

## Compatibility
- [ ] Updated compatibility matrix / contract docs (if needed)
