### PR TITLE
Hot-apply UDP multicast forward records

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup_parts/module_prelude.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup_parts/module_prelude.rs
@@ -2154,7 +2154,14 @@ interfaces = [
         assert!(udp_status["bind_addr"].as_str().expect("bind").ends_with(":0"));
         assert_eq!(udp_status["forward_addr"].as_str(), Some("239.255.0.1:4242"));
         assert_eq!(udp_status["iface"].as_str(), Some(runtime_iface.to_string().as_str()));
-        assert!(seeded_hot_apply_interfaces.is_empty());
+        assert_eq!(seeded_hot_apply_interfaces.len(), 1);
+        assert_eq!(seeded_hot_apply_interfaces[0].0, "auto-style-multicast");
+        assert_eq!(
+            seeded_hot_apply_interfaces[0].1.name.as_deref(),
+            Some("auto-style-multicast")
+        );
+        assert_eq!(seeded_hot_apply_interfaces[0].1.kind, "udp");
+        assert_eq!(seeded_hot_apply_interfaces[0].2, udp_runtime_refreshes[0].runtime_iface);
     }
 
     #[tokio::test]

--- a/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply_parts/record_hot_apply.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply_parts/record_hot_apply.rs
@@ -225,12 +225,6 @@ fn udp_forward_addr_result(record: &InterfaceRecord) -> Result<Option<String>, i
             ))
         }
     };
-    if host_is_multicast(host) {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "udp hot-apply does not support multicast targets",
-        ));
-    }
     let port = u16::try_from(port).map_err(|_| {
         io::Error::new(io::ErrorKind::InvalidInput, "udp hot-apply target_port is out of range")
     })?;
@@ -242,7 +236,11 @@ pub(crate) fn mark_udp_record_runtime_status(
     runtime_iface: Option<AddressHash>,
 ) {
     if let Ok((bind_addr, forward_addr)) = udp_bind_and_forward_addr(record) {
-        let role = if record.host.as_deref().is_some_and(host_is_multicast) {
+        let forward_host =
+            setting_str(record, "target_host").or_else(|| setting_str(record, "forward_ip"));
+        let role = if record.host.as_deref().is_some_and(host_is_multicast)
+            || forward_host.is_some_and(host_is_multicast)
+        {
             "multicast"
         } else if forward_addr.is_some() {
             "peer"

--- a/crates/apps/reticulumd/src/bin/reticulumd/tests/interface_hot_apply.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests/interface_hot_apply.rs
@@ -586,7 +586,11 @@ async fn hot_apply_spawns_udp_multicast_with_transport_peer_routing() {
         Vec::new(),
         Arc::downgrade(&daemon),
     );
-    let record = udp_record("udp-mcast", "239.255.0.1", 0);
+    let mut record = udp_record("udp-mcast", "127.0.0.1", 0);
+    record.settings = Some(json!({
+        "target_host": "239.255.0.1",
+        "target_port": 4242
+    }));
 
     let applied = bridge.apply_interfaces(vec![record]).expect("apply multicast udp");
     daemon.replace_interfaces(applied);
@@ -607,6 +611,10 @@ async fn hot_apply_spawns_udp_multicast_with_transport_peer_routing() {
     assert_eq!(
         runtime["interfaces"][0]["settings"]["_runtime"]["udp"]["status"]["role"].as_str(),
         Some("multicast")
+    );
+    assert_eq!(
+        runtime["interfaces"][0]["settings"]["_runtime"]["udp"]["status"]["forward_addr"].as_str(),
+        Some("239.255.0.1:4242")
     );
     assert_eq!(refresh.runtime_iface, runtime_iface);
 }

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/interface_mutation_helpers.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/interface_mutation_helpers.rs
@@ -196,7 +196,7 @@ impl RpcDaemon {
         if target_port.is_some_and(|value| u16::try_from(value).is_err()) {
             return false;
         }
-        !Self::host_is_multicast(target_host)
+        true
     }
 
     fn legacy_udp_bind_addr(iface: &InterfaceRecord) -> Option<String> {
@@ -256,8 +256,4 @@ impl RpcDaemon {
         if host.eq_ignore_ascii_case("localhost") { "127.0.0.1" } else { host }
     }
 
-    fn host_is_multicast(host: Option<&str>) -> bool {
-        host.and_then(|value| value.parse::<std::net::IpAddr>().ok())
-            .is_some_and(|ip| ip.is_multicast())
-    }
 }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/interface_mutation_policy.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/interface_mutation_policy.rs
@@ -31,6 +31,21 @@
         }
     }
 
+    fn udp_forward_interface(
+        name: &str,
+        host: &str,
+        port: u16,
+        target_host: &str,
+        target_port: u16,
+    ) -> InterfaceRecord {
+        let mut iface = udp_interface(name, host, port);
+        iface.settings = Some(json!({
+            "target_host": target_host,
+            "target_port": target_port
+        }));
+        iface
+    }
+
     struct RecordingInterfaceMutationBridge {
         applied: std::sync::Mutex<Vec<Vec<InterfaceRecord>>>,
     }
@@ -577,8 +592,10 @@
     }
 
     #[test]
-    fn set_interfaces_reports_multicast_udp_forward_target_requires_restart() {
+    fn set_interfaces_hot_applies_multicast_udp_forward_target() {
         let daemon = RpcDaemon::test_instance();
+        let bridge = std::sync::Arc::new(RecordingInterfaceMutationBridge::new());
+        daemon.set_interface_mutation_bridge(bridge.clone());
 
         let response = daemon
             .handle_rpc(rpc_request(
@@ -600,7 +617,17 @@
             ))
             .expect("set_interfaces response");
 
-        assert_restart_required(response);
+        assert!(response.error.is_none(), "unexpected error: {response:?}");
+        assert_eq!(
+            bridge.applied(),
+            vec![vec![udp_forward_interface(
+                "udp-peer",
+                "127.0.0.1",
+                4242,
+                "239.255.0.1",
+                4242
+            )]]
+        );
     }
 
     #[test]
@@ -832,9 +859,11 @@
     }
 
     #[test]
-    fn reload_config_reports_multicast_udp_forward_target_requires_restart() {
+    fn reload_config_hot_applies_multicast_udp_forward_target() {
         let daemon = RpcDaemon::test_instance();
         daemon.replace_interfaces(vec![udp_interface("udp-peer", "127.0.0.1", 4242)]);
+        let bridge = std::sync::Arc::new(RecordingInterfaceMutationBridge::new());
+        daemon.set_interface_mutation_bridge(bridge.clone());
 
         let response = daemon
             .handle_rpc(rpc_request(
@@ -856,7 +885,20 @@
             ))
             .expect("reload_config response");
 
-        assert_restart_required(response);
+        assert!(response.error.is_none(), "unexpected reload error: {response:?}");
+        let result = response.result.expect("result");
+        assert_eq!(result["hot_applied_legacy_tcp_only"], json!(false));
+        assert_eq!(result["hot_applied_interface_mutation"], json!(true));
+        assert_eq!(
+            bridge.applied(),
+            vec![vec![udp_forward_interface(
+                "udp-peer",
+                "127.0.0.1",
+                4242,
+                "239.255.0.1",
+                4242
+            )]]
+        );
     }
 
     #[test]

--- a/docs/runbooks/reticulumd-udp-interface.md
+++ b/docs/runbooks/reticulumd-udp-interface.md
@@ -24,9 +24,12 @@ forward_port = 4243
 
 The Rust-native aliases are `host`/`port` and `target_host`/`target_port`.
 When only a bind address is configured, the interface is receive-only and the
-runtime role is `listener`. When a forward address is configured, the runtime
-role is `peer`. Device-based UDP configs can derive IPv4 broadcast bind and
-forward addresses from the named host interface.
+runtime role is `listener`. When a unicast forward address is configured, the
+runtime role is `peer`. Explicit software multicast bind or multicast forward
+records use runtime role `multicast` and the transport peer-routing helper.
+This is local/software mutation coverage only; it is not production multicast
+or multi-host parity evidence. Device-based UDP configs can derive IPv4
+broadcast bind and forward addresses from the named host interface.
 
 ## Runtime Status
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -441,16 +441,17 @@ Scoped release evidence is split as follows:
   network services. `set_interfaces` and `reload_config` now hot-apply explicit
   loopback TCP server listeners, including the local `localhost` hostname,
   alongside TCP clients and explicit UDP
-  listener, peer, and multicast-bind records, with tests proving
+  listener, peer, multicast-bind, and multicast-forward records, with tests proving
   `device`-bound, non-local, and broader TCP server listener shapes stay
-  restart-required or invalid, UDP `device`-bound, partial-target,
-  out-of-range-target, and multicast-forward shapes remain restart-required or
-  invalid, and duplicate TCP server or UDP binds are rejected before mutation.
+  restart-required or invalid, UDP `device`-bound, partial-target, and
+  out-of-range-target shapes remain restart-required or invalid, and duplicate
+  TCP server or UDP binds are rejected before mutation.
   Hot-applied explicit TCP server records attach live daemon/RPC
   `_runtime.tcp.listener_status` metadata, hot-applied explicit UDP records
   attach the runtime iface and refresh live daemon/RPC `_runtime.udp.status`
-  counters under focused software tests, and multicast-bind hot-apply goes
-  through the transport peer-routing helper instead of a bare UDP spawn. Serial
+  counters under focused software tests, and multicast-bind and
+  multicast-forward hot-apply go through the transport peer-routing helper
+  instead of a bare UDP spawn. Serial
   now refreshes live open/reconnect, HDLC frame, packet, byte, EOF, queue,
   decode, serialize, read, and write-error counters.
   KISS/AX.25 KISS and KISS TCP now refresh live packet, data-frame,

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -20,7 +20,7 @@ Workspace paths are used for navigation. Published package names are
 
 | Python surface | Rust surface | Status | Implemented baseline | Residual gap |
 | --- | --- | --- | --- | --- |
-| `RNS/Reticulum.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | Deployable daemon, configuration, propagation-node activation, persistence, RPC, graceful shutdown, unified legacy `status`/`daemon_status_ex` daemon runtime snapshot visibility, daemon/RPC runtime status for Reticulum path-table restore success or failure, multiple live interfaces, and runtime `set_interfaces`/`reload_config` hot-apply for TCP clients, explicit loopback TCP server listeners including `localhost`, and explicit UDP listener, peer, and multicast-bind records. | Python runtime/config mutation remains wider for device-bound, multicast-forward, non-local listener, and broader interface shapes; interface breadth remains wider. |
+| `RNS/Reticulum.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | Deployable daemon, configuration, propagation-node activation, persistence, RPC, graceful shutdown, unified legacy `status`/`daemon_status_ex` daemon runtime snapshot visibility, daemon/RPC runtime status for Reticulum path-table restore success or failure, multiple live interfaces, and runtime `set_interfaces`/`reload_config` hot-apply for TCP clients, explicit loopback TCP server listeners including `localhost`, and explicit UDP listener, peer, multicast-bind, and multicast-forward records. | Python runtime/config mutation remains wider for device-bound, non-local listener, and broader interface shapes; interface breadth remains wider. |
 | `RNS/Identity.py` | `crates/libs/rns-core` | done | Identity material, hashing, signing, encryption, recall, and key conversion. | No confirmed parity blocker. |
 | `RNS/Destination.py` | `crates/libs/rns-core`, `crates/libs/rns-transport` | done | Destination hashing, descriptors, announces, proof validation, ratchets, and known-key stability checks. | No confirmed parity blocker. |
 | `RNS/Packet.py` | `crates/libs/rns-core`, `crates/libs/rns-transport` | done | Framing, serialization, contexts, proofs, receipts, Python-default link proof context, and header semantics. | No confirmed parity blocker. |
@@ -141,16 +141,17 @@ placeholders:
   strict startup, bound loopback status, and malformed-datagram
   `bytes_rx`/`decode_errors` telemetry without external network services.
   Runtime interface mutation now hot-applies explicit loopback TCP server
-  listeners, including `localhost`, plus explicit UDP listener, peer, and
-  multicast-bind records through `set_interfaces` and `reload_config`, while
-  `device`-bound, non-local, and broader TCP server listener shapes, plus UDP
-  `device`-bound, partial-target, out-of-range-target, and multicast-forward
-  records, remain restart-required or invalid. Duplicate TCP server and UDP
-  binds are rejected before mutation. Hot-applied explicit TCP server records
-  attach live daemon/RPC `_runtime.tcp.listener_status` metadata, hot-applied
-  explicit UDP records attach the runtime iface and refresh live daemon/RPC
-  `_runtime.udp.status` counters under focused software tests; multicast-bind
-  hot-apply uses the transport peer-routing helper.
+  listeners, including `localhost`, plus explicit UDP listener, peer,
+  multicast-bind, and multicast-forward records through `set_interfaces` and
+  `reload_config`, while `device`-bound, non-local, and broader TCP server
+  listener shapes, plus UDP `device`-bound, partial-target, and
+  out-of-range-target records, remain restart-required or invalid. Duplicate
+  TCP server and UDP binds are rejected before mutation. Hot-applied explicit
+  TCP server records attach live daemon/RPC `_runtime.tcp.listener_status`
+  metadata, hot-applied explicit UDP records attach the runtime iface and
+  refresh live daemon/RPC `_runtime.udp.status` counters under focused
+  software tests; multicast-bind and multicast-forward hot-apply use the
+  transport peer-routing helper.
 - Serial now refreshes live daemon/RPC status with open/reconnect, HDLC frame,
   packet, byte, EOF, queue, decode, serialize, read, and write-error counters.
   Serial KISS and AX.25 KISS retain Python-compatible AX.25 UI header wrapping


### PR DESCRIPTION
## Summary
- allow explicit UDP multicast-forward records through set_interfaces/reload_config hot-apply validation
- route loopback-bind plus multicast-forward runtime records through the multicast transport peer-routing helper and report role=multicast with forward_addr metadata
- narrow Reticulum parity docs and UDP runbook language to software/local multicast-forward mutation coverage

## Validation
- cargo test -p reticulumd interface_hot_apply -- --nocapture
- cargo test -p reticulumd hot_apply_spawns_udp_multicast_with_transport_peer_routing -- --nocapture
- cargo test -p reticulum-rs-rpc set_interfaces_hot_applies_multicast_udp_forward_target -- --nocapture
- cargo test -p reticulum-rs-rpc reload_config_hot_applies_multicast_udp_forward_target -- --nocapture
- cargo fmt --all -- --check
- tools/scripts/check-module-size.sh
- git diff --check