### PR TITLE
[codex] Clarify BLE MTU truncation diagnostics

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/mod_parts/ble_startup_max_retry_attempts.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/mod_parts/ble_startup_max_retry_attempts.rs
@@ -422,7 +422,7 @@ fn startup_probe_mismatch_diagnostic(expected_len: usize, actual_len: usize) -> 
     if actual_len == DEFAULT_ATT_NOTIFICATION_PAYLOAD_BYTES
         || actual_len < expected_len && actual_len < DEFAULT_ATT_NOTIFICATION_PAYLOAD_BYTES
     {
-        "; likely ATT MTU 23 / 20-byte notification payload; btleplug cannot request a larger MTU in this backend, so configure a host adapter that negotiates MTU before enabling notifications"
+        "; likely ATT MTU 23 / 20-byte notification payload; the BLE host/backend did not report a usable negotiated MTU before notifications, so verify btleplug 0.12+ platform MTU support or configure a host adapter that negotiates a larger ATT MTU"
     } else {
         ""
     }

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/mod_parts/plannedfailure.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/ble/mod_parts/plannedfailure.rs
@@ -283,6 +283,7 @@ mod tests {
             .expect_err("20-byte notification should fail lifecycle with MTU diagnostic");
 
         assert!(err.contains("likely ATT MTU 23"));
-        assert!(err.contains("btleplug cannot request a larger MTU"));
+        assert!(err.contains("did not report a usable negotiated MTU"));
+        assert!(err.contains("btleplug 0.12+"));
     }
 }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
@@ -332,7 +332,7 @@ impl RnodeBleKissSession {
         {
             return Err(RnodeBleKissError::Backend {
                 operation: "accept_notification_events",
-                message: "incomplete 20-byte RNode BLE notification; likely ATT MTU 23 / 20-byte notification payload, and btleplug cannot request a larger MTU before notifications in this backend".to_string(),
+                message: "incomplete 20-byte RNode BLE notification; likely ATT MTU 23 / 20-byte notification payload. The BLE host/backend did not report a usable negotiated MTU before notifications; verify btleplug 0.12+ platform MTU support or configure a host adapter that negotiates a larger ATT MTU.".to_string(),
             });
         }
         let mut notification = RnodeBleNotification::default();
@@ -406,7 +406,8 @@ mod tests {
             RnodeBleKissError::Backend { operation, message } => {
                 assert_eq!(operation, "accept_notification_events");
                 assert!(message.contains("likely ATT MTU 23"));
-                assert!(message.contains("btleplug cannot request a larger MTU"));
+                assert!(message.contains("did not report a usable negotiated MTU"));
+                assert!(message.contains("btleplug 0.12+"));
             }
             other => panic!("unexpected error: {other:?}"),
         }

--- a/docs/contracts/mobile-ble-host-contract.md
+++ b/docs/contracts/mobile-ble-host-contract.md
@@ -59,8 +59,8 @@ Required request/response/event types:
   session is considered ready.
 - Hosts that remain at the Bluetooth default `ATT MTU 23` (`20` payload bytes) must fail
   readiness with validation semantics instead of surfacing a healthy-but-silent session.
-- Native `btleplug` backends cannot request a larger MTU in version `0.11.8`; platform hosts
-  that can negotiate MTU must do so before enabling notifications.
+- Native `btleplug` backends use the platform-reported negotiated ATT MTU; platform hosts
+  that can negotiate MTU must do so and report the resulting value before enabling notifications.
 
 ## Conformance
 

--- a/docs/runbooks/reticulumd-lora-interface.md
+++ b/docs/runbooks/reticulumd-lora-interface.md
@@ -168,11 +168,17 @@ write/notification characteristics, subscribes to notifications, and writes
 raw KISS payload chunks to the backend characteristic writer. Outbound BLE
 packet writes are rejected before backend I/O when they exceed the configured
 RNode BLE MTU, and encoded raw-KISS bytes are chunked by the configured maximum
-BLE write length before they reach the backend. The RNode BLE notification path
-also preserves non-READY KISS command responses alongside decoded packet
-payloads, and its command monitor exposes retained probe status, radio status,
-non-fatal hardware errors, fatal command error, online state, and reported
-bitrate. Daemon `RNodeInterface` `ble://` startup appends the same RNode
+BLE write length before they reach the backend. The native backend reads the
+negotiated ATT MTU exposed by `btleplug` 0.12 after connect/service discovery,
+raises the default write chunk size when the platform reports a larger payload,
+and warns when a reported MTU remains below the 173-byte LXMF notification
+minimum. A 20-byte partial notification is diagnosed as likely ATT MTU 23 /
+20-byte payload evidence, which means the host/backend did not report a usable
+larger negotiated MTU before notifications. The RNode BLE notification path also
+preserves non-READY KISS command responses alongside decoded packet payloads,
+and its command monitor exposes retained probe status, radio status, non-fatal
+hardware errors, fatal command error, online state, and reported bitrate.
+Daemon `RNodeInterface` `ble://` startup appends the same RNode
 detect, firmware, platform, MCU, radio configuration, airtime-lock, and
 radio-on command frames used by serial/TCP RNode startup and validates startup
 and fatal command responses through the same RNode protocol state. If startup


### PR DESCRIPTION
## Summary

- update RNode BLE and BLE lifecycle ATT-MTU truncation diagnostics so they no longer describe the old btleplug 0.11.8 limitation as current behavior
- document that native btleplug backends now use the platform-reported negotiated ATT MTU from btleplug 0.12
- keep the 20-byte notification diagnostic focused on what it proves: the host/backend did not report a usable negotiated MTU before notifications

## Why

Issue #285 was addressed by the btleplug 0.12 and MTU-propagation work in #315, but a few diagnostics and contract docs still referenced the old “btleplug cannot request a larger MTU” framing. That made current BLE parity evidence read worse than the implementation actually is.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `rg -n "btleplug cannot request|cannot request a larger MTU|0\\.11\\.8" crates docs || true`
- `cargo test -p reticulum-rs-transport --features rnode-ble rnode_ble_notification_reports_likely_default_att_mtu_cap`
- `cargo test -p reticulumd ble_lifecycle_reports_likely_att_mtu_truncation`

Closes #285.
