### PR TITLE
[codex] Split transport wire encryption policy

### DIFF
--- a/crates/libs/rns-transport/src/transport/handler.rs
+++ b/crates/libs/rns-transport/src/transport/handler.rs
@@ -1,5 +1,5 @@
 use super::diag;
-use super::wire::should_encrypt_packet;
+use super::wire_encryption::should_encrypt_packet;
 use super::*;
 
 impl TransportHandler {

--- a/crates/libs/rns-transport/src/transport/mod.rs
+++ b/crates/libs/rns-transport/src/transport/mod.rs
@@ -311,6 +311,8 @@ mod links;
 mod path;
 // resource_wire: link-scoped resource packet handling on inbound wire paths.
 mod resource_wire;
+// wire_encryption: packet-context policy for transport-layer encryption.
+mod wire_encryption;
 // wire: inbound packet handlers and wire-level packet logic.
 mod wire;
 

--- a/crates/libs/rns-transport/src/transport/wire.rs
+++ b/crates/libs/rns-transport/src/transport/wire.rs
@@ -1,6 +1,7 @@
 use super::diag;
 use super::path::send_to_next_hop;
 use super::resource_wire;
+use super::wire_encryption::should_encrypt_packet;
 use super::*;
 use ed25519_dalek::{Signature, SIGNATURE_LENGTH};
 
@@ -322,27 +323,6 @@ pub(super) async fn handle_keepalive_response<'a>(
     }
 
     false
-}
-
-pub(super) fn should_encrypt_packet(packet: &Packet) -> bool {
-    if packet.header.packet_type != PacketType::Data {
-        return false;
-    }
-    if packet.header.destination_type != DestinationType::Single {
-        return false;
-    }
-    !matches!(
-        packet.context,
-        PacketContext::Resource
-            | PacketContext::ResourceAdvrtisement
-            | PacketContext::ResourceRequest
-            | PacketContext::ResourceHashUpdate
-            | PacketContext::ResourceProof
-            | PacketContext::ResourceInitiatorCancel
-            | PacketContext::ResourceReceiverCancel
-            | PacketContext::KeepAlive
-            | PacketContext::CacheRequest
-    )
 }
 
 pub(super) async fn handle_data<'a>(

--- a/crates/libs/rns-transport/src/transport/wire_encryption.rs
+++ b/crates/libs/rns-transport/src/transport/wire_encryption.rs
@@ -1,0 +1,22 @@
+use super::*;
+
+pub(super) fn should_encrypt_packet(packet: &Packet) -> bool {
+    if packet.header.packet_type != PacketType::Data {
+        return false;
+    }
+    if packet.header.destination_type != DestinationType::Single {
+        return false;
+    }
+    !matches!(
+        packet.context,
+        PacketContext::Resource
+            | PacketContext::ResourceAdvrtisement
+            | PacketContext::ResourceRequest
+            | PacketContext::ResourceHashUpdate
+            | PacketContext::ResourceProof
+            | PacketContext::ResourceInitiatorCancel
+            | PacketContext::ResourceReceiverCancel
+            | PacketContext::KeepAlive
+            | PacketContext::CacheRequest
+    )
+}


### PR DESCRIPTION
## Summary

- move the transport packet encryption-context predicate out of `transport/wire.rs` into a tiny `wire_encryption` module
- keep the inbound wire handlers unchanged while bringing `wire.rs` back under the active module-size budget

## Why

After the interface parity follow-ups, the repository-wide module-size gate was down to a single failure: `crates/libs/rns-transport/src/transport/wire.rs:510 (limit=500)`. This removes that gate failure without changing transport behavior.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `tools/scripts/check-module-size.sh`
- `cargo test -p reticulum-rs-transport --lib transport::tests`
