### PR TITLE
Stop hot-applied TCP servers on removal

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/tests/interface_hot_apply.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests/interface_hot_apply.rs
@@ -97,6 +97,17 @@ async fn wait_for_tcp_server_connect(host: &str, port: u16) -> TcpStream {
     panic!("tcp_server hot-apply listener did not accept connections: {last_error:?}");
 }
 
+async fn wait_for_tcp_server_rejects_connect(host: &str, port: u16) {
+    let endpoint = format!("{host}:{port}");
+    for _ in 0..40 {
+        if TcpStream::connect(&endpoint).await.is_err() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("tcp_server hot-apply listener still accepted connections after removal");
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn hot_apply_spawns_tcp_client_connections() {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
@@ -185,6 +196,59 @@ async fn hot_apply_spawns_tcp_server_localhost_listener() {
     );
 
     let _stream = wait_for_tcp_server_connect("127.0.0.1", port).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn hot_apply_removes_tcp_server_when_disabled_closes_listener() {
+    let reserved = TcpListener::bind("127.0.0.1:0").await.expect("reserve listener port");
+    let port = reserved.local_addr().expect("reserved listener addr").port();
+    drop(reserved);
+    let iface_manager = Arc::new(tokio::sync::Mutex::new(InterfaceManager::new(8)));
+    let mut managed = HashMap::new();
+    let refreshes = udp_refreshes();
+    let tcp_refreshes = tcp_listener_refreshes();
+
+    apply_hot_apply_interface_records(
+        &iface_manager,
+        &mut managed,
+        vec![tcp_server_record("listener", "127.0.0.1", port)],
+        None,
+        &tcp_refreshes,
+        &refreshes,
+        None,
+    )
+    .await;
+
+    let address = managed.get("listener").expect("managed tcp_server").address;
+    assert!(tcp_refreshes
+        .lock()
+        .expect("tcp listener refresh mutex poisoned")
+        .contains_key("listener"));
+    let stream = wait_for_tcp_server_connect("127.0.0.1", port).await;
+    drop(stream);
+
+    let mut disabled = tcp_server_record("listener", "127.0.0.1", port);
+    disabled.enabled = false;
+    apply_hot_apply_interface_records(
+        &iface_manager,
+        &mut managed,
+        vec![disabled],
+        None,
+        &tcp_refreshes,
+        &refreshes,
+        None,
+    )
+    .await;
+
+    assert!(managed.is_empty());
+    assert!(!tcp_refreshes
+        .lock()
+        .expect("tcp listener refresh mutex poisoned")
+        .contains_key("listener"));
+    let manager = iface_manager.lock().await;
+    assert_eq!(manager.role(&address), None);
+    drop(manager);
+    wait_for_tcp_server_rejects_connect("127.0.0.1", port).await;
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/interface_mutation_policy.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/interface_mutation_policy.rs
@@ -225,6 +225,29 @@
     }
 
     #[test]
+    fn set_interfaces_hot_applies_empty_interface_set() {
+        let daemon = RpcDaemon::test_instance();
+        daemon.replace_interfaces(vec![tcp_server_interface("listener", "127.0.0.1", 4242)]);
+        let bridge = std::sync::Arc::new(RecordingInterfaceMutationBridge::new());
+        daemon.set_interface_mutation_bridge(bridge.clone());
+
+        let response = daemon
+            .handle_rpc(rpc_request(
+                28,
+                "set_interfaces",
+                json!({
+                    "interfaces": []
+                }),
+            ))
+            .expect("set_interfaces response");
+
+        assert!(response.error.is_none(), "unexpected error: {response:?}");
+        assert_eq!(response.result.expect("result")["updated"], json!(true));
+        assert_eq!(bridge.applied(), vec![Vec::<InterfaceRecord>::new()]);
+        assert!(daemon.interfaces.lock().expect("interfaces mutex poisoned").is_empty());
+    }
+
+    #[test]
     fn set_interfaces_reports_non_loopback_tcp_server_requires_restart() {
         let daemon = RpcDaemon::test_instance();
 

--- a/crates/libs/rns-transport/src/iface_parts/interfacemanager.rs
+++ b/crates/libs/rns-transport/src/iface_parts/interfacemanager.rs
@@ -3,7 +3,7 @@ impl InterfaceManager {
         let (rx_send, rx_recv) = InterfaceChannel::make_rx_channel(rx_cap);
         let rx_recv = Arc::new(tokio::sync::Mutex::new(rx_recv));
 
-        Self { counter: 0, rx_recv, rx_send, cancel: CancellationToken::new(), ifaces: Vec::new() }
+        Self { counter: 0, rx_recv, rx_send, ifaces: Vec::new() }
     }
 
     pub fn new_channel(&mut self, tx_cap: usize) -> InterfaceChannel {
@@ -83,8 +83,9 @@ impl InterfaceManager {
         let mtu = inner.configured_mtu();
         let channel =
             self.new_channel_with_role_mode_mtu(DEFAULT_IFACE_TX_QUEUE_CAPACITY, role, mode, mtu);
+        let cancel = channel.stop.clone();
         let inner = Arc::new(Mutex::new(inner));
-        InterfaceContext::<T> { inner: inner.clone(), channel, cancel: self.cancel.clone() }
+        InterfaceContext::<T> { inner: inner.clone(), channel, cancel }
     }
 
     pub fn spawn<T: Interface, F, R>(&mut self, inner: T, worker: F) -> AddressHash

--- a/crates/libs/rns-transport/src/iface_parts/txmessagetype.rs
+++ b/crates/libs/rns-transport/src/iface_parts/txmessagetype.rs
@@ -221,6 +221,5 @@ pub struct InterfaceManager {
     counter: usize,
     rx_recv: Arc<tokio::sync::Mutex<InterfaceRxReceiver>>,
     rx_send: InterfaceRxSender,
-    cancel: CancellationToken,
     ifaces: Vec<LocalInterface>,
 }

--- a/crates/libs/rns-transport/src/iface_tests.rs
+++ b/crates/libs/rns-transport/src/iface_tests.rs
@@ -60,6 +60,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stop_interface_cancels_spawned_worker_context() {
+        struct TestInterface;
+
+        impl Interface for TestInterface {
+            fn mtu() -> usize {
+                64
+            }
+        }
+
+        let mut mgr = InterfaceManager::new(16);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let address = mgr.spawn(TestInterface, |context| async move {
+            context.cancel.cancelled().await;
+            let _ = tx.send(());
+        });
+
+        assert!(mgr.stop_interface(address));
+        tokio::time::timeout(std::time::Duration::from_secs(1), rx)
+            .await
+            .expect("worker should observe interface stop")
+            .expect("worker should report stop");
+    }
+
+    #[tokio::test]
     async fn direct_packet_over_configured_mtu_is_not_queued() {
         let mut mgr = InterfaceManager::new(16);
         let mut rx = mgr

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -440,9 +440,10 @@ Scoped release evidence is split as follows:
   and malformed-datagram `bytes_rx`/`decode_errors` telemetry without external
   network services. `set_interfaces` and `reload_config` now hot-apply explicit
   loopback TCP server listeners, including the local `localhost` hostname,
-  alongside TCP clients and explicit UDP
-  listener, peer, and multicast-bind records, with tests proving
-  `device`-bound, non-local, and broader TCP server listener shapes stay
+  alongside TCP clients and explicit UDP listener, peer, and multicast-bind
+  records; explicit TCP server hot-apply now covers listener removal/disable
+  cleanup as well as add/update lifecycle, with tests proving `device`-bound,
+  non-local, and broader TCP server listener shapes stay
   restart-required or invalid, UDP `device`-bound, partial-target,
   out-of-range-target, and multicast-forward shapes remain restart-required or
   invalid, and duplicate TCP server or UDP binds are rejected before mutation.

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -142,15 +142,18 @@ placeholders:
   `bytes_rx`/`decode_errors` telemetry without external network services.
   Runtime interface mutation now hot-applies explicit loopback TCP server
   listeners, including `localhost`, plus explicit UDP listener, peer, and
-  multicast-bind records through `set_interfaces` and `reload_config`, while
-  `device`-bound, non-local, and broader TCP server listener shapes, plus UDP
-  `device`-bound, partial-target, out-of-range-target, and multicast-forward
-  records, remain restart-required or invalid. Duplicate TCP server and UDP
-  binds are rejected before mutation. Hot-applied explicit TCP server records
-  attach live daemon/RPC `_runtime.tcp.listener_status` metadata, hot-applied
-  explicit UDP records attach the runtime iface and refresh live daemon/RPC
-  `_runtime.udp.status` counters under focused software tests; multicast-bind
-  hot-apply uses the transport peer-routing helper.
+  multicast-bind records through `set_interfaces` and `reload_config`.
+  Explicit TCP server hot-apply covers listener add/update plus
+  removal/disable cleanup, including runtime listener-status refresher
+  deregistration, while `device`-bound, non-local, and broader TCP server
+  listener shapes, plus UDP `device`-bound, partial-target,
+  out-of-range-target, and multicast-forward records, remain restart-required
+  or invalid. Duplicate TCP server and UDP binds are rejected before mutation.
+  Hot-applied explicit TCP server records attach live daemon/RPC
+  `_runtime.tcp.listener_status` metadata, hot-applied explicit UDP records
+  attach the runtime iface and refresh live daemon/RPC `_runtime.udp.status`
+  counters under focused software tests; multicast-bind hot-apply uses the
+  transport peer-routing helper.
 - Serial now refreshes live daemon/RPC status with open/reconnect, HDLC frame,
   packet, byte, EOF, queue, decode, serialize, read, and write-error counters.
   Serial KISS and AX.25 KISS retain Python-compatible AX.25 UI header wrapping


### PR DESCRIPTION
## Summary
- wire spawned interface workers to their per-interface stop tokens so stop_interface actually cancels runtime tasks
- add Reticulum hot-apply coverage proving disabled TCP server records close their listener, clear manager state, and unregister listener refresh metadata
- add RPC set_interfaces empty-set coverage and document explicit TCP server add/update/remove lifecycle parity

## Validation
- cargo test -p reticulum-rs-transport stop_interface_cancels_spawned_worker_context -- --nocapture
- cargo test -p reticulum-rs-rpc set_interfaces_hot_applies_empty_interface_set -- --nocapture
- cargo test -p reticulumd --bin reticulumd hot_apply_removes_tcp_server_when_disabled_closes_listener -- --nocapture
- cargo test -p reticulumd --bin reticulumd interface_hot_apply -- --nocapture
- cargo fmt --all -- --check
- tools/scripts/check-module-size.sh
- git diff --check