### PR TITLE
Gate propagation announce side effects

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/init_parts/rpcdaemon_sections/daemon_status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init_parts/rpcdaemon_sections/daemon_status_snapshot.rs
@@ -277,12 +277,16 @@ impl RpcDaemon {
             network_distance: hops,
             peering_timebase,
         };
+        let propagation_side_effects_enabled = !is_lxmf_propagation_aspect(aspect.as_deref()) || {
+            let propagation = self.current_propagation_state();
+            propagation.enabled || propagation.propagation_node_enabled
+        };
         let is_static = self.is_static_peer(peer.as_str());
         let remote_peering_cost_allowed = self.remote_peering_cost_allowed(peering_cost);
-        if !is_static && !remote_peering_cost_allowed {
+        if propagation_side_effects_enabled && !is_static && !remote_peering_cost_allowed {
             self.remove_peer_if_stale_or_expensive(peer.as_str(), timestamp)?;
         }
-        if !is_static && propagation_enabled == Some(false) {
+        if propagation_side_effects_enabled && !is_static && propagation_enabled == Some(false) {
             self.remove_autopeered_peer_if_propagation_disabled(
                 peer.as_str(),
                 peering_timebase.unwrap_or(timestamp),
@@ -297,11 +301,12 @@ impl RpcDaemon {
             .map(|record| record.last_seen)
             .unwrap_or_default();
         let static_path_response_refresh_allowed = !is_path_response || static_peer_last_seen == 0;
-        let should_peer = (is_static && static_path_response_refresh_allowed)
-            || (!is_static
-                && propagation_enabled != Some(false)
-                && remote_peering_cost_allowed
-                && self.should_autopeer_peer(hops));
+        let should_peer = propagation_side_effects_enabled
+            && ((is_static && static_path_response_refresh_allowed)
+                || (!is_static
+                    && propagation_enabled != Some(false)
+                    && remote_peering_cost_allowed
+                    && self.should_autopeer_peer(hops)));
         let peer_type = if is_static {
             Some("static".to_string())
         } else if should_peer {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_enable_autopeer_maxdepth.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/propagation_enable_autopeer_maxdepth.rs
@@ -107,6 +107,85 @@ fn propagation_enable_autopeer_maxdepth_unpeers_existing_deeper_autopeers() {
 }
 
 #[test]
+fn inactive_local_propagation_node_ignores_propagation_announce_side_effects() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "peer-propagation-inactive";
+    let entry = PropagationEntryRecord {
+        transient_id: "c2".repeat(32),
+        destination: "18".repeat(16),
+        payload_hex: "18".repeat(24),
+        received_at: 1_700_000_130,
+        size_bytes: 24,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store propagation entry");
+    let enabled_app_data = rmp_serde::to_vec_named(&MsgPackValue::Array(vec![
+        MsgPackValue::Boolean(true),
+        MsgPackValue::from(1_700_000_131i64),
+        MsgPackValue::Boolean(false),
+        MsgPackValue::from(333),
+        MsgPackValue::from(999),
+        MsgPackValue::Array(vec![
+            MsgPackValue::from(8),
+            MsgPackValue::from(2),
+            MsgPackValue::from(5),
+        ]),
+        MsgPackValue::Map(Vec::new()),
+    ]))
+    .expect("encode enabled propagation app data");
+
+    daemon
+        .accept_announce_with_metadata(
+            peer.to_string(),
+            1_700_000_132,
+            Some("Inactive Propagation Peer".to_string()),
+            Some("announce".to_string()),
+            Some(hex::encode(enabled_app_data)),
+            Some(vec!["propagation".to_string()]),
+            None,
+            None,
+            None,
+            Some(3),
+            Some(Some(1)),
+            Some(Some(4)),
+            Some("lxmf.propagation".to_string()),
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("accept propagation announce while local node inactive");
+
+    let peers = daemon
+        .handle_rpc(RpcRequest { id: 60, method: "list_peers".to_string(), params: None })
+        .expect("list peers")
+        .result
+        .expect("list peers result");
+    assert_eq!(peers["peers"].as_array().map(Vec::len), Some(0));
+    assert!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer)
+            .expect("inactive node should not queue peer propagation")
+            .is_empty(),
+        "Python only applies propagation announce peer side effects while the local router is a propagation node"
+    );
+
+    let event = daemon
+        .event_queue
+        .lock()
+        .expect("event_queue mutex poisoned")
+        .iter()
+        .rev()
+        .find(|event| event.event_type == "announce_received")
+        .cloned()
+        .expect("announce event");
+    assert_eq!(event.payload["peer"].as_str(), Some(peer));
+    assert_eq!(event.payload["aspect"].as_str(), Some("lxmf.propagation"));
+}
+
+#[test]
 fn disabled_propagation_node_announce_unpeers_existing_autopeer() {
     let daemon = RpcDaemon::test_instance();
     daemon

--- a/crates/libs/rns-rpc/src/rpc/helpers_parts/pn_metadata_to_json.rs
+++ b/crates/libs/rns-rpc/src/rpc/helpers_parts/pn_metadata_to_json.rs
@@ -138,6 +138,13 @@ fn is_lxmf_delivery_aspect(aspect: Option<&str>) -> bool {
     )
 }
 
+fn is_lxmf_propagation_aspect(aspect: Option<&str>) -> bool {
+    matches!(
+        aspect.map(str::trim).map(str::to_ascii_lowercase).as_deref(),
+        Some("lxmf.propagation" | "propagation")
+    )
+}
+
 fn inbound_ticket_from_record(record: &MessageRecord) -> Option<(i64, String)> {
     let fields = record.fields.as_ref()?.as_object()?;
     let lxmf = fields.get("_lxmf").and_then(JsonValue::as_object);

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1075,6 +1075,9 @@ Scoped release evidence is split as follows:
   fresh transient, now also emits one bounded `inbound_dropped` duplicate event
   with redacted destination identifiers and the transient ID, without storing a
   second message or incrementing receive counters.
+- Propagation announce handling now gates peer/queue side effects on active
+  local propagation handling, matching Python `Handlers.py` behavior while
+  still recording the announce for observability.
 - Remote propagation imports from fetch, download, and sync now keep duplicate
   payloads observer-visible by emitting bounded `inbound_dropped` duplicate
   events with operation, transient, byte-length, and optional peer context while

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -960,6 +960,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   already processed transient, or for an already stored message carried by a
   fresh transient, emits one bounded `inbound_dropped` duplicate event while
   preserving the same no-store/no-recount behavior.
+- Propagation announce handling now mirrors Python handler activation: valid
+  `lxmf.propagation` announces are recorded but do not create peers or queue
+  propagation entries unless local propagation handling is active.
 - Focused remote propagation import tests now cover duplicate observability for
   same-response duplicate payloads across sync/fetch/download and already
   processed remote fetch payloads: still-stored duplicates remain accepted for


### PR DESCRIPTION
## Summary
- gate `lxmf.propagation` announce peer/queue side effects on active local propagation handling
- keep inactive propagation announces observable without creating peers or queue marks
- add regression coverage beside existing autopeer/disabled-announce behavior and update parity docs

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p reticulum-rs-rpc inactive_local_propagation_node_ignores_propagation_announce_side_effects -- --nocapture`
- `cargo test -p reticulum-rs-rpc disabled_propagation -- --nocapture`
- `cargo test -p reticulum-rs-rpc announce_received_parses_propagation_peer_limits_from_python_app_data -- --nocapture`
- `cargo test -p reticulum-rs-rpc propagation_enable_autopeer_maxdepth_unpeers_existing_deeper_autopeers -- --nocapture`