### PR TITLE
[codex] Add Meshtastic tunnel interface

### DIFF
--- a/crates/libs/rns-transport/src/iface.rs
+++ b/crates/libs/rns-transport/src/iface.rs
@@ -10,6 +10,8 @@ pub mod kiss;
 
 pub mod lora;
 
+pub mod meshtastic;
+
 #[cfg(unix)]
 pub mod local;
 

--- a/crates/libs/rns-transport/src/iface/meshtastic.rs
+++ b/crates/libs/rns-transport/src/iface/meshtastic.rs
@@ -1,0 +1,7 @@
+include!("meshtastic_parts/module_prelude.rs");
+
+include!("meshtastic_parts/packet_handler.rs");
+
+include!("meshtastic_parts/tunnel.rs");
+
+include!("meshtastic_parts/interface.rs");

--- a/crates/libs/rns-transport/src/iface/meshtastic_parts/interface.rs
+++ b/crates/libs/rns-transport/src/iface/meshtastic_parts/interface.rs
@@ -1,0 +1,191 @@
+#[derive(Debug, Clone)]
+pub struct MeshtasticInterfaceHandle {
+    inbound_tx: mpsc::Sender<MeshtasticReceivedFrame>,
+    outbound_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<MeshtasticTransmitFrame>>>,
+}
+
+impl MeshtasticInterfaceHandle {
+    pub async fn inject_received(
+        &self,
+        frame: MeshtasticReceivedFrame,
+    ) -> Result<(), mpsc::error::SendError<MeshtasticReceivedFrame>> {
+        self.inbound_tx.send(frame).await
+    }
+
+    pub async fn recv_transmit(&self) -> Option<MeshtasticTransmitFrame> {
+        self.outbound_rx.lock().await.recv().await
+    }
+}
+
+#[derive(Debug)]
+pub struct MeshtasticInterface {
+    name: String,
+    config: MeshtasticInterfaceConfig,
+    inbound_tx: mpsc::Sender<MeshtasticReceivedFrame>,
+    inbound_rx: Arc<Mutex<Option<mpsc::Receiver<MeshtasticReceivedFrame>>>>,
+    outbound_tx: mpsc::Sender<MeshtasticTransmitFrame>,
+    outbound_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<MeshtasticTransmitFrame>>>,
+    runtime_status: Arc<Mutex<MeshtasticTunnelStatus>>,
+}
+
+impl MeshtasticInterface {
+    #[must_use]
+    pub fn new(name: impl Into<String>, config: MeshtasticInterfaceConfig) -> Self {
+        let (inbound_tx, inbound_rx) = mpsc::channel(MESHTASTIC_CHANNEL_CAPACITY);
+        let (outbound_tx, outbound_rx) = mpsc::channel(MESHTASTIC_CHANNEL_CAPACITY);
+        Self {
+            name: name.into(),
+            config,
+            inbound_tx,
+            inbound_rx: Arc::new(Mutex::new(Some(inbound_rx))),
+            outbound_tx,
+            outbound_rx: Arc::new(tokio::sync::Mutex::new(outbound_rx)),
+            runtime_status: Arc::new(Mutex::new(MeshtasticTunnelStatus::default())),
+        }
+    }
+
+    #[must_use]
+    pub fn handle(&self) -> MeshtasticInterfaceHandle {
+        MeshtasticInterfaceHandle {
+            inbound_tx: self.inbound_tx.clone(),
+            outbound_rx: self.outbound_rx.clone(),
+        }
+    }
+
+    #[must_use]
+    pub fn runtime_status_json(&self) -> serde_json::Value {
+        self.runtime_status
+            .lock()
+            .expect("meshtastic status mutex poisoned")
+            .to_json()
+    }
+
+    pub async fn spawn(context: InterfaceContext<Self>) {
+        let iface_stop = context.channel.stop.clone();
+        let iface_address = context.channel.address;
+        let (rx_channel, mut tx_channel) = context.channel.split();
+        let (name, config, mut inbound_rx, outbound_tx, runtime_status) = {
+            let guard = context.inner.lock().expect("meshtastic interface mutex poisoned");
+            let inbound_rx = guard
+                .inbound_rx
+                .lock()
+                .expect("meshtastic inbound mutex poisoned")
+                .take();
+            (
+                guard.name.clone(),
+                guard.config.clone(),
+                inbound_rx,
+                guard.outbound_tx.clone(),
+                guard.runtime_status.clone(),
+            )
+        };
+        let Some(ref mut inbound_rx) = inbound_rx else {
+            iface_stop.cancel();
+            return;
+        };
+        let mut tunnel = MeshtasticTunnel::new(config.clone());
+        let mut send_tick = tokio::time::interval(config.send_delay);
+        send_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                _ = context.cancel.cancelled() => break,
+                _ = iface_stop.cancelled() => break,
+                received = inbound_rx.recv() => {
+                    let Some(received) = received else { break };
+                    process_received_for_interface(
+                        &mut tunnel,
+                        received,
+                        iface_address,
+                        &rx_channel,
+                    ).await;
+                    record_meshtastic_status(&runtime_status, tunnel.status());
+                }
+                Some(message) = tx_channel.recv() => {
+                    if let Err(err) = queue_packet_for_meshtastic(&mut tunnel, message) {
+                        tunnel.status.last_error = Some(err);
+                    }
+                    record_meshtastic_status(&runtime_status, tunnel.status());
+                }
+                _ = send_tick.tick() => {
+                    if let Some(frame) = tunnel.next_transmit() {
+                        if let Err(err) = outbound_tx.send(frame).await {
+                            tunnel.status.last_error = Some(err.to_string());
+                            log::warn!(
+                                "meshtastic_interface outbound queue closed name={} iface={}",
+                                name,
+                                iface_address
+                            );
+                            break;
+                        }
+                    }
+                    record_meshtastic_status(&runtime_status, tunnel.status());
+                }
+            }
+        }
+
+        iface_stop.cancel();
+    }
+}
+
+impl Interface for MeshtasticInterface {
+    fn mtu() -> usize {
+        DEFAULT_MESHTASTIC_HW_MTU
+    }
+}
+
+async fn process_received_for_interface(
+    tunnel: &mut MeshtasticTunnel,
+    received: MeshtasticReceivedFrame,
+    iface_address: AddressHash,
+    rx_channel: &mpsc::Sender<RxMessage>,
+) {
+    match tunnel.process_received(received) {
+        Ok(Some(data)) => match Packet::from_bytes(&data) {
+            Ok(packet) => {
+                let _ = rx_channel
+                    .send(RxMessage {
+                        address: iface_address,
+                        packet,
+                        source: IfaceSource::None,
+                    })
+                    .await;
+            }
+            Err(err) => {
+                tunnel.status.decode_errors = tunnel.status.decode_errors.saturating_add(1);
+                tunnel.status.last_error = Some(format!("{err:?}"));
+            }
+        },
+        Ok(None) => {}
+        Err(err) => {
+            tunnel.status.decode_errors = tunnel.status.decode_errors.saturating_add(1);
+            tunnel.status.last_error = Some(err);
+        }
+    }
+}
+
+fn queue_packet_for_meshtastic(
+    tunnel: &mut MeshtasticTunnel,
+    message: TxMessage,
+) -> Result<(), String> {
+    let data = message.packet.to_bytes().map_err(|err| format!("{err:?}"))?;
+    tunnel.queue_outgoing_packet(&data)
+}
+
+fn record_meshtastic_status(
+    runtime_status: &Arc<Mutex<MeshtasticTunnelStatus>>,
+    status: MeshtasticTunnelStatus,
+) {
+    *runtime_status.lock().expect("meshtastic status mutex poisoned") = status;
+}
+
+pub fn spawn_meshtastic(
+    mgr: &mut InterfaceManager,
+    name: impl Into<String>,
+    config: MeshtasticInterfaceConfig,
+) -> (AddressHash, MeshtasticInterfaceHandle) {
+    let iface = MeshtasticInterface::new(name, config);
+    let handle = iface.handle();
+    let address = mgr.spawn_as(iface, MeshtasticInterface::spawn, IfaceRole::Unicast);
+    (address, handle)
+}

--- a/crates/libs/rns-transport/src/iface/meshtastic_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/meshtastic_parts/module_prelude.rs
@@ -99,7 +99,7 @@ pub struct MeshtasticTransmitFrame {
     pub channel_index: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MeshtasticTunnelStatus {
     pub queued_transmissions: usize,
     pub destination_routes: usize,
@@ -126,21 +126,5 @@ impl MeshtasticTunnelStatus {
             "decode_errors": self.decode_errors,
             "last_error": self.last_error,
         })
-    }
-}
-
-impl Default for MeshtasticTunnelStatus {
-    fn default() -> Self {
-        Self {
-            queued_transmissions: 0,
-            destination_routes: 0,
-            packets_rx: 0,
-            packets_tx: 0,
-            chunks_rx: 0,
-            chunks_tx: 0,
-            requested_retransmits: 0,
-            decode_errors: 0,
-            last_error: None,
-        }
     }
 }

--- a/crates/libs/rns-transport/src/iface/meshtastic_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/meshtastic_parts/module_prelude.rs
@@ -1,0 +1,146 @@
+use alloc::collections::{BTreeMap, VecDeque};
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use crate::hash::{AddressHash, ADDRESS_HASH_SIZE};
+use crate::iface::{IfaceRole, IfaceSource, InterfaceManager, RxMessage};
+use crate::packet::Packet;
+
+use super::{Interface, InterfaceContext, TxMessage};
+
+const REQUEST_PREFIX: &[u8; 3] = b"REQ";
+const DEFAULT_MESHTASTIC_HW_MTU: usize = 564;
+const DEFAULT_MESHTASTIC_PACKET_PAYLOAD: usize = 200;
+const DEFAULT_HOP_LIMIT: u8 = 7;
+const DEFAULT_BITRATE_BPS: u64 = 500;
+const DEFAULT_DESTINATION_CACHE_SIZE: usize = 20;
+const MAX_REQUESTED_CHUNKS_PER_NODE: usize = 10;
+const MESHTASTIC_CHANNEL_CAPACITY: usize = 128;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MeshtasticInterfaceConfig {
+    pub hop_limit: u8,
+    pub bitrate_bps: u64,
+    pub max_payload_bytes: usize,
+    pub send_delay: Duration,
+    pub destination_cache_size: usize,
+}
+
+impl MeshtasticInterfaceConfig {
+    #[must_use]
+    pub fn from_modem_preset(preset: u8) -> Self {
+        Self { send_delay: modem_preset_delay(preset), ..Self::default() }
+    }
+}
+
+impl Default for MeshtasticInterfaceConfig {
+    fn default() -> Self {
+        Self {
+            hop_limit: DEFAULT_HOP_LIMIT,
+            bitrate_bps: DEFAULT_BITRATE_BPS,
+            max_payload_bytes: DEFAULT_MESHTASTIC_PACKET_PAYLOAD,
+            send_delay: Duration::from_secs(7),
+            destination_cache_size: DEFAULT_DESTINATION_CACHE_SIZE,
+        }
+    }
+}
+
+#[must_use]
+pub fn modem_preset_delay(preset: u8) -> Duration {
+    match preset {
+        8 => Duration::from_millis(400),
+        6 => Duration::from_secs(1),
+        5 => Duration::from_secs(3),
+        7 => Duration::from_secs(12),
+        4 => Duration::from_secs(4),
+        3 => Duration::from_secs(6),
+        1 => Duration::from_secs(15),
+        0 => Duration::from_secs(8),
+        _ => Duration::from_secs(7),
+    }
+}
+
+#[must_use]
+pub fn calc_meshtastic_index(curr_index: u8) -> u8 {
+    curr_index.wrapping_add(1)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MeshtasticDestination {
+    Broadcast,
+    Node(u32),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MeshtasticReceivedFrame {
+    pub from: u32,
+    pub payload: Vec<u8>,
+}
+
+impl MeshtasticReceivedFrame {
+    #[must_use]
+    pub fn new(from: u32, payload: &[u8]) -> Self {
+        Self { from, payload: payload.to_vec() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MeshtasticTransmitFrame {
+    pub destination: MeshtasticDestination,
+    pub payload: Vec<u8>,
+    pub hop_limit: u8,
+    pub want_ack: bool,
+    pub want_response: bool,
+    pub channel_index: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MeshtasticTunnelStatus {
+    pub queued_transmissions: usize,
+    pub destination_routes: usize,
+    pub packets_rx: u64,
+    pub packets_tx: u64,
+    pub chunks_rx: u64,
+    pub chunks_tx: u64,
+    pub requested_retransmits: u64,
+    pub decode_errors: u64,
+    pub last_error: Option<String>,
+}
+
+impl MeshtasticTunnelStatus {
+    #[must_use]
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "queued_transmissions": self.queued_transmissions,
+            "destination_routes": self.destination_routes,
+            "packets_rx": self.packets_rx,
+            "packets_tx": self.packets_tx,
+            "chunks_rx": self.chunks_rx,
+            "chunks_tx": self.chunks_tx,
+            "requested_retransmits": self.requested_retransmits,
+            "decode_errors": self.decode_errors,
+            "last_error": self.last_error,
+        })
+    }
+}
+
+impl Default for MeshtasticTunnelStatus {
+    fn default() -> Self {
+        Self {
+            queued_transmissions: 0,
+            destination_routes: 0,
+            packets_rx: 0,
+            packets_tx: 0,
+            chunks_rx: 0,
+            chunks_tx: 0,
+            requested_retransmits: 0,
+            decode_errors: 0,
+            last_error: None,
+        }
+    }
+}

--- a/crates/libs/rns-transport/src/iface/meshtastic_parts/packet_handler.rs
+++ b/crates/libs/rns-transport/src/iface/meshtastic_parts/packet_handler.rs
@@ -56,6 +56,12 @@ impl MeshtasticPacketHandler {
         self.chunks.get(&abs_position).map(Vec::as_slice)
     }
 
+    #[must_use]
+    pub fn first_missing_position(&self) -> Option<u8> {
+        let final_position = self.positions.values().find(|position| **position < 0)?.unsigned_abs();
+        (1..final_position).find(|position| !self.chunks.contains_key(position))
+    }
+
     pub fn process_payload(&mut self, packet: &[u8]) -> Result<Option<Vec<u8>>, String> {
         let (index, position) = Self::metadata(packet)?;
         self.index = Some(index);

--- a/crates/libs/rns-transport/src/iface/meshtastic_parts/packet_handler.rs
+++ b/crates/libs/rns-transport/src/iface/meshtastic_parts/packet_handler.rs
@@ -1,0 +1,98 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MeshtasticPacketHandler {
+    index: Option<u8>,
+    chunks: BTreeMap<u8, Vec<u8>>,
+    positions: BTreeMap<u8, i8>,
+}
+
+impl MeshtasticPacketHandler {
+    #[must_use]
+    pub fn new_inbound() -> Self {
+        Self { index: None, chunks: BTreeMap::new(), positions: BTreeMap::new() }
+    }
+
+    pub fn new_outgoing(data: &[u8], index: u8, max_payload: usize) -> Result<Self, String> {
+        if max_payload == 0 {
+            return Err("meshtastic max_payload_bytes must be > 0".to_string());
+        }
+
+        let mut handler = Self::new_inbound();
+        handler.index = Some(index);
+        if data.is_empty() {
+            handler.insert_payload(index, -1, &[])?;
+            return Ok(handler);
+        }
+
+        let packet_count = data.len() / max_payload + 1;
+        if packet_count > i8::MAX as usize {
+            return Err("meshtastic packet requires more than 127 chunks".to_string());
+        }
+        let packet_size = data.len() / packet_count + 1;
+        for (offset, chunk) in data.chunks(packet_size).enumerate() {
+            let abs_position = u8::try_from(offset + 1)
+                .map_err(|_| "meshtastic chunk position must fit in u8".to_string())?;
+            let signed = i8::try_from(abs_position)
+                .map_err(|_| "meshtastic chunk position must fit in i8".to_string())?;
+            let signed = if offset + 1 == packet_count { -signed } else { signed };
+            handler.insert_payload(index, signed, chunk)?;
+        }
+        Ok(handler)
+    }
+
+    pub fn metadata(packet: &[u8]) -> Result<(u8, i8), String> {
+        if packet.len() < 2 {
+            return Err("meshtastic packet chunk is missing metadata".to_string());
+        }
+        Ok((packet[0], packet[1] as i8))
+    }
+
+    #[must_use]
+    pub fn positions(&self) -> Vec<i8> {
+        self.positions.values().copied().collect()
+    }
+
+    #[must_use]
+    pub fn payload_at(&self, abs_position: u8) -> Option<&[u8]> {
+        self.chunks.get(&abs_position).map(Vec::as_slice)
+    }
+
+    pub fn process_payload(&mut self, packet: &[u8]) -> Result<Option<Vec<u8>>, String> {
+        let (index, position) = Self::metadata(packet)?;
+        self.index = Some(index);
+        self.chunks.insert(position.unsigned_abs(), packet.to_vec());
+        self.positions.insert(position.unsigned_abs(), position);
+        if position < 0 || self.positions.values().any(|stored| *stored < 0) {
+            return Ok(self.assemble_data());
+        }
+        Ok(None)
+    }
+
+    fn insert_payload(&mut self, index: u8, position: i8, data: &[u8]) -> Result<(), String> {
+        if position == 0 {
+            return Err("meshtastic chunk position must not be zero".to_string());
+        }
+        let mut payload = Vec::with_capacity(2 + data.len());
+        payload.push(index);
+        payload.push(position as u8);
+        payload.extend_from_slice(data);
+        self.chunks.insert(position.unsigned_abs(), payload);
+        self.positions.insert(position.unsigned_abs(), position);
+        Ok(())
+    }
+
+    fn assemble_data(&self) -> Option<Vec<u8>> {
+        let mut expected = 1_u8;
+        for key in self.chunks.keys().copied() {
+            if key != expected {
+                return None;
+            }
+            expected = expected.saturating_add(1);
+        }
+
+        let mut data = Vec::new();
+        for payload in self.chunks.values() {
+            data.extend_from_slice(payload.get(2..)?);
+        }
+        Some(data)
+    }
+}

--- a/crates/libs/rns-transport/src/iface/meshtastic_parts/tunnel.rs
+++ b/crates/libs/rns-transport/src/iface/meshtastic_parts/tunnel.rs
@@ -1,0 +1,235 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum QueuedTransmission {
+    Chunk { index: u8, position: u8 },
+    Request(Vec<u8>),
+}
+
+#[derive(Debug)]
+pub struct MeshtasticTunnel {
+    config: MeshtasticInterfaceConfig,
+    outgoing_packet_storage: HashMap<u8, (MeshtasticDestination, MeshtasticPacketHandler)>,
+    packet_queue: VecDeque<QueuedTransmission>,
+    assembly: HashMap<u32, HashMap<u8, MeshtasticPacketHandler>>,
+    expected_index: HashMap<u32, VecDeque<(u8, u8)>>,
+    requested_index: HashMap<u32, VecDeque<(u8, u8)>>,
+    dest_to_node: HashMap<[u8; ADDRESS_HASH_SIZE], u32>,
+    dest_order: VecDeque<[u8; ADDRESS_HASH_SIZE]>,
+    packet_index: u8,
+    status: MeshtasticTunnelStatus,
+}
+
+impl MeshtasticTunnel {
+    #[must_use]
+    pub fn new(config: MeshtasticInterfaceConfig) -> Self {
+        Self {
+            config,
+            outgoing_packet_storage: HashMap::new(),
+            packet_queue: VecDeque::new(),
+            assembly: HashMap::new(),
+            expected_index: HashMap::new(),
+            requested_index: HashMap::new(),
+            dest_to_node: HashMap::new(),
+            dest_order: VecDeque::new(),
+            packet_index: 0,
+            status: MeshtasticTunnelStatus::default(),
+        }
+    }
+
+    pub fn queue_outgoing_packet(&mut self, data: &[u8]) -> Result<(), String> {
+        let destination = self.destination_for_packet(data);
+        let handler = MeshtasticPacketHandler::new_outgoing(
+            data,
+            self.packet_index,
+            self.config.max_payload_bytes,
+        )?;
+        for position in handler.positions() {
+            self.packet_queue.push_back(QueuedTransmission::Chunk {
+                index: self.packet_index,
+                position: position.unsigned_abs(),
+            });
+        }
+        self.outgoing_packet_storage.insert(self.packet_index, (destination, handler));
+        self.packet_index = calc_meshtastic_index(self.packet_index);
+        self.refresh_status();
+        Ok(())
+    }
+
+    pub fn process_received(
+        &mut self,
+        frame: MeshtasticReceivedFrame,
+    ) -> Result<Option<Vec<u8>>, String> {
+        self.status.chunks_rx = self.status.chunks_rx.saturating_add(1);
+        if frame.payload.starts_with(REQUEST_PREFIX) {
+            self.queue_retransmit_request(&frame.payload[REQUEST_PREFIX.len()..])?;
+            self.refresh_status();
+            return Ok(None);
+        }
+
+        let (new_index, position) = MeshtasticPacketHandler::metadata(&frame.payload)?;
+        let abs_position = position.unsigned_abs();
+        let expected = self.expected_index.entry(frame.from).or_default();
+        let requested = self.requested_index.entry(frame.from).or_default();
+        let expected_key = (new_index, abs_position);
+        let mut expect_followup = true;
+
+        if expected.iter().any(|entry| *entry == expected_key) {
+            expected.retain(|entry| *entry != expected_key);
+        } else if let Some(offset) = requested.iter().position(|entry| *entry == expected_key) {
+            requested.remove(offset);
+            expect_followup = false;
+        } else if let Some((missing_index, missing_position)) = expected.pop_front() {
+            requested.push_back((missing_index, missing_position));
+            while requested.len() > MAX_REQUESTED_CHUNKS_PER_NODE {
+                requested.pop_front();
+            }
+            self.packet_queue.push_front(QueuedTransmission::Request(request_payload(
+                missing_index,
+                missing_position as i8,
+            )));
+            self.status.requested_retransmits = self.status.requested_retransmits.saturating_add(1);
+        }
+
+        let complete = {
+            let by_index = self.assembly.entry(frame.from).or_default();
+            let handler =
+                by_index.entry(new_index).or_insert_with(MeshtasticPacketHandler::new_inbound);
+            handler.process_payload(&frame.payload)?
+        };
+        if position < 0 {
+            expected.push_front((calc_meshtastic_index(new_index), 1));
+        } else if expect_followup {
+            expected.push_front((new_index, abs_position.saturating_add(1)));
+        }
+
+        if let Some(data) = complete {
+            self.learn_destination(&data, frame.from);
+            if let Some(by_index) = self.assembly.get_mut(&frame.from) {
+                by_index.remove(&new_index);
+            }
+            self.status.packets_rx = self.status.packets_rx.saturating_add(1);
+            self.refresh_status();
+            return Ok(Some(data));
+        }
+
+        self.refresh_status();
+        Ok(None)
+    }
+
+    pub fn next_transmit(&mut self) -> Option<MeshtasticTransmitFrame> {
+        while let Some(next) = self.packet_queue.pop_front() {
+            match next {
+                QueuedTransmission::Request(payload) => {
+                    self.status.chunks_tx = self.status.chunks_tx.saturating_add(1);
+                    self.refresh_status();
+                    return Some(self.transmit_frame(MeshtasticDestination::Broadcast, payload));
+                }
+                QueuedTransmission::Chunk { index, position } => {
+                    let Some((destination, payload, final_chunk)) =
+                        self.outgoing_packet_storage.get(&index).and_then(
+                            |(destination, handler)| {
+                                let payload = handler.payload_at(position)?.to_vec();
+                                let final_chunk =
+                                    handler.positions().last().map(|last| last.unsigned_abs())
+                                        == Some(position);
+                                Some((*destination, payload, final_chunk))
+                            },
+                        )
+                    else {
+                        continue;
+                    };
+                    self.status.chunks_tx = self.status.chunks_tx.saturating_add(1);
+                    if final_chunk {
+                        self.status.packets_tx = self.status.packets_tx.saturating_add(1);
+                    }
+                    self.refresh_status();
+                    return Some(self.transmit_frame(destination, payload));
+                }
+            }
+        }
+        self.refresh_status();
+        None
+    }
+
+    #[must_use]
+    pub fn pending_transmit_len(&self) -> usize {
+        self.packet_queue.len()
+    }
+
+    #[must_use]
+    pub fn status(&self) -> MeshtasticTunnelStatus {
+        self.status.clone()
+    }
+
+    fn queue_retransmit_request(&mut self, metadata: &[u8]) -> Result<(), String> {
+        let (index, position) = MeshtasticPacketHandler::metadata(metadata)?;
+        self.packet_queue
+            .push_front(QueuedTransmission::Chunk { index, position: position.unsigned_abs() });
+        Ok(())
+    }
+
+    fn transmit_frame(
+        &self,
+        destination: MeshtasticDestination,
+        payload: Vec<u8>,
+    ) -> MeshtasticTransmitFrame {
+        MeshtasticTransmitFrame {
+            destination,
+            payload,
+            hop_limit: self.config.hop_limit,
+            want_ack: false,
+            want_response: false,
+            channel_index: 0,
+        }
+    }
+
+    fn destination_for_packet(&self, data: &[u8]) -> MeshtasticDestination {
+        packet_destination_field(data)
+            .and_then(|destination| self.dest_to_node.get(&destination).copied())
+            .map(MeshtasticDestination::Node)
+            .unwrap_or(MeshtasticDestination::Broadcast)
+    }
+
+    fn learn_destination(&mut self, data: &[u8], from: u32) {
+        let Some(destination) = packet_destination(data) else {
+            return;
+        };
+        if !self.dest_to_node.contains_key(&destination) {
+            self.dest_order.push_back(destination);
+        }
+        self.dest_to_node.insert(destination, from);
+        while self.dest_order.len() > self.config.destination_cache_size {
+            if let Some(stale) = self.dest_order.pop_front() {
+                self.dest_to_node.remove(&stale);
+            }
+        }
+    }
+
+    fn refresh_status(&mut self) {
+        self.status.queued_transmissions = self.packet_queue.len();
+        self.status.destination_routes = self.dest_to_node.len();
+    }
+}
+
+fn request_payload(index: u8, position: i8) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(REQUEST_PREFIX.len() + 2);
+    payload.extend_from_slice(REQUEST_PREFIX);
+    payload.push(index);
+    payload.push(position as u8);
+    payload
+}
+
+fn packet_destination(data: &[u8]) -> Option<[u8; ADDRESS_HASH_SIZE]> {
+    if data[0] & 0b1100_1100 != 0b0000_1100 {
+        return None;
+    }
+    packet_destination_field(data)
+}
+
+fn packet_destination_field(data: &[u8]) -> Option<[u8; ADDRESS_HASH_SIZE]> {
+    if data.len() < 2 + ADDRESS_HASH_SIZE {
+        return None;
+    }
+    let mut destination = [0_u8; ADDRESS_HASH_SIZE];
+    destination.copy_from_slice(&data[2..2 + ADDRESS_HASH_SIZE]);
+    Some(destination)
+}

--- a/crates/libs/rns-transport/src/iface/meshtastic_parts/tunnel.rs
+++ b/crates/libs/rns-transport/src/iface/meshtastic_parts/tunnel.rs
@@ -36,20 +36,23 @@ impl MeshtasticTunnel {
     }
 
     pub fn queue_outgoing_packet(&mut self, data: &[u8]) -> Result<(), String> {
+        let packet_index = self
+            .next_available_packet_index()
+            .ok_or_else(|| "meshtastic outgoing packet index space is full".to_string())?;
         let destination = self.destination_for_packet(data);
         let handler = MeshtasticPacketHandler::new_outgoing(
             data,
-            self.packet_index,
+            packet_index,
             self.config.max_payload_bytes,
         )?;
         for position in handler.positions() {
             self.packet_queue.push_back(QueuedTransmission::Chunk {
-                index: self.packet_index,
+                index: packet_index,
                 position: position.unsigned_abs(),
             });
         }
-        self.outgoing_packet_storage.insert(self.packet_index, (destination, handler));
-        self.packet_index = calc_meshtastic_index(self.packet_index);
+        self.outgoing_packet_storage.insert(packet_index, (destination, handler));
+        self.packet_index = calc_meshtastic_index(packet_index);
         self.refresh_status();
         Ok(())
     }
@@ -67,38 +70,48 @@ impl MeshtasticTunnel {
 
         let (new_index, position) = MeshtasticPacketHandler::metadata(&frame.payload)?;
         let abs_position = position.unsigned_abs();
-        let expected = self.expected_index.entry(frame.from).or_default();
-        let requested = self.requested_index.entry(frame.from).or_default();
         let expected_key = (new_index, abs_position);
-        let mut expect_followup = true;
+        let mut missing_request = None;
 
-        if expected.iter().any(|entry| *entry == expected_key) {
-            expected.retain(|entry| *entry != expected_key);
-        } else if let Some(offset) = requested.iter().position(|entry| *entry == expected_key) {
-            requested.remove(offset);
-            expect_followup = false;
-        } else if let Some((missing_index, missing_position)) = expected.pop_front() {
-            requested.push_back((missing_index, missing_position));
-            while requested.len() > MAX_REQUESTED_CHUNKS_PER_NODE {
-                requested.pop_front();
+        {
+            let expected = self.expected_index.entry(frame.from).or_default();
+            let requested = self.requested_index.entry(frame.from).or_default();
+            let was_expected = expected.iter().any(|entry| *entry == expected_key);
+            let requested_offset = requested.iter().position(|entry| *entry == expected_key);
+            if was_expected {
+                expected.retain(|entry| *entry != expected_key);
             }
-            self.packet_queue.push_front(QueuedTransmission::Request(request_payload(
-                missing_index,
-                missing_position as i8,
-            )));
-            self.status.requested_retransmits = self.status.requested_retransmits.saturating_add(1);
+            if let Some(offset) = requested_offset {
+                requested.remove(offset);
+            } else if !was_expected {
+                missing_request = expected.pop_front();
+            }
+        }
+        if let Some((missing_index, missing_position)) = missing_request {
+            self.request_missing_chunk(frame.from, missing_index, missing_position);
         }
 
-        let complete = {
+        let (complete, first_missing_position) = {
             let by_index = self.assembly.entry(frame.from).or_default();
             let handler =
                 by_index.entry(new_index).or_insert_with(MeshtasticPacketHandler::new_inbound);
-            handler.process_payload(&frame.payload)?
+            let complete = handler.process_payload(&frame.payload)?;
+            let first_missing_position = handler.first_missing_position();
+            (complete, first_missing_position)
         };
         if position < 0 {
-            expected.push_front((calc_meshtastic_index(new_index), 1));
-        } else if expect_followup {
-            expected.push_front((new_index, abs_position.saturating_add(1)));
+            self.expected_index
+                .entry(frame.from)
+                .or_default()
+                .push_front((calc_meshtastic_index(new_index), 1));
+        } else {
+            self.expected_index
+                .entry(frame.from)
+                .or_default()
+                .push_front((new_index, abs_position.saturating_add(1)));
+        }
+        if let Some(missing_position) = first_missing_position {
+            self.request_missing_chunk(frame.from, new_index, missing_position);
         }
 
         if let Some(data) = complete {
@@ -167,6 +180,34 @@ impl MeshtasticTunnel {
         Ok(())
     }
 
+    fn request_missing_chunk(&mut self, from: u32, index: u8, position: u8) {
+        let requested = self.requested_index.entry(from).or_default();
+        if requested.iter().any(|entry| *entry == (index, position)) {
+            return;
+        }
+        requested.push_back((index, position));
+        while requested.len() > MAX_REQUESTED_CHUNKS_PER_NODE {
+            requested.pop_front();
+        }
+        self.packet_queue
+            .push_front(QueuedTransmission::Request(request_payload(index, position as i8)));
+        self.status.requested_retransmits = self.status.requested_retransmits.saturating_add(1);
+    }
+
+    fn next_available_packet_index(&self) -> Option<u8> {
+        (0..=usize::from(u8::MAX))
+            .map(|offset| self.packet_index.wrapping_add(offset as u8))
+            .find(|index| {
+                !self.outgoing_packet_storage.contains_key(index)
+                    || !self.packet_queue.iter().any(|queued| match queued {
+                        QueuedTransmission::Chunk { index: queued_index, .. } => {
+                            queued_index == index
+                        }
+                        QueuedTransmission::Request(_) => false,
+                    })
+            })
+    }
+
     fn transmit_frame(
         &self,
         destination: MeshtasticDestination,
@@ -219,6 +260,9 @@ fn request_payload(index: u8, position: i8) -> Vec<u8> {
 }
 
 fn packet_destination(data: &[u8]) -> Option<[u8; ADDRESS_HASH_SIZE]> {
+    if data.is_empty() {
+        return None;
+    }
     if data[0] & 0b1100_1100 != 0b0000_1100 {
         return None;
     }

--- a/crates/libs/rns-transport/tests/meshtastic_interface.rs
+++ b/crates/libs/rns-transport/tests/meshtastic_interface.rs
@@ -1,0 +1,101 @@
+use std::time::Duration;
+
+use rns_transport::iface::meshtastic::{
+    calc_meshtastic_index, MeshtasticDestination, MeshtasticInterfaceConfig,
+    MeshtasticPacketHandler, MeshtasticReceivedFrame, MeshtasticTunnel,
+};
+
+#[test]
+fn packet_handler_splits_and_reassembles_python_metadata_format() {
+    let data = b"hello_world".repeat(20);
+    let handler =
+        MeshtasticPacketHandler::new_outgoing(&data, 7, 80).expect("split outgoing payload");
+
+    assert_eq!(handler.positions(), vec![1, 2, -3]);
+    assert_eq!(MeshtasticPacketHandler::metadata(handler.payload_at(1).unwrap()), Ok((7, 1)));
+    assert_eq!(MeshtasticPacketHandler::metadata(handler.payload_at(3).unwrap()), Ok((7, -3)));
+
+    let mut inbound = MeshtasticPacketHandler::new_inbound();
+    assert_eq!(inbound.process_payload(handler.payload_at(1).unwrap()).unwrap(), None);
+    assert_eq!(inbound.process_payload(handler.payload_at(2).unwrap()).unwrap(), None);
+    assert_eq!(inbound.process_payload(handler.payload_at(3).unwrap()).unwrap(), Some(data));
+}
+
+#[test]
+fn tunnel_requests_missing_chunks_and_completes_after_repair() {
+    let mut tunnel = MeshtasticTunnel::new(MeshtasticInterfaceConfig {
+        max_payload_bytes: 80,
+        ..MeshtasticInterfaceConfig::default()
+    });
+    let data = b"reticulum-over-meshtastic".repeat(8);
+    let handler =
+        MeshtasticPacketHandler::new_outgoing(&data, 4, 80).expect("split outgoing payload");
+
+    assert_eq!(
+        tunnel
+            .process_received(MeshtasticReceivedFrame::new(1001, handler.payload_at(1).unwrap()))
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        tunnel
+            .process_received(MeshtasticReceivedFrame::new(1001, handler.payload_at(3).unwrap()))
+            .unwrap(),
+        None
+    );
+
+    let request = tunnel.next_transmit().expect("missing chunk request");
+    assert_eq!(request.destination, MeshtasticDestination::Broadcast);
+    assert!(request.payload.starts_with(b"REQ"));
+    assert_eq!(MeshtasticPacketHandler::metadata(&request.payload[3..]), Ok((4, 2)));
+
+    assert_eq!(
+        tunnel
+            .process_received(MeshtasticReceivedFrame::new(1001, handler.payload_at(2).unwrap()))
+            .unwrap(),
+        Some(data)
+    );
+}
+
+#[test]
+fn tunnel_learns_link_destinations_for_direct_meshtastic_replies() {
+    let learned_destination = [0x42; 16];
+    let mut inbound = Vec::new();
+    inbound.push(0b0000_1100);
+    inbound.push(0);
+    inbound.extend_from_slice(&learned_destination);
+    inbound.push(0);
+    inbound.extend_from_slice(b"body");
+
+    let handler =
+        MeshtasticPacketHandler::new_outgoing(&inbound, 1, 200).expect("split inbound payload");
+    let mut tunnel = MeshtasticTunnel::new(MeshtasticInterfaceConfig::default());
+    assert_eq!(
+        tunnel
+            .process_received(MeshtasticReceivedFrame::new(77, handler.payload_at(1).unwrap()))
+            .unwrap(),
+        Some(inbound)
+    );
+
+    let mut outbound = Vec::new();
+    outbound.push(0);
+    outbound.push(0);
+    outbound.extend_from_slice(&learned_destination);
+    outbound.push(0);
+    outbound.extend_from_slice(b"reply");
+    tunnel.queue_outgoing_packet(&outbound).expect("queue outbound");
+
+    let transmit = tunnel.next_transmit().expect("transmit frame");
+    assert_eq!(transmit.destination, MeshtasticDestination::Node(77));
+}
+
+#[test]
+fn config_preserves_reference_preset_delays_and_index_wrap() {
+    assert_eq!(calc_meshtastic_index(255), 0);
+    assert_eq!(
+        MeshtasticInterfaceConfig::from_modem_preset(8).send_delay,
+        Duration::from_millis(400)
+    );
+    assert_eq!(MeshtasticInterfaceConfig::from_modem_preset(7).send_delay, Duration::from_secs(12));
+    assert_eq!(MeshtasticInterfaceConfig::from_modem_preset(99).send_delay, Duration::from_secs(7));
+}

--- a/crates/libs/rns-transport/tests/meshtastic_interface.rs
+++ b/crates/libs/rns-transport/tests/meshtastic_interface.rs
@@ -58,6 +58,79 @@ fn tunnel_requests_missing_chunks_and_completes_after_repair() {
 }
 
 #[test]
+fn tunnel_requests_next_gap_after_repaired_non_final_chunk() {
+    let mut tunnel = MeshtasticTunnel::new(MeshtasticInterfaceConfig {
+        max_payload_bytes: 80,
+        ..MeshtasticInterfaceConfig::default()
+    });
+    let data = b"reticulum-over-meshtastic".repeat(12);
+    let handler =
+        MeshtasticPacketHandler::new_outgoing(&data, 9, 80).expect("split outgoing payload");
+
+    assert_eq!(handler.positions(), vec![1, 2, 3, -4]);
+    assert_eq!(
+        tunnel
+            .process_received(MeshtasticReceivedFrame::new(1001, handler.payload_at(1).unwrap()))
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        tunnel
+            .process_received(MeshtasticReceivedFrame::new(1001, handler.payload_at(4).unwrap()))
+            .unwrap(),
+        None
+    );
+
+    let first_request = tunnel.next_transmit().expect("first missing chunk request");
+    assert_eq!(MeshtasticPacketHandler::metadata(&first_request.payload[3..]), Ok((9, 2)));
+    assert_eq!(
+        tunnel
+            .process_received(MeshtasticReceivedFrame::new(1001, handler.payload_at(2).unwrap()))
+            .unwrap(),
+        None
+    );
+
+    let second_request = tunnel.next_transmit().expect("second missing chunk request");
+    assert_eq!(MeshtasticPacketHandler::metadata(&second_request.payload[3..]), Ok((9, 3)));
+    assert_eq!(
+        tunnel
+            .process_received(MeshtasticReceivedFrame::new(1001, handler.payload_at(3).unwrap()))
+            .unwrap(),
+        Some(data)
+    );
+}
+
+#[test]
+fn tunnel_rejects_packet_index_wrap_before_overwriting_queued_payloads() {
+    let mut tunnel = MeshtasticTunnel::new(MeshtasticInterfaceConfig::default());
+
+    for index in 0..=u8::MAX {
+        let payload = format!("packet-{index:03}");
+        tunnel.queue_outgoing_packet(payload.as_bytes()).expect("queue packet");
+    }
+    let err = tunnel.queue_outgoing_packet(b"overflow").expect_err("index space should be full");
+    assert_eq!(err, "meshtastic outgoing packet index space is full");
+
+    let first = tunnel.next_transmit().expect("first queued packet");
+    assert_eq!(first.payload[0], 0);
+    assert_eq!(first.payload[1] as i8, -1);
+    assert_eq!(&first.payload[2..], b"packet-000");
+    tunnel.queue_outgoing_packet(b"after-drain").expect("drained index can be reused");
+}
+
+#[test]
+fn tunnel_handles_empty_reassembled_payload_without_destination_panic() {
+    let mut tunnel = MeshtasticTunnel::new(MeshtasticInterfaceConfig::default());
+
+    let received = tunnel
+        .process_received(MeshtasticReceivedFrame::new(1001, &[7, 0xff]))
+        .expect("empty final payload should not panic");
+
+    assert_eq!(received, Some(Vec::new()));
+    assert_eq!(tunnel.status().destination_routes, 0);
+}
+
+#[test]
 fn tunnel_learns_link_destinations_for_direct_meshtastic_replies() {
     let learned_destination = [0x42; 16];
     let mut inbound = Vec::new();

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -201,6 +201,11 @@ The project is best described by capability level:
   outbound I2P SAM peer baseline. Enabled unknown interface kinds remain
   parseable for operator visibility but are covered as explicit failed startup
   records with `unsupported interface kind` runtime metadata.
+- Meshtastic tunnel support now exists at the transport boundary with the
+  reference `RETICULUM_TUNNEL_APP` chunk metadata, modem-preset pacing,
+  missing-chunk request frames, node/destination route learning, and an
+  injectable bearer handle for serial/TCP/BLE adapters. Daemon config startup
+  and live Meshtastic hardware evidence remain future parity work.
 - RNodeMultiInterface has a transport-side vport slice: a single serial or TCP
   RNode endpoint can host nested subinterfaces, select virtual ports with KISS
   `CMD_SEL_INT`, route direct sends to the matching virtual child, and fan out

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -187,6 +187,11 @@ placeholders:
   requests, and live daemon/RPC `rnode_status` refresh plus compact
   `rnstatus-rs` human summaries for probe and radio state, with an opt-in
   prepared-host smoke harness for serial, TCP/Wi-Fi, or BLE RNode devices.
+- Meshtastic tunnel support is present in `rns-transport` as a Rust port of the
+  reference `RETICULUM_TUNNEL_APP` framing/reassembly layer, including modem
+  preset send pacing, missing-chunk request frames, node/destination route
+  learning, and an injectable bearer handle. It is not yet daemon config
+  startup or prepared-host Meshtastic hardware evidence.
 - Shared serial/TCP RNodeMulti baseline with nested vport subinterfaces,
   `CMD_SEL_INT` KISS vport selection, direct routing to virtual child
   interfaces, Python-style child enabled/interface-enabled handling, broadcast


### PR DESCRIPTION
﻿## Summary

- Add a Rust Meshtastic tunnel interface module under `rns-transport`.
- Port the reference `RETICULUM_TUNNEL_APP` chunk metadata, modem-preset pacing, missing-chunk request frames, packet reassembly, and node/destination route learning.
- Add focused Meshtastic compatibility tests and update parity docs to mark this as transport-boundary support, not daemon config startup or hardware evidence.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p reticulum-rs-transport --test meshtastic_interface`
- `git diff --check`

## Notes

- `bash tools/scripts/check-module-size.sh` through Git Bash is currently blocked by pre-existing dirty `xtask/src/main_parts/capture_platform_descriptor.rs:511` over the 500-line limit.
- Broader `cargo test -p reticulum-rs-transport --tests` currently has an unrelated deterministic failure in `transport::path_table::tests::restore_tunnel_path_defaults_missing_existing_mode_to_full_timeout` due to `std::time` instant subtraction overflow.
