### PR TITLE
[codex] Refresh interop artifact baseline

### DIFF
--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -68,8 +68,8 @@
     },
     {
       "path": "docs/contracts/mobile-ble-host-contract.md",
-      "bytes": 2838,
-      "sha256": "4d25c8e2ac0b839f08120bcccd175baf955f28e8225a9831c5ebbf157f4b8409"
+      "bytes": 2866,
+      "sha256": "27444acb71adb1ade6e01c0ffa3951c90598a08cafd54d21d5322ab5554ee822"
     },
     {
       "path": "docs/contracts/native-embedded-interop-profile-v1.md",


### PR DESCRIPTION
## Summary

Refresh `docs/contracts/baselines/interop-artifacts-manifest.json` after the mobile BLE host contract text changed, so the interop artifact drift gate matches the current committed contract file.

## Why

`cargo xtask release-check` was failing at the interop artifact drift stage because the manifest still carried the previous byte count and SHA-256 for `docs/contracts/mobile-ble-host-contract.md`.

## Validation

- `cargo run -p xtask -- interop-artifacts --update`
- `cargo run -p xtask -- interop-artifacts`
- `TIMEOUT_SECS=75 ./tools/scripts/kiss-fake-tcp-smoke.sh`
- `TIMEOUT_SECS=75 ./tools/scripts/kiss-fake-pty-smoke.sh`
- `TIMEOUT_SECS=75 ./tools/scripts/pipe-fake-subprocess-smoke.sh`
- `TIMEOUT_SECS=75 ./tools/scripts/udp-loopback-smoke.sh`
- `PATH="$PWD/.tmp/jre/bin:$PATH" cargo run -p xtask -- schema-client-check`
- `PATH="$PWD/.tmp/jre/bin:$PATH" cargo xtask release-check`

Note: the local Java 21 runtime used for schema-client/release-check validation was installed under ignored `.tmp/` because the host image did not have `java` on `PATH`; CI already provisions Java 21.
