### PR TITLE
Expose conversation list over SDK envelope

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/handle_rpc_legacy_message_catalog.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/handle_rpc_legacy_message_catalog.rs
@@ -4,6 +4,103 @@ impl RpcDaemon {
         request: RpcRequest,
     ) -> Result<RpcResponse, std::io::Error> {
         match request.method.as_str() {
+            "list_conversations" => {
+                let parsed = request
+                    .params
+                    .map(serde_json::from_value::<ListConversationsParams>)
+                    .transpose()
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?
+                    .unwrap_or_default();
+                let limit = parsed.limit.unwrap_or(100).clamp(1, 5000);
+                let peer_id =
+                    parsed.peer_id.as_deref().map(str::trim).filter(|value| !value.is_empty());
+                let mut records = if let Some(peer) = peer_id {
+                    self.store.list_messages_page_for_peer(5000, None, None, peer)
+                } else {
+                    self.store.list_messages_page(5000, None, None)
+                }
+                .map_err(std::io::Error::other)?;
+                records.sort_by(|left, right| {
+                    right.timestamp.cmp(&left.timestamp).then_with(|| right.id.cmp(&left.id))
+                });
+                let peer_names = self
+                    .peers
+                    .lock()
+                    .expect("peers mutex poisoned")
+                    .values()
+                    .map(|peer| {
+                        (
+                            peer.peer.to_ascii_lowercase(),
+                            peer.name.clone().unwrap_or_else(|| peer.peer.clone()),
+                        )
+                    })
+                    .collect::<std::collections::HashMap<_, _>>();
+                let mut conversations = Vec::<JsonValue>::new();
+                for record in records {
+                    let conversation_id = conversation_id_for_message(&record);
+                    let Some(existing) = conversations.iter_mut().find(|conversation| {
+                        conversation["conversation_id"].as_str() == Some(conversation_id.as_str())
+                    }) else {
+                        let display_name = peer_names
+                            .get(&conversation_id.to_ascii_lowercase())
+                            .cloned()
+                            .map(JsonValue::from)
+                            .unwrap_or(JsonValue::Null);
+                        conversations.push(json!({
+                            "conversation_id": conversation_id,
+                            "peer_destination_hex": conversation_id,
+                            "peer_display_name": display_name,
+                            "last_message_preview": message_preview(record.content.as_str()),
+                            "last_message_at_ms": record.timestamp,
+                            "unread_count": u64::from(record.direction == "in"),
+                            "last_message_state": record.receipt_status,
+                        }));
+                        continue;
+                    };
+                    if record.direction == "in" {
+                        let current = existing["unread_count"].as_u64().unwrap_or(0);
+                        existing["unread_count"] = JsonValue::from(current.saturating_add(1));
+                    }
+                }
+                if let Some((Some(before_ts), before_id)) =
+                    parse_timestamp_id_cursor(parsed.cursor.as_deref())
+                {
+                    conversations.retain(|conversation| {
+                        let timestamp = conversation["last_message_at_ms"].as_i64().unwrap_or(0);
+                        if timestamp != before_ts {
+                            return timestamp < before_ts;
+                        }
+                        match (conversation["conversation_id"].as_str(), before_id.as_deref()) {
+                            (Some(id), Some(before_id)) => id < before_id,
+                            _ => false,
+                        }
+                    });
+                }
+                let has_more = conversations.len() > limit;
+                if has_more {
+                    conversations.truncate(limit);
+                }
+                let next_cursor = if has_more {
+                    conversations.last().and_then(|conversation| {
+                        Some(format!(
+                            "{}:{}",
+                            conversation["last_message_at_ms"].as_i64()?,
+                            conversation["conversation_id"].as_str()?
+                        ))
+                    })
+                } else {
+                    None
+                };
+                Ok(RpcResponse {
+                    id: request.id,
+                    result: Some(json!({
+                        "conversations": conversations,
+                        "next_cursor": next_cursor,
+                        "meta": self.response_meta(),
+                    })),
+                    error: None,
+                })
+            }
             "list_messages" => {
                 let parsed = request
                     .params
@@ -356,4 +453,20 @@ impl RpcDaemon {
             _ => unreachable!("legacy message catalog route: {}", request.method),
         }
     }
+}
+
+fn conversation_id_for_message(record: &MessageRecord) -> String {
+    if record.direction == "out" {
+        record.destination.clone()
+    } else {
+        record.source.clone()
+    }
+}
+
+fn message_preview(content: &str) -> Option<String> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.chars().take(80).collect())
 }

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/handle_rpc_legacy_messages.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/handle_rpc_legacy_messages.rs
@@ -4,7 +4,8 @@ impl RpcDaemon {
         request: RpcRequest,
     ) -> Result<RpcResponse, std::io::Error> {
         match request.method.as_str() {
-            "list_messages"
+            "list_conversations"
+            | "list_messages"
             | "sdk_poll_events_v2"
             | "list_announces"
             | "list_peers"

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations.rs
@@ -2,6 +2,8 @@ include!("sdk_operations_parts/module_prelude.rs");
 
 include!("sdk_operations_parts/sdk_operation_specs.rs");
 
+include!("sdk_operations_parts/conversation_operation_specs.rs");
+
 include!("sdk_operations_parts/propagation_operation_specs.rs");
 
 include!("sdk_operations_parts/rpcdaemon.rs");

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/conversation_operation_specs.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/conversation_operation_specs.rs
@@ -1,0 +1,10 @@
+const CONVERSATION_SDK_OPERATION_SPECS: &[SdkOperationSpec] = &[SdkOperationSpec {
+    id: "app.message.conversation.list",
+    group: "messaging",
+    kind: "query",
+    transport_variant: "legacy_rpc",
+    description: "List durable conversation summaries for app chat flows.",
+    aliases: &["list_conversations"],
+    required_capabilities: &[],
+    rpc_method: "list_conversations",
+}];

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/rpcdaemon_sections/handle_sdk_envelope_execute_v2.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/rpcdaemon_sections/handle_sdk_envelope_execute_v2.rs
@@ -112,7 +112,7 @@ impl RpcDaemon {
             "sdk_voice_session_open_v2" => parsed.payload,
             "sdk_voice_session_update_v2" => parsed.payload,
             "sdk_voice_session_close_v2" => parsed.payload,
-            "list_messages" => {
+            "list_conversations" | "list_messages" => {
                 if parsed.payload.is_object() {
                     parsed.payload
                 } else {

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/rpcdaemon_sections/operation_spec.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_operations_parts/rpcdaemon_sections/operation_spec.rs
@@ -1,13 +1,10 @@
 impl RpcDaemon {
-
     fn operation_spec(&self, id_or_alias: &str) -> Option<ResolvedSdkOperationSpec> {
-        if let Some(spec) =
-            SDK_OPERATION_SPECS.iter().chain(PROPAGATION_SDK_OPERATION_SPECS.iter()).find(
-                |spec| {
-                    spec.id == id_or_alias
-                        || spec.aliases.iter().any(|alias| alias == &id_or_alias)
-                },
-            )
+        if let Some(spec) = SDK_OPERATION_SPECS
+            .iter()
+            .chain(CONVERSATION_SDK_OPERATION_SPECS.iter())
+            .chain(PROPAGATION_SDK_OPERATION_SPECS.iter())
+            .find(|spec| spec.id == id_or_alias || spec.aliases.iter().any(|alias| alias == &id_or_alias))
         {
             return Some(ResolvedSdkOperationSpec {
                 id: spec.id.to_owned(),
@@ -37,6 +34,7 @@ impl RpcDaemon {
     pub(super) fn operation_registry_json(&self) -> JsonValue {
         let mut entries = SDK_OPERATION_SPECS
             .iter()
+            .chain(CONVERSATION_SDK_OPERATION_SPECS.iter())
             .chain(PROPAGATION_SDK_OPERATION_SPECS.iter())
             .filter(|spec| {
                 spec.required_capabilities
@@ -392,7 +390,7 @@ impl RpcDaemon {
                 method: method.to_owned(),
                 params: Some(params),
             })?,
-            "list_messages" => self.handle_rpc_legacy_messages(RpcRequest {
+            "list_conversations" | "list_messages" => self.handle_rpc_legacy_messages(RpcRequest {
                 id: request_id,
                 method: method.to_owned(),
                 params: Some(params),

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/message_storage_stats_track_count_an.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/status_snapshot_parts/message_storage_stats_track_count_an.rs
@@ -305,6 +305,141 @@ fn sdk_envelope_history_list_rejects_mismatched_peer_and_conversation_filters() 
 }
 
 #[test]
+fn sdk_registry_and_envelope_expose_conversation_list_summaries() {
+    let daemon = RpcDaemon::test_instance();
+    daemon
+        .accept_announce_with_metadata(
+            "peer-a".to_string(),
+            1_700_000_090,
+            Some("Peer Alpha".to_string()),
+            Some("announce".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some("lxmf.delivery".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("accept peer-a announce");
+    for (id, source, destination, content, timestamp, direction, receipt_status) in [
+        (
+            "peer-a-old",
+            "peer-a",
+            "local-destination",
+            "older alpha",
+            1_700_000_100,
+            "in",
+            Some("delivered"),
+        ),
+        (
+            "peer-b-out",
+            "local-destination",
+            "peer-b",
+            "outbound beta",
+            1_700_000_101,
+            "out",
+            Some("sent"),
+        ),
+        (
+            "peer-a-new",
+            "peer-a",
+            "local-destination",
+            " newest alpha update ",
+            1_700_000_102,
+            "in",
+            Some("delivered"),
+        ),
+    ] {
+        daemon
+            .accept_inbound(MessageRecord {
+                id: id.to_string(),
+                source: source.to_string(),
+                destination: destination.to_string(),
+                title: id.to_string(),
+                content: content.to_string(),
+                timestamp,
+                direction: direction.to_string(),
+                fields: None,
+                receipt_status: receipt_status.map(str::to_string),
+            })
+            .expect("store conversation message");
+    }
+
+    let registry = daemon
+        .handle_rpc(rpc_request(43, "sdk_operation_registry_v2", json!({})))
+        .expect("operation registry")
+        .result
+        .expect("registry result");
+    let entries = registry["registry"]["entries"].as_array().expect("registry entries");
+    assert!(entries.iter().any(|entry| {
+        entry["id"] == json!("app.message.conversation.list")
+            && entry["aliases"].as_array().is_some_and(|aliases| {
+                aliases.iter().any(|alias| alias == "list_conversations")
+            })
+    }));
+
+    let first = daemon
+        .handle_rpc(rpc_request(
+            44,
+            "sdk_envelope_execute_v2",
+            json!({
+                "operation_id": "app.message.conversation.list",
+                "kind": "query",
+                "payload": {
+                    "limit": 1
+                }
+            }),
+        ))
+        .expect("conversation first page")
+        .result
+        .expect("first page result");
+    let first_payload = &first["response"]["payload"];
+    let first_conversations =
+        first_payload["conversations"].as_array().expect("first conversations");
+    assert_eq!(first_conversations.len(), 1);
+    assert_eq!(first_conversations[0]["conversation_id"], json!("peer-a"));
+    assert_eq!(first_conversations[0]["peer_destination_hex"], json!("peer-a"));
+    assert_eq!(first_conversations[0]["peer_display_name"], json!("Peer Alpha"));
+    assert_eq!(first_conversations[0]["last_message_preview"], json!("newest alpha update"));
+    assert_eq!(first_conversations[0]["unread_count"].as_u64(), Some(2));
+    assert_eq!(first_conversations[0]["last_message_state"], json!("delivered"));
+    assert_eq!(first_payload["next_cursor"].as_str(), Some("1700000102:peer-a"));
+
+    let second = daemon
+        .handle_rpc(rpc_request(
+            45,
+            "sdk_envelope_execute_v2",
+            json!({
+                "operation_id": "app.message.conversation.list",
+                "kind": "query",
+                "payload": {
+                    "cursor": first_payload["next_cursor"].as_str().unwrap(),
+                    "limit": 1
+                }
+            }),
+        ))
+        .expect("conversation second page")
+        .result
+        .expect("second page result");
+    let second_payload = &second["response"]["payload"];
+    let second_conversations =
+        second_payload["conversations"].as_array().expect("second conversations");
+    assert_eq!(second_conversations.len(), 1);
+    assert_eq!(second_conversations[0]["conversation_id"], json!("peer-b"));
+    assert_eq!(second_conversations[0]["unread_count"].as_u64(), Some(0));
+    assert_eq!(second_conversations[0]["last_message_state"], json!("sent"));
+    assert_eq!(second_payload["next_cursor"], JsonValue::Null);
+}
+
+#[test]
 fn list_messages_omits_next_cursor_when_exact_limit_is_exhausted() {
     let daemon = RpcDaemon::test_instance();
     for id in ["msg-a", "msg-b"] {

--- a/crates/libs/rns-rpc/src/rpc/params/core.rs
+++ b/crates/libs/rns-rpc/src/rpc/params/core.rs
@@ -209,6 +209,16 @@ struct ListMessagesParams {
 }
 
 #[derive(Debug, Deserialize, Default)]
+struct ListConversationsParams {
+    #[serde(default)]
+    peer_id: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
 struct ListAnnouncesParams {
     #[serde(default)]
     limit: Option<usize>,

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -850,8 +850,9 @@ Scoped release evidence is split as follows:
 - The typed ZeroMQ SDK backend now exposes durable direct-chat conversation
   summaries through `ZmqPipelineBackendClient::list_conversations`, preserving
   peer display names, unread counts, last-message previews with links, receipt
-  inclusion intent, and restart pagination cursors through
-  `app.message.conversation.list` on the SDK envelope path.
+  inclusion intent, and restart pagination cursors through the daemon-registered
+  `app.message.conversation.list` SDK envelope path and `list_conversations`
+  alias.
 - The native SDK app domain now exposes `app.messages().history(...)` and
   `app.messages().conversations(...)` on the existing `Client` surface, so
   direct-chat clients can bind message-list and conversation-list UI without

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -430,8 +430,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - The typed ZeroMQ SDK backend exposes durable direct-chat conversation
   summaries through `ZmqPipelineBackendClient::list_conversations`, preserving
   peer display names, unread counts, last-message previews with links, receipt
-  inclusion intent, and restart pagination cursors through
-  `app.message.conversation.list` on the SDK envelope path.
+  inclusion intent, and restart pagination cursors through the daemon-registered
+  `app.message.conversation.list` SDK envelope path and `list_conversations`
+  alias.
 - The native SDK app domain now exposes the same durable message-list and
   conversation-list flows as `app.messages().history(...)` and
   `app.messages().conversations(...)`, so direct-chat clients can stay on the
@@ -902,9 +903,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   `propagation_offer_duplicate_wanted_source_completed_python_to_rust` cases
   for haves-only `/get` side effects, offer side effects, duplicate wanted-ID
   handling, and peer queue lifecycle evidence.
-- Focused daemon/RPC tests cover delivery modes, propagation offers, paper
-  operation registry/envelope dispatch, peer maintenance, queue policy, source
-  accounting, stamps, tickets, receipts, and cancellation.
+- Focused daemon/RPC tests cover delivery modes, direct-chat history and
+  conversation-list SDK envelopes, propagation offers, paper operation
+  registry/envelope dispatch, peer maintenance, queue policy, source accounting,
+  stamps, tickets, receipts, and cancellation.
 - Focused daemon bridge tests cover deferred normal-stamp queue ownership,
   cancellation, retry metadata, and propagation-stamp preparation before
   delivery handoff.


### PR DESCRIPTION
## Summary
- register app.message.conversation.list in the daemon SDK operation registry with the list_conversations alias
- add the legacy conversation projection used by the SDK envelope path, grouping direct-chat records by remote peer with previews, unread counts, state, display names, and cursors
- document the daemon-registered conversation envelope coverage in the roadmap and LXMF parity matrix

## Validation
- cargo fmt --all -- --check
- cargo test -p reticulum-rs-rpc sdk_registry_and_envelope_expose_conversation_list_summaries -- --nocapture
- cargo test -p reticulum-rs-rpc sdk_envelope_history_list_filters_peer_and_preserves_cursor -- --nocapture
- cargo test -p reticulum-rs-rpc sdk_release_c_domain_methods_roundtrip -- --nocapture
- cargo test -p lxmf-sdk --features zmq-pipeline-backend list_conversations_uses_zmq_sdk_envelope_and_preserves_restart_summary -- --nocapture
- cargo run -p xtask -- interop-drift-check
- tools/scripts/check-module-size.sh
- git diff --check