### PR TITLE
Add Columba-compatible Reticulum BLE interface

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup_parts/module_prelude.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup_parts/module_prelude.rs
@@ -10,7 +10,7 @@ use crate::bridge_rnode_management::DaemonRNodeManagementHandle;
 use crate::interface_hot_apply::hot_apply_interface_seed_key;
 
 use crate::interfaces::{
-    auto, ble, common::interface_label, i2p, kiss, lora, pipe, rnode_multi, serial, udp,
+    auto, ble, common::interface_label, i2p, kiss, lora, pipe, reticulum_ble, rnode_multi, serial, udp,
     vrn76_kiss_ble, weave,
 };
 
@@ -47,6 +47,7 @@ pub(super) struct InterfaceStartupBatch {
     pub(super) serial_runtime_refreshes: Vec<SerialRuntimeRefresh>,
     pub(super) kiss_runtime_refreshes: Vec<KissRuntimeRefresh>,
     pub(super) ble_gatt_runtime_refreshes: Vec<BleGattRuntimeRefresh>,
+    pub(super) reticulum_ble_runtime_refreshes: Vec<ReticulumBleRuntimeRefresh>,
     pub(super) i2p_runtime_refreshes: Vec<I2pRuntimeRefresh>,
     pub(super) tcp_runtime_refreshes: Vec<TcpRuntimeRefresh>,
     pub(super) weave_runtime_refreshes: Vec<WeaveRuntimeRefresh>,
@@ -93,6 +94,12 @@ pub(crate) struct KissRuntimeRefresh {
 pub(crate) struct BleGattRuntimeRefresh {
     pub(crate) runtime_iface: AddressHash,
     pub(crate) status: ble::BleRuntimeStatusHandle,
+}
+
+#[derive(Clone)]
+pub(crate) struct ReticulumBleRuntimeRefresh {
+    pub(crate) runtime_iface: AddressHash,
+    pub(crate) status: reticulum_ble::ReticulumBleRuntimeStatusHandle,
 }
 
 struct UdpStartupSinks<'a> {
@@ -219,6 +226,7 @@ pub(super) async fn startup_configured_interfaces(
     let mut serial_runtime_refreshes = Vec::new();
     let mut kiss_runtime_refreshes = Vec::new();
     let mut ble_gatt_runtime_refreshes = Vec::new();
+    let mut reticulum_ble_runtime_refreshes = Vec::new();
     let mut i2p_runtime_refreshes = Vec::new();
     let mut tcp_runtime_refreshes = Vec::new();
     let mut weave_runtime_refreshes = Vec::new();
@@ -538,6 +546,21 @@ pub(super) async fn startup_configured_interfaces(
                     startup_successes += 1;
                 }
             }
+            "reticulum_ble" => {
+                if startup_reticulum_ble(
+                    iface,
+                    &label,
+                    iface_manager,
+                    &mut configured_interfaces[index],
+                    &mut startup_failures,
+                    &mut reticulum_ble_runtime_refreshes,
+                    transport_identity_hash,
+                )
+                .await
+                {
+                    startup_successes += 1;
+                }
+            }
             "vrn76_kiss_ble" => {
                 let startup = startup_vrn76_kiss_ble(
                     iface,
@@ -613,6 +636,7 @@ pub(super) async fn startup_configured_interfaces(
         serial_runtime_refreshes,
         kiss_runtime_refreshes,
         ble_gatt_runtime_refreshes,
+        reticulum_ble_runtime_refreshes,
         i2p_runtime_refreshes,
         tcp_runtime_refreshes,
         weave_runtime_refreshes,
@@ -1731,8 +1755,8 @@ mod tests {
     use super::{
         apply_interface_runtime_config, build_tcp_client_adapter, mark_ble_spawn_success,
         startup_configured_interfaces, startup_i2p, startup_kiss, startup_kiss_tcp_client,
-        startup_pipe, startup_rnode_multi, startup_serial, startup_tcp_server_record, startup_udp,
-        startup_weave, UdpStartupSinks,
+        startup_pipe, startup_reticulum_ble, startup_rnode_multi, startup_serial,
+        startup_tcp_server_record, startup_udp, startup_weave, UdpStartupSinks,
     };
     use crate::Args;
     use crate::bridge_rnode_management::DaemonRNodeManagementHandle;
@@ -2510,6 +2534,89 @@ interfaces = [
         assert_eq!(ble_status["iface"].as_str(), Some(runtime_iface.to_string().as_str()));
         assert_eq!(manager.role(&runtime_iface), Some(IfaceRole::Unicast));
         assert_eq!(manager.mode(&runtime_iface), Some(InterfaceMode::AccessPoint));
+    }
+
+    #[tokio::test]
+    async fn reticulum_ble_startup_marks_columba_runtime_status() {
+        let cfg = reticulum_daemon::config::DaemonConfig::from_toml(
+            r#"
+interfaces = [
+  { type = "BLEInterface", enabled = true, name = "columba-ble", mode = "ap" }
+]
+"#,
+        )
+        .expect("parse reticulum ble config");
+        let iface = &cfg.interfaces[0];
+        let identity = rns_core::identity::PrivateIdentity::new_from_rand(rand_core::OsRng);
+        let transport_identity = to_transport_private_identity(&identity);
+        let transport = Transport::new(TransportConfig::new("test", &transport_identity, true));
+        let manager = transport.iface_manager();
+        let mut local_identity = [0_u8; 16];
+        local_identity.copy_from_slice(identity.address_hash().as_slice());
+        let mut record = InterfaceRecord {
+            kind: iface.kind.clone(),
+            enabled: true,
+            host: None,
+            port: None,
+            name: iface.name.clone(),
+            settings: iface.settings_json(),
+        };
+        let mut startup_failures = Vec::new();
+        let mut refreshes = Vec::new();
+
+        let started = startup_reticulum_ble(
+            iface,
+            "columba-ble",
+            &manager,
+            &mut record,
+            &mut startup_failures,
+            &mut refreshes,
+            Some(local_identity),
+        )
+        .await;
+
+        assert!(started);
+        assert!(startup_failures.is_empty());
+        assert_eq!(refreshes.len(), 1);
+        let runtime = record
+            .settings
+            .as_ref()
+            .and_then(|settings| settings.get("_runtime"))
+            .expect("runtime settings");
+        assert_eq!(runtime["startup_status"].as_str(), Some("spawned"));
+        assert_eq!(runtime["runtime_status"].as_str(), Some("degraded"));
+        let runtime_iface =
+            runtime["iface"].as_str().expect("runtime iface").trim_matches('/').to_string();
+        let runtime_iface =
+            AddressHash::new_from_hex_string(&runtime_iface).expect("iface hash");
+        let manager = manager.lock().await;
+        assert_eq!(manager.role(&runtime_iface), Some(IfaceRole::Unicast));
+        assert_eq!(manager.mode(&runtime_iface), Some(InterfaceMode::AccessPoint));
+        assert_eq!(refreshes[0].runtime_iface, runtime_iface);
+        let ble_status = &runtime["reticulum_ble"]["status"];
+        assert_eq!(ble_status["link_state"].as_str(), Some("degraded"));
+        assert_eq!(ble_status["scan_state"].as_str(), Some("native_backend_pending"));
+        assert_eq!(
+            ble_status["advertising_state"].as_str(),
+            Some("native_backend_pending")
+        );
+        assert_eq!(
+            ble_status["service_uuid"].as_str(),
+            Some("37145b00-442d-4a94-917f-8f42c5da28e3")
+        );
+        assert_eq!(
+            ble_status["tx_char_uuid"].as_str(),
+            Some("37145b00-442d-4a94-917f-8f42c5da28e4")
+        );
+        assert_eq!(
+            ble_status["rx_char_uuid"].as_str(),
+            Some("37145b00-442d-4a94-917f-8f42c5da28e5")
+        );
+        assert_eq!(ble_status["mtu"].as_u64(), Some(185));
+        assert_eq!(ble_status["max_connections"].as_u64(), Some(7));
+        assert_eq!(ble_status["enable_central"].as_bool(), Some(true));
+        assert_eq!(ble_status["enable_peripheral"].as_bool(), Some(true));
+        assert_eq!(ble_status["iface"].as_str(), Some(runtime_iface.to_string().as_str()));
     }
 
     #[tokio::test]

--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup_parts/startup_udp.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup_parts/startup_udp.rs
@@ -407,6 +407,64 @@ async fn startup_ble(
     }
 }
 
+async fn startup_reticulum_ble(
+    iface: &InterfaceConfig,
+    label: &str,
+    iface_manager: &Arc<tokio::sync::Mutex<rns_transport::iface::InterfaceManager>>,
+    record: &mut InterfaceRecord,
+    startup_failures: &mut Vec<InterfaceStartupFailure>,
+    reticulum_ble_runtime_refreshes: &mut Vec<ReticulumBleRuntimeRefresh>,
+    transport_identity_hash: Option<[u8; 16]>,
+) -> bool {
+    let Some(local_identity) = transport_identity_hash else {
+        let err = "reticulum_ble requires the daemon transport identity hash".to_string();
+        record_startup_failure(
+            record,
+            startup_failures,
+            label.to_string(),
+            iface.kind.clone(),
+            err,
+        );
+        mark_interface_runtime_fields(record, "degraded", 0);
+        return false;
+    };
+    match reticulum_ble::spawn(iface_manager.clone(), iface, local_identity).await {
+        Ok(spawned) => {
+            let mode = iface.interface_mode().unwrap_or(InterfaceMode::Full);
+            let mut manager = iface_manager.lock().await;
+            manager.set_mode(spawned.iface, mode);
+            apply_interface_runtime_config(&mut manager, spawned.iface, iface);
+            drop(manager);
+            log::info!(
+                "[daemon] reticulum_ble enabled iface={} name={} service_uuid={}",
+                spawned.iface,
+                label,
+                iface.service_uuid.as_deref().unwrap_or(reticulum_ble::SERVICE_UUID)
+            );
+            let runtime_iface = spawned.iface.to_string();
+            mark_interface_startup_status(record, "spawned", None, Some(runtime_iface.as_str()));
+            mark_interface_runtime_fields(record, "degraded", 0);
+            mark_reticulum_ble_runtime_status(record, iface, spawned.iface, local_identity);
+            reticulum_ble_runtime_refreshes.push(ReticulumBleRuntimeRefresh {
+                runtime_iface: spawned.iface,
+                status: spawned.status,
+            });
+            true
+        }
+        Err(err) => {
+            record_startup_failure(
+                record,
+                startup_failures,
+                label.to_string(),
+                iface.kind.clone(),
+                err,
+            );
+            mark_interface_runtime_fields(record, "degraded", 0);
+            false
+        }
+    }
+}
+
 async fn mark_ble_spawn_success(
     iface: &InterfaceConfig,
     label: &str,
@@ -564,6 +622,56 @@ fn mark_ble_gatt_runtime_status(
                     "mtu": iface.mtu,
                     "scan_timeout_ms": iface.scan_timeout_ms,
                     "connect_timeout_ms": iface.ble_connect_timeout_ms.or(iface.connect_timeout_ms),
+                    "iface": runtime_iface.to_string(),
+                }
+            }),
+        );
+    });
+}
+
+fn mark_reticulum_ble_runtime_status(
+    record: &mut InterfaceRecord,
+    iface: &InterfaceConfig,
+    runtime_iface: AddressHash,
+    local_identity: [u8; 16],
+) {
+    let local_identity = local_identity.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+    with_interface_runtime_metadata(record, |runtime| {
+        runtime.insert(
+            "reticulum_ble".to_string(),
+            serde_json::json!({
+                "status": {
+                    "link_state": "degraded",
+                    "adapter": iface.adapter.as_deref(),
+                    "service_uuid": iface.service_uuid.as_deref().unwrap_or(reticulum_ble::SERVICE_UUID),
+                    "tx_char_uuid": iface.notify_char_uuid.as_deref().unwrap_or(reticulum_ble::TX_CHAR_UUID),
+                    "rx_char_uuid": iface.write_char_uuid.as_deref().unwrap_or(reticulum_ble::RX_CHAR_UUID),
+                    "identity_char_uuid": iface.identity_char_uuid.as_deref().unwrap_or(reticulum_ble::IDENTITY_CHAR_UUID),
+                    "local_identity": local_identity,
+                    "mtu": iface.mtu.unwrap_or(185),
+                    "max_connections": iface.max_connections.unwrap_or(7),
+                    "scan_duration_ms": iface.scan_duration_ms.unwrap_or(10_000),
+                    "discovery_interval_ms": iface.discovery_interval_ms.unwrap_or(5_000),
+                    "discovery_interval_idle_ms": iface.discovery_interval_idle_ms.unwrap_or(30_000),
+                    "advertising_refresh_interval_ms": iface.advertising_refresh_interval_ms.unwrap_or(30_000),
+                    "min_rssi_dbm": iface.min_rssi_dbm.unwrap_or(-85),
+                    "enable_central": iface.enable_central.unwrap_or(true),
+                    "enable_peripheral": iface.enable_peripheral.unwrap_or(true),
+                    "central_links": 0,
+                    "peripheral_links": 0,
+                    "scan_state": if iface.enable_central.unwrap_or(true) { "native_backend_pending" } else { "disabled" },
+                    "advertising_state": if iface.enable_peripheral.unwrap_or(true) { "native_backend_pending" } else { "disabled" },
+                    "peer_identities": [],
+                    "active_addresses": [],
+                    "fragments_rx": 0,
+                    "fragments_tx": 0,
+                    "packets_rx": 0,
+                    "packets_tx": 0,
+                    "malformed_fragments": 0,
+                    "reconnects": 0,
+                    "duplicate_rejections": 0,
+                    "stale_reassembly_drops": 0,
+                    "last_error": "reticulum_ble native dual-role backend is not yet available",
                     "iface": runtime_iface.to_string(),
                 }
             }),

--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_parts/module_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_parts/module_core.rs
@@ -189,6 +189,7 @@ pub(super) async fn bootstrap(args: Args) -> BootstrapContext {
     let serial_runtime_refreshes = startup.serial_runtime_refreshes;
     let kiss_runtime_refreshes = startup.kiss_runtime_refreshes;
     let ble_gatt_runtime_refreshes = startup.ble_gatt_runtime_refreshes;
+    let reticulum_ble_runtime_refreshes = startup.reticulum_ble_runtime_refreshes;
     let i2p_runtime_refreshes = startup.i2p_runtime_refreshes;
     let tcp_runtime_refreshes = startup.tcp_runtime_refreshes;
     let weave_runtime_refreshes = startup.weave_runtime_refreshes;
@@ -333,6 +334,7 @@ pub(super) async fn bootstrap(args: Args) -> BootstrapContext {
     spawn_serial_runtime_status_refresher(daemon.clone(), serial_runtime_refreshes);
     spawn_kiss_runtime_status_refresher(daemon.clone(), kiss_runtime_refreshes);
     spawn_ble_gatt_runtime_status_refresher(daemon.clone(), ble_gatt_runtime_refreshes);
+    spawn_reticulum_ble_runtime_status_refresher(daemon.clone(), reticulum_ble_runtime_refreshes);
     spawn_i2p_runtime_status_refresher(daemon.clone(), i2p_runtime_refreshes);
     spawn_tcp_runtime_status_refresher(daemon.clone(), tcp_runtime_refreshes);
     spawn_weave_runtime_status_refresher(daemon.clone(), weave_runtime_refreshes);
@@ -688,6 +690,40 @@ fn refresh_ble_gatt_runtime_status_once(
             daemon.update_interface_runtime_metadata_by_iface(
                 refresh.runtime_iface.to_string().as_str(),
                 "ble_gatt",
+                "status",
+                refresh.status.to_json(),
+            )
+        })
+        .count()
+}
+
+fn spawn_reticulum_ble_runtime_status_refresher(
+    daemon: Arc<RpcDaemon>,
+    refreshes: Vec<transport_startup::ReticulumBleRuntimeRefresh>,
+) {
+    if refreshes.is_empty() {
+        return;
+    }
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(INTERFACE_RUNTIME_STATUS_REFRESH_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            interval.tick().await;
+            refresh_reticulum_ble_runtime_status_once(&daemon, &refreshes);
+        }
+    });
+}
+
+fn refresh_reticulum_ble_runtime_status_once(
+    daemon: &RpcDaemon,
+    refreshes: &[transport_startup::ReticulumBleRuntimeRefresh],
+) -> usize {
+    refreshes
+        .iter()
+        .filter(|refresh| {
+            daemon.update_interface_runtime_metadata_by_iface(
+                refresh.runtime_iface.to_string().as_str(),
+                "reticulum_ble",
                 "status",
                 refresh.status.to_json(),
             )

--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport.rs
@@ -19,8 +19,8 @@ pub(super) use interface_startup::Vrn76RuntimeRefresh;
 pub(super) use interface_startup::{
     AutoRuntimeRefresh, BleGattRuntimeRefresh, I2pRuntimeRefresh, KissRuntimeRefresh,
     LoraRuntimeRefresh, PipeRuntimeRefresh, RNodeManagementBinding, RNodeMultiRuntimeRefresh,
-    SerialRuntimeRefresh, TcpRuntimeRefresh, TcpRuntimeStatusSource, UdpRuntimeRefresh,
-    WeaveControlBinding, WeaveRuntimeRefresh,
+    ReticulumBleRuntimeRefresh, SerialRuntimeRefresh, TcpRuntimeRefresh, TcpRuntimeStatusSource,
+    UdpRuntimeRefresh, WeaveControlBinding, WeaveRuntimeRefresh,
 };
 use path_restore::{
     mark_path_table_restore_status, mark_path_table_restore_status_on_enabled_interfaces,
@@ -63,6 +63,7 @@ pub(super) struct TransportStartupArtifacts {
     pub(super) serial_runtime_refreshes: Vec<SerialRuntimeRefresh>,
     pub(super) kiss_runtime_refreshes: Vec<KissRuntimeRefresh>,
     pub(super) ble_gatt_runtime_refreshes: Vec<BleGattRuntimeRefresh>,
+    pub(super) reticulum_ble_runtime_refreshes: Vec<ReticulumBleRuntimeRefresh>,
     pub(super) i2p_runtime_refreshes: Vec<I2pRuntimeRefresh>,
     pub(super) tcp_runtime_refreshes: Vec<TcpRuntimeRefresh>,
     pub(super) weave_runtime_refreshes: Vec<WeaveRuntimeRefresh>,
@@ -180,6 +181,7 @@ pub(super) async fn start_transport_and_interfaces(
     let mut serial_runtime_refreshes = Vec::new();
     let mut kiss_runtime_refreshes = Vec::new();
     let mut ble_gatt_runtime_refreshes = Vec::new();
+    let mut reticulum_ble_runtime_refreshes = Vec::new();
     let mut i2p_runtime_refreshes = Vec::new();
     let mut tcp_runtime_refreshes = Vec::new();
     let mut weave_runtime_refreshes = Vec::new();
@@ -266,6 +268,7 @@ pub(super) async fn start_transport_and_interfaces(
             serial_runtime_refreshes.extend(startup.serial_runtime_refreshes);
             kiss_runtime_refreshes.extend(startup.kiss_runtime_refreshes);
             ble_gatt_runtime_refreshes.extend(startup.ble_gatt_runtime_refreshes);
+            reticulum_ble_runtime_refreshes.extend(startup.reticulum_ble_runtime_refreshes);
             i2p_runtime_refreshes.extend(startup.i2p_runtime_refreshes);
             tcp_runtime_refreshes.extend(startup.tcp_runtime_refreshes);
             weave_runtime_refreshes.extend(startup.weave_runtime_refreshes);
@@ -398,6 +401,7 @@ pub(super) async fn start_transport_and_interfaces(
         serial_runtime_refreshes,
         kiss_runtime_refreshes,
         ble_gatt_runtime_refreshes,
+        reticulum_ble_runtime_refreshes,
         i2p_runtime_refreshes,
         tcp_runtime_refreshes,
         weave_runtime_refreshes,

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/mod.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/mod.rs
@@ -6,6 +6,7 @@ pub(super) mod kiss;
 pub(super) mod lora;
 pub(super) mod lora_state;
 pub(super) mod pipe;
+pub(super) mod reticulum_ble;
 pub(super) mod rnode_multi;
 pub(super) mod serial;
 pub(super) mod udp;

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble.rs
@@ -1,0 +1,8 @@
+#[path = "reticulum_ble_parts.rs"]
+mod reticulum_ble_parts;
+
+pub(crate) use reticulum_ble_parts::{
+    ReticulumBleRuntimeStatusHandle, IDENTITY_CHAR_UUID, RX_CHAR_UUID, SERVICE_UUID, TX_CHAR_UUID,
+};
+
+pub(crate) use reticulum_ble_parts::spawn;

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble_parts.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble_parts.rs
@@ -1,0 +1,22 @@
+#[path = "reticulum_ble_parts/fragment.rs"]
+#[cfg_attr(not(test), allow(dead_code))]
+mod fragment;
+#[path = "reticulum_ble_parts/runtime_core.rs"]
+#[cfg_attr(not(test), allow(dead_code))]
+mod runtime_core;
+#[path = "reticulum_ble_parts/runtime_iface.rs"]
+mod runtime_iface;
+
+pub(crate) use fragment::fragment_packet;
+#[cfg(test)]
+pub(crate) use fragment::FragmentError;
+#[cfg(test)]
+pub(crate) use runtime_core::{PeerRegistration, ReticulumBleRole, ReticulumBleRuntimeCore};
+pub(crate) use runtime_iface::{
+    spawn, ReticulumBleRuntimeStatusHandle, IDENTITY_CHAR_UUID, RX_CHAR_UUID, SERVICE_UUID,
+    TX_CHAR_UUID,
+};
+
+#[cfg(test)]
+#[path = "reticulum_ble_parts/tests.rs"]
+mod tests;

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble_parts/fragment.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble_parts/fragment.rs
@@ -1,0 +1,152 @@
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+
+const TYPE_START: u8 = 0x01;
+const TYPE_CONTINUE: u8 = 0x02;
+const TYPE_END: u8 = 0x03;
+const HEADER_SIZE: usize = 5;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FragmentError {
+    EmptyPacket,
+    MtuTooSmall(usize),
+    TooManyFragments(usize),
+    TooShort(usize),
+    Oversize(usize),
+    InvalidType(u8),
+    InvalidSequence { sequence: u16, total: u16 },
+    DuplicateMismatch(u16),
+}
+
+impl std::fmt::Display for FragmentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for FragmentError {}
+
+pub(crate) fn fragment_packet(packet: &[u8], mtu: usize) -> Result<Vec<Vec<u8>>, FragmentError> {
+    if packet.is_empty() {
+        return Err(FragmentError::EmptyPacket);
+    }
+    if mtu <= HEADER_SIZE {
+        return Err(FragmentError::MtuTooSmall(mtu));
+    }
+    let payload_size = mtu - HEADER_SIZE;
+    let total = packet.len().div_ceil(payload_size);
+    let total_u16 = u16::try_from(total).map_err(|_| FragmentError::TooManyFragments(total))?;
+    let mut fragments = Vec::with_capacity(total);
+    for (index, chunk) in packet.chunks(payload_size).enumerate() {
+        let kind = if index == 0 {
+            TYPE_START
+        } else if index + 1 == total {
+            TYPE_END
+        } else {
+            TYPE_CONTINUE
+        };
+        let sequence = u16::try_from(index).expect("fragment index already bounded by u16");
+        let mut fragment = Vec::with_capacity(HEADER_SIZE + chunk.len());
+        fragment.push(kind);
+        fragment.extend_from_slice(&sequence.to_be_bytes());
+        fragment.extend_from_slice(&total_u16.to_be_bytes());
+        fragment.extend_from_slice(chunk);
+        fragments.push(fragment);
+    }
+    Ok(fragments)
+}
+
+#[derive(Debug, Clone)]
+struct ReassemblyState {
+    total: u16,
+    fragments: BTreeMap<u16, Vec<u8>>,
+    start_time: Instant,
+}
+
+#[derive(Debug)]
+pub(super) struct BleReassembler {
+    timeout: Duration,
+    buffers: BTreeMap<[u8; 16], ReassemblyState>,
+}
+
+impl BleReassembler {
+    pub(super) fn new(timeout: Duration) -> Self {
+        Self { timeout, buffers: BTreeMap::new() }
+    }
+
+    pub(super) fn receive_fragment(
+        &mut self,
+        sender: [u8; 16],
+        fragment: &[u8],
+        now: Instant,
+    ) -> Result<Option<Vec<u8>>, FragmentError> {
+        let parsed = ParsedFragment::parse(fragment)?;
+        let state = self.buffers.entry(sender).or_insert_with(|| ReassemblyState {
+            total: parsed.total,
+            fragments: BTreeMap::new(),
+            start_time: now,
+        });
+        if now.duration_since(state.start_time) > self.timeout || parsed.sequence == 0 {
+            state.fragments.clear();
+            state.total = parsed.total;
+            state.start_time = now;
+        }
+        if state.total != parsed.total {
+            self.buffers.remove(&sender);
+            return Err(FragmentError::InvalidSequence {
+                sequence: parsed.sequence,
+                total: parsed.total,
+            });
+        }
+        if let Some(existing) = state.fragments.get(&parsed.sequence) {
+            if existing == parsed.payload {
+                return Ok(None);
+            }
+            self.buffers.remove(&sender);
+            return Err(FragmentError::DuplicateMismatch(parsed.sequence));
+        }
+        state.fragments.insert(parsed.sequence, parsed.payload.to_vec());
+        if state.fragments.len() != parsed.total as usize {
+            return Ok(None);
+        }
+        let mut packet = Vec::new();
+        for sequence in 0..parsed.total {
+            let Some(payload) = state.fragments.get(&sequence) else {
+                return Ok(None);
+            };
+            packet.extend_from_slice(payload);
+        }
+        self.buffers.remove(&sender);
+        Ok(Some(packet))
+    }
+
+    pub(super) fn drop_stale(&mut self, now: Instant) -> u64 {
+        let before = self.buffers.len();
+        self.buffers.retain(|_, state| now.duration_since(state.start_time) <= self.timeout);
+        before.saturating_sub(self.buffers.len()) as u64
+    }
+}
+
+struct ParsedFragment<'a> {
+    sequence: u16,
+    total: u16,
+    payload: &'a [u8],
+}
+
+impl<'a> ParsedFragment<'a> {
+    fn parse(fragment: &'a [u8]) -> Result<Self, FragmentError> {
+        if fragment.len() < HEADER_SIZE {
+            return Err(FragmentError::TooShort(fragment.len()));
+        }
+        let kind = fragment[0];
+        if !matches!(kind, TYPE_START | TYPE_CONTINUE | TYPE_END) {
+            return Err(FragmentError::InvalidType(kind));
+        }
+        let sequence = u16::from_be_bytes([fragment[1], fragment[2]]);
+        let total = u16::from_be_bytes([fragment[3], fragment[4]]);
+        if total == 0 || sequence >= total {
+            return Err(FragmentError::InvalidSequence { sequence, total });
+        }
+        Ok(Self { sequence, total, payload: &fragment[HEADER_SIZE..] })
+    }
+}

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble_parts/runtime_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble_parts/runtime_core.rs
@@ -1,0 +1,132 @@
+use super::fragment::{BleReassembler, FragmentError};
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::{Duration, Instant};
+
+const MAX_BLE_FRAGMENT_BYTES: usize = 512;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReticulumBleRole {
+    Central,
+    Peripheral,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PeerRegistration {
+    Added,
+    Updated,
+    DuplicateRejected { retained_role: ReticulumBleRole },
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct ReticulumBleCounters {
+    pub(crate) duplicate_rejections: u64,
+    pub(crate) stale_reassembly_drops: u64,
+    pub(crate) malformed_fragments: u64,
+    pub(crate) fragments_rx: u64,
+    pub(crate) packets_rx: u64,
+}
+
+#[derive(Debug, Clone)]
+struct ReticulumBlePeer {
+    active_address: String,
+    addresses: BTreeSet<String>,
+    role: ReticulumBleRole,
+    mtu: usize,
+}
+
+#[derive(Debug)]
+pub(crate) struct ReticulumBleRuntimeCore {
+    local_identity: [u8; 16],
+    reassembler: BleReassembler,
+    peers: BTreeMap<[u8; 16], ReticulumBlePeer>,
+    pub(crate) counters: ReticulumBleCounters,
+}
+
+impl ReticulumBleRuntimeCore {
+    pub(crate) fn new(local_identity: [u8; 16]) -> Self {
+        Self {
+            local_identity,
+            reassembler: BleReassembler::new(Duration::from_secs(30)),
+            peers: BTreeMap::new(),
+            counters: ReticulumBleCounters::default(),
+        }
+    }
+
+    pub(crate) fn register_peer(
+        &mut self,
+        identity: [u8; 16],
+        address: impl Into<String>,
+        role: ReticulumBleRole,
+        mtu: usize,
+    ) -> PeerRegistration {
+        let address = address.into();
+        let retained_role = if self.local_identity < identity {
+            ReticulumBleRole::Central
+        } else {
+            ReticulumBleRole::Peripheral
+        };
+        match self.peers.get_mut(&identity) {
+            Some(peer) if peer.role != role => {
+                peer.addresses.insert(address.clone());
+                if role == retained_role {
+                    peer.role = role;
+                    peer.active_address = address;
+                    peer.mtu = mtu;
+                }
+                self.counters.duplicate_rejections =
+                    self.counters.duplicate_rejections.saturating_add(1);
+                PeerRegistration::DuplicateRejected { retained_role }
+            }
+            Some(peer) => {
+                peer.addresses.insert(address.clone());
+                peer.active_address = address;
+                peer.mtu = mtu;
+                PeerRegistration::Updated
+            }
+            None => {
+                let mut addresses = BTreeSet::new();
+                addresses.insert(address.clone());
+                self.peers.insert(
+                    identity,
+                    ReticulumBlePeer { active_address: address, addresses, role, mtu },
+                );
+                PeerRegistration::Added
+            }
+        }
+    }
+
+    pub(crate) fn active_address(&self, identity: &[u8; 16]) -> Option<&str> {
+        self.peers.get(identity).map(|peer| peer.active_address.as_str())
+    }
+
+    pub(crate) fn receive_fragment(
+        &mut self,
+        identity: [u8; 16],
+        fragment: &[u8],
+        now: Instant,
+    ) -> Result<Option<Vec<u8>>, FragmentError> {
+        if fragment.len() > MAX_BLE_FRAGMENT_BYTES {
+            self.counters.malformed_fragments = self.counters.malformed_fragments.saturating_add(1);
+            return Err(FragmentError::Oversize(fragment.len()));
+        }
+        self.counters.stale_reassembly_drops =
+            self.counters.stale_reassembly_drops.saturating_add(self.reassembler.drop_stale(now));
+        match self.reassembler.receive_fragment(identity, fragment, now) {
+            Ok(Some(packet)) => {
+                self.counters.fragments_rx = self.counters.fragments_rx.saturating_add(1);
+                self.counters.packets_rx = self.counters.packets_rx.saturating_add(1);
+                Ok(Some(packet))
+            }
+            Ok(None) => {
+                self.counters.fragments_rx = self.counters.fragments_rx.saturating_add(1);
+                Ok(None)
+            }
+            Err(err) => {
+                self.counters.malformed_fragments =
+                    self.counters.malformed_fragments.saturating_add(1);
+                Err(err)
+            }
+        }
+    }
+}

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble_parts/runtime_iface.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble_parts/runtime_iface.rs
@@ -1,0 +1,329 @@
+use super::fragment_packet;
+
+use reticulum_daemon::config::InterfaceConfig;
+
+use rns_transport::buffer::OutputBuffer;
+use rns_transport::hash::AddressHash;
+use rns_transport::iface::{Interface, InterfaceContext, InterfaceManager};
+use rns_transport::serde::Serialize;
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+pub(crate) const SERVICE_UUID: &str = "37145b00-442d-4a94-917f-8f42c5da28e3";
+pub(crate) const TX_CHAR_UUID: &str = "37145b00-442d-4a94-917f-8f42c5da28e4";
+pub(crate) const RX_CHAR_UUID: &str = "37145b00-442d-4a94-917f-8f42c5da28e5";
+pub(crate) const IDENTITY_CHAR_UUID: &str = "37145b00-442d-4a94-917f-8f42c5da28e6";
+
+const DEFAULT_MTU: usize = 185;
+const MIN_MTU: usize = 23;
+const MAX_MTU: usize = 517;
+const RETICULUM_BLE_PACKET_BUFFER: usize = 8192;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReticulumBleSpawnResult {
+    pub(crate) iface: AddressHash,
+    pub(crate) status: ReticulumBleRuntimeStatusHandle,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReticulumBleSettings {
+    adapter: Option<String>,
+    service_uuid: String,
+    tx_char_uuid: String,
+    rx_char_uuid: String,
+    identity_char_uuid: String,
+    mtu: usize,
+    max_connections: usize,
+    scan_duration: Duration,
+    discovery_interval: Duration,
+    discovery_interval_idle: Duration,
+    advertising_refresh_interval: Duration,
+    min_rssi_dbm: i32,
+    enable_central: bool,
+    enable_peripheral: bool,
+    local_identity: [u8; 16],
+}
+
+impl ReticulumBleSettings {
+    pub(crate) fn from_config(
+        iface: &InterfaceConfig,
+        local_identity: [u8; 16],
+    ) -> Result<Self, String> {
+        let mtu = iface.mtu.unwrap_or(DEFAULT_MTU);
+        if !(MIN_MTU..=MAX_MTU).contains(&mtu) {
+            return Err("reticulum_ble.mtu must be between 23 and 517".to_string());
+        }
+        let enable_central = iface.enable_central.unwrap_or(true);
+        let enable_peripheral = iface.enable_peripheral.unwrap_or(true);
+        if !enable_central && !enable_peripheral {
+            return Err("reticulum_ble.enable_central and enable_peripheral cannot both be false"
+                .to_string());
+        }
+        Ok(Self {
+            adapter: iface.adapter.clone(),
+            service_uuid: iface.service_uuid.clone().unwrap_or_else(|| SERVICE_UUID.to_string()),
+            tx_char_uuid: iface
+                .notify_char_uuid
+                .clone()
+                .unwrap_or_else(|| TX_CHAR_UUID.to_string()),
+            rx_char_uuid: iface.write_char_uuid.clone().unwrap_or_else(|| RX_CHAR_UUID.to_string()),
+            identity_char_uuid: iface
+                .identity_char_uuid
+                .clone()
+                .unwrap_or_else(|| IDENTITY_CHAR_UUID.to_string()),
+            mtu,
+            max_connections: iface.max_connections.unwrap_or(7),
+            scan_duration: Duration::from_millis(iface.scan_duration_ms.unwrap_or(10_000)),
+            discovery_interval: Duration::from_millis(iface.discovery_interval_ms.unwrap_or(5_000)),
+            discovery_interval_idle: Duration::from_millis(
+                iface.discovery_interval_idle_ms.unwrap_or(30_000),
+            ),
+            advertising_refresh_interval: Duration::from_millis(
+                iface.advertising_refresh_interval_ms.unwrap_or(30_000),
+            ),
+            min_rssi_dbm: iface.min_rssi_dbm.unwrap_or(-85),
+            enable_central,
+            enable_peripheral,
+            local_identity,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ReticulumBleRuntimeStatus {
+    link_state: String,
+    adapter: Option<String>,
+    service_uuid: String,
+    tx_char_uuid: String,
+    rx_char_uuid: String,
+    identity_char_uuid: String,
+    local_identity: String,
+    mtu: usize,
+    max_connections: usize,
+    scan_duration_ms: u64,
+    discovery_interval_ms: u64,
+    discovery_interval_idle_ms: u64,
+    advertising_refresh_interval_ms: u64,
+    min_rssi_dbm: i32,
+    enable_central: bool,
+    enable_peripheral: bool,
+    central_links: u64,
+    peripheral_links: u64,
+    scan_state: String,
+    advertising_state: String,
+    peer_identities: Vec<String>,
+    active_addresses: Vec<String>,
+    fragments_rx: u64,
+    fragments_tx: u64,
+    packets_rx: u64,
+    packets_tx: u64,
+    malformed_fragments: u64,
+    reconnects: u64,
+    duplicate_rejections: u64,
+    stale_reassembly_drops: u64,
+    serialize_errors: u64,
+    last_error: Option<String>,
+    iface: Option<String>,
+}
+
+impl ReticulumBleRuntimeStatus {
+    fn from_settings(settings: &ReticulumBleSettings) -> Self {
+        Self {
+            link_state: "configured".to_string(),
+            adapter: settings.adapter.clone(),
+            service_uuid: settings.service_uuid.clone(),
+            tx_char_uuid: settings.tx_char_uuid.clone(),
+            rx_char_uuid: settings.rx_char_uuid.clone(),
+            identity_char_uuid: settings.identity_char_uuid.clone(),
+            local_identity: identity_hex(&settings.local_identity),
+            mtu: settings.mtu,
+            max_connections: settings.max_connections,
+            scan_duration_ms: settings.scan_duration.as_millis() as u64,
+            discovery_interval_ms: settings.discovery_interval.as_millis() as u64,
+            discovery_interval_idle_ms: settings.discovery_interval_idle.as_millis() as u64,
+            advertising_refresh_interval_ms: settings.advertising_refresh_interval.as_millis()
+                as u64,
+            min_rssi_dbm: settings.min_rssi_dbm,
+            enable_central: settings.enable_central,
+            enable_peripheral: settings.enable_peripheral,
+            central_links: 0,
+            peripheral_links: 0,
+            scan_state: "configured".to_string(),
+            advertising_state: "configured".to_string(),
+            peer_identities: Vec::new(),
+            active_addresses: Vec::new(),
+            fragments_rx: 0,
+            fragments_tx: 0,
+            packets_rx: 0,
+            packets_tx: 0,
+            malformed_fragments: 0,
+            reconnects: 0,
+            duplicate_rejections: 0,
+            stale_reassembly_drops: 0,
+            serialize_errors: 0,
+            last_error: None,
+            iface: None,
+        }
+    }
+
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "link_state": self.link_state,
+            "adapter": self.adapter,
+            "service_uuid": self.service_uuid,
+            "tx_char_uuid": self.tx_char_uuid,
+            "rx_char_uuid": self.rx_char_uuid,
+            "identity_char_uuid": self.identity_char_uuid,
+            "local_identity": self.local_identity,
+            "mtu": self.mtu,
+            "max_connections": self.max_connections,
+            "scan_duration_ms": self.scan_duration_ms,
+            "discovery_interval_ms": self.discovery_interval_ms,
+            "discovery_interval_idle_ms": self.discovery_interval_idle_ms,
+            "advertising_refresh_interval_ms": self.advertising_refresh_interval_ms,
+            "min_rssi_dbm": self.min_rssi_dbm,
+            "enable_central": self.enable_central,
+            "enable_peripheral": self.enable_peripheral,
+            "central_links": self.central_links,
+            "peripheral_links": self.peripheral_links,
+            "scan_state": self.scan_state,
+            "advertising_state": self.advertising_state,
+            "peer_identities": self.peer_identities,
+            "active_addresses": self.active_addresses,
+            "fragments_rx": self.fragments_rx,
+            "fragments_tx": self.fragments_tx,
+            "packets_rx": self.packets_rx,
+            "packets_tx": self.packets_tx,
+            "malformed_fragments": self.malformed_fragments,
+            "reconnects": self.reconnects,
+            "duplicate_rejections": self.duplicate_rejections,
+            "stale_reassembly_drops": self.stale_reassembly_drops,
+            "serialize_errors": self.serialize_errors,
+            "last_error": self.last_error,
+            "iface": self.iface,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReticulumBleRuntimeStatusHandle {
+    inner: Arc<Mutex<ReticulumBleRuntimeStatus>>,
+}
+
+impl ReticulumBleRuntimeStatusHandle {
+    fn new(status: ReticulumBleRuntimeStatus) -> Self {
+        Self { inner: Arc::new(Mutex::new(status)) }
+    }
+
+    fn update(&self, f: impl FnOnce(&mut ReticulumBleRuntimeStatus)) {
+        if let Ok(mut guard) = self.inner.lock() {
+            f(&mut guard);
+        }
+    }
+
+    pub(crate) fn to_json(&self) -> serde_json::Value {
+        self.inner.lock().expect("reticulum BLE runtime status mutex poisoned").to_json()
+    }
+}
+
+pub(crate) async fn spawn(
+    iface_manager: Arc<tokio::sync::Mutex<InterfaceManager>>,
+    iface: &InterfaceConfig,
+    local_identity: [u8; 16],
+) -> Result<ReticulumBleSpawnResult, String> {
+    let settings = ReticulumBleSettings::from_config(iface, local_identity)?;
+    let status =
+        ReticulumBleRuntimeStatusHandle::new(ReticulumBleRuntimeStatus::from_settings(&settings));
+    let interface = ReticulumBleInterface {
+        settings,
+        status: status.clone(),
+        label: iface.name.clone().unwrap_or_else(|| "<unnamed>".to_string()),
+    };
+    let iface = iface_manager
+        .lock()
+        .await
+        .spawn(interface, |context| async move { ReticulumBleInterface::run(context).await });
+    status.update(|status| status.iface = Some(iface.to_string()));
+    Ok(ReticulumBleSpawnResult { iface, status })
+}
+
+struct ReticulumBleInterface {
+    settings: ReticulumBleSettings,
+    status: ReticulumBleRuntimeStatusHandle,
+    label: String,
+}
+
+impl ReticulumBleInterface {
+    async fn run(context: InterfaceContext<Self>) {
+        let (settings, status, label) = {
+            let guard = context.inner.lock().expect("reticulum BLE interface mutex poisoned");
+            (guard.settings.clone(), guard.status.clone(), guard.label.clone())
+        };
+        status.update(|runtime| {
+            runtime.link_state = "degraded".to_string();
+            runtime.scan_state = if settings.enable_central {
+                "native_backend_pending".to_string()
+            } else {
+                "disabled".to_string()
+            };
+            runtime.advertising_state = if settings.enable_peripheral {
+                "native_backend_pending".to_string()
+            } else {
+                "disabled".to_string()
+            };
+            runtime.last_error =
+                Some("reticulum_ble native dual-role backend is not yet available".to_string());
+        });
+        log::warn!(
+            "[daemon] reticulum_ble name={} configured without native dual-role backend",
+            label
+        );
+
+        let (_, mut tx_channel) = context.channel.split();
+        let mut tx_buffer = [0_u8; RETICULUM_BLE_PACKET_BUFFER];
+        loop {
+            tokio::select! {
+                _ = context.cancel.cancelled() => break,
+                maybe = tx_channel.recv() => {
+                    let Some(message) = maybe else { break };
+                    let mut output = OutputBuffer::new(&mut tx_buffer);
+                    if message.packet.serialize(&mut output).is_err() {
+                        status.update(|runtime| {
+                            runtime.serialize_errors = runtime.serialize_errors.saturating_add(1);
+                            runtime.last_error = Some("packet serialize failed".to_string());
+                        });
+                        continue;
+                    }
+                    match fragment_packet(output.as_slice(), settings.mtu) {
+                        Ok(fragments) => status.update(|runtime| {
+                            runtime.packets_tx = runtime.packets_tx.saturating_add(1);
+                            runtime.fragments_tx = runtime
+                                .fragments_tx
+                                .saturating_add(fragments.len() as u64);
+                        }),
+                        Err(err) => status.update(|runtime| {
+                            runtime.malformed_fragments = runtime.malformed_fragments.saturating_add(1);
+                            runtime.last_error = Some(err.to_string());
+                        }),
+                    }
+                }
+            }
+        }
+        status.update(|runtime| runtime.link_state = "stopped".to_string());
+    }
+}
+
+impl Interface for ReticulumBleInterface {
+    fn mtu() -> usize {
+        MAX_MTU
+    }
+
+    fn configured_mtu(&self) -> usize {
+        self.settings.mtu
+    }
+}
+
+fn identity_hex(identity: &[u8; 16]) -> String {
+    identity.iter().map(|byte| format!("{byte:02x}")).collect()
+}

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble_parts/tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble_parts/tests.rs
@@ -50,7 +50,7 @@ fn reticulum_ble_rejects_duplicate_mismatch_timeout_and_oversize() {
     let now = Instant::now();
     let mut core = ReticulumBleRuntimeCore::new(ident(0x10));
     let peer = ident(0x20);
-    let fragments = fragment_packet(&vec![b'X'; 200], 100).expect("fragment");
+    let fragments = fragment_packet(&[b'X'; 200], 100).expect("fragment");
     assert_eq!(core.receive_fragment(peer, &fragments[0], now).expect("receive"), None);
     assert_eq!(core.receive_fragment(peer, &fragments[1], now).expect("receive"), None);
     let mut changed = fragments[1].clone();
@@ -60,7 +60,7 @@ fn reticulum_ble_rejects_duplicate_mismatch_timeout_and_oversize() {
         Err(FragmentError::DuplicateMismatch(1))
     ));
 
-    let stale = fragment_packet(&vec![b'Z'; 200], 100).expect("fragment");
+    let stale = fragment_packet(&[b'Z'; 200], 100).expect("fragment");
     assert_eq!(core.receive_fragment(peer, &stale[0], now).expect("receive"), None);
     let later = now + Duration::from_secs(31);
     assert_eq!(core.receive_fragment(peer, &stale[1], later).expect("receive"), None);

--- a/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble_parts/tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interfaces/reticulum_ble_parts/tests.rs
@@ -1,0 +1,110 @@
+use super::{
+    fragment_packet, FragmentError, PeerRegistration, ReticulumBleRole, ReticulumBleRuntimeCore,
+};
+
+use std::time::{Duration, Instant};
+
+fn ident(byte: u8) -> [u8; 16] {
+    [byte; 16]
+}
+
+#[test]
+fn reticulum_ble_fragment_codec_matches_pinned_golden_vectors() {
+    let fragments = fragment_packet(b"Hello, Reticulum!", 185).expect("fragment");
+    assert_eq!(fragments.len(), 1);
+    assert_eq!(&fragments[0][..5], &[0x01, 0x00, 0x00, 0x00, 0x01]);
+    assert_eq!(&fragments[0][5..], b"Hello, Reticulum!");
+
+    let fragments = fragment_packet(&vec![b'A'; 500], 185).expect("fragment");
+    assert_eq!(fragments.len(), 3);
+    assert_eq!(&fragments[0][..5], &[0x01, 0x00, 0x00, 0x00, 0x03]);
+    assert_eq!(&fragments[1][..5], &[0x02, 0x00, 0x01, 0x00, 0x03]);
+    assert_eq!(&fragments[2][..5], &[0x03, 0x00, 0x02, 0x00, 0x03]);
+    assert_eq!(fragments[0].len(), 185);
+    assert_eq!(fragments[1].len(), 185);
+    assert_eq!(fragments[2].len(), 145);
+}
+
+#[test]
+fn reticulum_ble_reassembles_lone_and_out_of_order_fragments() {
+    let now = Instant::now();
+    let mut core = ReticulumBleRuntimeCore::new(ident(0x10));
+    let peer = ident(0x20);
+    let lone = fragment_packet(b"short", 185).expect("fragment");
+    assert_eq!(
+        core.receive_fragment(peer, &lone[0], now).expect("receive"),
+        Some(b"short".to_vec())
+    );
+
+    let original = vec![b'F'; 150];
+    let fragments = fragment_packet(&original, 50).expect("fragment");
+    assert_eq!(fragments.len(), 4);
+    assert_eq!(core.receive_fragment(peer, &fragments[0], now).expect("receive"), None);
+    assert_eq!(core.receive_fragment(peer, &fragments[2], now).expect("receive"), None);
+    assert_eq!(core.receive_fragment(peer, &fragments[1], now).expect("receive"), None);
+    assert_eq!(core.receive_fragment(peer, &fragments[3], now).expect("receive"), Some(original));
+}
+
+#[test]
+fn reticulum_ble_rejects_duplicate_mismatch_timeout_and_oversize() {
+    let now = Instant::now();
+    let mut core = ReticulumBleRuntimeCore::new(ident(0x10));
+    let peer = ident(0x20);
+    let fragments = fragment_packet(&vec![b'X'; 200], 100).expect("fragment");
+    assert_eq!(core.receive_fragment(peer, &fragments[0], now).expect("receive"), None);
+    assert_eq!(core.receive_fragment(peer, &fragments[1], now).expect("receive"), None);
+    let mut changed = fragments[1].clone();
+    changed[5] = b'Y';
+    assert!(matches!(
+        core.receive_fragment(peer, &changed, now),
+        Err(FragmentError::DuplicateMismatch(1))
+    ));
+
+    let stale = fragment_packet(&vec![b'Z'; 200], 100).expect("fragment");
+    assert_eq!(core.receive_fragment(peer, &stale[0], now).expect("receive"), None);
+    let later = now + Duration::from_secs(31);
+    assert_eq!(core.receive_fragment(peer, &stale[1], later).expect("receive"), None);
+    assert_eq!(core.counters.stale_reassembly_drops, 1);
+
+    let oversize = vec![0_u8; 513];
+    assert!(matches!(
+        core.receive_fragment(peer, &oversize, later),
+        Err(FragmentError::Oversize(513))
+    ));
+}
+
+#[test]
+fn reticulum_ble_tracks_identity_mac_rotation_and_role_deduplication() {
+    let mut core = ReticulumBleRuntimeCore::new(ident(0x10));
+    let peer = ident(0x20);
+    assert_eq!(
+        core.register_peer(peer, "AA:BB:CC:00:00:01", ReticulumBleRole::Central, 185),
+        PeerRegistration::Added
+    );
+    assert_eq!(
+        core.register_peer(peer, "AA:BB:CC:00:00:02", ReticulumBleRole::Central, 247),
+        PeerRegistration::Updated
+    );
+    assert_eq!(core.active_address(&peer), Some("AA:BB:CC:00:00:02"));
+    assert_eq!(
+        core.register_peer(peer, "AA:BB:CC:00:00:03", ReticulumBleRole::Peripheral, 247),
+        PeerRegistration::DuplicateRejected { retained_role: ReticulumBleRole::Central }
+    );
+    assert_eq!(core.active_address(&peer), Some("AA:BB:CC:00:00:02"));
+    assert_eq!(core.counters.duplicate_rejections, 1);
+}
+
+#[test]
+fn reticulum_ble_role_policy_keeps_peripheral_when_peer_identity_is_lower() {
+    let mut core = ReticulumBleRuntimeCore::new(ident(0x30));
+    let peer = ident(0x20);
+    assert_eq!(
+        core.register_peer(peer, "central-attempt", ReticulumBleRole::Central, 185),
+        PeerRegistration::Added
+    );
+    assert_eq!(
+        core.register_peer(peer, "peripheral-attempt", ReticulumBleRole::Peripheral, 185),
+        PeerRegistration::DuplicateRejected { retained_role: ReticulumBleRole::Peripheral }
+    );
+    assert_eq!(core.active_address(&peer), Some("peripheral-attempt"));
+}

--- a/crates/apps/reticulumd/src/config_parts/interfaceconfig_sections/enabled.rs
+++ b/crates/apps/reticulumd/src/config_parts/interfaceconfig_sections/enabled.rs
@@ -312,6 +312,34 @@ impl InterfaceConfig {
                     self.max_reconnect_backoff_ms,
                 );
             }
+            "reticulum_ble" => {
+                insert_opt_string(&mut settings, "adapter", self.adapter.as_ref());
+                insert_opt_string(&mut settings, "service_uuid", self.service_uuid.as_ref());
+                insert_opt_string(&mut settings, "tx_char_uuid", self.notify_char_uuid.as_ref());
+                insert_opt_string(&mut settings, "rx_char_uuid", self.write_char_uuid.as_ref());
+                insert_opt_string(
+                    &mut settings,
+                    "identity_char_uuid",
+                    self.identity_char_uuid.as_ref(),
+                );
+                insert_opt_u64(&mut settings, "mtu", self.mtu.map(|v| v as u64));
+                insert_opt_u64(&mut settings, "max_connections", self.max_connections.map(|v| v as u64));
+                insert_opt_u64(&mut settings, "scan_duration_ms", self.scan_duration_ms);
+                insert_opt_u64(&mut settings, "discovery_interval_ms", self.discovery_interval_ms);
+                insert_opt_u64(
+                    &mut settings,
+                    "discovery_interval_idle_ms",
+                    self.discovery_interval_idle_ms,
+                );
+                insert_opt_u64(
+                    &mut settings,
+                    "advertising_refresh_interval_ms",
+                    self.advertising_refresh_interval_ms,
+                );
+                insert_opt_i64(&mut settings, "min_rssi_dbm", self.min_rssi_dbm.map(i64::from));
+                insert_opt_bool(&mut settings, "enable_central", self.enable_central);
+                insert_opt_bool(&mut settings, "enable_peripheral", self.enable_peripheral);
+            }
             "vrn76_kiss_ble" => {
                 insert_opt_string(&mut settings, "adapter", self.adapter.as_ref());
                 insert_opt_string(&mut settings, "peripheral_id", self.peripheral_id.as_ref());
@@ -436,6 +464,7 @@ impl InterfaceConfig {
             "pipe" => self.validate_pipe(index),
             "i2p" => self.validate_i2p(index),
             "ble_gatt" => self.validate_ble(index),
+            "reticulum_ble" => self.validate_reticulum_ble(index),
             "vrn76_kiss_ble" => self.validate_vrn76_kiss_ble(index),
             "lora" => self.validate_lora(index, original_kind),
             "rnode_multi" => self.validate_rnode_multi(index),
@@ -620,6 +649,9 @@ impl InterfaceConfig {
         if self.kind == "vrn76_kiss_ble" {
             self.normalize_vrn76_kiss_ble_aliases(index)?;
         }
+        if self.kind == "reticulum_ble" {
+            self.normalize_reticulum_ble_aliases(index)?;
+        }
         if self.kind == "kiss" {
             self.normalize_kiss_aliases(index, original_kind)?;
         }
@@ -682,6 +714,64 @@ impl InterfaceConfig {
         }
         if self.take_bool_alias_for_kind("kiss_framing", index, "tcp_client")?.unwrap_or(false) {
             self.kind = "kiss_tcp_client".to_string();
+        }
+        Ok(())
+    }
+
+    fn normalize_reticulum_ble_aliases(&mut self, index: usize) -> Result<(), String> {
+        const SERVICE_UUID: &str = "37145b00-442d-4a94-917f-8f42c5da28e3";
+        const TX_UUID: &str = "37145b00-442d-4a94-917f-8f42c5da28e4";
+        const RX_UUID: &str = "37145b00-442d-4a94-917f-8f42c5da28e5";
+        const IDENTITY_UUID: &str = "37145b00-442d-4a94-917f-8f42c5da28e6";
+
+        if self.service_uuid.is_none() {
+            self.service_uuid = Some(SERVICE_UUID.to_string());
+        }
+        if self.notify_char_uuid.is_none() {
+            self.notify_char_uuid = self
+                .take_string_alias_for_kind("tx_char_uuid", index, "reticulum_ble")?
+                .and_then(non_empty_string)
+                .or_else(|| Some(TX_UUID.to_string()));
+        } else {
+            let _ = self.take_string_alias_for_kind("tx_char_uuid", index, "reticulum_ble")?;
+        }
+        if self.write_char_uuid.is_none() {
+            self.write_char_uuid = self
+                .take_string_alias_for_kind("rx_char_uuid", index, "reticulum_ble")?
+                .and_then(non_empty_string)
+                .or_else(|| Some(RX_UUID.to_string()));
+        } else {
+            let _ = self.take_string_alias_for_kind("rx_char_uuid", index, "reticulum_ble")?;
+        }
+        if self.identity_char_uuid.is_none() {
+            self.identity_char_uuid = Some(IDENTITY_UUID.to_string());
+        }
+        if self.mtu.is_none() {
+            self.mtu = Some(185);
+        }
+        if self.max_connections.is_none() {
+            self.max_connections = Some(7);
+        }
+        if self.min_rssi_dbm.is_none() {
+            self.min_rssi_dbm = Some(-85);
+        }
+        if self.scan_duration_ms.is_none() {
+            self.scan_duration_ms = Some(10_000);
+        }
+        if self.discovery_interval_ms.is_none() {
+            self.discovery_interval_ms = Some(5_000);
+        }
+        if self.discovery_interval_idle_ms.is_none() {
+            self.discovery_interval_idle_ms = Some(30_000);
+        }
+        if self.advertising_refresh_interval_ms.is_none() {
+            self.advertising_refresh_interval_ms = Some(30_000);
+        }
+        if self.enable_central.is_none() {
+            self.enable_central = Some(true);
+        }
+        if self.enable_peripheral.is_none() {
+            self.enable_peripheral = Some(true);
         }
         Ok(())
     }

--- a/crates/apps/reticulumd/src/config_parts/interfaceconfig_sections/validate_serial.rs
+++ b/crates/apps/reticulumd/src/config_parts/interfaceconfig_sections/validate_serial.rs
@@ -362,6 +362,65 @@ impl InterfaceConfig {
         Ok(())
     }
 
+    fn validate_reticulum_ble(&self, index: usize) -> Result<(), String> {
+        self.reject_unknown_new_kind_keys(index, "reticulum_ble")?;
+        if !self.enabled() {
+            return Ok(());
+        }
+        if let Some(adapter) = self.adapter.as_deref() {
+            require_non_empty(
+                Some(adapter),
+                &format!("interfaces[{index}].adapter cannot be empty for reticulum_ble"),
+            )?;
+        }
+        for (field, value) in [
+            ("service_uuid", self.service_uuid.as_deref()),
+            ("tx_char_uuid", self.notify_char_uuid.as_deref()),
+            ("rx_char_uuid", self.write_char_uuid.as_deref()),
+            ("identity_char_uuid", self.identity_char_uuid.as_deref()),
+        ] {
+            let value = value.unwrap_or_default();
+            if !is_uuid_like(value) {
+                return Err(format!(
+                    "interfaces[{index}].{field} must be a 16-, 32-, or 128-bit UUID for reticulum_ble"
+                ));
+            }
+        }
+        if let Some(mtu) = self.mtu {
+            if !(23..=517).contains(&mtu) {
+                return Err(format!(
+                    "interfaces[{index}].mtu must be between 23 and 517 for reticulum_ble"
+                ));
+            }
+        }
+        if self.max_connections.is_some_and(|value| value == 0) {
+            return Err(format!(
+                "interfaces[{index}].max_connections must be > 0 for reticulum_ble"
+            ));
+        }
+        if self.min_rssi_dbm.is_some_and(|value| !(-127..=20).contains(&value)) {
+            return Err(format!(
+                "interfaces[{index}].min_rssi_dbm must be between -127 and 20 for reticulum_ble"
+            ));
+        }
+        for (field, value) in [
+            ("scan_duration_ms", self.scan_duration_ms),
+            ("discovery_interval_ms", self.discovery_interval_ms),
+            ("discovery_interval_idle_ms", self.discovery_interval_idle_ms),
+            ("advertising_refresh_interval_ms", self.advertising_refresh_interval_ms),
+        ] {
+            if value == Some(0) {
+                return Err(format!("interfaces[{index}].{field} must be > 0 for reticulum_ble"));
+            }
+        }
+        if self.enable_central == Some(false) && self.enable_peripheral == Some(false) {
+            return Err(format!(
+                "interfaces[{index}].enable_central and enable_peripheral cannot both be false for reticulum_ble"
+            ));
+        }
+        Ok(())
+    }
+
     fn validate_vrn76_kiss_ble(&self, index: usize) -> Result<(), String> {
         self.reject_unknown_new_kind_keys(index, "vrn76_kiss_ble")?;
         if let Some(flow_control) = self.flow_control.as_ref() {

--- a/crates/apps/reticulumd/src/config_parts/module_prelude.rs
+++ b/crates/apps/reticulumd/src/config_parts/module_prelude.rs
@@ -375,11 +375,29 @@ pub struct InterfaceConfig {
     #[serde(default)]
     pub notify_char_uuid: Option<String>,
     #[serde(default)]
+    pub identity_char_uuid: Option<String>,
+    #[serde(default)]
     pub scan_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub scan_duration_ms: Option<u64>,
+    #[serde(default)]
+    pub discovery_interval_ms: Option<u64>,
+    #[serde(default)]
+    pub discovery_interval_idle_ms: Option<u64>,
+    #[serde(default)]
+    pub advertising_refresh_interval_ms: Option<u64>,
     #[serde(default)]
     pub ble_connect_timeout_ms: Option<u64>,
     #[serde(default)]
     pub connect_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub max_connections: Option<usize>,
+    #[serde(default)]
+    pub min_rssi_dbm: Option<i32>,
+    #[serde(default)]
+    pub enable_central: Option<bool>,
+    #[serde(default)]
+    pub enable_peripheral: Option<bool>,
     #[serde(default)]
     pub region: Option<String>,
     #[serde(default)]

--- a/crates/apps/reticulumd/src/config_parts/non_empty_string.rs
+++ b/crates/apps/reticulumd/src/config_parts/non_empty_string.rs
@@ -73,6 +73,7 @@ fn normalize_interface_kind(value: &str) -> String {
         "WeaveInterface" => "weave".to_string(),
         "I2PInterface" => "i2p".to_string(),
         "Vrn76KissBluetoothInterface" | "Vrn76KissBleInterface" => "vrn76_kiss_ble".to_string(),
+        "AndroidBLE" | "AndroidBLEInterface" | "BLEInterface" => "reticulum_ble".to_string(),
         value => value.to_string(),
     }
 }
@@ -151,6 +152,12 @@ fn insert_opt_string_array(
 }
 
 fn insert_opt_u64(target: &mut JsonMap<String, JsonValue>, key: &str, value: Option<u64>) {
+    if let Some(value) = value {
+        target.insert(key.to_string(), JsonValue::Number(value.into()));
+    }
+}
+
+fn insert_opt_i64(target: &mut JsonMap<String, JsonValue>, key: &str, value: Option<i64>) {
     if let Some(value) = value {
         target.insert(key.to_string(), JsonValue::Number(value.into()));
     }

--- a/crates/apps/reticulumd/tests/config_parts/module_prelude.rs
+++ b/crates/apps/reticulumd/tests/config_parts/module_prelude.rs
@@ -225,6 +225,95 @@ interfaces = [
 }
 
 #[test]
+fn parses_reticulum_ble_aliases_with_columba_defaults() {
+    for alias in ["AndroidBLE", "AndroidBLEInterface", "BLEInterface", "reticulum_ble"] {
+        let input = format!(
+            r#"
+interfaces = [
+  {{ type = "{alias}", enabled = true, name = "columba-ble" }}
+]
+"#
+        );
+        let cfg = DaemonConfig::from_toml(&input).expect("parse reticulum BLE alias");
+        let iface = &cfg.interfaces[0];
+        assert_eq!(iface.kind, "reticulum_ble");
+        assert_eq!(iface.service_uuid.as_deref(), Some("37145b00-442d-4a94-917f-8f42c5da28e3"));
+        assert_eq!(iface.notify_char_uuid.as_deref(), Some("37145b00-442d-4a94-917f-8f42c5da28e4"));
+        assert_eq!(iface.write_char_uuid.as_deref(), Some("37145b00-442d-4a94-917f-8f42c5da28e5"));
+        assert_eq!(iface.identity_char_uuid.as_deref(), Some("37145b00-442d-4a94-917f-8f42c5da28e6"));
+        assert_eq!(iface.mtu, Some(185));
+        assert_eq!(iface.max_connections, Some(7));
+        assert_eq!(iface.scan_duration_ms, Some(10_000));
+        assert_eq!(iface.discovery_interval_ms, Some(5_000));
+        assert_eq!(iface.discovery_interval_idle_ms, Some(30_000));
+        assert_eq!(iface.min_rssi_dbm, Some(-85));
+        assert_eq!(iface.enable_central, Some(true));
+        assert_eq!(iface.enable_peripheral, Some(true));
+
+        let settings = iface.settings_json().expect("settings");
+        assert_eq!(settings["service_uuid"], "37145b00-442d-4a94-917f-8f42c5da28e3");
+        assert_eq!(settings["tx_char_uuid"], "37145b00-442d-4a94-917f-8f42c5da28e4");
+        assert_eq!(settings["rx_char_uuid"], "37145b00-442d-4a94-917f-8f42c5da28e5");
+        assert_eq!(settings["identity_char_uuid"], "37145b00-442d-4a94-917f-8f42c5da28e6");
+        assert_eq!(settings["mtu"], 185);
+    }
+}
+
+#[test]
+fn parses_reticulum_ble_custom_peer_settings() {
+    let cfg = DaemonConfig::from_toml(
+        r#"
+interfaces = [
+  { type = "reticulum_ble", enabled = true, name = "columba-ble", adapter = "hci0", tx_char_uuid = "2A37", rx_char_uuid = "2A38", identity_char_uuid = "2A39", mtu = 247, max_connections = 4, scan_duration_ms = 7000, discovery_interval_ms = 11000, discovery_interval_idle_ms = 31000, advertising_refresh_interval_ms = 17000, min_rssi_dbm = -95, enable_central = true, enable_peripheral = false }
+]
+"#,
+    )
+    .expect("parse reticulum BLE settings");
+    let iface = &cfg.interfaces[0];
+    assert_eq!(iface.notify_char_uuid.as_deref(), Some("2A37"));
+    assert_eq!(iface.write_char_uuid.as_deref(), Some("2A38"));
+    assert_eq!(iface.identity_char_uuid.as_deref(), Some("2A39"));
+    assert_eq!(iface.mtu, Some(247));
+    assert_eq!(iface.max_connections, Some(4));
+    assert_eq!(iface.min_rssi_dbm, Some(-95));
+
+    let settings = iface.settings_json().expect("settings");
+    assert_eq!(settings["adapter"], "hci0");
+    assert_eq!(settings["tx_char_uuid"], "2A37");
+    assert_eq!(settings["rx_char_uuid"], "2A38");
+    assert_eq!(settings["mtu"], 247);
+    assert_eq!(settings["max_connections"], 4);
+    assert_eq!(settings["min_rssi_dbm"], -95);
+    assert_eq!(settings["enable_peripheral"], false);
+}
+
+#[test]
+fn rejects_invalid_reticulum_ble_settings() {
+    for (toml, expected) in [
+        (
+            r#"[{ type = "reticulum_ble", enabled = true, service_uuid = "bad" }]"#,
+            "service_uuid must be a 16-, 32-, or 128-bit UUID",
+        ),
+        (
+            r#"[{ type = "reticulum_ble", enabled = true, mtu = 22 }]"#,
+            "mtu must be between 23 and 517",
+        ),
+        (
+            r#"[{ type = "reticulum_ble", enabled = true, discovery_interval_ms = 0 }]"#,
+            "discovery_interval_ms must be > 0",
+        ),
+        (
+            r#"[{ type = "reticulum_ble", enabled = true, enable_central = false, enable_peripheral = false }]"#,
+            "enable_central and enable_peripheral cannot both be false",
+        ),
+    ] {
+        let input = format!("interfaces = {toml}");
+        let err = DaemonConfig::from_toml(&input).expect_err("reject invalid reticulum BLE");
+        assert!(err.to_string().contains(expected), "unexpected error: {err}");
+    }
+}
+
+#[test]
 fn rejects_enabled_tcp_server_empty_host() {
     let input = r#"
 interfaces = [

--- a/docs/runbooks/reticulumd-reticulum-ble-interface.md
+++ b/docs/runbooks/reticulumd-reticulum-ble-interface.md
@@ -1,0 +1,110 @@
+# reticulumd Columba-Compatible Reticulum BLE Interface
+
+This runbook documents the `reticulum_ble` daemon interface for Columba and
+`ble-reticulum` Protocol v2.2 peer links. It is separate from `ble_gatt`, which
+remains the generic configured-peripheral GATT adapter.
+
+## Interface Kind
+
+- Primary kind: `reticulum_ble`
+- Compatibility aliases: `AndroidBLE`, `AndroidBLEInterface`, `BLEInterface`
+- Runtime status key: `_runtime.reticulum_ble`
+- Runtime dependency boundary: BLE OS dependencies stay in the `reticulumd`
+  adapter layer; `rns-transport` remains BLE-agnostic.
+
+## Default GATT Shape
+
+The daemon defaults to Columba Protocol v2.2 UUIDs:
+
+- Service: `37145b00-442d-4a94-917f-8f42c5da28e3`
+- TX notification characteristic: `37145b00-442d-4a94-917f-8f42c5da28e4`
+- RX write characteristic: `37145b00-442d-4a94-917f-8f42c5da28e5`
+- Identity characteristic: `37145b00-442d-4a94-917f-8f42c5da28e6`
+
+The identity value is the daemon transport identity hash, exactly 16 bytes.
+
+## Example
+
+```toml
+interfaces = [
+  { type = "reticulum_ble", enabled = true, name = "columba-ble" }
+]
+```
+
+Optional peer settings:
+
+```toml
+interfaces = [
+  {
+    type = "reticulum_ble",
+    enabled = true,
+    name = "columba-ble",
+    adapter = "hci0",
+    mtu = 247,
+    max_connections = 4,
+    scan_duration_ms = 10000,
+    discovery_interval_ms = 5000,
+    discovery_interval_idle_ms = 30000,
+    advertising_refresh_interval_ms = 30000,
+    min_rssi_dbm = -85,
+    enable_central = true,
+    enable_peripheral = true,
+  }
+]
+```
+
+## Protocol Notes
+
+The central flow is:
+
+1. Scan for the service UUID.
+2. Connect and discover GATT services.
+3. Read the identity characteristic.
+4. Request MTU.
+5. Subscribe to TX notifications.
+6. Write the local 16-byte identity to RX.
+
+The peripheral flow is:
+
+1. Advertise the service UUID.
+2. Serve RX, TX, and identity characteristics.
+3. Treat the first 16-byte RX write as the peer identity.
+4. Key peer state by identity, not BLE address, so MAC rotation updates the
+   active address rather than creating duplicate Reticulum peers.
+
+When central and peripheral links exist to the same identity, the lower stable
+identity hash keeps the central role. The other direction is closed without
+dropping the peer record.
+
+## Fragmentation
+
+The Rust fragment codec mirrors pinned `ble-reticulum` commit
+`07d941304c9a1dc3a8e58087b3b974ff3d229e56`:
+
+- Header: 5 bytes, `type: u8`, `sequence: u16`, `total: u16`
+- Byte order: network/big-endian for sequence and total
+- Types: `0x01` start, `0x02` continue, `0x03` end
+- Payload per fragment: negotiated peer MTU minus 5 bytes
+- Reassembly timeout: 30 seconds
+- Fragments larger than 512 bytes are rejected and counted
+
+Keepalive uses a raw one-byte `0x00` on idle links every 15 seconds; links are
+disconnected after three failed keepalives.
+
+## Status
+
+`_runtime.reticulum_ble.status` reports the configured UUIDs, local identity,
+role enablement, scan and advertising state, peer identities, active addresses,
+MTU, fragment and packet counters, duplicate role rejections, stale reassembly
+drops, reconnects, malformed fragments, and the last runtime error.
+
+## Native Backend Status
+
+The daemon now has config parsing, runtime status plumbing, Columba-compatible
+fragment/reassembly logic, identity-based peer bookkeeping, and software unit
+coverage. The OS-specific dual-role BLE backend is intentionally isolated behind
+the daemon adapter boundary. Until that backend is implemented for the target
+platform, `reticulum_ble` starts with scan and advertising states marked
+`native_backend_pending`.
+
+`ble_gatt`, RNode BLE, and VR-N76 BLE behavior are unchanged.


### PR DESCRIPTION
## Summary

- Add a new `reticulum_ble` daemon interface surface for Columba / `ble-reticulum` Protocol v2.2 peer communication while leaving existing `ble_gatt` unchanged.
- Normalize `AndroidBLE`, `AndroidBLEInterface`, and `BLEInterface` aliases to `reticulum_ble`, with Columba UUID defaults and validation for MTU, intervals, RSSI, roles, and connection limits.
- Add daemon startup/status plumbing under `_runtime.reticulum_ble`, plus a runbook documenting UUIDs, identity handshake, fragmentation, role policy, and current native backend status.
- Implement the pinned `ble-reticulum` fragment/reassembly codec and identity-keyed peer bookkeeping in the daemon adapter layer, keeping OS BLE dependencies out of `rns-transport`.

## Notes

The new interface currently reports `native_backend_pending` for scan/advertising state. This PR establishes the config, protocol core, runtime status boundary, and tests; platform-specific dual-role BLE radio backends can now attach behind this daemon adapter boundary.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p reticulumd --test config --no-fail-fast`
- `cargo test -p reticulumd --bin reticulumd reticulum_ble --no-fail-fast`
- `cargo test -p reticulumd --all-targets --no-fail-fast`
- `tools/scripts/check-boundaries.sh`