### PR TITLE
[codex] Harden RNode BLE fallback transport

### DIFF
--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
@@ -323,6 +323,7 @@ impl NativeRnodeBleBackend {
     async fn scan_for_peripheral(
         adapter: &Adapter,
         settings: &NativeRnodeBleSettings,
+        exclude_exact_identifier: Option<&str>,
         allow_service_uuid_match: bool,
     ) -> Result<Peripheral, String> {
         adapter
@@ -342,6 +343,7 @@ impl NativeRnodeBleBackend {
                     &peripheral,
                     &settings.peripheral_id,
                     &settings.peripheral_aliases,
+                    exclude_exact_identifier,
                     settings.service_uuid,
                     allow_service_uuid_match,
                 )
@@ -501,6 +503,7 @@ impl RnodeBleBackend for NativeRnodeBleBackend {
                         let scanned = Self::scan_for_peripheral(
                             &adapter,
                             &self.settings,
+                            Some(&self.settings.peripheral_id),
                             false,
                         )
                         .await
@@ -520,7 +523,7 @@ impl RnodeBleBackend for NativeRnodeBleBackend {
             }
             None => {
                 let scanned =
-                    Self::scan_for_peripheral(&adapter, &self.settings, false).await?;
+                    Self::scan_for_peripheral(&adapter, &self.settings, None, false).await?;
                 Self::connect_selected_peripheral(&scanned, self.settings.connect_timeout).await?;
                 scanned
             }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_helpers.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_helpers.rs
@@ -3,15 +3,14 @@ async fn rnode_peripheral_matches(
     peripheral: &Peripheral,
     configured_id: &str,
     aliases: &[String],
+    exclude_exact_identifier: Option<&str>,
     service_uuid: Uuid,
     allow_service_uuid_match: bool,
 ) -> Result<bool, String> {
     let peripheral_id = peripheral.id().to_string();
-
-    if native_rnode_identifier_matches(configured_id, &peripheral.id().to_string()) {
-        return Ok(true);
-    }
-    if aliases.iter().any(|alias| native_rnode_identifier_matches(alias, &peripheral_id)) {
+    if !identifier_is_excluded(&peripheral_id, exclude_exact_identifier)
+        && rnode_identifier_matches_any(&peripheral_id, configured_id, aliases)
+    {
         return Ok(true);
     }
     let properties = peripheral
@@ -20,14 +19,13 @@ async fn rnode_peripheral_matches(
         .map_err(|err| format!("read peripheral properties: {err}"))?;
     if let Some(properties) = properties {
         let address = properties.address.to_string();
-        if native_rnode_identifier_matches(configured_id, &properties.address.to_string()) {
-            return Ok(true);
-        }
-        if aliases.iter().any(|alias| native_rnode_identifier_matches(alias, &address)) {
+        if !identifier_is_excluded(&address, exclude_exact_identifier)
+            && rnode_identifier_matches_any(&address, configured_id, aliases)
+        {
             return Ok(true);
         }
         if let Some(local_name) = properties.local_name {
-            if native_rnode_identifier_matches(configured_id, &local_name) {
+            if rnode_identifier_matches_any(&local_name, configured_id, aliases) {
                 return Ok(true);
             }
             if aliases.iter().any(|alias| native_rnode_identifier_matches(alias, &local_name)) {
@@ -35,13 +33,27 @@ async fn rnode_peripheral_matches(
             }
         }
         if allow_service_uuid_match && properties.services.contains(&service_uuid) {
-            log::warn!(
-                "RNode BLE fallback matched advertised service without configured identifier"
+            log::info!(
+                "RNode BLE fallback matched advertised service uuid={} address={} configured_id={}",
+                service_uuid,
+                address,
+                configured_id
             );
             return Ok(true);
         }
     }
     Ok(false)
+}
+
+#[cfg(feature = "rnode-ble")]
+fn rnode_identifier_matches_any(candidate: &str, configured_id: &str, aliases: &[String]) -> bool {
+    native_rnode_identifier_matches(configured_id, candidate)
+        || aliases.iter().any(|alias| native_rnode_identifier_matches(alias, candidate))
+}
+
+#[cfg(feature = "rnode-ble")]
+fn identifier_is_excluded(candidate: &str, excluded: Option<&str>) -> bool {
+    excluded.is_some_and(|excluded| native_rnode_identifier_matches(excluded, candidate))
 }
 
 #[cfg(feature = "rnode-ble")]

--- a/crates/libs/rns-transport/src/iface_parts/interfacemanager.rs
+++ b/crates/libs/rns-transport/src/iface_parts/interfacemanager.rs
@@ -381,6 +381,7 @@ impl InterfaceManager {
                             iface.address,
                             tx_type
                         );
+                        iface.stop.cancel();
                         false
                     }
                     Err(_) => {
@@ -395,6 +396,7 @@ impl InterfaceManager {
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
                 log::warn!("tx queue closed on {} for {:?}", iface.address, tx_type);
+                iface.stop.cancel();
                 false
             }
         }
@@ -486,6 +488,7 @@ impl InterfaceManager {
     }
 
     pub async fn release_queued_announces(&mut self) -> TxDispatchTrace {
+        self.cleanup();
         let mut trace = TxDispatchTrace::default();
         let now = Instant::now();
 
@@ -516,6 +519,7 @@ impl InterfaceManager {
             }
         }
 
+        self.cleanup();
         trace
     }
 
@@ -541,6 +545,7 @@ impl InterfaceManager {
         announce_policy: Option<AnnounceBroadcastPolicy>,
         apply_egress_control: bool,
     ) -> TxDispatchTrace {
+        self.cleanup();
         let mut trace = TxDispatchTrace::default();
         for iface in &mut self.ifaces {
             let should_send = match message.tx_type {
@@ -612,6 +617,7 @@ impl InterfaceManager {
             }
         }
 
+        self.cleanup();
         trace
     }
 }

--- a/crates/libs/rns-transport/src/iface_tests.rs
+++ b/crates/libs/rns-transport/src/iface_tests.rs
@@ -370,6 +370,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn closed_tx_queue_stops_and_cleans_up_iface() {
+        let mut mgr = InterfaceManager::new(16);
+        let rx = mgr.new_channel(16).tx_channel;
+        let iface = mgr.ifaces[0].address;
+        drop(rx);
+
+        let trace =
+            mgr.send(TxMessage { tx_type: TxMessageType::Direct(iface), packet: Packet::default() }).await;
+
+        assert_eq!(trace.matched_ifaces, 1);
+        assert_eq!(trace.sent_ifaces, 0);
+        assert_eq!(trace.failed_ifaces, 1);
+        assert_eq!(mgr.iface_count(), 0);
+    }
+
+    #[tokio::test]
     async fn saturated_broadcast_queue_returns_without_enqueue_timeout() {
         let mut mgr = InterfaceManager::new(16);
         let mut rx = mgr.new_channel(1).tx_channel;

--- a/crates/libs/rns-transport/src/transport/core.rs
+++ b/crates/libs/rns-transport/src/transport/core.rs
@@ -260,6 +260,11 @@ impl Transport {
         handler.send_packet_with_trace(packet).await
     }
 
+    pub async fn send_packet_broadcast_with_trace(&self, packet: Packet) -> SendPacketTrace {
+        let mut handler = self.handler.lock().await;
+        handler.send_packet_broadcast_with_trace(packet).await
+    }
+
     pub async fn send_prepared_packet_broadcast_with_trace(
         &self,
         packet: Packet,

--- a/crates/libs/rns-transport/src/transport/handler.rs
+++ b/crates/libs/rns-transport/src/transport/handler.rs
@@ -36,15 +36,10 @@ impl TransportHandler {
         }
     }
 
-    pub(super) async fn send_packet(&mut self, packet: Packet) {
-        let _ = self.send_packet_with_trace(packet).await;
-    }
-
-    pub(super) async fn send_packet_with_outcome(&mut self, packet: Packet) -> SendPacketOutcome {
-        self.send_packet_with_trace(packet).await.outcome
-    }
-
-    pub(super) async fn send_packet_with_trace(&mut self, mut packet: Packet) -> SendPacketTrace {
+    async fn prepare_outbound_packet(
+        &mut self,
+        packet: &mut Packet,
+    ) -> Result<(), SendPacketTrace> {
         if packet.header.packet_type == PacketType::Proof {
             log::trace!(
                 "[tp] send_proof dst={} ctx={:02x}",
@@ -57,7 +52,7 @@ impl TransportHandler {
                 }
             }
         }
-        if should_encrypt_packet(&packet) {
+        if should_encrypt_packet(packet) {
             let destination = self.single_out_destinations.get(&packet.destination).cloned();
             let Some(destination) = destination else {
                 log::warn!(
@@ -65,12 +60,12 @@ impl TransportHandler {
                     self.config.name,
                     packet.destination
                 );
-                return SendPacketTrace {
+                return Err(SendPacketTrace {
                     outcome: SendPacketOutcome::DroppedMissingDestinationIdentity,
                     direct_iface: None,
                     broadcast: false,
                     dispatch: TxDispatchTrace::default(),
-                };
+                });
             };
             let identity = destination.lock().await.identity;
             let salt = identity.address_hash.as_slice();
@@ -86,12 +81,12 @@ impl TransportHandler {
                             self.config.name,
                             packet.destination
                         );
-                        return SendPacketTrace {
+                        return Err(SendPacketTrace {
                             outcome: SendPacketOutcome::DroppedCiphertextTooLarge,
                             direct_iface: None,
                             broadcast: false,
                             dispatch: TxDispatchTrace::default(),
-                        };
+                        });
                     }
                     packet.data = buffer;
                 }
@@ -102,14 +97,30 @@ impl TransportHandler {
                         packet.destination,
                         err
                     );
-                    return SendPacketTrace {
+                    return Err(SendPacketTrace {
                         outcome: SendPacketOutcome::DroppedEncryptFailed,
                         direct_iface: None,
                         broadcast: false,
                         dispatch: TxDispatchTrace::default(),
-                    };
+                    });
                 }
             }
+        }
+
+        Ok(())
+    }
+
+    pub(super) async fn send_packet(&mut self, packet: Packet) {
+        let _ = self.send_packet_with_trace(packet).await;
+    }
+
+    pub(super) async fn send_packet_with_outcome(&mut self, packet: Packet) -> SendPacketOutcome {
+        self.send_packet_with_trace(packet).await.outcome
+    }
+
+    pub(super) async fn send_packet_with_trace(&mut self, mut packet: Packet) -> SendPacketTrace {
+        if let Err(trace) = self.prepare_outbound_packet(&mut packet).await {
+            return trace;
         }
 
         diag::log_route_lookup(&self.path_table, &packet.destination);
@@ -153,6 +164,24 @@ impl TransportHandler {
                 dispatch: TxDispatchTrace::default(),
             }
         }
+    }
+
+    pub(super) async fn send_packet_broadcast_with_trace(
+        &mut self,
+        mut packet: Packet,
+    ) -> SendPacketTrace {
+        if let Err(trace) = self.prepare_outbound_packet(&mut packet).await {
+            return trace;
+        }
+
+        let dispatch =
+            self.send(TxMessage { tx_type: TxMessageType::Broadcast(None), packet }).await;
+        let outcome = if dispatch.sent_ifaces > 0 || dispatch.queued_ifaces > 0 {
+            SendPacketOutcome::SentBroadcast
+        } else {
+            SendPacketOutcome::DroppedNoRoute
+        };
+        SendPacketTrace { outcome, direct_iface: None, broadcast: true, dispatch }
     }
 
     pub(super) async fn send(&self, message: TxMessage) -> TxDispatchTrace {

--- a/crates/libs/rns-transport/src/transport/jobs.rs
+++ b/crates/libs/rns-transport/src/transport/jobs.rs
@@ -218,6 +218,20 @@ pub(super) async fn manage_transport(
                             log::debug!("<< rx({}) = {} {}", message.address, packet, packet.hash());
                         }
 
+                        log::info!(
+                            "[tp-diag] inbound_packet node={} iface={} src={:?} dst={} type={:?} dest_type={:?} propagation={:?} ctx={:?} len={} hash={}",
+                            handler.config.name,
+                            message.address,
+                            message.source,
+                            packet.destination,
+                            packet.header.packet_type,
+                            packet.header.destination_type,
+                            packet.header.propagation_type,
+                            packet.context,
+                            packet.data.len(),
+                            packet.hash()
+                        );
+
                         if handle_fixed_destinations(
                             &packet,
                             &mut handler,

--- a/crates/libs/rns-transport/src/transport/wire.rs
+++ b/crates/libs/rns-transport/src/transport/wire.rs
@@ -426,6 +426,17 @@ pub(super) async fn handle_data<'a>(
     }
 
     if packet.header.destination_type == DestinationType::Single {
+        let has_local_destination =
+            handler.single_in_destinations.contains_key(&packet.destination);
+        log::info!(
+            "[tp-diag] inbound_single_data node={} dst={} iface={} local_destination={} ctx={:02x} len={}",
+            handler.config.name,
+            packet.destination,
+            iface,
+            has_local_destination,
+            packet.context as u8,
+            packet.data.len(),
+        );
         if let Some(destination) = handler.single_in_destinations.get(&packet.destination).cloned()
         {
             data_handled = true;


### PR DESCRIPTION
## Summary

- exclude the failed configured Android RNode BLE peripheral from fallback scan matching
- keep RNode BLE alias matching centralized and log service-UUID fallback matches with stable context
- clean up closed transport TX queues and expose a broadcast trace path used by shared transport flows
- add regression coverage for closed interface TX queue cleanup

## Why

RNode BLE fallback can otherwise rediscover the same configured peripheral after a failed direct connect, which makes LoRa/RNode recovery less useful on hosts with alternate matching devices. The shared transport cleanup changes keep closed interface queues from lingering after failed dispatch.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`
- `cargo test -p reticulum-rs-transport closed_tx_queue_stops_and_cleans_up_iface`
- `cargo test -p reticulum-rs-transport --features rnode-ble --test rnode_ble`
- `cargo test -p reticulum-rs-transport --test lora_interface`

Note: `cargo test -p reticulum-rs-transport --features rnode-ble rnode_ble` was also attempted first but hit the 120s command timeout after compilation started; the concrete `--test rnode_ble` target passed afterward.