### PR TITLE
Expose path restore skip accounting

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport.rs
@@ -289,11 +289,12 @@ pub(super) async fn start_transport_and_interfaces(
         {
             Ok(report) => {
                 let restored = report.restored_active_paths;
+                let skipped = report.skipped;
                 restored_path_identities = report.restored_identities;
                 if restored > 0 {
                     log::info!("[daemon] restored {} Reticulum path table entries", restored);
                 }
-                PathTableRestoreStatus::Ok { restored_active_paths: restored }
+                PathTableRestoreStatus::Ok { restored_active_paths: restored, skipped }
             }
             Err(err) => {
                 let message = err.to_string();

--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport_path_restore.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport_path_restore.rs
@@ -1,20 +1,22 @@
 use super::super::with_interface_runtime_metadata;
 use rns_rpc::InterfaceRecord;
+use rns_transport::transport::ReticulumPathTableRestoreSkipped;
 use serde_json::{json, Value as JsonValue};
 
 #[derive(Clone, Debug)]
 pub(super) enum PathTableRestoreStatus {
-    Ok { restored_active_paths: usize },
+    Ok { restored_active_paths: usize, skipped: ReticulumPathTableRestoreSkipped },
     Error { message: String },
 }
 
 impl PathTableRestoreStatus {
     fn runtime_json(&self) -> JsonValue {
         match self {
-            Self::Ok { restored_active_paths } => {
+            Self::Ok { restored_active_paths, skipped } => {
                 json!({
                     "status": "ok",
                     "restored_active_paths": restored_active_paths,
+                    "skipped": skipped_runtime_json(skipped),
                 })
             }
             Self::Error { message } => {
@@ -25,6 +27,23 @@ impl PathTableRestoreStatus {
             }
         }
     }
+}
+
+fn skipped_runtime_json(skipped: &ReticulumPathTableRestoreSkipped) -> JsonValue {
+    json!({
+        "active_unmapped_interface": skipped.active_unmapped_interface,
+        "active_expired": skipped.active_expired,
+        "active_missing_cached_announce": skipped.active_missing_cached_announce,
+        "active_invalid_cached_announce": skipped.active_invalid_cached_announce,
+        "active_mismatched_cached_announce": skipped.active_mismatched_cached_announce,
+        "active_identity_conflict": skipped.active_identity_conflict,
+        "tunnel_duplicate_packet_hash": skipped.tunnel_duplicate_packet_hash,
+        "tunnel_expired": skipped.tunnel_expired,
+        "tunnel_missing_cached_announce": skipped.tunnel_missing_cached_announce,
+        "tunnel_invalid_cached_announce": skipped.tunnel_invalid_cached_announce,
+        "tunnel_mismatched_cached_announce": skipped.tunnel_mismatched_cached_announce,
+        "tunnel_identity_conflict": skipped.tunnel_identity_conflict,
+    })
 }
 
 pub(super) fn mark_path_table_restore_status(

--- a/crates/apps/reticulumd/src/bin/reticulumd/tests_parts/bootstrap_restores_path_cache.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests_parts/bootstrap_restores_path_cache.rs
@@ -256,6 +256,11 @@ fn bootstrap_skips_malformed_cached_announce_entry_without_restore_error() {
     let restore_status = path_table_restore_runtime_status(&context.daemon);
     assert_eq!(restore_status["status"].as_str(), Some("ok"));
     assert_eq!(restore_status["restored_active_paths"].as_u64(), Some(1));
+    assert_eq!(
+        restore_status["skipped"]["active_invalid_cached_announce"].as_u64(),
+        Some(1)
+    );
+    assert_eq!(restore_status["skipped"]["active_missing_cached_announce"].as_u64(), Some(0));
 }
 
 #[test]

--- a/crates/libs/rns-transport/src/transport/mod.rs
+++ b/crates/libs/rns-transport/src/transport/mod.rs
@@ -68,7 +68,10 @@ mod reticulum_announce_cache;
 mod reticulum_path_store;
 mod tunnels;
 
-pub use reticulum_path_store::{RestoredReticulumPathIdentity, ReticulumPathTableRestoreReport};
+pub use reticulum_path_store::{
+    RestoredReticulumPathIdentity, ReticulumPathTableRestoreReport,
+    ReticulumPathTableRestoreSkipped,
+};
 
 pub mod test_bridge {
     use std::cell::RefCell;

--- a/crates/libs/rns-transport/src/transport/reticulum_announce_cache.rs
+++ b/crates/libs/rns-transport/src/transport/reticulum_announce_cache.rs
@@ -26,37 +26,46 @@ impl ReticulumAnnounceCache {
         tokio::fs::write(self.path(packet_hash), payload).await
     }
 
-    pub(super) async fn restore(&self, packet_hash: Hash) -> io::Result<Option<CachedAnnounce>> {
-        let Some(packet) = self.read_packet(packet_hash).await? else {
-            return Ok(None);
+    pub(super) async fn restore_classified(
+        &self,
+        packet_hash: Hash,
+    ) -> io::Result<CachedAnnounceRestore> {
+        let packet = match self.read_packet(packet_hash).await? {
+            CachedAnnouncePacketRestore::Restored(packet) => packet,
+            CachedAnnouncePacketRestore::Missing => return Ok(CachedAnnounceRestore::Missing),
+            CachedAnnouncePacketRestore::Invalid => return Ok(CachedAnnounceRestore::Invalid),
         };
         if packet.header.packet_type != PacketType::Announce {
-            return Ok(None);
+            return Ok(CachedAnnounceRestore::Invalid);
         }
         let Ok(announce) = DestinationAnnounce::validate(&packet) else {
-            return Ok(None);
+            return Ok(CachedAnnounceRestore::Invalid);
         };
         let destination = announce.destination;
-        Ok(Some(CachedAnnounce { packet, destination }))
+        Ok(CachedAnnounceRestore::Restored(Box::new(CachedAnnounce { packet, destination })))
     }
 
-    async fn read_packet(&self, packet_hash: Hash) -> io::Result<Option<Packet>> {
+    async fn read_packet(&self, packet_hash: Hash) -> io::Result<CachedAnnouncePacketRestore> {
         let payload = match tokio::fs::read(self.path(packet_hash)).await {
             Ok(payload) => payload,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                return Ok(CachedAnnouncePacketRestore::Missing)
+            }
             Err(err) => return Err(err),
         };
         let value: RmpValue = match rmpv::decode::read_value(&mut std::io::Cursor::new(payload)) {
             Ok(value) => value,
-            Err(_) => return Ok(None),
+            Err(_) => return Ok(CachedAnnouncePacketRestore::Invalid),
         };
         let RmpValue::Array(fields) = value else {
-            return Ok(None);
+            return Ok(CachedAnnouncePacketRestore::Invalid);
         };
         let Some(raw) = fields.first().and_then(rmp_bytes) else {
-            return Ok(None);
+            return Ok(CachedAnnouncePacketRestore::Invalid);
         };
-        Ok(Packet::from_bytes(raw).ok())
+        Ok(Packet::from_bytes(raw)
+            .map(CachedAnnouncePacketRestore::Restored)
+            .unwrap_or(CachedAnnouncePacketRestore::Invalid))
     }
 
     fn path(&self, packet_hash: Hash) -> PathBuf {
@@ -67,6 +76,18 @@ impl ReticulumAnnounceCache {
 pub(super) struct CachedAnnounce {
     pub(super) packet: Packet,
     pub(super) destination: SingleOutputDestination,
+}
+
+pub(super) enum CachedAnnounceRestore {
+    Restored(Box<CachedAnnounce>),
+    Missing,
+    Invalid,
+}
+
+enum CachedAnnouncePacketRestore {
+    Restored(Packet),
+    Missing,
+    Invalid,
 }
 
 fn encode_cached_announce(iface: AddressHash, packet: Packet) -> io::Result<Vec<u8>> {

--- a/crates/libs/rns-transport/src/transport/reticulum_path_store.rs
+++ b/crates/libs/rns-transport/src/transport/reticulum_path_store.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::transport::reticulum_announce_cache::{CachedAnnounce, ReticulumAnnounceCache};
+use crate::transport::reticulum_announce_cache::{
+    CachedAnnounce, CachedAnnounceRestore, ReticulumAnnounceCache,
+};
 use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::Path;
@@ -9,6 +11,23 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub struct ReticulumPathTableRestoreReport {
     pub restored_active_paths: usize,
     pub restored_identities: Vec<RestoredReticulumPathIdentity>,
+    pub skipped: ReticulumPathTableRestoreSkipped,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ReticulumPathTableRestoreSkipped {
+    pub active_unmapped_interface: usize,
+    pub active_expired: usize,
+    pub active_missing_cached_announce: usize,
+    pub active_invalid_cached_announce: usize,
+    pub active_mismatched_cached_announce: usize,
+    pub active_identity_conflict: usize,
+    pub tunnel_duplicate_packet_hash: usize,
+    pub tunnel_expired: usize,
+    pub tunnel_missing_cached_announce: usize,
+    pub tunnel_invalid_cached_announce: usize,
+    pub tunnel_mismatched_cached_announce: usize,
+    pub tunnel_identity_conflict: usize,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -108,6 +127,8 @@ impl Transport {
         let now = std::time::Instant::now();
         let now_unix_secs = now_unix_secs();
 
+        let mut report = ReticulumPathTableRestoreReport::default();
+
         let path_entries = match tokio::fs::read(&path).await {
             Ok(payload) => PathTable::decode_python_entries(&payload)
                 .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "decode path table"))?,
@@ -120,6 +141,7 @@ impl Transport {
             let iface_manager = self.iface_manager.lock().await;
             for mut entry in path_entries {
                 let Some(iface) = iface_manager.address_for_full_hash(&entry.interface_hash) else {
+                    report.skipped.active_unmapped_interface += 1;
                     continue;
                 };
                 entry.iface = iface;
@@ -130,10 +152,26 @@ impl Transport {
         let mut path_candidates = Vec::new();
         for entry in mapped_entries {
             if python_path_entry_expired(&entry, now_unix_secs) {
+                report.skipped.active_expired += 1;
                 continue;
             }
-            if let Some(cached) = announce_cache.restore(entry.packet_hash).await? {
-                path_candidates.push(PathRestoreCandidate { entry, cached });
+            match announce_cache.restore_classified(entry.packet_hash).await? {
+                CachedAnnounceRestore::Restored(cached) => {
+                    let cached = *cached;
+                    if cached.packet.destination != entry.destination
+                        || cached.destination.desc.address_hash != entry.destination
+                    {
+                        report.skipped.active_mismatched_cached_announce += 1;
+                    } else {
+                        path_candidates.push(PathRestoreCandidate { entry, cached });
+                    }
+                }
+                CachedAnnounceRestore::Missing => {
+                    report.skipped.active_missing_cached_announce += 1;
+                }
+                CachedAnnounceRestore::Invalid => {
+                    report.skipped.active_invalid_cached_announce += 1;
+                }
             }
         }
 
@@ -145,7 +183,9 @@ impl Transport {
             Err(err) => return Err(err),
         };
         for tunnel in &mut tunnels {
+            let before = tunnel.paths.len();
             tunnel.paths.retain(|path| !python_tunnel_path_entry_expired(path, now_unix_secs));
+            report.skipped.tunnel_expired += before.saturating_sub(tunnel.paths.len());
         }
         tunnels.retain(|entry| !entry.paths.is_empty());
 
@@ -153,24 +193,34 @@ impl Transport {
         for tunnel in &tunnels {
             for path in &tunnel.paths {
                 if tunnel_announces.contains_key(&path.packet_hash) {
+                    report.skipped.tunnel_duplicate_packet_hash += 1;
                     continue;
                 }
-                if let Some(cached) = announce_cache.restore(path.packet_hash).await? {
-                    if cached.packet.destination != path.destination
-                        || cached.destination.desc.address_hash != path.destination
-                    {
-                        continue;
+                match announce_cache.restore_classified(path.packet_hash).await? {
+                    CachedAnnounceRestore::Restored(cached) => {
+                        let cached = *cached;
+                        if cached.packet.destination != path.destination
+                            || cached.destination.desc.address_hash != path.destination
+                        {
+                            report.skipped.tunnel_mismatched_cached_announce += 1;
+                            continue;
+                        }
+                        let iface = path
+                            .interface_hash
+                            .map(|hash| AddressHash::new_from_hash(&hash))
+                            .unwrap_or(path.destination);
+                        tunnel_announces.insert(path.packet_hash, (cached, iface));
                     }
-                    let iface = path
-                        .interface_hash
-                        .map(|hash| AddressHash::new_from_hash(&hash))
-                        .unwrap_or(path.destination);
-                    tunnel_announces.insert(path.packet_hash, (cached, iface));
+                    CachedAnnounceRestore::Missing => {
+                        report.skipped.tunnel_missing_cached_announce += 1;
+                    }
+                    CachedAnnounceRestore::Invalid => {
+                        report.skipped.tunnel_invalid_cached_announce += 1;
+                    }
                 }
             }
         }
 
-        let mut report = ReticulumPathTableRestoreReport::default();
         let mut handler = self.handler.lock().await;
 
         for candidate in path_candidates {
@@ -180,6 +230,7 @@ impl Transport {
                 &candidate.cached.destination,
                 candidate.entry.destination,
             ) {
+                report.skipped.active_identity_conflict += 1;
                 continue;
             }
             let dest_hash = candidate.cached.destination.desc.address_hash;
@@ -205,6 +256,7 @@ impl Transport {
                 &cached.destination,
                 cached.packet.destination,
             ) {
+                report.skipped.tunnel_identity_conflict += 1;
                 continue;
             }
             let dest_hash = cached.destination.desc.address_hash;

--- a/crates/libs/rns-transport/src/transport/tests_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/module_prelude.rs
@@ -669,7 +669,11 @@ async fn reticulum_path_table_restore_skips_when_connected_to_shared_instance() 
     let restored_iface = *restored.iface_manager().lock().await.new_channel(16).address();
     assert_eq!(restored_iface, iface, "test relies on deterministic iface hashes");
 
-    assert_eq!(restored.restore_reticulum_path_table(temp.path()).await.expect("restore"), 0);
+    let restore_report = restored
+        .restore_reticulum_path_table_report(temp.path())
+        .await
+        .expect("restore");
+    assert_eq!(restore_report.restored_active_paths, 0);
     assert!(
         !restored.has_path(&destination).await,
         "shared-instance clients should not restore local path-table entries from storage"
@@ -718,7 +722,12 @@ async fn reticulum_path_table_restore_skips_expired_python_path_entries() {
     let restored_iface = *restored.iface_manager().lock().await.new_channel(16).address();
     assert_eq!(restored_iface, iface, "test relies on deterministic iface hashes");
 
-    assert_eq!(restored.restore_reticulum_path_table(temp.path()).await.expect("restore"), 0);
+    let restore_report = restored
+        .restore_reticulum_path_table_report(temp.path())
+        .await
+        .expect("restore");
+    assert_eq!(restore_report.restored_active_paths, 0);
+    assert_eq!(restore_report.skipped.active_expired, 1);
     assert!(
         !restored.has_path(&destination).await,
         "expired Python path-table entry must not restore stale route state"
@@ -940,7 +949,12 @@ async fn reticulum_tunnel_table_restore_skips_expired_python_tunnel_paths() {
         restored.iface_manager().lock().await.full_hash(&restored_iface).expect("iface hash");
     assert_eq!(restored_iface_hash, iface_hash, "test relies on deterministic iface hashes");
 
-    assert_eq!(restored.restore_reticulum_path_table(temp.path()).await.expect("restore"), 0);
+    let restore_report = restored
+        .restore_reticulum_path_table_report(temp.path())
+        .await
+        .expect("restore");
+    assert_eq!(restore_report.restored_active_paths, 0);
+    assert_eq!(restore_report.skipped.tunnel_expired, 1);
 
     let tunnel_synth =
         super::tunnels::synthesize_tunnel_packet(&tunnel_identity, restored_iface_hash);

--- a/crates/libs/rns-transport/src/transport/tests_parts/reticulum_path_restore_bad_cache.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/reticulum_path_restore_bad_cache.rs
@@ -26,6 +26,7 @@ async fn reticulum_path_table_restore_skips_malformed_cached_announce_entry() {
         .await
         .expect("restore");
     assert_eq!(restore_report.restored_active_paths, 1);
+    assert_eq!(restore_report.skipped.active_invalid_cached_announce, 1);
     assert_eq!(restore_report.restored_identities.len(), 1);
     assert_eq!(restore_report.restored_identities[0].destination, good.destination);
     assert!(restored.has_path(&good.destination).await, "valid cached row should restore");
@@ -69,6 +70,7 @@ async fn reticulum_path_table_restore_skips_missing_cached_announce_entry() {
         .await
         .expect("restore");
     assert_eq!(restore_report.restored_active_paths, 1);
+    assert_eq!(restore_report.skipped.active_missing_cached_announce, 1);
     assert_eq!(restore_report.restored_identities.len(), 1);
     assert_eq!(restore_report.restored_identities[0].destination, good.destination);
     assert!(restored.has_path(&good.destination).await, "valid cached row should restore");
@@ -107,6 +109,7 @@ async fn reticulum_path_table_restore_skips_mismatched_cached_announce_destinati
         .await
         .expect("restore");
     assert_eq!(restore_report.restored_active_paths, 1);
+    assert_eq!(restore_report.skipped.active_mismatched_cached_announce, 1);
     assert_eq!(restore_report.restored_identities.len(), 1);
     assert_eq!(restore_report.restored_identities[0].destination, good.destination);
     assert!(restored.has_path(&good.destination).await, "valid cached row should restore");
@@ -158,6 +161,7 @@ async fn reticulum_tunnel_table_restore_skips_malformed_cached_announce_entry() 
         .await
         .expect("restore");
     assert_eq!(restore_report.restored_active_paths, 0);
+    assert_eq!(restore_report.skipped.tunnel_invalid_cached_announce, 1);
     assert_eq!(restore_report.restored_identities.len(), 1);
     assert_eq!(restore_report.restored_identities[0].destination, good.destination);
 
@@ -227,6 +231,7 @@ async fn reticulum_tunnel_table_restore_skips_missing_cached_announce_entry() {
         .await
         .expect("restore");
     assert_eq!(restore_report.restored_active_paths, 0);
+    assert_eq!(restore_report.skipped.tunnel_missing_cached_announce, 1);
     assert_eq!(restore_report.restored_identities.len(), 1);
     assert_eq!(restore_report.restored_identities[0].destination, good.destination);
 
@@ -291,6 +296,7 @@ async fn reticulum_tunnel_table_restore_skips_mismatched_cached_announce_destina
         .await
         .expect("restore");
     assert_eq!(restore_report.restored_active_paths, 0);
+    assert_eq!(restore_report.skipped.tunnel_mismatched_cached_announce, 1);
     assert_eq!(restore_report.restored_identities.len(), 1);
     assert_eq!(restore_report.restored_identities[0].destination, good.destination);
 
@@ -443,6 +449,12 @@ fn append_mismatched_tunnel_path_entry(storage_path: &std::path::Path, destinati
     let mut tunnels =
         super::tunnels::TunnelTable::decode_python_entries(&payload).expect("decode tunnels");
     let seed = &tunnels.first().expect("valid seed tunnel").paths[0];
+    let mismatched_packet_hash = Hash::new_from_slice(b"mismatch-tunnel-packet");
+    std::fs::copy(
+        cached_announce_path(storage_path, &seed.packet_hash),
+        cached_announce_path(storage_path, &mismatched_packet_hash),
+    )
+    .expect("copy cached announce under mismatched packet hash");
     let mismatched_path = super::tunnels::PythonTunnelPathEntry {
         destination,
         timestamp_secs: seed.timestamp_secs,
@@ -451,7 +463,7 @@ fn append_mismatched_tunnel_path_entry(storage_path: &std::path::Path, destinati
         expires_secs: seed.expires_secs,
         random_blobs: seed.random_blobs.clone(),
         interface_hash: seed.interface_hash,
-        packet_hash: seed.packet_hash,
+        packet_hash: mismatched_packet_hash,
     };
     tunnels[0].paths.push(mismatched_path);
     std::fs::write(

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -134,6 +134,11 @@ Scoped release evidence is split as follows:
   are persisted for daemon announce-identity lookup, and daemon status reports
   `_runtime.reticulum.path_table_restore.status` as `ok` or `error` so corrupt
   `destination_table` state remains observable without making startup fatal.
+  The same daemon status payload now exposes
+  `_runtime.reticulum.path_table_restore.skipped` counters for per-reason
+  active/tunnel restore skips, including unmapped interfaces, expired rows,
+  missing or invalid cached announces, mismatched cached destinations, duplicate
+  tunnel packet hashes, and identity conflicts.
 - Reticulum path-table persistence now writes only routes with cached announce
   material and restore hardens Python-format active and tunnel path-table rows
   by ignoring stale/expired path rows, so restart bootstrap cannot revive

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -353,6 +353,10 @@ Malformed per-entry cached announce files and cached announces whose decoded
 destination does not match the active/tunnel path row are skipped without
 poisoning other valid restored routes, while malformed `destination_table` or
 `tunnels` files still surface as daemon restore errors.
+Daemon/RPC `_runtime.reticulum.path_table_restore.skipped` now reports
+per-reason active/tunnel skip counters for unmapped interfaces, expired rows,
+missing or invalid cached announces, mismatched cached destinations, duplicate
+tunnel packet hashes, and identity conflicts.
 Shared-instance clients now skip local path-table save and restore work like
 Python Reticulum.
 Tunnel-only restored announces are also retained as cache material, so paths


### PR DESCRIPTION
## Summary
- classify Reticulum cached-announce restore misses as missing, invalid, mismatched, duplicate, expired, unmapped, or identity-conflict skip reasons
- expose those per-reason counters in daemon `_runtime.reticulum.path_table_restore.skipped` status
- extend active/tunnel path-cache restore tests and docs for the new observability surface

## Validation
- cargo fmt --all -- --check
- cargo test -p reticulum-rs-transport reticulum_path_table_restore -- --nocapture
- cargo test -p reticulum-rs-transport reticulum_tunnel_table_restore -- --nocapture
- cargo test -p reticulumd bootstrap_restores_path_cache -- --nocapture
- cargo test -p reticulumd --test code_quality_issue_369
- cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
- tools/scripts/check-module-size.sh
- tools/scripts/check-boundaries.sh
- git diff --check