### PR TITLE
Expose outbound stamp cost query

### DIFF
--- a/crates/libs/lxmf-sdk/src/app/operations_parts/built_in_entries.rs
+++ b/crates/libs/lxmf-sdk/src/app/operations_parts/built_in_entries.rs
@@ -469,6 +469,14 @@ fn built_in_entries() -> Vec<OperationEntry> {
             "Resolve the runtime delivery destination hash.",
         )
         .with_alias("status"),
+        OperationEntry::new(
+            "app.delivery.outbound_stamp_cost",
+            "delivery",
+            OperationKind::Query,
+            TransportVariant::LegacyRpc,
+            "Return the cached outbound delivery stamp cost for one destination.",
+        )
+        .with_alias("get_outbound_stamp_cost"),
     ]
     ]
     .concat()

--- a/crates/libs/lxmf-sdk/src/app/operations_parts/built_in_registry_canonicalizes_alia.rs
+++ b/crates/libs/lxmf-sdk/src/app/operations_parts/built_in_registry_canonicalizes_alia.rs
@@ -25,6 +25,13 @@ mod tests {
             registry.canonicalize("sdk_paper_decode_v2").expect("canonical id").as_str(),
             "app.paper.decode"
         );
+        assert_eq!(
+            registry
+                .canonicalize("get_outbound_stamp_cost")
+                .expect("canonical outbound stamp cost id")
+                .as_str(),
+            "app.delivery.outbound_stamp_cost"
+        );
     }
 
     #[test]

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/registry.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/tests/registry.rs
@@ -19,6 +19,7 @@ fn operation_registry_uses_zmq_sdk_method_for_chat_peer_and_propagation_operatio
         "app.message.conversation.list",
         "app.message.history.list",
         "app.delivery.destination_hash",
+        "app.delivery.outbound_stamp_cost",
         "app.delivery.cancel",
         "app.peer.connect",
         "app.peer.disconnect",

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_misc.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_misc.rs
@@ -89,6 +89,24 @@ impl RpcDaemon {
                     error: None,
                 })
             }
+            "get_outbound_stamp_cost" => {
+                let params = request.params.ok_or_else(|| {
+                    std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing params")
+                })?;
+                let parsed: OutboundStampCostParams = serde_json::from_value(params)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+                let destination = normalize_destination_hash_param(&parsed.destination)?;
+                let stamp_cost = self.outbound_stamp_cost_for(destination.as_str())?;
+
+                Ok(RpcResponse {
+                    id: request.id,
+                    result: Some(json!({
+                        "destination": destination,
+                        "stamp_cost": stamp_cost,
+                    })),
+                    error: None,
+                })
+            }
             "ticket_generate" => {
                 let params = request.params.ok_or_else(|| {
                     std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing params")

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_router.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_router.rs
@@ -43,10 +43,15 @@ impl RpcDaemon {
             | "propagation_remote_download"
             | "propagation_acknowledge_sync_completion"
             | "propagation_remote_unpeer" => self.handle_rpc_legacy_propagation(request),
-            "paper_ingest_uri" | "stamp_policy_get" | "stamp_policy_set" | "ticket_generate"
-            | "path_status" | "request_path" | "announce_now" | "announce_received" => {
-                self.handle_rpc_legacy_misc(request)
-            }
+            "paper_ingest_uri"
+            | "stamp_policy_get"
+            | "stamp_policy_set"
+            | "ticket_generate"
+            | "get_outbound_stamp_cost"
+            | "path_status"
+            | "request_path"
+            | "announce_now"
+            | "announce_received" => self.handle_rpc_legacy_misc(request),
             "rnode_management" | "weave_remote_display_control" => {
                 self.handle_rpc_legacy_misc(request)
             }

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/rpcdaemon_sections/handle_sdk_envelope_execute_v2.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/rpcdaemon_sections/handle_sdk_envelope_execute_v2.rs
@@ -52,6 +52,7 @@ impl RpcDaemon {
             | "propagation_remote_unpeer"
             | "propagation_acknowledge_sync_completion"
             | "get_outbound_propagation_cost"
+            | "get_outbound_stamp_cost"
             | "get_outbound_propagation_node"
             | "set_outbound_propagation_node"
             | "list_propagation_nodes"

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/rpcdaemon_sections/operation_spec.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/rpcdaemon_sections/operation_spec.rs
@@ -148,6 +148,11 @@ impl RpcDaemon {
                     Err(err) => return Err(err),
                 }
             }
+            "get_outbound_stamp_cost" => self.handle_rpc_legacy_misc(RpcRequest {
+                id: request_id,
+                method: method.to_owned(),
+                params: Some(params),
+            })?,
             "sdk_snapshot_v2" => self.handle_sdk_snapshot_v2(RpcRequest {
                 id: request_id,
                 method: method.to_owned(),

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/sdk_operation_specs.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/sdk_operation_specs.rs
@@ -497,4 +497,14 @@ const SDK_OPERATION_SPECS: &[SdkOperationSpec] = &[
         required_capabilities: &[],
         rpc_method: "status",
     },
+    SdkOperationSpec {
+        id: "app.delivery.outbound_stamp_cost",
+        group: "delivery",
+        kind: "query",
+        transport_variant: "legacy_rpc",
+        description: "Return the cached outbound delivery stamp cost for one destination.",
+        aliases: &["get_outbound_stamp_cost"],
+        required_capabilities: &[],
+        rpc_method: "get_outbound_stamp_cost",
+    },
 ];

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/announce_received_parses_delivery_st.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/announce_received_parses_delivery_st.rs
@@ -1,6 +1,7 @@
 #[test]
 fn announce_received_parses_delivery_stamp_cost_from_python_app_data() {
     let daemon = RpcDaemon::test_instance();
+    let destination = "00112233445566778899aabbccddeeff";
     let app_data = rmp_serde::to_vec_named(&MsgPackValue::Array(vec![
         MsgPackValue::Binary(b"Peer Stamp".to_vec()),
         MsgPackValue::from(22),
@@ -12,7 +13,7 @@ fn announce_received_parses_delivery_stamp_cost_from_python_app_data() {
             45,
             "announce_received",
             json!({
-                "peer": "peer-delivery-stamp",
+                "peer": destination,
                 "timestamp": 1_700_000_012i64,
                 "app_data_hex": hex::encode(app_data),
                 "aspect": "lxmf.delivery",
@@ -22,9 +23,38 @@ fn announce_received_parses_delivery_stamp_cost_from_python_app_data() {
     assert!(announce.error.is_none());
 
     assert_eq!(
-        daemon.outbound_stamp_cost_for("peer-delivery-stamp").expect("stamp cost lookup"),
+        daemon.outbound_stamp_cost_for(destination).expect("stamp cost lookup"),
         Some(22)
     );
+
+    let queried = daemon
+        .handle_rpc(rpc_request(
+            46,
+            "get_outbound_stamp_cost",
+            json!({ "destination_hash": destination }),
+        ))
+        .expect("query outbound stamp cost");
+    assert!(queried.error.is_none());
+    let result = queried.result.expect("query result");
+    assert_eq!(result["destination"].as_str(), Some(destination));
+    assert_eq!(result["stamp_cost"].as_u64(), Some(22));
+
+    let envelope = daemon
+        .handle_rpc(rpc_request(
+            47,
+            "sdk_envelope_execute_v2",
+            json!({
+                "operation_id": "get_outbound_stamp_cost",
+                "kind": "query",
+                "payload": { "destination": destination },
+            }),
+        ))
+        .expect("query outbound stamp cost through sdk envelope");
+    assert!(envelope.error.is_none());
+    let response = envelope.result.expect("envelope result")["response"].clone();
+    assert_eq!(response["operation_id"].as_str(), Some("app.delivery.outbound_stamp_cost"));
+    assert_eq!(response["payload"]["destination"].as_str(), Some(destination));
+    assert_eq!(response["payload"]["stamp_cost"].as_u64(), Some(22));
 }
 
 #[test]

--- a/crates/libs/rns-rpc/src/rpc/params/core.rs
+++ b/crates/libs/rns-rpc/src/rpc/params/core.rs
@@ -172,6 +172,12 @@ struct StampPolicySetParams {
 }
 
 #[derive(Debug, Deserialize)]
+struct OutboundStampCostParams {
+    #[serde(alias = "destination_hash", alias = "hash")]
+    destination: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct TicketGenerateParams {
     destination: String,
     #[serde(default)]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -531,6 +531,9 @@ Scoped release evidence is split as follows:
   identity misses after delivery path-request timeout now enter nonterminal
   `queued: waiting for announce` state, so later delivery announces can requeue
   them instead of leaving a terminal `failed:*` receipt.
+- Destination-level outbound delivery stamp costs learned from Python-style
+  `lxmf.delivery` announces are now queryable through `get_outbound_stamp_cost`
+  and the `app.delivery.outbound_stamp_cost` SDK envelope operation.
 - Direct and propagated resource sends support receipt-state separation,
   timeout/failure propagation, and active resource cancellation.
 - Link sends now register packet/resource receipt tracking before handoff and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -130,6 +130,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   persist as nonterminal `queued: waiting for announce`, preserving them for
   the delivery-announce wakeup path while propagated/propagation-node misses
   stay terminal.
+- `get_outbound_stamp_cost` now exposes Python-style destination-level cached
+  delivery stamp-cost lookup through legacy RPC and the SDK envelope registry,
+  returning `null` when no delivery announce cost has been learned.
 
 ### Tickets and stamps
 


### PR DESCRIPTION
## Summary
- add `get_outbound_stamp_cost` as a destination-level cached delivery stamp-cost query
- expose the same behavior through `app.delivery.outbound_stamp_cost` / SDK envelope registry
- document the narrowed LXMRouter convenience-surface parity gap

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p reticulum-rs-rpc announce_received_parses_delivery_stamp_cost_from_python_app_data -- --nocapture`
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend built_in_registry_canonicalizes_aliases -- --nocapture`
- `cargo test -p lxmf-sdk --features zmq-pipeline-backend operation_registry_uses_zmq_sdk_method_for_chat_peer_and_propagation_operations -- --nocapture`