### PR TITLE
Fix/autointerface multicast race

### DIFF
--- a/crates/libs/rns-transport/src/iface/weave.rs
+++ b/crates/libs/rns-transport/src/iface/weave.rs
@@ -987,8 +987,8 @@ where
     let local_switch_id = switch_id_for_identity(&options.switch_identity);
 
     match packet_type {
-        WDCL_T_DISCOVER => {
-            if target == local_switch_id {
+        WDCL_T_DISCOVER
+            if target == local_switch_id => {
                 if let Some(remote_switch_id) =
                     accept_discovery_response(&options.switch_identity, frame)
                 {
@@ -1027,9 +1027,8 @@ where
                     }
                 }
             }
-        }
-        WDCL_T_ENDPOINT_PKT => {
-            if target == local_switch_id && payload.len() > ENDPOINT_ID_LEN {
+        WDCL_T_ENDPOINT_PKT
+            if target == local_switch_id && payload.len() > ENDPOINT_ID_LEN => {
                 let data_len = payload.len() - ENDPOINT_ID_LEN;
                 let mut endpoint = [0_u8; ENDPOINT_ID_LEN];
                 endpoint.copy_from_slice(&payload[data_len..]);
@@ -1047,12 +1046,10 @@ where
                     }
                 }
             }
-        }
-        WDCL_T_LOG => {
-            if target == local_switch_id {
+        WDCL_T_LOG
+            if target == local_switch_id => {
                 process_weave_log(payload, options, state).await;
             }
-        }
         WDCL_T_DISP if target == local_switch_id => {
             process_weave_display(payload, options);
         }

--- a/crates/libs/rns-transport/src/iface/weave.rs
+++ b/crates/libs/rns-transport/src/iface/weave.rs
@@ -987,69 +987,64 @@ where
     let local_switch_id = switch_id_for_identity(&options.switch_identity);
 
     match packet_type {
-        WDCL_T_DISCOVER
-            if target == local_switch_id => {
-                if let Some(remote_switch_id) =
-                    accept_discovery_response(&options.switch_identity, frame)
-                {
-                    state.lock().await.remote_switch_id = Some(remote_switch_id);
-                    let handshake =
-                        weave_handshake_frame(&options.switch_identity, remote_switch_id);
-                    update_weave_status(&options.runtime_status, |status| {
-                        status.remote_switch_id = Some(remote_switch_id);
-                        status.last_error = None;
-                    });
-                    let handshake = weave_wire_frame(&handshake);
-                    match stream.write_all(&handshake).await {
-                        Ok(()) => {
-                            let _ = stream.flush().await;
-                            update_weave_status(&options.runtime_status, |status| {
-                                status.bytes_tx =
-                                    status.bytes_tx.saturating_add(handshake.len() as u64);
-                                status.frames_tx = status.frames_tx.saturating_add(1);
-                            });
-                        }
-                        Err(err) => {
-                            update_weave_status(&options.runtime_status, |status| {
-                                status.mark_reconnecting(format!(
-                                    "weave handshake write failed iface={} device={} err={}",
-                                    options.parent_iface, options.device, err
-                                ));
-                            });
-                            log::warn!(
-                                "Weave handshake write error iface={} device={} err={}",
-                                options.parent_iface,
-                                options.device,
-                                err
-                            );
-                            return false;
-                        }
-                    }
-                }
-            }
-        WDCL_T_ENDPOINT_PKT
-            if target == local_switch_id && payload.len() > ENDPOINT_ID_LEN => {
-                let data_len = payload.len() - ENDPOINT_ID_LEN;
-                let mut endpoint = [0_u8; ENDPOINT_ID_LEN];
-                endpoint.copy_from_slice(&payload[data_len..]);
-                let address = ensure_weave_endpoint(endpoint, options, state.clone()).await;
-                if let Some(address) = address {
-                    if let Ok(packet) =
-                        Packet::deserialize(&mut InputBuffer::new(&payload[..data_len]))
-                    {
+        WDCL_T_DISCOVER if target == local_switch_id => {
+            if let Some(remote_switch_id) =
+                accept_discovery_response(&options.switch_identity, frame)
+            {
+                state.lock().await.remote_switch_id = Some(remote_switch_id);
+                let handshake = weave_handshake_frame(&options.switch_identity, remote_switch_id);
+                update_weave_status(&options.runtime_status, |status| {
+                    status.remote_switch_id = Some(remote_switch_id);
+                    status.last_error = None;
+                });
+                let handshake = weave_wire_frame(&handshake);
+                match stream.write_all(&handshake).await {
+                    Ok(()) => {
+                        let _ = stream.flush().await;
                         update_weave_status(&options.runtime_status, |status| {
-                            status.mark_endpoint_packet_rx(endpoint, address);
+                            status.bytes_tx =
+                                status.bytes_tx.saturating_add(handshake.len() as u64);
+                            status.frames_tx = status.frames_tx.saturating_add(1);
                         });
-                        let _ = rx_channel
-                            .send(RxMessage { address, packet, source: IfaceSource::None })
-                            .await;
+                    }
+                    Err(err) => {
+                        update_weave_status(&options.runtime_status, |status| {
+                            status.mark_reconnecting(format!(
+                                "weave handshake write failed iface={} device={} err={}",
+                                options.parent_iface, options.device, err
+                            ));
+                        });
+                        log::warn!(
+                            "Weave handshake write error iface={} device={} err={}",
+                            options.parent_iface,
+                            options.device,
+                            err
+                        );
+                        return false;
                     }
                 }
             }
-        WDCL_T_LOG
-            if target == local_switch_id => {
-                process_weave_log(payload, options, state).await;
+        }
+        WDCL_T_ENDPOINT_PKT if target == local_switch_id && payload.len() > ENDPOINT_ID_LEN => {
+            let data_len = payload.len() - ENDPOINT_ID_LEN;
+            let mut endpoint = [0_u8; ENDPOINT_ID_LEN];
+            endpoint.copy_from_slice(&payload[data_len..]);
+            let address = ensure_weave_endpoint(endpoint, options, state.clone()).await;
+            if let Some(address) = address {
+                if let Ok(packet) = Packet::deserialize(&mut InputBuffer::new(&payload[..data_len]))
+                {
+                    update_weave_status(&options.runtime_status, |status| {
+                        status.mark_endpoint_packet_rx(endpoint, address);
+                    });
+                    let _ = rx_channel
+                        .send(RxMessage { address, packet, source: IfaceSource::None })
+                        .await;
+                }
             }
+        }
+        WDCL_T_LOG if target == local_switch_id => {
+            process_weave_log(payload, options, state).await;
+        }
         WDCL_T_DISP if target == local_switch_id => {
             process_weave_display(payload, options);
         }

--- a/crates/libs/rns-transport/src/transport/handler.rs
+++ b/crates/libs/rns-transport/src/transport/handler.rs
@@ -250,6 +250,12 @@ impl TransportHandler {
                     PacketContext::KeepAlive
                         | PacketContext::LinkClose
                         | PacketContext::ResourceRequest
+                        // The channel protocol has its own sequencing/dedup, so
+                        // transport-level dedup must not suppress channel frames.
+                        // Otherwise a retransmit needed after the receiver's
+                        // channel opens (link-activation race) is dropped as a
+                        // duplicate of the pre-open copy, stalling auth.
+                        | PacketContext::Channel
                 );
             }
             PacketType::Proof => {

--- a/crates/libs/rns-transport/src/transport/handler.rs
+++ b/crates/libs/rns-transport/src/transport/handler.rs
@@ -400,7 +400,6 @@ impl TransportHandler {
     /// Resolve the interface an inbound *link-associated* packet (LinkRequest /
     /// Proof / link Data) should be handled on, eagerly learning the sender's
     /// unicast route in the process.
-
     pub(super) async fn ingress_route_iface(
         &mut self,
         packet: &Packet,

--- a/crates/libs/rns-transport/src/transport/handler.rs
+++ b/crates/libs/rns-transport/src/transport/handler.rs
@@ -357,6 +357,46 @@ impl TransportHandler {
         Some(virtual_hash)
     }
 
+    /// Resolve the interface an inbound *link-associated* packet (LinkRequest /
+    /// Proof / link Data) should be handled on, eagerly learning the sender's
+    /// unicast route in the process.
+    ///
+    /// On a multicast iface this registers (or refreshes) the peer's virtual
+    /// unicast iface from the packet's source address — the "detect over
+    /// multicast, then unicast" step — and returns that virtual hash. Binding
+    /// the resulting link to it means the link's proof/data replies target the
+    /// virtual iface, which `PeerRouting` resolves to a unicast send instead of
+    /// being dropped by the multicast tx-guard (which only excepts LinkProof).
+    /// Announces already do this via `unicast_iface_for_source`; doing it for
+    /// link traffic too closes the announce-vs-link-request race that stalled
+    /// the AutoInterface auth handshake.
+    ///
+    /// Falls back to `iface` unchanged when the packet did not arrive over a
+    /// multicast iface from a UDP peer (e.g. TCP/Serial links), so those paths
+    /// keep their existing ingress iface.
+    pub(super) async fn ingress_route_iface(
+        &mut self,
+        iface: AddressHash,
+        source: IfaceSource,
+    ) -> AddressHash {
+        match self.unicast_iface_for_source(iface, source).await {
+            Some(virtual_iface) => virtual_iface,
+            None => {
+                // Expected on non-multicast ifaces (TCP/Serial) and for packets
+                // already attributed to a virtual unicast iface. Kept at trace so
+                // it costs zero instructions in production (release_max_level) and
+                // does not spam this per-inbound-packet path.
+                log::trace!(
+                    "tp({}): no unicast route learned for source {:?} on iface {}; keeping ingress iface",
+                    self.config.name,
+                    source,
+                    iface,
+                );
+                iface
+            }
+        }
+    }
+
     /// Register a `PeerRouting` map for a multicast iface at
     /// construction time. Called by
     /// `Transport::add_multicast_udp_interface`.

--- a/crates/libs/rns-transport/src/transport/handler.rs
+++ b/crates/libs/rns-transport/src/transport/handler.rs
@@ -363,35 +363,61 @@ impl TransportHandler {
         Some(virtual_hash)
     }
 
+    /// Whether an inbound link-associated packet targets something we will
+    /// actually route or deliver — i.e. it is "accepted" rather than dropped.
+    /// Used to gate eager unicast-route learning so that unauthenticated
+    /// multicast senders cannot grow `unicast_udp_ifaces` / the `iface_manager`
+    /// virtual-iface set with requests to unknown destinations.
+    ///
+    /// The criteria mirror the accept branches of the individual handlers:
+    ///   - Link packets (`Proof` / `Data` with `DestinationType::Link`) are
+    ///     accepted when we already track the link — as an inbound link, an
+    ///     outbound link (matched by id), or a forward in the `link_table`.
+    ///   - Everything else (`LinkRequest` and single `Data`, both
+    ///     `DestinationType::Single`) is accepted when the destination is a
+    ///     local input destination or has a known next hop — exactly
+    ///     `handle_link_request`'s destination/intermediate split.
+    pub(super) async fn should_learn_unicast_route(&self, packet: &Packet) -> bool {
+        if packet.header.destination_type == DestinationType::Link {
+            // `LinkId == AddressHash`, so the link id is `packet.destination`.
+            if self.in_links.contains_key(&packet.destination)
+                || self.link_table.knows(&packet.destination)
+            {
+                return true;
+            }
+            for link in self.out_links.values() {
+                if *link.lock().await.id() == packet.destination {
+                    return true;
+                }
+            }
+            false
+        } else {
+            self.single_in_destinations.contains_key(&packet.destination)
+                || self.path_table.next_hop_full(&packet.destination).is_some()
+        }
+    }
+
     /// Resolve the interface an inbound *link-associated* packet (LinkRequest /
     /// Proof / link Data) should be handled on, eagerly learning the sender's
     /// unicast route in the process.
-    ///
-    /// On a multicast iface this registers (or refreshes) the peer's virtual
-    /// unicast iface from the packet's source address — the "detect over
-    /// multicast, then unicast" step — and returns that virtual hash. Binding
-    /// the resulting link to it means the link's proof/data replies target the
-    /// virtual iface, which `PeerRouting` resolves to a unicast send instead of
-    /// being dropped by the multicast tx-guard (which only excepts LinkProof).
-    /// Announces already do this via `unicast_iface_for_source`; doing it for
-    /// link traffic too closes the announce-vs-link-request race that stalled
-    /// the AutoInterface auth handshake.
-    ///
-    /// Falls back to `iface` unchanged when the packet did not arrive over a
-    /// multicast iface from a UDP peer (e.g. TCP/Serial links), so those paths
-    /// keep their existing ingress iface.
+
     pub(super) async fn ingress_route_iface(
         &mut self,
+        packet: &Packet,
         iface: AddressHash,
         source: IfaceSource,
     ) -> AddressHash {
+        if !self.should_learn_unicast_route(packet).await {
+            log::info!(
+                "tp({}): unrecognized target: {}, keeping ingress as-is.",
+                self.config.name,
+                packet.destination.to_hex_string()
+            );
+            return iface;
+        }
         match self.unicast_iface_for_source(iface, source).await {
             Some(virtual_iface) => virtual_iface,
             None => {
-                // Expected on non-multicast ifaces (TCP/Serial) and for packets
-                // already attributed to a virtual unicast iface. Kept at trace so
-                // it costs zero instructions in production (release_max_level) and
-                // does not spam this per-inbound-packet path.
                 log::trace!(
                     "tp({}): no unicast route learned for source {:?} on iface {}; keeping ingress iface",
                     self.config.name,

--- a/crates/libs/rns-transport/src/transport/jobs.rs
+++ b/crates/libs/rns-transport/src/transport/jobs.rs
@@ -298,27 +298,25 @@ pub(super) async fn manage_transport(
                                 message.address,
                                 message.source,
                             ).await,
-                            // Link traffic: learn the sender's unicast route from its
-                            // source address (detect-over-multicast, then unicast) and
+                            // Link traffic: learn the sender's unicast route and
                             // bind the link to that virtual iface, so replies are
-                            // unicast rather than dropped by the multicast tx-guard.
-                            // No-op fallback to `message.address` on non-multicast ifaces.
+                            // unicast
                             PacketType::LinkRequest => {
                                 let route_iface = handler
-                                    .ingress_route_iface(message.address, message.source)
+                                    .ingress_route_iface(&packet, message.address, message.source)
                                     .await;
                                 handle_link_request(&packet, route_iface, handler).await
                             }
                             PacketType::Proof => {
                                 let route_iface = handler
-                                    .ingress_route_iface(message.address, message.source)
+                                    .ingress_route_iface(&packet, message.address, message.source)
                                     .await;
                                 drop(handler);
                                 handle_proof(packet, handler_arc.clone(), route_iface).await;
                             }
                             PacketType::Data => {
                                 let route_iface = handler
-                                    .ingress_route_iface(message.address, message.source)
+                                    .ingress_route_iface(&packet, message.address, message.source)
                                     .await;
                                 handle_data(&packet, route_iface, handler).await
                             }

--- a/crates/libs/rns-transport/src/transport/jobs.rs
+++ b/crates/libs/rns-transport/src/transport/jobs.rs
@@ -298,16 +298,30 @@ pub(super) async fn manage_transport(
                                 message.address,
                                 message.source,
                             ).await,
-                            PacketType::LinkRequest => handle_link_request(
-                                &packet,
-                                message.address,
-                                handler
-                            ).await,
-                            PacketType::Proof => {
-                                drop(handler);
-                                handle_proof(packet, handler_arc.clone(), message.address).await;
+                            // Link traffic: learn the sender's unicast route from its
+                            // source address (detect-over-multicast, then unicast) and
+                            // bind the link to that virtual iface, so replies are
+                            // unicast rather than dropped by the multicast tx-guard.
+                            // No-op fallback to `message.address` on non-multicast ifaces.
+                            PacketType::LinkRequest => {
+                                let route_iface = handler
+                                    .ingress_route_iface(message.address, message.source)
+                                    .await;
+                                handle_link_request(&packet, route_iface, handler).await
                             }
-                            PacketType::Data => handle_data(&packet, message.address, handler).await,
+                            PacketType::Proof => {
+                                let route_iface = handler
+                                    .ingress_route_iface(message.address, message.source)
+                                    .await;
+                                drop(handler);
+                                handle_proof(packet, handler_arc.clone(), route_iface).await;
+                            }
+                            PacketType::Data => {
+                                let route_iface = handler
+                                    .ingress_route_iface(message.address, message.source)
+                                    .await;
+                                handle_data(&packet, route_iface, handler).await
+                            }
                         }
                     }
                 };

--- a/crates/libs/rns-transport/src/transport/link_table.rs
+++ b/crates/libs/rns-transport/src/transport/link_table.rs
@@ -81,6 +81,13 @@ impl LinkTable {
         self.entries.insert(link_id, entry);
     }
 
+    /// Whether the table has any entry (validated or pending) for `link_id`.
+    /// Unlike `original_destination`, this does not filter on `validated`, so it
+    /// also recognizes link requests still awaiting their proof.
+    pub fn knows(&self, link_id: &LinkId) -> bool {
+        self.entries.contains_key(link_id)
+    }
+
     pub fn original_destination(&self, link_id: &LinkId) -> Option<AddressHash> {
         self.entries.get(link_id).filter(|e| e.validated).map(|e| e.original_destination)
     }

--- a/crates/libs/rns-transport/src/transport/tests.rs
+++ b/crates/libs/rns-transport/src/transport/tests.rs
@@ -19,3 +19,5 @@ include!("tests_parts/encrypted_resource_control_packet.rs");
 include!("tests_parts/transport_register_channel_handler_d.rs");
 
 include!("tests_parts/unicast_iface_for_source_returns_non.rs");
+
+include!("tests_parts/inbound_link_request_registers_unicast.rs");

--- a/crates/libs/rns-transport/src/transport/tests_parts/inbound_link_request_registers_unicast.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/inbound_link_request_registers_unicast.rs
@@ -1,17 +1,18 @@
 use super::path::handle_link_request;
 
-// Regression coverage for the flaky AutoInterface/multicast e2e failure:
-// when a link request/handshake arrives over a multicast iface *before* the
-// peer's announce is processed, the inbound link used to bind to the host
-// multicast iface. Its proof/data replies then targeted `Direct(iface_address)`
-// which `PeerRouting` cannot resolve, so the multicast tx-guard dropped every
-// reply except the LinkProof — stalling the auth handshake (`recv round1/round2:
-// auth timeout`). The fix registers the peer's virtual unicast route from the
-// inbound packet's source address (detect-via-multicast, then unicast) and pins
-// the link to that virtual iface, so replies are unicast to the discovered peer.
+// Coverage for unicast-route learning on multicast-interface ingress.
+
+/// Build a `LinkRequest` packet targeting `dest_desc` (as a client would send).
+fn link_request_to(dest_desc: DestinationDesc) -> Packet {
+    let (link_events, _keep) = tokio::sync::broadcast::channel(4);
+    let mut outbound = Link::new(dest_desc, link_events);
+    outbound.request()
+}
 
 /// `ingress_route_iface` on a multicast iface eagerly registers the sender's
-/// virtual unicast route from its source addr and returns that virtual hash.
+/// virtual unicast route from its source addr and returns that virtual hash —
+/// but only for a packet we accept (here, a link request to a local input
+/// destination).
 #[tokio::test]
 async fn ingress_route_iface_registers_virtual_route_on_multicast() {
     let identity = PrivateIdentity::new_from_rand(OsRng);
@@ -19,11 +20,22 @@ async fn ingress_route_iface_registers_virtual_route_on_multicast() {
     let mc_iface = register_fake_multicast_iface(&transport).await;
     let handler = transport.get_handler();
 
+    // Local destination the request targets → the request is accepted.
+    let server_dest =
+        SingleInputDestination::new(PrivateIdentity::new_from_rand(OsRng), DestinationName::new("lxmf", "delivery"));
+    let dest_desc = server_dest.desc;
+    handler
+        .lock()
+        .await
+        .single_in_destinations
+        .insert(dest_desc.address_hash, Arc::new(Mutex::new(server_dest)));
+    let request_packet = link_request_to(dest_desc);
+
     let peer = peer_addr(4242);
     let route_iface = handler
         .lock()
         .await
-        .ingress_route_iface(mc_iface, crate::iface::IfaceSource::Udp(peer))
+        .ingress_route_iface(&request_packet, mc_iface, crate::iface::IfaceSource::Udp(peer))
         .await;
 
     assert_ne!(route_iface, mc_iface, "must resolve to a fresh virtual unicast iface");
@@ -34,8 +46,8 @@ async fn ingress_route_iface_registers_virtual_route_on_multicast() {
     assert_eq!(routing.addr_for_hash(&route_iface), Some(peer));
 }
 
-/// On a non-multicast iface (no PeerRouting) it is a pass-through: the caller's
-/// iface is returned unchanged and nothing is registered.
+/// On a non-multicast iface (no PeerRouting) it is a pass-through even for an
+/// accepted packet: the caller's iface is returned unchanged, nothing registers.
 #[tokio::test]
 async fn ingress_route_iface_passes_through_on_non_multicast() {
     let identity = PrivateIdentity::new_from_rand(OsRng);
@@ -43,21 +55,67 @@ async fn ingress_route_iface_passes_through_on_non_multicast() {
     let unicast_iface = new_unicast_iface_in(&transport).await;
     let handler = transport.get_handler();
 
+    // Accepted (local destination) so the pass-through is due to the iface not
+    // being multicast, not the acceptance gate.
+    let server_dest =
+        SingleInputDestination::new(PrivateIdentity::new_from_rand(OsRng), DestinationName::new("lxmf", "delivery"));
+    let dest_desc = server_dest.desc;
+    handler
+        .lock()
+        .await
+        .single_in_destinations
+        .insert(dest_desc.address_hash, Arc::new(Mutex::new(server_dest)));
+    let request_packet = link_request_to(dest_desc);
+
     let peer = peer_addr(4242);
     let route_iface = handler
         .lock()
         .await
-        .ingress_route_iface(unicast_iface, crate::iface::IfaceSource::Udp(peer))
+        .ingress_route_iface(&request_packet, unicast_iface, crate::iface::IfaceSource::Udp(peer))
         .await;
 
     assert_eq!(route_iface, unicast_iface, "non-multicast iface must pass through unchanged");
     assert!(handler.lock().await.unicast_udp_ifaces.is_empty());
 }
 
+/// An inbound `LinkRequest` to an *unknown* destination must not learn a route:
+/// on a multicast iface, `handle_link_request` drops it, so registering a
+/// virtual unicast iface would only leak `unicast_udp_ifaces` / `iface_manager`
+/// entries (until the idle GC) for any sender on the multicast group.
+#[tokio::test]
+async fn inbound_link_request_to_unknown_destination_does_not_register() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &identity, true));
+    let mc_iface = register_fake_multicast_iface(&transport).await;
+    let handler = transport.get_handler();
+
+    // A link request targeting a destination we neither host nor have a path to.
+    let unknown_dest =
+        SingleInputDestination::new(PrivateIdentity::new_from_rand(OsRng), DestinationName::new("lxmf", "delivery"));
+    let request_packet = link_request_to(unknown_dest.desc);
+
+    let peer = peer_addr(4242);
+    let route_iface = handler
+        .lock()
+        .await
+        .ingress_route_iface(&request_packet, mc_iface, crate::iface::IfaceSource::Udp(peer))
+        .await;
+    assert_eq!(route_iface, mc_iface, "unknown-destination request must keep the ingress iface");
+
+    handle_link_request(&request_packet, route_iface, handler.lock().await).await;
+
+    let guard = handler.lock().await;
+    assert!(guard.unicast_udp_ifaces.is_empty(), "no virtual unicast iface may be registered");
+    let routing = guard.multicast_peer_routings.get(&mc_iface).expect("routing").lock().await;
+    assert_eq!(routing.hash_for_addr(&peer), None, "no peer route may be learned");
+    drop(routing);
+    assert!(guard.in_links.is_empty(), "dropped request must not create an in-link");
+}
+
 /// End-to-end at the handler level: an inbound `LinkRequest` from a UDP peer on a
-/// multicast iface (no prior announce) creates an in-link pinned to the peer's
-/// virtual unicast iface — so its proof/data replies unicast instead of being
-/// dropped by the tx-guard. Pre-fix the link bound to the host multicast iface.
+/// multicast iface creates an in-link pinned to the peer's virtual unicast iface
+/// — so its proof/data replies are unicast instead of being routed at (and
+/// dropped by) the multicast iface.
 #[tokio::test]
 async fn inbound_link_request_pins_in_link_to_unicast_route() {
     let local_identity = PrivateIdentity::new_from_rand(OsRng);
@@ -76,9 +134,7 @@ async fn inbound_link_request_pins_in_link_to_unicast_route() {
         .insert(dest_desc.address_hash, Arc::new(Mutex::new(server_dest)));
 
     // Client-side outbound link → take its LinkRequest packet.
-    let (link_events, _keep) = tokio::sync::broadcast::channel(4);
-    let mut outbound = Link::new(dest_desc, link_events);
-    let request_packet = outbound.request();
+    let request_packet = link_request_to(dest_desc);
 
     // Replicate the jobs.rs inbound dispatch for a LinkRequest arriving on the
     // multicast socket from `peer` before any announce from that peer.
@@ -86,7 +142,7 @@ async fn inbound_link_request_pins_in_link_to_unicast_route() {
     let route_iface = handler
         .lock()
         .await
-        .ingress_route_iface(mc_iface, crate::iface::IfaceSource::Udp(peer))
+        .ingress_route_iface(&request_packet, mc_iface, crate::iface::IfaceSource::Udp(peer))
         .await;
     handle_link_request(&request_packet, route_iface, handler.lock().await).await;
 

--- a/crates/libs/rns-transport/src/transport/tests_parts/inbound_link_request_registers_unicast.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/inbound_link_request_registers_unicast.rs
@@ -1,0 +1,110 @@
+use super::path::handle_link_request;
+
+// Regression coverage for the flaky AutoInterface/multicast e2e failure:
+// when a link request/handshake arrives over a multicast iface *before* the
+// peer's announce is processed, the inbound link used to bind to the host
+// multicast iface. Its proof/data replies then targeted `Direct(iface_address)`
+// which `PeerRouting` cannot resolve, so the multicast tx-guard dropped every
+// reply except the LinkProof — stalling the auth handshake (`recv round1/round2:
+// auth timeout`). The fix registers the peer's virtual unicast route from the
+// inbound packet's source address (detect-via-multicast, then unicast) and pins
+// the link to that virtual iface, so replies are unicast to the discovered peer.
+
+/// `ingress_route_iface` on a multicast iface eagerly registers the sender's
+/// virtual unicast route from its source addr and returns that virtual hash.
+#[tokio::test]
+async fn ingress_route_iface_registers_virtual_route_on_multicast() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &identity, true));
+    let mc_iface = register_fake_multicast_iface(&transport).await;
+    let handler = transport.get_handler();
+
+    let peer = peer_addr(4242);
+    let route_iface = handler
+        .lock()
+        .await
+        .ingress_route_iface(mc_iface, crate::iface::IfaceSource::Udp(peer))
+        .await;
+
+    assert_ne!(route_iface, mc_iface, "must resolve to a fresh virtual unicast iface");
+
+    let guard = handler.lock().await;
+    let routing = guard.multicast_peer_routings.get(&mc_iface).expect("routing").lock().await;
+    assert_eq!(routing.hash_for_addr(&peer), Some(route_iface));
+    assert_eq!(routing.addr_for_hash(&route_iface), Some(peer));
+}
+
+/// On a non-multicast iface (no PeerRouting) it is a pass-through: the caller's
+/// iface is returned unchanged and nothing is registered.
+#[tokio::test]
+async fn ingress_route_iface_passes_through_on_non_multicast() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &identity, true));
+    let unicast_iface = new_unicast_iface_in(&transport).await;
+    let handler = transport.get_handler();
+
+    let peer = peer_addr(4242);
+    let route_iface = handler
+        .lock()
+        .await
+        .ingress_route_iface(unicast_iface, crate::iface::IfaceSource::Udp(peer))
+        .await;
+
+    assert_eq!(route_iface, unicast_iface, "non-multicast iface must pass through unchanged");
+    assert!(handler.lock().await.unicast_udp_ifaces.is_empty());
+}
+
+/// End-to-end at the handler level: an inbound `LinkRequest` from a UDP peer on a
+/// multicast iface (no prior announce) creates an in-link pinned to the peer's
+/// virtual unicast iface — so its proof/data replies unicast instead of being
+/// dropped by the tx-guard. Pre-fix the link bound to the host multicast iface.
+#[tokio::test]
+async fn inbound_link_request_pins_in_link_to_unicast_route() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &local_identity, true));
+    let mc_iface = register_fake_multicast_iface(&transport).await;
+    let handler = transport.get_handler();
+
+    // Register a local service (input) destination the client will link to.
+    let server_dest =
+        SingleInputDestination::new(PrivateIdentity::new_from_rand(OsRng), DestinationName::new("lxmf", "delivery"));
+    let dest_desc = server_dest.desc;
+    handler
+        .lock()
+        .await
+        .single_in_destinations
+        .insert(dest_desc.address_hash, Arc::new(Mutex::new(server_dest)));
+
+    // Client-side outbound link → take its LinkRequest packet.
+    let (link_events, _keep) = tokio::sync::broadcast::channel(4);
+    let mut outbound = Link::new(dest_desc, link_events);
+    let request_packet = outbound.request();
+
+    // Replicate the jobs.rs inbound dispatch for a LinkRequest arriving on the
+    // multicast socket from `peer` before any announce from that peer.
+    let peer = peer_addr(4242);
+    let route_iface = handler
+        .lock()
+        .await
+        .ingress_route_iface(mc_iface, crate::iface::IfaceSource::Udp(peer))
+        .await;
+    handle_link_request(&request_packet, route_iface, handler.lock().await).await;
+
+    assert_ne!(route_iface, mc_iface, "link request from a fresh peer resolves to a virtual iface");
+
+    let guard = handler.lock().await;
+
+    // Peer route learned from the link request's source address.
+    let routing = guard.multicast_peer_routings.get(&mc_iface).expect("routing").lock().await;
+    assert_eq!(routing.hash_for_addr(&peer), Some(route_iface));
+    drop(routing);
+
+    // The in-link is pinned to the virtual unicast iface (not the multicast host).
+    let in_link = guard.in_links.values().next().expect("in-link should be created").clone();
+    drop(guard);
+    assert_eq!(
+        in_link.lock().await.ingress_iface(),
+        Some(route_iface),
+        "in-link must bind to the unicast virtual iface so replies are unicast, not dropped",
+    );
+}

--- a/crates/libs/rns-transport/src/transport/tests_parts/inbound_link_request_registers_unicast.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/inbound_link_request_registers_unicast.rs
@@ -108,3 +108,34 @@ async fn inbound_link_request_pins_in_link_to_unicast_route() {
         "in-link must bind to the unicast virtual iface so replies are unicast, not dropped",
     );
 }
+
+/// Channel frames must bypass the transport-level duplicate filter. The channel
+/// protocol has its own sequencing/dedup, and a retransmit is required when the
+/// first copy arrives before the receiver's channel is open (a link-activation
+/// race exposed once the multicast first-dial no longer forces a slow retry).
+/// Deduping the retransmit drops the only copy the open channel would have seen,
+/// stalling the auth handshake (`recv round1/round2: auth timeout`).
+#[tokio::test]
+async fn duplicate_filter_allows_repeated_channel_frames() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &identity, false));
+    let handler = transport.get_handler();
+
+    let packet = Packet {
+        header: Header {
+            destination_type: DestinationType::Link,
+            packet_type: PacketType::Data,
+            ..Default::default()
+        },
+        context: PacketContext::Channel,
+        destination: AddressHash::new_from_rand(OsRng),
+        data: PacketDataBuffer::new_from_slice(b"channel round1 frame"),
+        ..Default::default()
+    };
+
+    assert!(handler.lock().await.filter_duplicate_packets(&packet).await);
+    assert!(
+        handler.lock().await.filter_duplicate_packets(&packet).await,
+        "channel retransmit must not be suppressed as a transport-level duplicate",
+    );
+}


### PR DESCRIPTION
Fixes an intermittent AutoInterface (UDP multicast) auth-handshake failure (recv round1/round2: auth timeout). Two independent races, both exposed once the multicast first-dial succeeds promptly instead of falling back to a slow retry, are addressed:

Announce-vs-link-request race — a link binding to the wrong iface, so replies got dropped by the multicast tx-guard.
Channel dedup race — a channel retransmit suppressed by the transport-level duplicate filter.
Details
1. Learn peer unicast route from inbound link packets ([159350e7])

AutoInterface follows the reference model: multicast is for peer discovery, data is delivered unicast to each discovered peer. Previously the lib only learned a peer's virtual unicast route from RNS-layer announces (unicast_iface_for_source). A link request/handshake arriving before that peer's announce was processed bound the link to the host multicast iface; its proof/data replies targeted Direct(iface_address), which PeerRouting can't resolve, so the tx-guard dropped every reply except the LinkProof — stalling auth until warm-up timed out.

The fix broadens the "detect-over-multicast, then unicast" step to inbound LinkRequest / Proof / link Data via TransportHandler::ingress_route_iface, so a link binds to the peer's virtual unicast iface from the first packet we hear. Non-multicast ifaces (TCP/Serial) fall through unchanged.

2. Exempt channel frames from transport-level dedup ([35afb990])

The Reticulum Channel protocol has its own sequencing/dedup, so the transport-level duplicate filter must not suppress ctx=Channel frames (mirroring the existing ResourceRequest/Resource exemptions). On link activation a peer can send its first channel frame before the receiver's channel is open; the receiver drops it but records it in the dedup cache, so every retransmit arriving after the channel opens is dropped as a duplicate and the frame never reaches the open channel.

Testing
Adds regression coverage in inbound_link_request_registers_unicast.rs:

ingress_route_iface registers a virtual unicast route on a multicast iface, and passes through unchanged on non-multicast ifaces
an inbound LinkRequest pins the in-link to the peer's virtual unicast iface
channel frames bypass the duplicate filter across repeated calls
