### PR TITLE
fix: Android RNode BLE peripheral id construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,8 @@ dependencies = [
  "objc2-core-bluetooth",
  "objc2-foundation",
  "once_cell",
+ "serde",
+ "serde_bytes",
  "static_assertions",
  "thiserror 2.0.18",
  "tokio",
@@ -3116,6 +3118,7 @@ checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/crates/libs/rns-transport/Cargo.toml
+++ b/crates/libs/rns-transport/Cargo.toml
@@ -49,7 +49,7 @@ rns-core.workspace = true
 [features]
 default = []
 fernet-aes128 = []
-rnode-ble = ["dep:btleplug", "dep:futures", "dep:uuid"]
+rnode-ble = ["dep:btleplug", "btleplug/serde", "dep:futures", "dep:uuid"]
 vrn76-kiss-ble = ["rnode-ble"]
 
 [dev-dependencies]

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
@@ -380,7 +380,19 @@ impl NativeRnodeBleBackend {
         let Ok(address) = settings.peripheral_id.parse::<BDAddr>() else {
             return Ok(None);
         };
-        let peripheral_id = PeripheralId::from(address);
+        let peripheral_id: PeripheralId = match serde_json::to_value(address)
+            .and_then(serde_json::from_value)
+        {
+            Ok(id) => id,
+            Err(err) => {
+                log::warn!(
+                    "RNode BLE could not build Android peripheral id peripheral_id={} err={}",
+                    settings.peripheral_id,
+                    err
+                );
+                return Ok(None);
+            }
+        };
         match adapter.add_peripheral(&peripheral_id).await {
             Ok(peripheral) => {
                 log::info!(


### PR DESCRIPTION
Summary:

fixes bug in rnode/ble code

configured_peripheral() built a PeripheralId via PeripheralId::from(address),
which only compiles on btleplug's WinRT backend — the sole backend providing
impl From<BDAddr> for PeripheralId. On the Android/droidplug backend
PeripheralId(pub(super) BDAddr) has a private field and no such conversion,
so the aarch64-linux-android build failed to compile (E0308).

Enable btleplug's serde feature and construct the PeripheralId via a
serde round-trip through its inner BDAddr instead, falling back to Ok(None)
on the (practically impossible) error to match the existing
"peripheral unavailable" path.

Note:

Code for android fails at build stage, this might indicate that there insufficient test coverage, or insufficient build coverage across targets/features. Or this might be tested in release branch, in that case, no problem, I guess. Though, we can run full test suite at night by timer on main branch to capture those bugs faster.