### PR TITLE
Hot-apply Pipe interface records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,6 +2184,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sha2",
+ "shlex",
  "tempfile",
  "tokio",
  "zeroize",

--- a/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply.rs
@@ -1,5 +1,6 @@
 use rns_rpc::{InterfaceMutationBridge, InterfaceRecord, RpcDaemon};
 use rns_transport::hash::AddressHash;
+use rns_transport::iface::pipe::{PipeInterface, PipeRuntimeStatusHandle};
 use rns_transport::iface::tcp_client::TcpClient;
 use rns_transport::iface::tcp_server::{TcpListenerRuntimeStatusHandle, TcpServer};
 use rns_transport::iface::udp::{UdpInterface, UdpRuntimeStatusHandle};
@@ -13,12 +14,18 @@ use tokio::sync::mpsc::{channel, error::TrySendError, Receiver, Sender};
 use crate::bootstrap::{
     mark_interface_runtime_fields, mark_interface_runtime_managed, mark_interface_startup_status,
 };
+#[cfg(test)]
+use interface_hot_apply_parts::pipe_runtime_refresh::refresh_hot_apply_pipe_runtime_status_once;
+use interface_hot_apply_parts::pipe_runtime_refresh::{
+    attach_hot_apply_pipe_runtime_status, spawn_hot_apply_pipe_runtime_status_refresher,
+    HotApplyPipeRefresh,
+};
 use interface_hot_apply_parts::record_hot_apply::{
     apply_record_runtime_config, hot_apply_interface_key, hot_apply_interface_record_changed,
     hot_apply_interface_seed_key as record_hot_apply_interface_seed_key, interface_record_mode,
-    mark_tcp_server_record_runtime_status, mark_udp_record_runtime_status, tcp_endpoint,
-    tcp_server_bind_addr, tcp_server_client_mtu, udp_bind_and_forward_addr,
-    validate_hot_apply_uniqueness,
+    mark_pipe_record_runtime_status, mark_tcp_server_record_runtime_status,
+    mark_udp_record_runtime_status, pipe_adapter, tcp_endpoint, tcp_server_bind_addr,
+    tcp_server_client_mtu, udp_bind_and_forward_addr, validate_hot_apply_uniqueness,
 };
 #[cfg(test)]
 use interface_hot_apply_parts::tcp_runtime_refresh::refresh_hot_apply_tcp_listener_runtime_status_once;
@@ -43,9 +50,37 @@ pub(super) struct InterfaceHotApplyBridge {
     tcp_listener_refreshes: Arc<StdMutex<HashMap<String, HotApplyTcpListenerRefresh>>>,
     #[cfg(test)]
     udp_refreshes: Arc<StdMutex<HashMap<String, HotApplyUdpRefresh>>>,
+    #[cfg(test)]
+    pipe_refreshes: Arc<StdMutex<HashMap<String, HotApplyPipeRefresh>>>,
 }
 
 const INTERFACE_HOT_APPLY_QUEUE_CAPACITY: usize = 64;
+
+#[derive(Clone)]
+struct HotApplyRuntimeRefreshes {
+    tcp_listeners: Arc<StdMutex<HashMap<String, HotApplyTcpListenerRefresh>>>,
+    udp: Arc<StdMutex<HashMap<String, HotApplyUdpRefresh>>>,
+    pipe: Arc<StdMutex<HashMap<String, HotApplyPipeRefresh>>>,
+}
+
+impl HotApplyRuntimeRefreshes {
+    fn new() -> Self {
+        Self {
+            tcp_listeners: Arc::new(StdMutex::new(HashMap::new())),
+            udp: Arc::new(StdMutex::new(HashMap::new())),
+            pipe: Arc::new(StdMutex::new(HashMap::new())),
+        }
+    }
+
+    fn spawn_refreshers(&self, daemon: Weak<RpcDaemon>) {
+        spawn_hot_apply_tcp_listener_runtime_status_refresher(
+            daemon.clone(),
+            self.tcp_listeners.clone(),
+        );
+        spawn_hot_apply_udp_runtime_status_refresher(daemon.clone(), self.udp.clone());
+        spawn_hot_apply_pipe_runtime_status_refresher(daemon, self.pipe.clone());
+    }
+}
 
 impl InterfaceHotApplyBridge {
     #[cfg(test)]
@@ -80,30 +115,26 @@ impl InterfaceHotApplyBridge {
         daemon: Option<Weak<RpcDaemon>>,
     ) -> Self {
         let (tx, rx) = channel(INTERFACE_HOT_APPLY_QUEUE_CAPACITY);
-        let tcp_listener_refreshes = Arc::new(StdMutex::new(HashMap::new()));
-        let udp_refreshes = Arc::new(StdMutex::new(HashMap::new()));
+        let refreshes = HotApplyRuntimeRefreshes::new();
         if let Some(daemon) = daemon.clone() {
-            spawn_hot_apply_tcp_listener_runtime_status_refresher(
-                daemon.clone(),
-                tcp_listener_refreshes.clone(),
-            );
-            spawn_hot_apply_udp_runtime_status_refresher(daemon, udp_refreshes.clone());
+            refreshes.spawn_refreshers(daemon);
         }
         tokio::spawn(run_interface_mutation_worker(
             iface_manager,
             rx,
             seeded,
             transport.clone(),
-            tcp_listener_refreshes.clone(),
-            udp_refreshes.clone(),
+            refreshes.clone(),
             daemon,
         ));
         Self {
             tx,
             #[cfg(test)]
-            tcp_listener_refreshes,
+            tcp_listener_refreshes: refreshes.tcp_listeners,
             #[cfg(test)]
-            udp_refreshes,
+            udp_refreshes: refreshes.udp,
+            #[cfg(test)]
+            pipe_refreshes: refreshes.pipe,
         }
     }
 }
@@ -118,7 +149,7 @@ impl InterfaceMutationBridge for InterfaceHotApplyBridge {
             .iter()
             .cloned()
             .map(|mut record| {
-                if matches!(record.kind.as_str(), "tcp_client" | "tcp_server" | "udp")
+                if matches!(record.kind.as_str(), "tcp_client" | "tcp_server" | "udp" | "pipe")
                     && record.enabled
                 {
                     mark_interface_startup_status(&mut record, "spawned", None, None);
@@ -127,6 +158,7 @@ impl InterfaceMutationBridge for InterfaceHotApplyBridge {
                     match record.kind.as_str() {
                         "tcp_server" => mark_tcp_server_record_runtime_status(&mut record, None),
                         "udp" => mark_udp_record_runtime_status(&mut record, None),
+                        "pipe" => mark_pipe_record_runtime_status(&mut record, None),
                         _ => {}
                     }
                 }
@@ -163,8 +195,7 @@ async fn run_interface_mutation_worker(
     mut rx: Receiver<InterfaceHotApplyCommand>,
     seeded: Vec<(String, InterfaceRecord, AddressHash)>,
     transport: Option<Arc<Transport>>,
-    tcp_listener_refreshes: Arc<StdMutex<HashMap<String, HotApplyTcpListenerRefresh>>>,
-    udp_refreshes: Arc<StdMutex<HashMap<String, HotApplyUdpRefresh>>>,
+    refreshes: HotApplyRuntimeRefreshes,
     daemon: Option<Weak<RpcDaemon>>,
 ) {
     let mut managed = seeded
@@ -180,8 +211,7 @@ async fn run_interface_mutation_worker(
                     &mut managed,
                     interfaces,
                     transport.as_ref(),
-                    &tcp_listener_refreshes,
-                    &udp_refreshes,
+                    &refreshes,
                     daemon.as_ref(),
                 )
                 .await;
@@ -195,8 +225,7 @@ async fn apply_hot_apply_interface_records(
     managed: &mut HashMap<String, ManagedHotApplyInterface>,
     interfaces: Vec<InterfaceRecord>,
     transport: Option<&Arc<Transport>>,
-    tcp_listener_refreshes: &Arc<StdMutex<HashMap<String, HotApplyTcpListenerRefresh>>>,
-    udp_refreshes: &Arc<StdMutex<HashMap<String, HotApplyUdpRefresh>>>,
+    refreshes: &HotApplyRuntimeRefreshes,
     daemon: Option<&Weak<RpcDaemon>>,
 ) {
     let desired = interfaces
@@ -218,11 +247,13 @@ async fn apply_hot_apply_interface_records(
         };
         if should_remove {
             if let Some(current) = managed.remove(&key) {
-                tcp_listener_refreshes
+                refreshes
+                    .tcp_listeners
                     .lock()
                     .expect("tcp listener refresh mutex poisoned")
                     .remove(&key);
-                udp_refreshes.lock().expect("udp refresh mutex poisoned").remove(&key);
+                refreshes.udp.lock().expect("udp refresh mutex poisoned").remove(&key);
+                refreshes.pipe.lock().expect("pipe refresh mutex poisoned").remove(&key);
                 stop_hot_apply_interface(iface_manager, transport, current.address).await;
             }
         }
@@ -244,7 +275,8 @@ async fn apply_hot_apply_interface_records(
             match runtime_status {
                 Some(HotApplyRuntimeStatus::TcpListener(status)) => {
                     attach_hot_apply_tcp_listener_runtime_status(daemon, &record, address, &status);
-                    tcp_listener_refreshes
+                    refreshes
+                        .tcp_listeners
                         .lock()
                         .expect("tcp listener refresh mutex poisoned")
                         .insert(
@@ -261,9 +293,20 @@ async fn apply_hot_apply_interface_records(
                         status.iface = Some(address.to_string());
                     });
                     attach_hot_apply_udp_runtime_status(daemon, &record, address, &status);
-                    udp_refreshes.lock().expect("udp refresh mutex poisoned").insert(
+                    refreshes.udp.lock().expect("udp refresh mutex poisoned").insert(
                         key.clone(),
                         HotApplyUdpRefresh {
+                            record: record.clone(),
+                            runtime_iface: address,
+                            status,
+                        },
+                    );
+                }
+                Some(HotApplyRuntimeStatus::Pipe(status)) => {
+                    attach_hot_apply_pipe_runtime_status(daemon, &record, address, &status);
+                    refreshes.pipe.lock().expect("pipe refresh mutex poisoned").insert(
+                        key.clone(),
+                        HotApplyPipeRefresh {
                             record: record.clone(),
                             runtime_iface: address,
                             status,
@@ -280,6 +323,7 @@ async fn apply_hot_apply_interface_records(
 enum HotApplyRuntimeStatus {
     TcpListener(TcpListenerRuntimeStatusHandle),
     Udp(UdpRuntimeStatusHandle),
+    Pipe(PipeRuntimeStatusHandle),
 }
 
 pub(super) fn hot_apply_interface_seed_key(record: &InterfaceRecord) -> Option<String> {
@@ -356,6 +400,23 @@ async fn spawn_hot_apply_interface(
                     Some(HotApplyRuntimeStatus::Udp(status)),
                 )
             }
+        }
+        "pipe" => {
+            let adapter = match pipe_adapter(record) {
+                Ok(adapter) => adapter,
+                Err(error) => {
+                    log::warn!("[daemon] hot-apply pipe rejected invalid command: {error}");
+                    return None;
+                }
+            };
+            let status = adapter.runtime_status_handle();
+            let address = iface_manager.lock().await.spawn_as_with_mode(
+                adapter,
+                PipeInterface::spawn,
+                IfaceRole::Unicast,
+                mode,
+            );
+            (address, Some(HotApplyRuntimeStatus::Pipe(status)))
         }
         _ => return None,
     };

--- a/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply_parts.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply_parts.rs
@@ -1,3 +1,5 @@
+#[path = "interface_hot_apply_parts/pipe_runtime_refresh.rs"]
+pub(super) mod pipe_runtime_refresh;
 #[path = "interface_hot_apply_parts/record_hot_apply.rs"]
 pub(super) mod record_hot_apply;
 #[path = "interface_hot_apply_parts/record_settings.rs"]

--- a/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply_parts/pipe_runtime_refresh.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply_parts/pipe_runtime_refresh.rs
@@ -1,0 +1,79 @@
+use rns_rpc::{InterfaceRecord, RpcDaemon};
+use rns_transport::hash::AddressHash;
+use rns_transport::iface::pipe::PipeRuntimeStatusHandle;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex, Weak};
+use std::time::Duration;
+
+const HOT_APPLY_PIPE_STATUS_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+
+#[derive(Clone)]
+pub(crate) struct HotApplyPipeRefresh {
+    pub(crate) record: InterfaceRecord,
+    pub(crate) runtime_iface: AddressHash,
+    pub(crate) status: PipeRuntimeStatusHandle,
+}
+
+pub(crate) fn attach_hot_apply_pipe_runtime_status(
+    daemon: Option<&Weak<RpcDaemon>>,
+    record: &InterfaceRecord,
+    runtime_iface: AddressHash,
+    status: &PipeRuntimeStatusHandle,
+) {
+    let Some(daemon) = daemon.and_then(Weak::upgrade) else {
+        return;
+    };
+    let _ = daemon.update_interface_runtime_metadata_by_record(
+        record,
+        runtime_iface.to_string().as_str(),
+        "pipe",
+        "status",
+        status.to_json(),
+    );
+}
+
+pub(crate) fn spawn_hot_apply_pipe_runtime_status_refresher(
+    daemon: Weak<RpcDaemon>,
+    refreshes: Arc<StdMutex<HashMap<String, HotApplyPipeRefresh>>>,
+) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(HOT_APPLY_PIPE_STATUS_REFRESH_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            interval.tick().await;
+            let Some(daemon) = daemon.upgrade() else {
+                break;
+            };
+            refresh_hot_apply_pipe_runtime_status_once(&daemon, &refreshes);
+        }
+    });
+}
+
+pub(crate) fn refresh_hot_apply_pipe_runtime_status_once(
+    daemon: &RpcDaemon,
+    refreshes: &Arc<StdMutex<HashMap<String, HotApplyPipeRefresh>>>,
+) -> usize {
+    refreshes
+        .lock()
+        .expect("pipe refresh mutex poisoned")
+        .values()
+        .filter(|refresh| {
+            if daemon.update_interface_runtime_metadata_by_iface(
+                refresh.runtime_iface.to_string().as_str(),
+                "pipe",
+                "status",
+                refresh.status.to_json(),
+            ) {
+                true
+            } else {
+                daemon.update_interface_runtime_metadata_by_record(
+                    &refresh.record,
+                    refresh.runtime_iface.to_string().as_str(),
+                    "pipe",
+                    "status",
+                    refresh.status.to_json(),
+                )
+            }
+        })
+        .count()
+}

--- a/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply_parts/record_hot_apply.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply_parts/record_hot_apply.rs
@@ -1,10 +1,12 @@
 use rns_rpc::InterfaceRecord;
 use rns_transport::hash::AddressHash;
+use rns_transport::iface::pipe::PipeInterface;
 use rns_transport::iface::{InterfaceManager, InterfaceMode};
 use std::io;
+use std::time::Duration;
 
 use super::record_settings::interface_record_shared_config;
-use super::record_settings::{setting_bool, setting_str, setting_u64};
+use super::record_settings::{setting_bool, setting_f64, setting_str, setting_u64};
 
 pub(crate) fn validate_hot_apply_uniqueness(
     interfaces: &[InterfaceRecord],
@@ -31,6 +33,9 @@ pub(crate) fn validate_hot_apply_uniqueness(
                 ));
             }
         }
+        if record.kind == "pipe" && record.enabled {
+            pipe_adapter(record)?;
+        }
         let Some(key) = hot_apply_interface_key(record) else {
             continue;
         };
@@ -49,6 +54,7 @@ pub(crate) fn hot_apply_interface_key(record: &InterfaceRecord) -> Option<String
         "tcp_client" => tcp_interface_key(record),
         "tcp_server" => tcp_server_interface_key(record),
         "udp" => udp_interface_key(record),
+        "pipe" => pipe_interface_key(record),
         _ => None,
     }
 }
@@ -77,6 +83,12 @@ pub(crate) fn hot_apply_interface_seed_key(record: &InterfaceRecord) -> Option<S
         "udp" => {
             udp_bind_and_forward_addr(record).ok()?;
             udp_interface_key(record)
+        }
+        "pipe" => {
+            if record.enabled {
+                pipe_adapter(record).ok()?;
+            }
+            pipe_interface_key(record)
         }
         _ => None,
     }
@@ -119,6 +131,8 @@ pub(crate) fn hot_apply_interface_record_changed(
         || (current.kind == "tcp_server"
             && tcp_server_client_mtu(current) != tcp_server_client_mtu(next))
         || (current.kind == "udp" && udp_forward_addr(current) != udp_forward_addr(next))
+        || (current.kind == "pipe"
+            && pipe_runtime_signature(current) != pipe_runtime_signature(next))
 }
 
 pub(crate) fn tcp_endpoint(record: &InterfaceRecord) -> Option<String> {
@@ -286,6 +300,77 @@ pub(crate) fn mark_tcp_server_record_runtime_status(
             );
         });
     }
+}
+
+pub(crate) fn pipe_interface_key(record: &InterfaceRecord) -> Option<String> {
+    if record.kind != "pipe" {
+        return None;
+    }
+    if let Some(name) =
+        record.name.as_ref().map(|value| value.trim()).filter(|value| !value.is_empty())
+    {
+        return Some(name.to_string());
+    }
+    pipe_command(record).ok()
+}
+
+pub(crate) fn pipe_adapter(record: &InterfaceRecord) -> Result<PipeInterface, io::Error> {
+    let command = pipe_command(record)?;
+    PipeInterface::parse_command(command.as_str()).map_err(|err| {
+        io::Error::new(io::ErrorKind::InvalidInput, format!("pipe hot-apply {err}"))
+    })?;
+    let respawn_delay = pipe_respawn_delay(record)?;
+    Ok(PipeInterface::new(command)
+        .with_respawn_delay(respawn_delay)
+        .with_mtu(pipe_mtu(record).unwrap_or(PipeInterface::DEFAULT_MTU)))
+}
+
+pub(crate) fn mark_pipe_record_runtime_status(
+    record: &mut InterfaceRecord,
+    runtime_iface: Option<AddressHash>,
+) {
+    let Ok(adapter) = pipe_adapter(record) else {
+        return;
+    };
+    let iface = runtime_iface.map(|value| value.to_string());
+    crate::bootstrap::with_interface_runtime_metadata(record, |runtime| {
+        runtime.insert(
+            "pipe".to_string(),
+            serde_json::json!({
+                "status": adapter.runtime_status_json(),
+                "mtu": adapter.mtu_value(),
+                "iface": iface,
+            }),
+        );
+    });
+}
+
+fn pipe_runtime_signature(record: &InterfaceRecord) -> Option<(String, u64, usize)> {
+    let command = pipe_command(record).ok()?;
+    let respawn_millis = u64::try_from(pipe_respawn_delay(record).ok()?.as_millis()).ok()?;
+    let mtu = pipe_mtu(record).unwrap_or(PipeInterface::DEFAULT_MTU).max(256);
+    Some((command, respawn_millis, mtu))
+}
+
+fn pipe_command(record: &InterfaceRecord) -> Result<String, io::Error> {
+    setting_str(record, "command").map(ToOwned::to_owned).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "pipe hot-apply requires command")
+    })
+}
+
+fn pipe_respawn_delay(record: &InterfaceRecord) -> Result<Duration, io::Error> {
+    let delay = setting_f64(record, "respawn_delay").unwrap_or(5.0);
+    if delay < 0.0 || !delay.is_finite() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "pipe hot-apply respawn_delay must be finite and >= 0",
+        ));
+    }
+    Ok(Duration::from_secs_f64(delay))
+}
+
+fn pipe_mtu(record: &InterfaceRecord) -> Option<usize> {
+    setting_u64(record, "mtu").and_then(|value| usize::try_from(value).ok())
 }
 
 fn host_is_multicast(host: &str) -> bool {

--- a/crates/apps/reticulumd/src/bin/reticulumd/tests/interface_hot_apply.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests/interface_hot_apply.rs
@@ -1,6 +1,7 @@
 use super::{
-    apply_hot_apply_interface_records, refresh_hot_apply_tcp_listener_runtime_status_once,
-    refresh_hot_apply_udp_runtime_status_once, HotApplyUdpRefresh, InterfaceHotApplyBridge,
+    apply_hot_apply_interface_records, refresh_hot_apply_pipe_runtime_status_once,
+    refresh_hot_apply_tcp_listener_runtime_status_once, refresh_hot_apply_udp_runtime_status_once,
+    HotApplyPipeRefresh, HotApplyRuntimeRefreshes, HotApplyUdpRefresh, InterfaceHotApplyBridge,
     InterfaceManager, InterfaceMutationBridge, InterfaceRecord, ManagedHotApplyInterface,
 };
 use rand_core::OsRng;
@@ -63,13 +64,32 @@ fn udp_peer_record(
     record
 }
 
+fn pipe_record(name: &str, command: &str) -> InterfaceRecord {
+    InterfaceRecord {
+        kind: "pipe".to_string(),
+        enabled: true,
+        host: None,
+        port: None,
+        name: Some(name.to_string()),
+        settings: Some(json!({ "command": command })),
+    }
+}
+
 fn udp_refreshes() -> Arc<std::sync::Mutex<HashMap<String, HotApplyUdpRefresh>>> {
+    Arc::new(std::sync::Mutex::new(HashMap::new()))
+}
+
+fn pipe_refreshes() -> Arc<std::sync::Mutex<HashMap<String, HotApplyPipeRefresh>>> {
     Arc::new(std::sync::Mutex::new(HashMap::new()))
 }
 
 fn tcp_listener_refreshes(
 ) -> Arc<std::sync::Mutex<HashMap<String, super::HotApplyTcpListenerRefresh>>> {
     Arc::new(std::sync::Mutex::new(HashMap::new()))
+}
+
+fn runtime_refreshes() -> HotApplyRuntimeRefreshes {
+    HotApplyRuntimeRefreshes::new()
 }
 
 fn test_bridge(
@@ -79,6 +99,7 @@ fn test_bridge(
         tx,
         tcp_listener_refreshes: tcp_listener_refreshes(),
         udp_refreshes: udp_refreshes(),
+        pipe_refreshes: pipe_refreshes(),
     }
 }
 
@@ -205,14 +226,12 @@ async fn hot_apply_spawns_tcp_client_with_record_runtime_settings() {
         "announce_interval": 21600
     }));
 
-    let refreshes = udp_refreshes();
-    let tcp_refreshes = tcp_listener_refreshes();
+    let refreshes = runtime_refreshes();
     apply_hot_apply_interface_records(
         &iface_manager,
         &mut managed,
         vec![record],
         None,
-        &tcp_refreshes,
         &refreshes,
         None,
     )
@@ -256,14 +275,12 @@ async fn hot_apply_updates_existing_tcp_client_runtime_settings() {
         "publish_ifac": true
     }));
 
-    let refreshes = udp_refreshes();
-    let tcp_refreshes = tcp_listener_refreshes();
+    let refreshes = runtime_refreshes();
     apply_hot_apply_interface_records(
         &iface_manager,
         &mut managed,
         vec![record],
         None,
-        &tcp_refreshes,
         &refreshes,
         None,
     )
@@ -289,14 +306,12 @@ async fn hot_apply_spawns_udp_unicast_listener_with_runtime_metadata() {
     let mut managed = HashMap::new();
     let record = udp_record("udp-loopback", "127.0.0.1", 0);
 
-    let refreshes = udp_refreshes();
-    let tcp_refreshes = tcp_listener_refreshes();
+    let refreshes = runtime_refreshes();
     apply_hot_apply_interface_records(
         &iface_manager,
         &mut managed,
         vec![record.clone()],
         None,
-        &tcp_refreshes,
         &refreshes,
         None,
     )
@@ -385,6 +400,25 @@ async fn wait_for_hot_apply_udp_refresh(
     panic!("hot-applied udp refresh was not registered");
 }
 
+async fn wait_for_hot_apply_pipe_refresh(
+    bridge: &InterfaceHotApplyBridge,
+) -> (rns_transport::hash::AddressHash, HotApplyPipeRefresh) {
+    for _ in 0..20 {
+        if let Some(refresh) = bridge
+            .pipe_refreshes
+            .lock()
+            .expect("pipe refresh mutex poisoned")
+            .values()
+            .next()
+            .cloned()
+        {
+            return (refresh.runtime_iface, refresh);
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("hot-applied pipe refresh was not registered");
+}
+
 async fn wait_for_hot_apply_tcp_listener_refresh(
     bridge: &InterfaceHotApplyBridge,
 ) -> (rns_transport::hash::AddressHash, super::HotApplyTcpListenerRefresh) {
@@ -446,6 +480,64 @@ async fn hot_apply_tcp_server_refresh_attaches_listener_status() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn hot_apply_spawns_pipe_with_runtime_metadata() {
+    let iface_manager = Arc::new(tokio::sync::Mutex::new(InterfaceManager::new(8)));
+    let bridge = InterfaceHotApplyBridge::spawn(iface_manager.clone(), Vec::new());
+    let mut record = pipe_record("pipe-cat", "cat");
+    record.settings = Some(json!({ "command": "cat", "mtu": 512, "respawn_delay": 0.25 }));
+
+    let applied = bridge.apply_interfaces(vec![record]).expect("apply pipe interface");
+    let runtime = applied[0]
+        .settings
+        .as_ref()
+        .and_then(|value| value.get("_runtime"))
+        .expect("runtime metadata");
+    assert_eq!(runtime.get("startup_status").and_then(|value| value.as_str()), Some("spawned"));
+    assert_eq!(runtime.get("runtime_status").and_then(|value| value.as_str()), Some("running"));
+    let pipe = runtime.get("pipe").expect("pipe runtime metadata");
+    assert_eq!(pipe.get("mtu").and_then(|value| value.as_u64()), Some(512));
+    assert_eq!(
+        pipe.get("status").and_then(|value| value.get("command")).and_then(|value| value.as_str()),
+        Some("cat")
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn hot_apply_pipe_refresh_attaches_runtime_status() {
+    let daemon = Arc::new(RpcDaemon::test_instance());
+    let iface_manager = Arc::new(tokio::sync::Mutex::new(InterfaceManager::new(8)));
+    let bridge = InterfaceHotApplyBridge::spawn_with_daemon(
+        iface_manager,
+        Vec::new(),
+        Arc::downgrade(&daemon),
+    );
+
+    let applied =
+        bridge.apply_interfaces(vec![pipe_record("pipe-cat", "cat")]).expect("apply pipe");
+    daemon.replace_interfaces(applied);
+    let (runtime_iface, refresh) = wait_for_hot_apply_pipe_refresh(&bridge).await;
+    refresh.status.record_error_for_test("backoff", "test pipe closed");
+
+    assert_eq!(refresh_hot_apply_pipe_runtime_status_once(&daemon, &bridge.pipe_refreshes), 1);
+    let result = daemon
+        .handle_rpc(RpcRequest { id: 774, method: "daemon_status_ex".to_string(), params: None })
+        .expect("daemon status")
+        .result
+        .expect("daemon status result");
+    let status = &result["interfaces"][0]["settings"]["_runtime"]["pipe"]["status"];
+
+    assert_eq!(
+        result["interfaces"][0]["settings"]["_runtime"]["iface"].as_str(),
+        Some(runtime_iface.to_string().as_str())
+    );
+    assert_eq!(status["command"].as_str(), Some("cat"));
+    assert_eq!(status["process_state"].as_str(), Some("backoff"));
+    assert_eq!(status["pipe_is_open"].as_bool(), Some(false));
+    assert_eq!(status["respawn_attempts"].as_u64(), Some(1));
+    assert_eq!(status["last_error"].as_str(), Some("test pipe closed"));
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn hot_apply_spawns_udp_unicast_peer_with_runtime_metadata() {
     let iface_manager = Arc::new(tokio::sync::Mutex::new(InterfaceManager::new(8)));
     let bridge = InterfaceHotApplyBridge::spawn(iface_manager.clone(), Vec::new());
@@ -473,14 +565,12 @@ async fn hot_apply_replaces_udp_when_bind_changes() {
     let iface_manager = Arc::new(tokio::sync::Mutex::new(InterfaceManager::new(8)));
     let mut managed = HashMap::new();
 
-    let refreshes = udp_refreshes();
-    let tcp_refreshes = tcp_listener_refreshes();
+    let refreshes = runtime_refreshes();
     apply_hot_apply_interface_records(
         &iface_manager,
         &mut managed,
         vec![udp_record("udp-loopback", "127.0.0.1", 0)],
         None,
-        &tcp_refreshes,
         &refreshes,
         None,
     )
@@ -491,7 +581,6 @@ async fn hot_apply_replaces_udp_when_bind_changes() {
         &mut managed,
         vec![udp_record("udp-loopback", "127.0.0.2", 0)],
         None,
-        &tcp_refreshes,
         &refreshes,
         None,
     )
@@ -521,14 +610,12 @@ async fn hot_apply_replaces_startup_seeded_udp_when_bind_changes() {
         },
     )]);
 
-    let refreshes = udp_refreshes();
-    let tcp_refreshes = tcp_listener_refreshes();
+    let refreshes = runtime_refreshes();
     apply_hot_apply_interface_records(
         &iface_manager,
         &mut managed,
         vec![udp_record("udp-loopback", "127.0.0.2", 0)],
         None,
-        &tcp_refreshes,
         &refreshes,
         None,
     )
@@ -557,14 +644,12 @@ async fn hot_apply_removes_startup_seeded_udp_when_disabled() {
     let mut disabled = udp_record("udp-loopback", "127.0.0.1", 4242);
     disabled.enabled = false;
 
-    let refreshes = udp_refreshes();
-    let tcp_refreshes = tcp_listener_refreshes();
+    let refreshes = runtime_refreshes();
     apply_hot_apply_interface_records(
         &iface_manager,
         &mut managed,
         vec![disabled],
         None,
-        &tcp_refreshes,
         &refreshes,
         None,
     )
@@ -573,6 +658,39 @@ async fn hot_apply_removes_startup_seeded_udp_when_disabled() {
     assert!(managed.is_empty());
     let manager = iface_manager.lock().await;
     assert_eq!(manager.role(&address), None);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn hot_apply_replaces_pipe_when_command_changes() {
+    let iface_manager = Arc::new(tokio::sync::Mutex::new(InterfaceManager::new(8)));
+    let mut managed = HashMap::new();
+    let refreshes = runtime_refreshes();
+
+    apply_hot_apply_interface_records(
+        &iface_manager,
+        &mut managed,
+        vec![pipe_record("pipe-cat", "cat")],
+        None,
+        &refreshes,
+        None,
+    )
+    .await;
+    let first = managed.get("pipe-cat").expect("first pipe").address;
+    apply_hot_apply_interface_records(
+        &iface_manager,
+        &mut managed,
+        vec![pipe_record("pipe-cat", "cat -u")],
+        None,
+        &refreshes,
+        None,
+    )
+    .await;
+
+    let second = managed.get("pipe-cat").expect("replacement pipe").address;
+    assert_ne!(first, second);
+    let manager = iface_manager.lock().await;
+    assert_eq!(manager.role(&first), None);
+    assert_eq!(manager.role(&second), Some(IfaceRole::Unicast));
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/libs/rns-rpc/Cargo.toml
+++ b/crates/libs/rns-rpc/Cargo.toml
@@ -26,6 +26,7 @@ hkdf.workspace = true
 log.workspace = true
 base64.workspace = true
 serde_json.workspace = true
+shlex.workspace = true
 ciborium.workspace = true
 serde_bytes.workspace = true
 rusqlite = { workspace = true }

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/interface_mutation_helpers.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/interface_mutation_helpers.rs
@@ -26,7 +26,7 @@ impl RpcDaemon {
         );
         details.insert(
             "legacy_hot_apply_supported_kinds".to_string(),
-            json!(["tcp_client", "tcp_server", "udp"]),
+            json!(["tcp_client", "tcp_server", "udp", "pipe"]),
         );
         error.details = Some(Box::new(details));
 
@@ -131,6 +131,7 @@ impl RpcDaemon {
             "tcp_client" => true,
             "tcp_server" => Self::tcp_server_record_is_hot_apply_safe(iface),
             "udp" => Self::udp_record_is_hot_apply_safe(iface),
+            "pipe" => Self::pipe_record_is_hot_apply_safe(iface),
             _ => false,
         }
     }
@@ -140,6 +141,7 @@ impl RpcDaemon {
             "tcp_client" => Self::legacy_tcp_interface_key(iface),
             "tcp_server" => Self::legacy_tcp_server_interface_key(iface),
             "udp" => Self::legacy_udp_interface_key(iface),
+            "pipe" => Self::legacy_pipe_interface_key(iface),
             _ => None,
         }
     }
@@ -208,6 +210,33 @@ impl RpcDaemon {
         Some(format!("{host}:{port}"))
     }
 
+    fn legacy_pipe_interface_key(iface: &InterfaceRecord) -> Option<String> {
+        if iface.kind != "pipe" {
+            return None;
+        }
+        if let Some(name) = iface.name.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+            return Some(name.to_string());
+        }
+        Self::interface_setting_str(iface, "command").map(ToOwned::to_owned)
+    }
+
+    fn pipe_record_is_hot_apply_safe(iface: &InterfaceRecord) -> bool {
+        if iface.kind != "pipe" {
+            return false;
+        }
+        if !iface.enabled {
+            return Self::legacy_pipe_interface_key(iface).is_some();
+        }
+        let Some(command) = Self::interface_setting_str(iface, "command") else {
+            return false;
+        };
+        if shlex::split(command).is_none_or(|argv| argv.is_empty()) {
+            return false;
+        }
+        let respawn_delay = Self::interface_setting_f64(iface, "respawn_delay").unwrap_or(5.0);
+        respawn_delay >= 0.0 && respawn_delay.is_finite()
+    }
+
     fn legacy_tcp_server_bind_addr(iface: &InterfaceRecord) -> Option<String> {
         if iface.kind != "tcp_server" {
             return None;
@@ -227,6 +256,10 @@ impl RpcDaemon {
 
     fn interface_setting_u64(iface: &InterfaceRecord, key: &str) -> Option<u64> {
         Self::interface_setting(iface, key)?.as_u64()
+    }
+
+    fn interface_setting_f64(iface: &InterfaceRecord, key: &str) -> Option<f64> {
+        Self::interface_setting(iface, key)?.as_f64()
     }
 
     fn interface_setting_bool(iface: &InterfaceRecord, key: &str) -> Option<bool> {

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/interface_mutation_policy.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/interface_mutation_policy.rs
@@ -31,6 +31,17 @@
         }
     }
 
+    fn pipe_interface(name: &str, command: &str) -> InterfaceRecord {
+        InterfaceRecord {
+            kind: "pipe".to_string(),
+            enabled: true,
+            host: None,
+            port: None,
+            name: Some(name.to_string()),
+            settings: Some(json!({ "command": command })),
+        }
+    }
+
     struct RecordingInterfaceMutationBridge {
         applied: std::sync::Mutex<Vec<Vec<InterfaceRecord>>>,
     }
@@ -459,6 +470,33 @@
     }
 
     #[test]
+    fn set_interfaces_hot_applies_pipe_records() {
+        let daemon = RpcDaemon::test_instance();
+        let bridge = std::sync::Arc::new(RecordingInterfaceMutationBridge::new());
+        daemon.set_interface_mutation_bridge(bridge.clone());
+
+        let response = daemon
+            .handle_rpc(rpc_request(
+                37,
+                "set_interfaces",
+                json!({
+                    "interfaces": [{
+                        "type": "pipe",
+                        "enabled": true,
+                        "name": "pipe-cat",
+                        "settings": { "command": "cat" }
+                    }]
+                }),
+            ))
+            .expect("set_interfaces response");
+
+        assert!(response.error.is_none(), "unexpected error: {response:?}");
+        assert_eq!(bridge.applied(), vec![vec![pipe_interface("pipe-cat", "cat")]]);
+        let interfaces = daemon.interfaces.lock().expect("interfaces mutex poisoned").clone();
+        assert_eq!(interfaces, vec![pipe_interface("pipe-cat", "cat")]);
+    }
+
+    #[test]
     fn set_interfaces_hot_applies_multicast_udp_records() {
         let daemon = RpcDaemon::test_instance();
         let bridge = std::sync::Arc::new(RecordingInterfaceMutationBridge::new());
@@ -796,6 +834,35 @@
         assert_eq!(result["hot_applied_legacy_tcp_only"], json!(false));
         assert_eq!(result["hot_applied_interface_mutation"], json!(true));
         assert_eq!(bridge.applied(), vec![vec![udp_interface("udp-main", "127.0.0.1", 4248)]]);
+    }
+
+    #[test]
+    fn reload_config_hot_applies_pipe_only_diff() {
+        let daemon = RpcDaemon::test_instance();
+        daemon.replace_interfaces(vec![pipe_interface("pipe-cat", "cat")]);
+        let bridge = std::sync::Arc::new(RecordingInterfaceMutationBridge::new());
+        daemon.set_interface_mutation_bridge(bridge.clone());
+
+        let response = daemon
+            .handle_rpc(rpc_request(
+                38,
+                "reload_config",
+                json!({
+                    "interfaces": [{
+                        "type": "pipe",
+                        "enabled": true,
+                        "name": "pipe-cat",
+                        "settings": { "command": "cat -u" }
+                    }]
+                }),
+            ))
+            .expect("reload_config response");
+
+        assert!(response.error.is_none(), "unexpected reload error: {response:?}");
+        let result = response.result.expect("result");
+        assert_eq!(result["hot_applied_legacy_tcp_only"], json!(false));
+        assert_eq!(result["hot_applied_interface_mutation"], json!(true));
+        assert_eq!(bridge.applied(), vec![vec![pipe_interface("pipe-cat", "cat -u")]]);
     }
 
     #[test]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -195,7 +195,9 @@ Scoped release evidence is split as follows:
   `RNODE_HIL_ARTIFACT_MANIFEST` verification for
   `schema = "reticulum_interface_hil_matrix_artifacts.v1"` matrix artifacts,
   Pipe subprocess HDLC with a software fake-subprocess smoke for strict daemon
-  startup and refreshed `rnstatus-rs` JSON/human runtime status, UDP
+  startup and refreshed `rnstatus-rs` JSON/human runtime status plus
+  `set_interfaces`/`reload_config` hot-apply for Pipe records with live
+  `_runtime.pipe.status` refresh, UDP
   unicast/multicast plus
   Python-style UDP `device` broadcast-address defaults, IPv4 broadcast socket
   sends, shared-`port` forward fallback semantics, and a software loopback
@@ -443,14 +445,17 @@ Scoped release evidence is split as follows:
   alongside TCP clients and explicit UDP
   listener, peer, and multicast-bind records, with tests proving
   `device`-bound, non-local, and broader TCP server listener shapes stay
-  restart-required or invalid, UDP `device`-bound, partial-target,
+  restart-required or invalid, Pipe records validate command quoting and finite
+  nonnegative respawn delays before mutation, UDP `device`-bound, partial-target,
   out-of-range-target, and multicast-forward shapes remain restart-required or
   invalid, and duplicate TCP server or UDP binds are rejected before mutation.
   Hot-applied explicit TCP server records attach live daemon/RPC
   `_runtime.tcp.listener_status` metadata, hot-applied explicit UDP records
   attach the runtime iface and refresh live daemon/RPC `_runtime.udp.status`
-  counters under focused software tests, and multicast-bind hot-apply goes
-  through the transport peer-routing helper instead of a bare UDP spawn. Serial
+  counters, hot-applied Pipe records attach and refresh live daemon/RPC
+  `_runtime.pipe.status` under focused software tests, and multicast-bind
+  hot-apply goes through the transport peer-routing helper instead of a bare
+  UDP spawn. Serial
   now refreshes live open/reconnect, HDLC frame, packet, byte, EOF, queue,
   decode, serialize, read, and write-error counters.
   KISS/AX.25 KISS and KISS TCP now refresh live packet, data-frame,

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -1,6 +1,6 @@
 # Reticulum Parity Matrix
 
-Last reassessed: 2026-07-06
+Last reassessed: 2026-07-08
 
 This is the maintained row-level status for Python Reticulum compatibility.
 Repository-level posture and execution order live in
@@ -20,7 +20,7 @@ Workspace paths are used for navigation. Published package names are
 
 | Python surface | Rust surface | Status | Implemented baseline | Residual gap |
 | --- | --- | --- | --- | --- |
-| `RNS/Reticulum.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | Deployable daemon, configuration, propagation-node activation, persistence, RPC, graceful shutdown, unified legacy `status`/`daemon_status_ex` daemon runtime snapshot visibility, daemon/RPC runtime status for Reticulum path-table restore success or failure, multiple live interfaces, and runtime `set_interfaces`/`reload_config` hot-apply for TCP clients, explicit loopback TCP server listeners including `localhost`, and explicit UDP listener, peer, and multicast-bind records. | Python runtime/config mutation remains wider for device-bound, multicast-forward, non-local listener, and broader interface shapes; interface breadth remains wider. |
+| `RNS/Reticulum.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | partial | Deployable daemon, configuration, propagation-node activation, persistence, RPC, graceful shutdown, unified legacy `status`/`daemon_status_ex` daemon runtime snapshot visibility, daemon/RPC runtime status for Reticulum path-table restore success or failure, multiple live interfaces, and runtime `set_interfaces`/`reload_config` hot-apply for TCP clients, explicit loopback TCP server listeners including `localhost`, explicit UDP listener, peer, and multicast-bind records, and Pipe subprocess records with refreshed `_runtime.pipe.status`. | Python runtime/config mutation remains wider for device-bound, multicast-forward, non-local listener, and broader interface shapes; interface breadth remains wider. |
 | `RNS/Identity.py` | `crates/libs/rns-core` | done | Identity material, hashing, signing, encryption, recall, and key conversion. | No confirmed parity blocker. |
 | `RNS/Destination.py` | `crates/libs/rns-core`, `crates/libs/rns-transport` | done | Destination hashing, descriptors, announces, proof validation, ratchets, and known-key stability checks. | No confirmed parity blocker. |
 | `RNS/Packet.py` | `crates/libs/rns-core`, `crates/libs/rns-transport` | done | Framing, serialization, contexts, proofs, receipts, Python-default link proof context, and header semantics. | No confirmed parity blocker. |
@@ -130,6 +130,11 @@ placeholders:
   status reporting through daemon/RPC `_runtime.pipe.status`. A software
   fake-subprocess smoke now proves strict daemon startup and `rnstatus-rs`
   JSON/human reporting for a running `cat` subprocess without external devices.
+  Runtime interface mutation now hot-applies enabled or disabled Pipe records
+  through `set_interfaces` and `reload_config`, validates command quoting plus
+  finite nonnegative respawn delays before mutation, replaces the runtime
+  interface when command, respawn delay, or MTU changes, and refreshes live
+  daemon/RPC `_runtime.pipe.status` for hot-applied subprocesses.
 - UDP unicast and multicast with peer routing, multicast proof fallback,
   Python-style `device` broadcast-address defaults via host interface lookup,
   IPv4 broadcast socket sends, and Python `UDPInterface` alias semantics where
@@ -141,16 +146,18 @@ placeholders:
   strict startup, bound loopback status, and malformed-datagram
   `bytes_rx`/`decode_errors` telemetry without external network services.
   Runtime interface mutation now hot-applies explicit loopback TCP server
-  listeners, including `localhost`, plus explicit UDP listener, peer, and
-  multicast-bind records through `set_interfaces` and `reload_config`, while
+  listeners, including `localhost`, explicit UDP listener, peer, and
+  multicast-bind records, and Pipe subprocess records through `set_interfaces`
+  and `reload_config`, while
   `device`-bound, non-local, and broader TCP server listener shapes, plus UDP
   `device`-bound, partial-target, out-of-range-target, and multicast-forward
   records, remain restart-required or invalid. Duplicate TCP server and UDP
   binds are rejected before mutation. Hot-applied explicit TCP server records
   attach live daemon/RPC `_runtime.tcp.listener_status` metadata, hot-applied
   explicit UDP records attach the runtime iface and refresh live daemon/RPC
-  `_runtime.udp.status` counters under focused software tests; multicast-bind
-  hot-apply uses the transport peer-routing helper.
+  `_runtime.udp.status` counters, and hot-applied Pipe records attach and
+  refresh live daemon/RPC `_runtime.pipe.status` under focused software tests;
+  multicast-bind hot-apply uses the transport peer-routing helper.
 - Serial now refreshes live daemon/RPC status with open/reconnect, HDLC frame,
   packet, byte, EOF, queue, decode, serialize, read, and write-error counters.
   Serial KISS and AX.25 KISS retain Python-compatible AX.25 UI header wrapping


### PR DESCRIPTION
## Summary
- extend legacy interface mutation policy so `set_interfaces` and `reload_config` can hot-apply valid Pipe records
- spawn, replace, remove, and refresh hot-applied Pipe subprocess interfaces in `reticulumd` with live `_runtime.pipe.status` metadata
- document the Reticulum parity increment and remaining restart-required interface shapes

## Validation
- cargo fmt --all -- --check
- cargo test -p reticulum-rs-rpc set_interfaces_hot_applies_pipe_records -- --nocapture
- cargo test -p reticulum-rs-rpc reload_config_hot_applies_pipe_only_diff -- --nocapture
- cargo test -p reticulumd hot_apply_spawns_pipe_with_runtime_metadata -- --nocapture
- cargo test -p reticulumd hot_apply_pipe_refresh_attaches_runtime_status -- --nocapture
- cargo test -p reticulumd hot_apply_replaces_pipe_when_command_changes -- --nocapture
- cargo test -p reticulumd interface_hot_apply -- --nocapture
- cargo test -p reticulum-rs-rpc --lib
- tools/scripts/check-module-size.sh
- tools/scripts/check-boundaries.sh
- git diff --check