### PR TITLE
Cover unsafe UDP reload restart policy

### DIFF
--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/interface_mutation_policy.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/interface_mutation_policy.rs
@@ -78,6 +78,18 @@
         );
     }
 
+    fn assert_reload_restart_required_without_apply(
+        daemon: &RpcDaemon,
+        bridge: &RecordingInterfaceMutationBridge,
+        response: RpcResponse,
+        expected_interfaces: Vec<InterfaceRecord>,
+    ) {
+        assert_restart_required(response);
+        assert!(bridge.applied().is_empty(), "restart-required reload must not hot-apply");
+        let interfaces = daemon.interfaces.lock().expect("interfaces mutex poisoned").clone();
+        assert_eq!(interfaces, expected_interfaces);
+    }
+
     #[test]
     fn set_interfaces_rejects_startup_only_interface_kinds() {
         let daemon = RpcDaemon::test_instance();
@@ -834,7 +846,10 @@
     #[test]
     fn reload_config_reports_multicast_udp_forward_target_requires_restart() {
         let daemon = RpcDaemon::test_instance();
-        daemon.replace_interfaces(vec![udp_interface("udp-peer", "127.0.0.1", 4242)]);
+        let original_interfaces = vec![udp_interface("udp-peer", "127.0.0.1", 4242)];
+        daemon.replace_interfaces(original_interfaces.clone());
+        let bridge = std::sync::Arc::new(RecordingInterfaceMutationBridge::new());
+        daemon.set_interface_mutation_bridge(bridge.clone());
 
         let response = daemon
             .handle_rpc(rpc_request(
@@ -856,7 +871,98 @@
             ))
             .expect("reload_config response");
 
-        assert_restart_required(response);
+        assert_reload_restart_required_without_apply(&daemon, &bridge, response, original_interfaces);
+    }
+
+    #[test]
+    fn reload_config_reports_device_udp_requires_restart_without_partial_apply() {
+        let daemon = RpcDaemon::test_instance();
+        let original_interfaces = vec![udp_interface("udp-device", "127.0.0.1", 4242)];
+        daemon.replace_interfaces(original_interfaces.clone());
+        let bridge = std::sync::Arc::new(RecordingInterfaceMutationBridge::new());
+        daemon.set_interface_mutation_bridge(bridge.clone());
+
+        let response = daemon
+            .handle_rpc(rpc_request(
+                37,
+                "reload_config",
+                json!({
+                    "interfaces": [{
+                        "type": "udp",
+                        "enabled": true,
+                        "host": "127.0.0.1",
+                        "port": 4242,
+                        "name": "udp-device",
+                        "settings": {
+                            "device": "eth0"
+                        }
+                    }]
+                }),
+            ))
+            .expect("reload_config response");
+
+        assert_reload_restart_required_without_apply(&daemon, &bridge, response, original_interfaces);
+    }
+
+    #[test]
+    fn reload_config_reports_out_of_range_udp_forward_port_requires_restart_without_partial_apply() {
+        let daemon = RpcDaemon::test_instance();
+        let original_interfaces = vec![udp_interface("udp-peer", "127.0.0.1", 4242)];
+        daemon.replace_interfaces(original_interfaces.clone());
+        let bridge = std::sync::Arc::new(RecordingInterfaceMutationBridge::new());
+        daemon.set_interface_mutation_bridge(bridge.clone());
+
+        let response = daemon
+            .handle_rpc(rpc_request(
+                38,
+                "reload_config",
+                json!({
+                    "interfaces": [{
+                        "type": "udp",
+                        "enabled": true,
+                        "host": "127.0.0.1",
+                        "port": 4242,
+                        "name": "udp-peer",
+                        "settings": {
+                            "target_host": "127.0.0.1",
+                            "target_port": 70000
+                        }
+                    }]
+                }),
+            ))
+            .expect("reload_config response");
+
+        assert_reload_restart_required_without_apply(&daemon, &bridge, response, original_interfaces);
+    }
+
+    #[test]
+    fn reload_config_reports_partial_udp_forward_target_requires_restart_without_partial_apply() {
+        let daemon = RpcDaemon::test_instance();
+        let original_interfaces = vec![udp_interface("udp-peer", "127.0.0.1", 4242)];
+        daemon.replace_interfaces(original_interfaces.clone());
+        let bridge = std::sync::Arc::new(RecordingInterfaceMutationBridge::new());
+        daemon.set_interface_mutation_bridge(bridge.clone());
+
+        let response = daemon
+            .handle_rpc(rpc_request(
+                39,
+                "reload_config",
+                json!({
+                    "interfaces": [{
+                        "type": "udp",
+                        "enabled": true,
+                        "host": "127.0.0.1",
+                        "port": 4242,
+                        "name": "udp-peer",
+                        "settings": {
+                            "target_host": "127.0.0.1"
+                        }
+                    }]
+                }),
+            ))
+            .expect("reload_config response");
+
+        assert_reload_restart_required_without_apply(&daemon, &bridge, response, original_interfaces);
     }
 
     #[test]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -445,7 +445,8 @@ Scoped release evidence is split as follows:
   `device`-bound, non-local, and broader TCP server listener shapes stay
   restart-required or invalid, UDP `device`-bound, partial-target,
   out-of-range-target, and multicast-forward shapes remain restart-required or
-  invalid, and duplicate TCP server or UDP binds are rejected before mutation.
+  invalid, including `reload_config` no-partial-apply evidence for unsafe UDP
+  records, and duplicate TCP server or UDP binds are rejected before mutation.
   Hot-applied explicit TCP server records attach live daemon/RPC
   `_runtime.tcp.listener_status` metadata, hot-applied explicit UDP records
   attach the runtime iface and refresh live daemon/RPC `_runtime.udp.status`

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -145,8 +145,10 @@ placeholders:
   multicast-bind records through `set_interfaces` and `reload_config`, while
   `device`-bound, non-local, and broader TCP server listener shapes, plus UDP
   `device`-bound, partial-target, out-of-range-target, and multicast-forward
-  records, remain restart-required or invalid. Duplicate TCP server and UDP
-  binds are rejected before mutation. Hot-applied explicit TCP server records
+  records, remain restart-required or invalid, with `reload_config` evidence
+  that unsafe UDP records do not invoke the mutation bridge or change stored
+  interfaces. Duplicate TCP server and UDP binds are rejected before mutation.
+  Hot-applied explicit TCP server records
   attach live daemon/RPC `_runtime.tcp.listener_status` metadata, hot-applied
   explicit UDP records attach the runtime iface and refresh live daemon/RPC
   `_runtime.udp.status` counters under focused software tests; multicast-bind


### PR DESCRIPTION
## Summary
- add reload_config coverage for device-bound UDP records, partial UDP forward targets, and out-of-range UDP forward ports
- assert unsafe UDP reloads return CONFIG_RESTART_REQUIRED without invoking the interface mutation bridge or changing stored interfaces
- tighten Reticulum parity docs around reload_config no-partial-apply evidence for unsafe UDP records

## Validation
- cargo fmt --all -- --check
- cargo test -p reticulum-rs-rpc reload_config_reports_device_udp_requires_restart_without_partial_apply -- --nocapture
- cargo test -p reticulum-rs-rpc reload_config_reports_out_of_range_udp_forward_port_requires_restart_without_partial_apply -- --nocapture
- cargo test -p reticulum-rs-rpc reload_config_reports_partial_udp_forward_target_requires_restart_without_partial_apply -- --nocapture
- cargo test -p reticulum-rs-rpc reload_config_reports_multicast_udp_forward_target_requires_restart -- --nocapture
- cargo test -p reticulumd --bin reticulumd interface_hot_apply -- --nocapture
- git diff --check

## Note
- tools/scripts/check-module-size.sh was attempted and reported unrelated pre-existing oversized reticulumd test-part files: tests_parts/bootstrap_reports_auto_interface_as.rs and tests_parts/vrn76_builder_rejects_missing_periph.rs. This PR only changes rns-rpc interface mutation policy tests and status docs.