### PR TITLE
[codex] Document Meshtastic tunnel usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ cargo run -p rns-tools --bin rnx -- e2e --timeout-secs 20
 - CLI quick reference: `docs/lxmf-cli.md`
 - Architecture overview: `docs/architecture/overview.md`
 - JSON and wire-field mapping: `docs/architecture/json-lxmf-fields.md`
+- Meshtastic tunnel interface: `docs/interfaces/meshtastic.md`
 - Compatibility contract: `docs/contracts/compatibility-contract.md`
 - Compatibility matrix: `docs/contracts/compatibility-matrix.md`
 - Third-party compatibility kit: `docs/contracts/third-party-compatibility-kit.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ These are the first places to update when behavior changes:
 - `docs/status/lxmf-parity-matrix.md`: maintained LXMF row-level parity status
 - `docs/contracts/`: public contracts, compatibility policy, support policy, API
   behavior, and protocol-facing guarantees
+- `docs/interfaces/`: interface-specific configuration and usage guidance for
+  transport surfaces that are not primarily operator runbooks
 - `docs/sdk/`: integration guidance for embedding `lxmf-sdk`
 - `docs/runbooks/`: operator and release procedures
 - `docs/architecture/`: active architecture policy and governance docs
@@ -47,6 +49,8 @@ are kept in Git history instead of the live documentation tree.
 - `docs/sdk/README.md`: starting point for SDK integrators
 - `docs/lxmf-rs-api.md`: API surface and stability summary
 - `docs/lxmf-cli.md`: operator CLI quick reference
+- `docs/interfaces/meshtastic.md`: Meshtastic tunnel configuration and library
+  integration guide
 - `docs/PerformancesComparison.html`: retained performance comparison snapshot;
   use the benchmarking runbook for current measurements
 - `docs/runbooks/release-readiness.md`: release gate checklist

--- a/docs/interfaces/meshtastic.md
+++ b/docs/interfaces/meshtastic.md
@@ -1,0 +1,239 @@
+# Meshtastic Tunnel Interface
+
+## Purpose
+
+The Meshtastic interface carries opaque Reticulum packet bytes through
+Meshtastic application payloads. It implements the tunnel framing used by the
+reference `RETICULUM_TUNNEL_APP` integration while keeping the radio, serial,
+TCP, BLE, or protobuf bearer outside the Reticulum packet boundary:
+
+```text
+Reticulum packet bytes -> Meshtastic tunnel chunks -> bearer app payload writes
+bearer app payload reads -> Meshtastic tunnel reassembly -> Reticulum packet bytes
+```
+
+Use this interface when an application already has a Meshtastic bearer and
+wants Reticulum packet routing, chunking, retransmit requests, and destination
+route learning in `reticulum-rs-transport`.
+
+## Current Support Boundary
+
+This is a transport-library interface, not a daemon-configured hardware
+adapter yet.
+
+Implemented:
+
+- `rns_transport::iface::meshtastic` public types.
+- Reference tunnel chunk metadata: first byte packet index, second byte signed
+  chunk position, with negative position marking the final chunk.
+- Missing-chunk request frames using `REQ` plus the requested index and
+  position metadata.
+- Modem-preset send pacing through `MeshtasticInterfaceConfig`.
+- One-byte packet-index wrap handling without overwriting queued packets.
+- Node route learning from inbound Reticulum packet destination fields.
+- An injectable `MeshtasticInterfaceHandle` for serial, TCP, BLE, or native
+  Meshtastic API adapters.
+- Runtime counters through `MeshtasticTunnelStatus`.
+
+Not implemented yet:
+
+- `reticulumd` TOML startup for `MeshtasticInterface`.
+- Native serial, TCP, BLE, or protobuf Meshtastic device discovery.
+- Prepared-host Meshtastic hardware smoke evidence.
+- Channel selection beyond the current outbound `channel_index = 0` default.
+- Rich Meshtastic device or radio management.
+
+Do not add a `MeshtasticInterface` entry to `reticulumd` config yet; enabled
+unknown interface kinds are reported as unsupported startup records by the
+daemon.
+
+## Configuration
+
+Use `MeshtasticInterfaceConfig` when constructing either a standalone
+`MeshtasticTunnel` or a spawned `MeshtasticInterface`.
+
+Defaults:
+
+| Field | Default | Meaning |
+| --- | ---: | --- |
+| `hop_limit` | `7` | Hop limit copied to outbound `MeshtasticTransmitFrame` values. |
+| `bitrate_bps` | `500` | Interface bitrate metadata for Reticulum pacing/accounting. |
+| `max_payload_bytes` | `200` | Maximum Reticulum payload bytes carried in each tunnel chunk after the two metadata bytes. Must be greater than zero. |
+| `send_delay` | `7s` | Delay between queued outbound Meshtastic tunnel transmissions. |
+| `destination_cache_size` | `20` | Number of Reticulum destination-to-node routes retained for direct replies. |
+
+The advertised interface MTU is `564`, matching the current Meshtastic hardware
+MTU assumption. `max_payload_bytes` is deliberately lower so app payloads leave
+space for Meshtastic transport overhead and device-specific limits.
+
+### Modem Presets
+
+`MeshtasticInterfaceConfig::from_modem_preset(preset)` keeps the default
+fields and selects a send delay for common Meshtastic modem presets:
+
+| Preset | Send delay |
+| ---: | ---: |
+| `8` | `400ms` |
+| `6` | `1s` |
+| `5` | `3s` |
+| `7` | `12s` |
+| `4` | `4s` |
+| `3` | `6s` |
+| `1` | `15s` |
+| `0` | `8s` |
+| other | `7s` |
+
+Override `send_delay` directly when local channel conditions or region limits
+require a more conservative pacing policy.
+
+Example:
+
+```rust
+use std::time::Duration;
+
+use rns_transport::iface::meshtastic::MeshtasticInterfaceConfig;
+
+let mut config = MeshtasticInterfaceConfig::from_modem_preset(8);
+config.hop_limit = 3;
+config.max_payload_bytes = 180;
+config.send_delay = Duration::from_secs(2);
+config.destination_cache_size = 32;
+```
+
+## Library Usage
+
+The lowest-level API is `MeshtasticTunnel`. It is useful for adapters that want
+to own their own task scheduling:
+
+```rust
+use rns_transport::iface::meshtastic::{
+    MeshtasticInterfaceConfig, MeshtasticReceivedFrame, MeshtasticTunnel,
+};
+
+let mut tunnel = MeshtasticTunnel::new(MeshtasticInterfaceConfig::default());
+
+// Queue an outbound Reticulum packet byte buffer.
+tunnel.queue_outgoing_packet(&reticulum_packet_bytes)?;
+
+// Drain the next Meshtastic app payload to send through the bearer.
+if let Some(frame) = tunnel.next_transmit() {
+    // Send frame.payload through the Meshtastic RETICULUM_TUNNEL_APP port.
+    // Use frame.destination, frame.hop_limit, and frame.channel_index when the
+    // bearer API exposes those controls.
+}
+
+// Feed an inbound Meshtastic app payload back into the tunnel.
+let received = MeshtasticReceivedFrame::new(from_node_id, &app_payload);
+if let Some(reticulum_packet_bytes) = tunnel.process_received(received)? {
+    // Decode or forward the complete Reticulum packet bytes.
+}
+```
+
+`queue_outgoing_packet` rejects payloads that cannot be split into at most
+`i8::MAX` chunks. It also refuses to reuse a one-byte packet index while queued
+chunks for an older packet with the same index are still pending.
+
+## InterfaceManager Usage
+
+Use `spawn_meshtastic` when the Meshtastic tunnel should behave like a normal
+Reticulum interface inside `InterfaceManager` while an external bearer task
+does the actual device I/O:
+
+```rust
+use rns_transport::iface::InterfaceManager;
+use rns_transport::iface::meshtastic::{
+    spawn_meshtastic, MeshtasticInterfaceConfig, MeshtasticReceivedFrame,
+};
+
+let mut manager = InterfaceManager::new(128);
+let (_iface_address, handle) = spawn_meshtastic(
+    &mut manager,
+    "mesh-main",
+    MeshtasticInterfaceConfig::from_modem_preset(8),
+);
+
+// In the bearer receive path:
+handle
+    .inject_received(MeshtasticReceivedFrame::new(from_node_id, &app_payload))
+    .await?;
+
+// In the bearer transmit path:
+if let Some(frame) = handle.recv_transmit().await {
+    // Map frame.destination to broadcast or direct Meshtastic send.
+    // Write frame.payload as the Meshtastic app payload.
+}
+```
+
+`MeshtasticInterfaceHandle::inject_received` accepts only the Meshtastic app
+payload bytes for the Reticulum tunnel app. Strip any Meshtastic protobuf,
+serial framing, BLE packet framing, or device envelope before constructing
+`MeshtasticReceivedFrame`.
+
+`MeshtasticInterfaceHandle::recv_transmit` yields `MeshtasticTransmitFrame`:
+
+| Field | Adapter responsibility |
+| --- | --- |
+| `destination` | Broadcast when `MeshtasticDestination::Broadcast`; direct-send to a node when `MeshtasticDestination::Node(id)`. |
+| `payload` | Write as the Meshtastic tunnel app payload. |
+| `hop_limit` | Apply to the Meshtastic send request when supported by the bearer. |
+| `want_ack` | Currently `false`; pass through if the bearer requires an explicit value. |
+| `want_response` | Currently `false`; pass through if the bearer requires an explicit value. |
+| `channel_index` | Currently `0`; pass through to the Meshtastic channel selector when supported. |
+
+## Routing Behavior
+
+The tunnel learns direct node routes from complete inbound Reticulum packet
+bytes. If a packet contains a Reticulum destination field, the tunnel remembers
+that destination hash as reachable through the Meshtastic node that sent the
+frame. Later outbound packets for that destination use
+`MeshtasticDestination::Node(node_id)` instead of broadcast until the route is
+evicted from the bounded destination cache.
+
+This cache is local runtime state. It is not persisted and it is not a
+substitute for Reticulum path-table persistence.
+
+## Retransmit Behavior
+
+Inbound chunks are reassembled by packet index and chunk position. When the
+tunnel sees a later chunk before an expected earlier chunk, it queues a request
+frame:
+
+```text
+"REQ" || packet_index || missing_position
+```
+
+The request is sent as a normal outbound Meshtastic tunnel payload. A peer that
+receives the request retransmits the referenced chunk if the packet is still in
+its local outgoing storage. When multiple adjacent chunks are missing, the
+tunnel keeps requesting the next missing position after each repaired non-final
+chunk arrives.
+
+## Status
+
+`MeshtasticTunnel::status()` and `MeshtasticInterface::runtime_status_json()`
+expose:
+
+| Field | Meaning |
+| --- | --- |
+| `queued_transmissions` | Pending chunk or request frames waiting to be sent. |
+| `destination_routes` | Learned destination-to-node route entries. |
+| `packets_rx` | Complete Reticulum packets reassembled from Meshtastic chunks. |
+| `packets_tx` | Complete Reticulum packets whose final chunk has been transmitted. |
+| `chunks_rx` | Meshtastic tunnel chunks or request frames received. |
+| `chunks_tx` | Meshtastic tunnel chunks or request frames transmitted. |
+| `requested_retransmits` | Missing-chunk request frames queued locally. |
+| `decode_errors` | Malformed Meshtastic chunks or Reticulum packet decode failures. |
+| `last_error` | Last recorded tunnel, queue, or decode error. |
+
+## Validation
+
+Focused coverage lives in:
+
+```powershell
+cargo test -p reticulum-rs-transport --test meshtastic_interface
+```
+
+That test target covers reference metadata splitting/reassembly,
+modem-preset pacing, missing-chunk requests, chained repair after adjacent
+loss, one-byte packet-index wrap protection, empty-payload handling, and
+destination route learning for direct replies.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -204,8 +204,10 @@ The project is best described by capability level:
 - Meshtastic tunnel support now exists at the transport boundary with the
   reference `RETICULUM_TUNNEL_APP` chunk metadata, modem-preset pacing,
   missing-chunk request frames, node/destination route learning, and an
-  injectable bearer handle for serial/TCP/BLE adapters. Daemon config startup
-  and live Meshtastic hardware evidence remain future parity work.
+  injectable bearer handle for serial/TCP/BLE adapters. Configuration and
+  library integration guidance lives in `docs/interfaces/meshtastic.md`.
+  Daemon config startup and live Meshtastic hardware evidence remain future
+  parity work.
 - RNodeMultiInterface has a transport-side vport slice: a single serial or TCP
   RNode endpoint can host nested subinterfaces, select virtual ports with KISS
   `CMD_SEL_INT`, route direct sends to the matching virtual child, and fan out

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -190,8 +190,9 @@ placeholders:
 - Meshtastic tunnel support is present in `rns-transport` as a Rust port of the
   reference `RETICULUM_TUNNEL_APP` framing/reassembly layer, including modem
   preset send pacing, missing-chunk request frames, node/destination route
-  learning, and an injectable bearer handle. It is not yet daemon config
-  startup or prepared-host Meshtastic hardware evidence.
+  learning, an injectable bearer handle, and configuration/usage guidance in
+  `docs/interfaces/meshtastic.md`. It is not yet daemon config startup or
+  prepared-host Meshtastic hardware evidence.
 - Shared serial/TCP RNodeMulti baseline with nested vport subinterfaces,
   `CMD_SEL_INT` KISS vport selection, direct routing to virtual child
   interfaces, Python-style child enabled/interface-enabled handling, broadcast


### PR DESCRIPTION
## Summary
- add a Meshtastic tunnel interface guide covering configuration, modem-preset pacing, bearer-adapter usage, routing, retransmit behavior, status counters, and validation
- link the guide from the root docs entry points and existing parity/status Meshtastic notes
- explicitly document that reticulumd TOML startup and prepared-host Meshtastic hardware evidence remain future work

## Validation
- git diff --check origin/main..HEAD