### PR TITLE
Isolate LXMF delivery announce side effects

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/init_parts/rpcdaemon_sections/daemon_status_snapshot.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/init_parts/rpcdaemon_sections/daemon_status_snapshot.rs
@@ -277,12 +277,13 @@ impl RpcDaemon {
             network_distance: hops,
             peering_timebase,
         };
+        let is_delivery_announce = is_lxmf_delivery_aspect(aspect.as_deref());
         let is_static = self.is_static_peer(peer.as_str());
         let remote_peering_cost_allowed = self.remote_peering_cost_allowed(peering_cost);
-        if !is_static && !remote_peering_cost_allowed {
+        if !is_delivery_announce && !is_static && !remote_peering_cost_allowed {
             self.remove_peer_if_stale_or_expensive(peer.as_str(), timestamp)?;
         }
-        if !is_static && propagation_enabled == Some(false) {
+        if !is_delivery_announce && !is_static && propagation_enabled == Some(false) {
             self.remove_autopeered_peer_if_propagation_disabled(
                 peer.as_str(),
                 peering_timebase.unwrap_or(timestamp),
@@ -297,11 +298,12 @@ impl RpcDaemon {
             .map(|record| record.last_seen)
             .unwrap_or_default();
         let static_path_response_refresh_allowed = !is_path_response || static_peer_last_seen == 0;
-        let should_peer = (is_static && static_path_response_refresh_allowed)
-            || (!is_static
-                && propagation_enabled != Some(false)
-                && remote_peering_cost_allowed
-                && self.should_autopeer_peer(hops));
+        let should_peer = !is_delivery_announce
+            && ((is_static && static_path_response_refresh_allowed)
+                || (!is_static
+                    && propagation_enabled != Some(false)
+                    && remote_peering_cost_allowed
+                    && self.should_autopeer_peer(hops)));
         let peer_type = if is_static {
             Some("static".to_string())
         } else if should_peer {
@@ -378,7 +380,7 @@ impl RpcDaemon {
             peering_cost,
         };
         self.store.insert_announce(&announce_record).map_err(std::io::Error::other)?;
-        if is_lxmf_delivery_aspect(aspect.as_deref()) {
+        if is_delivery_announce {
             let woken = self.wake_lxmf_delivery_outbound_for_announce(record.peer.as_str())?;
             if woken > 0 {
                 log::debug!(

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/announce_received_parses_delivery_st.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/announce_received_parses_delivery_st.rs
@@ -28,6 +28,71 @@ fn announce_received_parses_delivery_stamp_cost_from_python_app_data() {
 }
 
 #[test]
+fn delivery_announce_does_not_create_propagation_peer_or_queue_entries() {
+    let daemon = RpcDaemon::test_instance();
+    let peer = "bb".repeat(16);
+    daemon
+        .handle_rpc(rpc_request(
+            46,
+            "propagation_enable",
+            json!({
+                "enabled": true,
+                "autopeer": true,
+            }),
+        ))
+        .expect("enable propagation");
+    let entry = PropagationEntryRecord {
+        transient_id: "d1".repeat(32),
+        destination: "16".repeat(16),
+        payload_hex: "11".repeat(32),
+        received_at: 1_700_000_010,
+        size_bytes: 32,
+        stamp_value: None,
+    };
+    daemon.store.upsert_propagation_entry(&entry).expect("store entry");
+    let app_data = rmp_serde::to_vec_named(&MsgPackValue::Array(vec![
+        MsgPackValue::Binary(b"Delivery Only".to_vec()),
+        MsgPackValue::from(12),
+    ]))
+    .expect("encode app data");
+
+    let announce = daemon
+        .handle_rpc(rpc_request(
+            47,
+            "announce_received",
+            json!({
+                "peer": peer.as_str(),
+                "timestamp": 1_700_000_012i64,
+                "app_data_hex": hex::encode(app_data),
+                "aspect": "lxmf.delivery",
+                "hops": 1,
+            }),
+        ))
+        .expect("delivery announce");
+    assert!(announce.error.is_none());
+
+    assert_eq!(daemon.outbound_stamp_cost_for(peer.as_str()).expect("stamp cost lookup"), Some(12));
+    assert!(!daemon.peer_record_exists(peer.as_str(), false));
+    assert!(
+        daemon
+            .store
+            .list_peer_unhandled_propagation(peer.as_str())
+            .expect("pending propagation")
+            .is_empty()
+    );
+    let announce_event = daemon
+        .event_queue
+        .lock()
+        .expect("event queue")
+        .iter()
+        .find(|event| event.event_type == "announce_received")
+        .cloned()
+        .expect("announce event");
+    assert_eq!(announce_event.payload["aspect"], json!("lxmf.delivery"));
+    assert_eq!(announce_event.payload["stamp_cost"], json!(12));
+}
+
+#[test]
 fn announce_received_ignores_python_invalid_delivery_stamp_cost_from_app_data() {
     let daemon = RpcDaemon::test_instance();
     let app_data = rmp_serde::to_vec_named(&MsgPackValue::Array(vec![

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -527,10 +527,12 @@ Scoped release evidence is split as follows:
 - RPC daemon `lxmf.delivery` announce ingestion now wakes stored pending
   direct/default-direct and opportunistic outbound messages for the announced
   destination while leaving propagated, paper, terminal, already-sending, and
-  other-destination records untouched. Reticulumd direct/opportunistic peer
-  identity misses after delivery path-request timeout now enter nonterminal
-  `queued: waiting for announce` state, so later delivery announces can requeue
-  them instead of leaving a terminal `failed:*` receipt.
+  other-destination records untouched. Delivery announces stay isolated from
+  propagation-router side effects: they do not admit propagation peers, refresh
+  propagation metadata, or queue stored propagation entries. Reticulumd
+  direct/opportunistic peer identity misses after delivery path-request timeout
+  now enter nonterminal `queued: waiting for announce` state, so later delivery
+  announces can requeue them instead of leaving a terminal `failed:*` receipt.
 - Direct and propagated resource sends support receipt-state separation,
   timeout/failure propagation, and active resource cancellation.
 - Link sends now register packet/resource receipt tracking before handoff and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -126,10 +126,12 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - RPC daemon `lxmf.delivery` announces reschedule stored pending direct,
   default-direct, and opportunistic outbound messages for the announced
   destination, without waking propagated, paper, terminal, already-sending, or
-  nonmatching records. Reticulumd direct/opportunistic identity/path misses now
-  persist as nonterminal `queued: waiting for announce`, preserving them for
-  the delivery-announce wakeup path while propagated/propagation-node misses
-  stay terminal.
+  nonmatching records. Delivery announces also stay out of propagation-router
+  peer admission, metadata refresh, and stored-entry queue side effects, keeping
+  Python's delivery-vs-propagation announce boundary explicit. Reticulumd
+  direct/opportunistic identity/path misses now persist as nonterminal
+  `queued: waiting for announce`, preserving them for the delivery-announce
+  wakeup path while propagated/propagation-node misses stay terminal.
 
 ### Tickets and stamps
 


### PR DESCRIPTION
## Summary
- keep lxmf.delivery announce handling out of propagation peer admission and queue refresh paths
- preserve delivery stamp-cost caching, announce events, and pending direct/opportunistic wakeups
- document the closed LXMF handler/router parity gap in the roadmap and parity matrix

## Validation
- cargo fmt --all -- --check
- cargo test -p reticulum-rs-rpc delivery_announce_does_not_create_propagation_peer_or_queue_entries -- --nocapture
- cargo test -p reticulum-rs-rpc announce_received_parses_delivery_stamp_cost_from_python_app_data -- --nocapture
- cargo test -p reticulum-rs-rpc announce_received_wakes_pending_direct_and_opportunistic_outbound -- --nocapture
- cargo test -p reticulum-rs-rpc announce_received_parses_propagation_peer_limits_from_python_app_data -- --nocapture
- tools/scripts/check-module-size.sh
- git diff --check