### PR TITLE
[codex] Reject over-MTU RNode BLE packets before queueing

### DIFF
--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
@@ -7,16 +7,13 @@ use std::pin::Pin;
 use std::time::{Duration, Instant};
 
 #[cfg(feature = "rnode-ble")]
-use crate::buffer::{InputBuffer, OutputBuffer};
+use crate::buffer::InputBuffer;
 
 #[cfg(feature = "rnode-ble")]
 use crate::iface::{IfaceSource, Interface, InterfaceContext, RxMessage};
 
 #[cfg(feature = "rnode-ble")]
 use crate::packet::Packet;
-
-#[cfg(feature = "rnode-ble")]
-use crate::serde::Serialize;
 
 #[cfg(feature = "rnode-ble")]
 use btleplug::api::{

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
@@ -308,7 +308,7 @@ impl NativeRnodeBleKissInterface {
                 ),
             }
 
-            let mut tx_buffer = vec![0_u8; config.mtu];
+            let packet_mtu = config.mtu;
             let mut reconnect_needed = false;
             let mut command_monitor = rnode_config
                 .map(|config| RnodeBleCommandMonitor::new(config, startup_response_timeout));
@@ -389,15 +389,47 @@ impl NativeRnodeBleKissInterface {
 
                 if radio_config_sent {
                     while let Ok(message) = tx_channel.try_recv() {
-                        let mut output = OutputBuffer::new(&mut tx_buffer[..]);
-                        if message.packet.serialize(&mut output).is_err() {
-                            log::warn!("RNode BLE packet serialize failed iface={}", label);
+                        let raw = match message.packet.to_bytes() {
+                            Ok(raw) => raw,
+                            Err(err) => {
+                                log::warn!(
+                                    "RNode BLE packet serialize failed iface={} packet_type={:?} \
+                                     context={:?} dst={} data_len={} mtu={} err={:?}",
+                                    label,
+                                    message.packet.header.packet_type,
+                                    message.packet.context,
+                                    message.packet.destination,
+                                    message.packet.data.len(),
+                                    packet_mtu,
+                                    err
+                                );
+                                continue;
+                            }
+                        };
+                        if raw.len() > packet_mtu {
+                            log::warn!(
+                                "RNode BLE packet exceeds configured MTU iface={} packet_type={:?} \
+                                 context={:?} dst={} data_len={} wire_len={} mtu={}",
+                                label,
+                                message.packet.header.packet_type,
+                                message.packet.context,
+                                message.packet.destination,
+                                message.packet.data.len(),
+                                raw.len(),
+                                packet_mtu
+                            );
                             continue;
                         }
-                        if let Err(err) = runtime.send_packet(output.as_slice()).await {
+                        if let Err(err) = runtime.send_packet(&raw).await {
                             log::warn!(
-                                "RNode BLE packet write failed iface={} err={:?}",
+                                "RNode BLE packet write failed iface={} packet_type={:?} \
+                                 context={:?} dst={} wire_len={} mtu={} err={:?}",
                                 label,
+                                message.packet.header.packet_type,
+                                message.packet.context,
+                                message.packet.destination,
+                                raw.len(),
+                                packet_mtu,
                                 err
                             );
                             reconnect_needed = true;

--- a/crates/libs/rns-transport/src/iface_parts/interfacemanager_send.rs
+++ b/crates/libs/rns-transport/src/iface_parts/interfacemanager_send.rs
@@ -24,6 +24,7 @@ impl InterfaceManager {
         self.cleanup();
         let mut trace = TxDispatchTrace::default();
         let mut saw_closed_queue = false;
+        let packet_wire_len = packet_wire_len_for_dispatch(&message);
         let scoped_path_request_iface = match message.tx_type {
             TxMessageType::Broadcast(Some(address)) if apply_egress_control => Some(address),
             _ => None,
@@ -86,6 +87,14 @@ impl InterfaceManager {
                     trace.failed_ifaces += 1;
                     continue;
                 }
+                let Some(wire_len) = packet_wire_len else {
+                    trace.failed_ifaces += 1;
+                    continue;
+                };
+                if !packet_fits_iface_mtu(iface, &message, wire_len) {
+                    trace.failed_ifaces += 1;
+                    continue;
+                }
 
                 let is_paced_announce = message.packet.header.packet_type == PacketType::Announce
                     && message.packet.header.hops > 0
@@ -144,6 +153,7 @@ impl InterfaceManager {
         let mut trace = TxDispatchTrace::default();
         let mut saw_closed_queue = false;
         let message = TxMessage { tx_type: TxMessageType::Broadcast(None), packet };
+        let packet_wire_len = packet_wire_len_for_dispatch(&message);
 
         for iface in &mut self.ifaces {
             if iface.address != address || !iface.outgoing || iface.stop.is_cancelled() {
@@ -151,6 +161,14 @@ impl InterfaceManager {
             }
 
             trace.matched_ifaces += 1;
+            let Some(wire_len) = packet_wire_len else {
+                trace.failed_ifaces += 1;
+                continue;
+            };
+            if !packet_fits_iface_mtu(iface, &message, wire_len) {
+                trace.failed_ifaces += 1;
+                continue;
+            }
             match Self::send_to_iface(iface, message.clone()).await {
                 TxIfaceSendResult::Sent => trace.sent_ifaces += 1,
                 TxIfaceSendResult::Failed => trace.failed_ifaces += 1,
@@ -227,4 +245,43 @@ enum TxIfaceSendResult {
     Sent,
     Failed,
     Closed,
+}
+
+fn packet_wire_len_for_dispatch(message: &TxMessage) -> Option<usize> {
+    match message.packet.to_bytes() {
+        Ok(raw) => Some(raw.len()),
+        Err(err) => {
+            log::warn!(
+                "tx packet serialize failed before interface enqueue tx_type={:?} \
+                 packet_type={:?} context={:?} dst={} data_len={} err={:?}",
+                message.tx_type,
+                message.packet.header.packet_type,
+                message.packet.context,
+                message.packet.destination,
+                message.packet.data.len(),
+                err
+            );
+            None
+        }
+    }
+}
+
+fn packet_fits_iface_mtu(iface: &LocalInterface, message: &TxMessage, wire_len: usize) -> bool {
+    if wire_len <= iface.mtu {
+        return true;
+    }
+
+    log::warn!(
+        "tx packet exceeds interface mtu iface={} tx_type={:?} packet_type={:?} \
+         context={:?} dst={} data_len={} wire_len={} mtu={}",
+        iface.address,
+        message.tx_type,
+        message.packet.header.packet_type,
+        message.packet.context,
+        message.packet.destination,
+        message.packet.data.len(),
+        wire_len,
+        iface.mtu
+    );
+    false
 }

--- a/crates/libs/rns-transport/src/iface_tests.rs
+++ b/crates/libs/rns-transport/src/iface_tests.rs
@@ -59,6 +59,64 @@ mod tests {
         assert_eq!(mgr.mtu(context.channel.address()), Some(220));
     }
 
+    #[tokio::test]
+    async fn direct_packet_over_configured_mtu_is_not_queued() {
+        let mut mgr = InterfaceManager::new(16);
+        let mut rx = mgr
+            .new_channel_with_role_mode_mtu(16, IfaceRole::Unicast, InterfaceMode::Full, 20)
+            .tx_channel;
+        let iface = mgr.ifaces[0].address;
+        let packet = packet_with_wire_len(21);
+
+        let trace = mgr.send(TxMessage { tx_type: TxMessageType::Direct(iface), packet }).await;
+
+        assert_eq!(trace.matched_ifaces, 1);
+        assert_eq!(trace.sent_ifaces, 0);
+        assert_eq!(trace.failed_ifaces, 1);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn direct_packet_at_configured_mtu_is_queued() {
+        let mut mgr = InterfaceManager::new(16);
+        let mut rx = mgr
+            .new_channel_with_role_mode_mtu(16, IfaceRole::Unicast, InterfaceMode::Full, 20)
+            .tx_channel;
+        let iface = mgr.ifaces[0].address;
+        let packet = packet_with_wire_len(20);
+
+        let trace =
+            mgr.send(TxMessage { tx_type: TxMessageType::Direct(iface), packet: packet.clone() }).await;
+
+        assert_eq!(trace.matched_ifaces, 1);
+        assert_eq!(trace.sent_ifaces, 1);
+        assert_eq!(trace.failed_ifaces, 0);
+        let sent = rx.try_recv().expect("packet should fit configured mtu");
+        assert_eq!(sent.packet, packet);
+    }
+
+    #[tokio::test]
+    async fn broadcast_over_one_iface_mtu_still_uses_larger_iface() {
+        let mut mgr = InterfaceManager::new(16);
+        let mut small_rx = mgr
+            .new_channel_with_role_mode_mtu(16, IfaceRole::Unicast, InterfaceMode::Full, 20)
+            .tx_channel;
+        let mut large_rx = mgr
+            .new_channel_with_role_mode_mtu(16, IfaceRole::Unicast, InterfaceMode::Full, 24)
+            .tx_channel;
+        let packet = packet_with_wire_len(22);
+
+        let trace =
+            mgr.send(TxMessage { tx_type: TxMessageType::Broadcast(None), packet: packet.clone() }).await;
+
+        assert_eq!(trace.matched_ifaces, 2);
+        assert_eq!(trace.sent_ifaces, 1);
+        assert_eq!(trace.failed_ifaces, 1);
+        assert!(small_rx.try_recv().is_err());
+        let sent = large_rx.try_recv().expect("larger iface should receive packet");
+        assert_eq!(sent.packet, packet);
+    }
+
     #[test]
     fn set_announce_pacing_updates_registered_iface() {
         let mut mgr = InterfaceManager::new(16);
@@ -136,6 +194,15 @@ mod tests {
         assert_eq!(mgr.iface_count(), 1);
         assert!(mgr.stop_interface(addr));
         assert_eq!(mgr.iface_count(), 0);
+    }
+
+    fn packet_with_wire_len(wire_len: usize) -> Packet {
+        let mut packet = Packet::default();
+        let base_len = packet.to_bytes().expect("default packet serializes").len();
+        assert!(wire_len >= base_len, "test packet wire length must include header");
+        packet.data.safe_write(&vec![0; wire_len - base_len]);
+        assert_eq!(packet.to_bytes().expect("sized packet serializes").len(), wire_len);
+        packet
     }
 
     #[test]

--- a/crates/libs/rns-transport/tests/rnode_ble_parts/rnode_ble_runtime_polls_command_noti.rs
+++ b/crates/libs/rns-transport/tests/rnode_ble_parts/rnode_ble_runtime_polls_command_noti.rs
@@ -31,6 +31,35 @@ async fn rnode_ble_runtime_rejects_outbound_packets_larger_than_mtu_before_ble_w
 }
 
 #[tokio::test]
+async fn rnode_ble_runtime_sends_packet_at_mtu_after_deferred_radio_config() {
+    let lora_config = LoraConfig::us915_default();
+    let payload = vec![0x42; usize::from(lora_config.max_payload_bytes)];
+    let config = RnodeBleKissConfig {
+        mtu: payload.len(),
+        max_write_len: 1024,
+        deferred_frames: lora_config.radio_config_frames(),
+        ..Default::default()
+    };
+    let backend = TestRnodeBleBackend::default();
+    let mut runtime = RnodeBleKissRuntime::new(backend, config);
+
+    runtime.startup().await.expect("startup");
+    runtime.send_deferred_frames().await.expect("radio config");
+    let writes_after_radio_config = runtime.backend().writes.len();
+    runtime.send_packet(&payload).await.expect("payload at mtu should send");
+
+    assert_eq!(runtime.backend().writes.len(), writes_after_radio_config + 1);
+    assert_eq!(
+        runtime.backend().writes.last(),
+        Some(&RnodeBleWrite {
+            characteristic_uuid: RNODE_BLE_WRITE_CHARACTERISTIC_UUID,
+            with_response: false,
+            payload: encode_data_frame(&payload),
+        })
+    );
+}
+
+#[tokio::test]
 async fn rnode_ble_runtime_splits_outbound_kiss_frames_by_ble_write_limit() {
     let config = RnodeBleKissConfig { max_write_len: 4, ..Default::default() };
     let backend = TestRnodeBleBackend::default();

--- a/crates/libs/rns-transport/tests/rnode_ble_parts/rnode_ble_runtime_polls_command_noti.rs
+++ b/crates/libs/rns-transport/tests/rnode_ble_parts/rnode_ble_runtime_polls_command_noti.rs
@@ -30,6 +30,7 @@ async fn rnode_ble_runtime_rejects_outbound_packets_larger_than_mtu_before_ble_w
     );
 }
 
+#[cfg(feature = "rnode-ble")]
 #[tokio::test]
 async fn rnode_ble_runtime_sends_packet_at_mtu_after_deferred_radio_config() {
     let lora_config = LoraConfig::us915_default();

--- a/docs/runbooks/reticulumd-lora-interface.md
+++ b/docs/runbooks/reticulumd-lora-interface.md
@@ -285,9 +285,14 @@ configuration. It then writes configuration frames for frequency, bandwidth, TX
 power, spreading factor, coding rate, optional short-term and long-term airtime
 locks, and radio-on state. Airtime locks are encoded as Python-compatible
 hundredths of a percent. Packet I/O then uses KISS data frames with
-`max_payload_bytes` as the interface MTU. READY flow control is disabled by
-default for RNode parity and is enabled only when `flow_control = true` is
-configured. Like Python RNode startup, a flow-controlled stream is considered
+`max_payload_bytes` as the interface MTU. Outbound packets whose serialized
+Reticulum wire length exceeds that MTU are rejected before they are queued to
+the interface, with diagnostics that include packet context, size, and budget.
+For BLE RNodes this rejection does not mark the BLE session disconnected; it
+means the packet was unsuitable for the configured LoRa/RNode payload budget.
+READY flow control is disabled by default for RNode parity and is enabled only
+when `flow_control = true` is configured. Like Python RNode startup, a
+flow-controlled stream is considered
 ready after startup frames are flushed: the first outbound packet is sent
 immediately, then later packets wait for device `CMD_READY` frames. If an RNode
 misses `CMD_READY`, the stream unlocks flow control after the Python-compatible
@@ -415,7 +420,8 @@ closed-queue cleanup regression, then writes artifacts under
 - configured RNode BLE identifier and alias matching
 - configured Android peripheral exclusion during fallback scan
 - RNode BLE command-monitor startup, degraded fallback, and runtime status JSON
-- RNode BLE packet, shutdown, and management-frame chunking
+- RNode BLE packet MTU rejection, successful MTU-sized transmit, shutdown, and
+  management-frame chunking
 - RNode BLE management handle queueing
 - reticulumd daemon RnodeBle management bridge dispatch
 - `rnodeconf-rs` extended management command-to-RPC matrix

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -251,10 +251,10 @@ The project is best described by capability level:
   radio-on, and command-error free. A software-only RNode BLE smoke records
   `evidence_scope = "software_rnode_ble_fallback_management"` under
   `target/rnode-ble-software-smoke/` for feature-gated fallback, command-monitor,
-  management dispatch, `reticulumd` daemon `RnodeBle` management bridge
-  dispatch, `rnodeconf-rs` extended management command-to-RPC coverage,
-  persistent/destructive CLI guard enforcement, and shared
-  closed-queue cleanup regressions. A fake TCP RNode smoke records
+  management dispatch, outbound RNode BLE MTU rejection and MTU-sized transmit,
+  `reticulumd` daemon `RnodeBle` management bridge dispatch, `rnodeconf-rs`
+  extended management command-to-RPC coverage, persistent/destructive CLI guard
+  enforcement, and shared closed-queue cleanup regressions. A fake TCP RNode smoke records
   `evidence_scope = "software_fake_tcp_rnode_prepared_host_management"` by
   running the ordinary prepared-host path against a deterministic local KISS TCP
   peer and verifying startup, radio configuration, radio-state query, and blink

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -432,10 +432,11 @@ Software-only RNode BLE fallback/management evidence now writes
 `evidence_scope = "software_rnode_ble_fallback_management"` under
 `target/rnode-ble-software-smoke/`, covering feature-gated identifier/alias
 matching, configured Android peripheral fallback exclusion, command-monitor
-status/degraded fallback, management-frame chunking/queueing, `rnodeconf-rs`
-extended management command-to-RPC coverage, feature-gated `reticulumd` daemon
-`RnodeBle` management bridge dispatch, persistent/destructive CLI guard enforcement,
-and shared closed-queue cleanup regressions. A fake TCP RNode smoke now records
+status/degraded fallback, outbound RNode BLE MTU rejection and MTU-sized transmit,
+management-frame chunking/queueing, `rnodeconf-rs` extended management
+command-to-RPC coverage, feature-gated `reticulumd` daemon `RnodeBle`
+management bridge dispatch, persistent/destructive CLI guard enforcement, and
+shared closed-queue cleanup regressions. A fake TCP RNode smoke now records
 `evidence_scope = "software_fake_tcp_rnode_prepared_host_management"` by
 running the ordinary prepared-host path against a deterministic local KISS TCP
 peer and verifying startup, radio configuration, radio-state query, and blink


### PR DESCRIPTION
## Summary

Fixes #399 by rejecting serialized packets that exceed an interface's configured MTU before they are queued to that interface. This keeps oversized Reticulum traffic from reaching the native RNode BLE worker as an opaque `packet serialize failed` warning.

## What changed

- Add dispatcher-side serialized packet wire-length checks against each interface MTU.
- Preserve mixed-interface routing: broadcasts can still reach larger-MTU interfaces while failing only the constrained one.
- Improve RNode BLE fallback diagnostics with packet type, context, destination, wire length, and MTU.
- Add focused regressions for direct over-MTU rejection, exact-MTU success, mixed-MTU broadcast behavior, and RNode BLE exact-MTU transmit after deferred radio config.
- Document the intended LoRa/RNode behavior and update parity/status notes.

## Validation

- `cargo test -p reticulum-rs-transport --features rnode-ble --test rnode_ble`
- `cargo test -p reticulum-rs-transport --features rnode-ble`
- `cargo fmt --all -- --check`
- `tools/scripts/check-boundaries.sh`
- `git diff --check`

Observed existing warning: `crates/apps/lxmf-cli/src/main.rs` is present in multiple bin targets.