### PR TITLE
[codex] complete LXMF module helper parity

### DIFF
--- a/crates/libs/lxmf-core/src/announce.rs
+++ b/crates/libs/lxmf-core/src/announce.rs
@@ -1,7 +1,9 @@
-use alloc::string::{FromUtf8Error, String};
+use alloc::string::{FromUtf8Error, String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt;
+
+use crate::constants::{PN_META_NAME, SF_COMPRESSION};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AnnounceSlot {
@@ -88,6 +90,49 @@ impl fmt::Display for AnnounceParseError {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PnAnnounceParseError {
+    InvalidMsgpack,
+    NotArray,
+    InsufficientPeerData,
+    InvalidTimebase,
+    IndeterminatePropagationNodeStatus,
+    InvalidTransferOrSyncLimit,
+    InvalidStampCosts,
+    InvalidStampCostValues,
+    InvalidMetadata,
+}
+
+impl fmt::Display for PnAnnounceParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidMsgpack => f.write_str("invalid propagation node announce msgpack"),
+            Self::NotArray => f.write_str("propagation node announce data must be an array"),
+            Self::InsufficientPeerData => f.write_str(
+                "invalid announce data: insufficient peer data, likely from deprecated LXMF version",
+            ),
+            Self::InvalidTimebase => {
+                f.write_str("invalid announce data: could not decode timebase")
+            }
+            Self::IndeterminatePropagationNodeStatus => f.write_str(
+                "invalid announce data: indeterminate propagation node status",
+            ),
+            Self::InvalidTransferOrSyncLimit => f.write_str(
+                "invalid announce data: could not decode propagation transfer or sync limit",
+            ),
+            Self::InvalidStampCosts => {
+                f.write_str("invalid announce data: could not decode stamp costs")
+            }
+            Self::InvalidStampCostValues => f.write_str(
+                "invalid announce data: could not decode target, flexibility, or peering stamp cost",
+            ),
+            Self::InvalidMetadata => {
+                f.write_str("invalid announce data: could not decode metadata")
+            }
+        }
+    }
+}
+
 pub fn parse_announce_slots(data: &[u8]) -> Result<Vec<AnnounceSlot>, AnnounceParseError> {
     let mut out = Vec::new();
     let mut i = 0usize;
@@ -161,6 +206,148 @@ pub fn display_name_from_delivery_app_data(
     Ok(name)
 }
 
+pub fn display_name_from_app_data(app_data: Option<&[u8]>) -> Option<String> {
+    let data = non_empty_app_data(app_data)?;
+    if app_data_uses_current_format(data) {
+        let peer_data: rmpv::Value = decode_msgpack(data).ok()?;
+        let rmpv::Value::Array(values) = peer_data else {
+            return None;
+        };
+        let display_name = values.first()?;
+        if matches!(display_name, rmpv::Value::Nil) {
+            return None;
+        }
+        value_to_utf8(display_name)
+    } else {
+        decode_utf8_owned(data.to_vec()).ok()
+    }
+}
+
+pub fn stamp_cost_from_app_data(app_data: Option<&[u8]>) -> Option<i64> {
+    let data = non_empty_app_data(app_data)?;
+    if !app_data_uses_current_format(data) {
+        return None;
+    }
+    let peer_data: rmpv::Value = decode_msgpack(data).ok()?;
+    let rmpv::Value::Array(values) = peer_data else {
+        return None;
+    };
+    values.get(1).and_then(value_to_i64)
+}
+
+pub fn compression_support_from_app_data(app_data: Option<&[u8]>) -> Option<bool> {
+    let data = non_empty_app_data(app_data)?;
+    if !app_data_uses_current_format(data) {
+        return Some(true);
+    }
+    let peer_data: rmpv::Value = decode_msgpack(data).ok()?;
+    let rmpv::Value::Array(values) = peer_data else {
+        return None;
+    };
+    let Some(supported_features) = values.get(2) else {
+        return Some(true);
+    };
+    let rmpv::Value::Array(features) = supported_features else {
+        return Some(true);
+    };
+    Some(features.iter().any(|feature| value_to_i64(feature) == Some(i64::from(SF_COMPRESSION))))
+}
+
+pub fn pn_name_from_app_data(app_data: Option<&[u8]>) -> Option<String> {
+    let data = app_data?;
+    if !pn_announce_data_is_valid(data) {
+        return None;
+    }
+    let rmpv::Value::Array(values) = decode_msgpack::<rmpv::Value>(data).ok()? else {
+        return None;
+    };
+    let rmpv::Value::Map(metadata) = values.get(6)? else {
+        return None;
+    };
+    metadata_value(metadata, PN_META_NAME).and_then(value_to_utf8)
+}
+
+pub fn pn_stamp_cost_from_app_data(app_data: Option<&[u8]>) -> Option<i64> {
+    let data = app_data?;
+    if !pn_announce_data_is_valid(data) {
+        return None;
+    }
+    let rmpv::Value::Array(values) = decode_msgpack::<rmpv::Value>(data).ok()? else {
+        return None;
+    };
+    let rmpv::Value::Array(stamp_costs) = values.get(5)? else {
+        return None;
+    };
+    stamp_costs.first().and_then(value_to_i64)
+}
+
+pub fn pn_announce_data_is_valid(data: &[u8]) -> bool {
+    validate_pn_announce_data(data).is_ok()
+}
+
+pub fn validate_pn_announce_data(data: &[u8]) -> Result<(), PnAnnounceParseError> {
+    let decoded = rmp_serde::from_slice::<rmpv::Value>(data)
+        .map_err(|_| PnAnnounceParseError::InvalidMsgpack)?;
+    let rmpv::Value::Array(values) = decoded else {
+        return Err(PnAnnounceParseError::NotArray);
+    };
+    if values.len() < 7 {
+        return Err(PnAnnounceParseError::InsufficientPeerData);
+    }
+    if value_to_i64(&values[1]).is_none() {
+        return Err(PnAnnounceParseError::InvalidTimebase);
+    }
+    if !matches!(values[2], rmpv::Value::Boolean(_)) {
+        return Err(PnAnnounceParseError::IndeterminatePropagationNodeStatus);
+    }
+    if value_to_i64(&values[3]).is_none() || value_to_i64(&values[4]).is_none() {
+        return Err(PnAnnounceParseError::InvalidTransferOrSyncLimit);
+    }
+    let rmpv::Value::Array(stamp_costs) = &values[5] else {
+        return Err(PnAnnounceParseError::InvalidStampCosts);
+    };
+    if stamp_costs.len() < 3
+        || stamp_costs.iter().take(3).any(|value| value_to_i64(value).is_none())
+    {
+        return Err(PnAnnounceParseError::InvalidStampCostValues);
+    }
+    if !matches!(values[6], rmpv::Value::Map(_)) {
+        return Err(PnAnnounceParseError::InvalidMetadata);
+    }
+    Ok(())
+}
+
+fn non_empty_app_data(app_data: Option<&[u8]>) -> Option<&[u8]> {
+    let data = app_data?;
+    if data.is_empty() {
+        None
+    } else {
+        Some(data)
+    }
+}
+
+fn app_data_uses_current_format(data: &[u8]) -> bool {
+    matches!(data.first(), Some(0x90..=0x9f) | Some(0xdc))
+}
+
+fn value_to_utf8(value: &rmpv::Value) -> Option<String> {
+    match value {
+        rmpv::Value::Binary(bytes) => decode_utf8_owned(bytes.clone()).ok(),
+        rmpv::Value::String(text) => text.as_str().map(ToString::to_string),
+        _ => None,
+    }
+}
+
+fn value_to_i64(value: &rmpv::Value) -> Option<i64> {
+    value.as_i64().or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
+}
+
+fn metadata_value(metadata: &[(rmpv::Value, rmpv::Value)], key: u8) -> Option<&rmpv::Value> {
+    metadata.iter().find_map(|(candidate, value)| {
+        (value_to_i64(candidate) == Some(i64::from(key))).then_some(value)
+    })
+}
+
 fn encode_msgpack(value: &rmpv::Value) -> Result<Vec<u8>, rmp_serde::encode::Error> {
     rmp_serde::to_vec(value)
 }
@@ -179,6 +366,14 @@ fn decode_utf8_owned(data: Vec<u8>) -> Result<String, FromUtf8Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::constants::{
+        PN_META_AUTH_BAND, PN_META_CUSTOM, PN_META_NAME, PN_META_SYNC_STRATUM,
+        PN_META_SYNC_THROTTLE, PN_META_UTIL_PRESSURE, PN_META_VERSION, SF_COMPRESSION,
+    };
+
+    fn encode_value(value: &rmpv::Value) -> Vec<u8> {
+        rmp_serde::to_vec(value).expect("test fixture encodes")
+    }
 
     #[test]
     fn encode_and_decode_delivery_display_name_round_trip() {
@@ -201,5 +396,118 @@ mod tests {
         // genuine absent name).
         let data = [0xa2_u8, 0xff, 0xfe];
         assert!(display_name_from_delivery_app_data(&data).is_err());
+    }
+
+    #[test]
+    fn lxmf_module_display_name_helper_accepts_current_and_legacy_formats() {
+        let current = encode_value(&rmpv::Value::Array(vec![
+            rmpv::Value::Binary(b" Alice\0 Router ".to_vec()),
+            rmpv::Value::Integer(12_i64.into()),
+        ]));
+        assert_eq!(
+            display_name_from_app_data(Some(&current)),
+            Some(" Alice\0 Router ".to_string())
+        );
+        assert_eq!(
+            display_name_from_app_data(Some(b"Legacy Router")),
+            Some("Legacy Router".to_string())
+        );
+        assert_eq!(display_name_from_app_data(Some(&[])), None);
+        assert_eq!(display_name_from_app_data(None), None);
+    }
+
+    #[test]
+    fn lxmf_module_stamp_cost_and_compression_helpers_match_python_defaults() {
+        let with_compression = encode_value(&rmpv::Value::Array(vec![
+            rmpv::Value::Binary(b"Alice".to_vec()),
+            rmpv::Value::Integer(8_i64.into()),
+            rmpv::Value::Array(vec![rmpv::Value::Integer(i64::from(SF_COMPRESSION).into())]),
+        ]));
+        let without_feature_list = encode_value(&rmpv::Value::Array(vec![
+            rmpv::Value::Binary(b"Alice".to_vec()),
+            rmpv::Value::Integer(4_i64.into()),
+            rmpv::Value::String("not-a-list".into()),
+        ]));
+        let no_compression = encode_value(&rmpv::Value::Array(vec![
+            rmpv::Value::Binary(b"Alice".to_vec()),
+            rmpv::Value::Integer(2_i64.into()),
+            rmpv::Value::Array(vec![rmpv::Value::Integer(0xAA_i64.into())]),
+        ]));
+
+        assert_eq!(stamp_cost_from_app_data(Some(&with_compression)), Some(8));
+        assert_eq!(stamp_cost_from_app_data(Some(b"legacy")), None);
+        assert_eq!(compression_support_from_app_data(Some(&with_compression)), Some(true));
+        assert_eq!(compression_support_from_app_data(Some(&without_feature_list)), Some(true));
+        assert_eq!(compression_support_from_app_data(Some(&no_compression)), Some(false));
+        assert_eq!(compression_support_from_app_data(Some(b"legacy")), Some(true));
+        assert_eq!(compression_support_from_app_data(None), None);
+    }
+
+    #[test]
+    fn propagation_node_app_data_helpers_validate_metadata_shape() {
+        let valid = encode_value(&rmpv::Value::Array(vec![
+            rmpv::Value::Binary(b"Peer".to_vec()),
+            rmpv::Value::Integer(17_i64.into()),
+            rmpv::Value::Boolean(true),
+            rmpv::Value::Integer(65_536_i64.into()),
+            rmpv::Value::Integer(32_768_i64.into()),
+            rmpv::Value::Array(vec![
+                rmpv::Value::Integer(11_i64.into()),
+                rmpv::Value::Integer(2_i64.into()),
+                rmpv::Value::Integer(5_i64.into()),
+            ]),
+            rmpv::Value::Map(vec![
+                (
+                    rmpv::Value::Integer(i64::from(PN_META_VERSION).into()),
+                    rmpv::Value::Integer(1_i64.into()),
+                ),
+                (
+                    rmpv::Value::Integer(i64::from(PN_META_NAME).into()),
+                    rmpv::Value::Binary(b"Node Alpha".to_vec()),
+                ),
+                (
+                    rmpv::Value::Integer(i64::from(PN_META_SYNC_STRATUM).into()),
+                    rmpv::Value::Integer(0_i64.into()),
+                ),
+                (
+                    rmpv::Value::Integer(i64::from(PN_META_SYNC_THROTTLE).into()),
+                    rmpv::Value::Integer(1_i64.into()),
+                ),
+                (
+                    rmpv::Value::Integer(i64::from(PN_META_AUTH_BAND).into()),
+                    rmpv::Value::Integer(0_i64.into()),
+                ),
+                (
+                    rmpv::Value::Integer(i64::from(PN_META_UTIL_PRESSURE).into()),
+                    rmpv::Value::Integer(0_i64.into()),
+                ),
+                (
+                    rmpv::Value::Integer(i64::from(PN_META_CUSTOM).into()),
+                    rmpv::Value::Map(Vec::new()),
+                ),
+            ]),
+        ]));
+        let invalid = encode_value(&rmpv::Value::Array(vec![
+            rmpv::Value::Binary(b"Peer".to_vec()),
+            rmpv::Value::String("bad-timebase".into()),
+            rmpv::Value::Boolean(true),
+            rmpv::Value::Integer(65_536_i64.into()),
+            rmpv::Value::Integer(32_768_i64.into()),
+            rmpv::Value::Array(vec![
+                rmpv::Value::Integer(11_i64.into()),
+                rmpv::Value::Integer(2_i64.into()),
+                rmpv::Value::Integer(5_i64.into()),
+            ]),
+            rmpv::Value::Map(Vec::new()),
+        ]));
+
+        assert!(pn_announce_data_is_valid(&valid));
+        assert_eq!(validate_pn_announce_data(&valid), Ok(()));
+        assert_eq!(pn_name_from_app_data(Some(&valid)), Some("Node Alpha".to_string()));
+        assert_eq!(pn_stamp_cost_from_app_data(Some(&valid)), Some(11));
+        assert!(!pn_announce_data_is_valid(&invalid));
+        assert_eq!(validate_pn_announce_data(&invalid), Err(PnAnnounceParseError::InvalidTimebase));
+        assert_eq!(pn_name_from_app_data(Some(&invalid)), None);
+        assert_eq!(pn_stamp_cost_from_app_data(Some(&invalid)), None);
     }
 }

--- a/crates/libs/lxmf-core/src/constants.rs
+++ b/crates/libs/lxmf-core/src/constants.rs
@@ -1,9 +1,72 @@
+pub const APP_NAME: &str = "lxmf";
+
+pub const FIELD_EMBEDDED_LXMS: u8 = 0x01;
 pub const FIELD_TELEMETRY: u8 = 0x02;
+pub const FIELD_TELEMETRY_STREAM: u8 = 0x03;
+pub const FIELD_ICON_APPEARANCE: u8 = 0x04;
 pub const FIELD_FILE_ATTACHMENTS: u8 = 0x05;
+pub const FIELD_IMAGE: u8 = 0x06;
+pub const FIELD_AUDIO: u8 = 0x07;
+pub const FIELD_THREAD: u8 = 0x08;
 pub const FIELD_COMMANDS: u8 = 0x09;
+pub const FIELD_RESULTS: u8 = 0x0A;
+pub const FIELD_GROUP: u8 = 0x0B;
 pub const FIELD_TICKET: u8 = 0x0C;
+pub const FIELD_EVENT: u8 = 0x0D;
 pub const FIELD_RNR_REFS: u8 = 0x0E;
+pub const FIELD_RENDERER: u8 = 0x0F;
 pub const FIELD_APP_EXTENSIONS: u8 = 0x10;
+pub const FIELD_REPLY_TO: u8 = 0x30;
+pub const FIELD_REPLY_QUOTE: u8 = 0x31;
+pub const FIELD_REACTION: u8 = 0x40;
+pub const FIELD_COMMENT: u8 = 0x41;
+pub const FIELD_CONTINUATION: u8 = 0x42;
+pub const FIELD_CUSTOM_TYPE: u8 = 0xFB;
+pub const FIELD_CUSTOM_DATA: u8 = 0xFC;
+pub const FIELD_CUSTOM_META: u8 = 0xFD;
+pub const FIELD_NON_SPECIFIC: u8 = 0xFE;
+pub const FIELD_DEBUG: u8 = 0xFF;
+
+pub const AM_CODEC2_450PWB: u8 = 0x01;
+pub const AM_CODEC2_450: u8 = 0x02;
+pub const AM_CODEC2_700C: u8 = 0x03;
+pub const AM_CODEC2_1200: u8 = 0x04;
+pub const AM_CODEC2_1300: u8 = 0x05;
+pub const AM_CODEC2_1400: u8 = 0x06;
+pub const AM_CODEC2_1600: u8 = 0x07;
+pub const AM_CODEC2_2400: u8 = 0x08;
+pub const AM_CODEC2_3200: u8 = 0x09;
+pub const AM_OPUS_OGG: u8 = 0x10;
+pub const AM_OPUS_LBW: u8 = 0x11;
+pub const AM_OPUS_MBW: u8 = 0x12;
+pub const AM_OPUS_PTT: u8 = 0x13;
+pub const AM_OPUS_RT_HDX: u8 = 0x14;
+pub const AM_OPUS_RT_FDX: u8 = 0x15;
+pub const AM_OPUS_STANDARD: u8 = 0x16;
+pub const AM_OPUS_HQ: u8 = 0x17;
+pub const AM_OPUS_BROADCAST: u8 = 0x18;
+pub const AM_OPUS_LOSSLESS: u8 = 0x19;
+pub const AM_CUSTOM: u8 = 0xFF;
+
+pub const RENDERER_PLAIN: u8 = 0x00;
+pub const RENDERER_MICRON: u8 = 0x01;
+pub const RENDERER_MARKDOWN: u8 = 0x02;
+pub const RENDERER_BBCODE: u8 = 0x03;
+
+pub const REACTION_TO: u8 = 0x00;
+pub const REACTION_CONTENT: u8 = 0x01;
+pub const COMMENT_FOR: u8 = 0x00;
+pub const CONTINUATION_OF: u8 = 0x00;
+
+pub const PN_META_VERSION: u8 = 0x00;
+pub const PN_META_NAME: u8 = 0x01;
+pub const PN_META_SYNC_STRATUM: u8 = 0x02;
+pub const PN_META_SYNC_THROTTLE: u8 = 0x03;
+pub const PN_META_AUTH_BAND: u8 = 0x04;
+pub const PN_META_UTIL_PRESSURE: u8 = 0x05;
+pub const PN_META_CUSTOM: u8 = 0xFF;
+
+pub const SF_COMPRESSION: u8 = 0x00;
 
 pub const DESTINATION_LENGTH: usize = 16;
 pub const SIGNATURE_LENGTH: usize = 64;

--- a/crates/libs/lxmf-core/src/lib.rs
+++ b/crates/libs/lxmf-core/src/lib.rs
@@ -14,6 +14,11 @@ pub mod payload_fields;
 #[cfg(feature = "std")]
 pub mod wire_fields;
 
+pub use announce::{
+    compression_support_from_app_data, display_name_from_app_data, pn_announce_data_is_valid,
+    pn_name_from_app_data, pn_stamp_cost_from_app_data, stamp_cost_from_app_data,
+    validate_pn_announce_data, PnAnnounceParseError,
+};
 pub use error::LxmfError;
 pub use message::{
     decide_delivery, DeliveryDecision, Message, MessageMethod, MessageState, Payload,

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1,6 +1,6 @@
 # Current Roadmap Status
 
-Last reassessed: 2026-06-27
+Last reassessed: 2026-06-28
 
 This file is the repository-level source of truth for parity posture, release
 confidence, and execution order. Detailed row-level status lives in:
@@ -339,6 +339,10 @@ The project is best described by capability level:
 - Documented basic LXMF field IDs are exported through `lxmf-wire`, and the
   typed ZeroMQ SDK send path preserves those field keys plus
   `_lxmf_fields_msgpack_b64` for REM/RCH payload compatibility.
+- The pinned Python `LXMF.py` module helper surface is now exposed in
+  `lxmf-wire`, including delivery app-data display-name and stamp-cost parsing,
+  compression support defaults, and propagation-node announce name/cost
+  validation with both Python-style boolean and typed Rust diagnostic paths.
 - The typed ZeroMQ SDK send and batch-send paths now treat payload `body` as
   message content when `content` is absent, while still preserving `body` in
   fields, so direct-chat links/body text do not get JSON-stringified.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -1,6 +1,6 @@
 # LXMF Parity Matrix
 
-Last reassessed: 2026-06-19
+Last reassessed: 2026-06-28
 
 This is the maintained row-level status for Python LXMF compatibility.
 Repository-level posture and execution order live in
@@ -20,7 +20,7 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 
 | Python module | Rust surface | Status | Implemented baseline | Residual gap |
 | --- | --- | --- | --- | --- |
-| `LXMF/LXMF.py` | `crates/libs/lxmf-core` | partial | Constants, payload fields, message identity, inbound decoding, and wire helpers. | The complete convenience/module surface is not mirrored. |
+| `LXMF/LXMF.py` | `crates/libs/lxmf-core` | done | Pinned module constants, payload fields, message identity, inbound decoding, wire helpers, delivery app-data helpers, compression support detection, and propagation-node announce helper validation. | No confirmed `LXMF.py` blocker in the pinned Python reference. |
 | `LXMF/LXMessage.py` | `crates/libs/lxmf-core` | done | Wire, storage, propagation, paper, signatures, message IDs, binary fidelity, and timestamp precision metadata. | No confirmed base-message blocker. |
 | `LXMF/LXMPeer.py` | `crates/libs/rns-rpc`, `crates/apps/reticulumd` | done | Persistent peers, queue marks, offer selection, policy gates, peering keys, throttling, maintenance, source accounting, cumulative acceptance, serialized restored queue snapshots, boolean/list/numeric offer responses, transfer/retry/restart recovery, and unpeer cleanup. | No confirmed `LXMPeer.py` blocker in the pinned Python-only coverage. |
 | `LXMF/LXMRouter.py` | `crates/libs/rns-rpc`, `crates/apps/reticulumd` | partial | Outbound modes, selected propagation nodes, direct/propagated resources, cancellation, fetch/download/sync RPCs, receipts, persistence, propagation-node side effects, retry/failure handling, and Python live remote lifecycle coverage. | No confirmed propagation-router lifecycle blocker remains; broader non-propagation router convenience surface remains narrower than Python. |
@@ -38,6 +38,7 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - PARITY_ITEM id=message.file_unpack_helpers status=done
 - PARITY_ITEM id=message.signature_verify status=done
 - PARITY_ITEM id=message.object_accessors status=done
+- PARITY_ITEM id=module.app_data_helpers status=done
 - PARITY_ITEM id=stamper.validate_pn_stamp status=done
 - PARITY_ITEM id=stamper.generate_stamp status=done
 - PARITY_ITEM id=stamper.cancel_work status=done
@@ -75,6 +76,12 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - The typed ZeroMQ SDK send and batch-send paths map payload `body` into the
   LXMF message content when `content` is absent, while retaining the original
   `body` field for clients that store or render direct-chat bodies.
+- The pinned Python `LXMF.py` convenience constants and app-data helpers are
+  exposed from `lxmf-wire`: delivery display names, delivery stamp cost,
+  compression support defaults, propagation-node names, propagation-node stamp
+  cost, and propagation-node announce validation. Rust callers also get a
+  typed propagation-node validation error for diagnostics instead of only the
+  Python-style boolean result.
 
 ### Delivery and receipts
 


### PR DESCRIPTION
## Summary
- fill out lxmf-core constants for the pinned LXMF.py module surface
- expose Python-named app-data helpers from lxmf-wire for delivery names, stamp cost, compression support, propagation-node name/cost, and PN announce validation
- add a typed Rust PN announce validation error alongside the Python-style boolean helper
- update the roadmap and LXMF parity matrix to mark LXMF/LXMF.py done against the pinned reference

## Self-review
- rebased the work onto current origin/main after PR #391 landed
- resolved the announce.rs overlap by preserving main's explicit encode/decode error behavior and keeping the new Python-compatible helpers separate
- checked the pinned Python LXMF reference used by CI: 727830cefda83d9c6e3982b48675425f3f988f9c

## Validation
- cargo fmt --all -- --check
- cargo clippy -p lxmf-wire --all-targets --all-features --no-deps -- -D warnings
- cargo test -p lxmf-wire
