### PR TITLE
Route app delivery cancel locally

### DIFF
--- a/crates/libs/lxmf-sdk/src/app/control.rs
+++ b/crates/libs/lxmf-sdk/src/app/control.rs
@@ -10,7 +10,7 @@ use super::runtime::{
     RuntimeStatus, SendReceipt, SendRequest,
 };
 use super::session::{SessionState, SharedBackend};
-use crate::{Client as CoreClient, LxmfSdk, SdkBackend, ShutdownMode};
+use crate::{CancelResult, Client as CoreClient, LxmfSdk, MessageId, SdkBackend, ShutdownMode};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -182,6 +182,14 @@ impl<B: SdkBackend> Client<B> {
         };
         let snapshot = client.status(message_id.into()).map_err(Error::from)?;
         Ok(snapshot.map(map_delivery_snapshot))
+    }
+
+    pub fn cancel_delivery(&self, message_id: impl Into<MessageId>) -> Result<CancelResult, Error> {
+        let state = self.state.lock().expect("app client mutex poisoned");
+        let Some(client) = state.client.as_ref() else {
+            return Err(Error::not_started());
+        };
+        client.cancel(message_id.into()).map_err(Error::from)
     }
 
     pub fn status(&self) -> Result<RuntimeStatus, Error> {

--- a/crates/libs/lxmf-sdk/src/app/dispatch.rs
+++ b/crates/libs/lxmf-sdk/src/app/dispatch.rs
@@ -125,6 +125,27 @@ impl<B: SdkBackend> Client<B> {
                     serde_json::to_value(status).expect("delivery status should serialize"),
                 ))
             }
+            "app.delivery.cancel" => {
+                let message_id = payload
+                    .get("message_id")
+                    .and_then(|value| value.as_str())
+                    .filter(|value| !value.trim().is_empty())
+                    .ok_or_else(|| {
+                        invalid_envelope(
+                            "delivery cancel envelope requires payload.message_id",
+                            canonical_id.as_str(),
+                        )
+                    })?;
+                let result = self.cancel_delivery(message_id.to_owned())?;
+                Ok(envelope_result(
+                    canonical_id,
+                    correlation_id,
+                    serde_json::json!({
+                        "message_id": message_id,
+                        "result": result,
+                    }),
+                ))
+            }
             "app.event.poll" => {
                 let cursor = payload
                     .get("cursor")

--- a/crates/libs/lxmf-sdk/src/app/node_tests_runtime_voice.rs
+++ b/crates/libs/lxmf-sdk/src/app/node_tests_runtime_voice.rs
@@ -97,6 +97,35 @@ fn execute_envelope_routes_delivery_send_locally() {
 }
 
 #[test]
+fn execute_envelope_routes_delivery_cancel_locally() {
+    let app = Client::new(MockBackend::new());
+    app.start(Config::testing_default()).expect("start");
+
+    let response = app
+        .command(
+            "app.delivery.cancel",
+            serde_json::json!({
+                "message_id": "msg-cancel"
+            }),
+        )
+        .expect("delivery cancel");
+
+    assert_eq!(response.operation_id.as_str(), "app.delivery.cancel");
+    assert_eq!(
+        response.payload.get("message_id").and_then(|value| value.as_str()),
+        Some("msg-cancel")
+    );
+    assert_eq!(
+        response.payload.get("result").and_then(|value| value.as_str()),
+        Some("accepted")
+    );
+    assert!(
+        response.payload.get("command").is_none(),
+        "cancel should not fall through to the generic remote-command path"
+    );
+}
+
+#[test]
 fn execute_envelope_routes_custom_commands_via_remote_command_backend() {
     let backend = MockBackend::new();
     backend.queue_remote_command_result(Ok(crate::domain::RemoteCommandResponse {

--- a/crates/libs/lxmf-sdk/src/app/tests/node_behavior_parts/execute_envelope_routes_delivery_sen.rs
+++ b/crates/libs/lxmf-sdk/src/app/tests/node_behavior_parts/execute_envelope_routes_delivery_sen.rs
@@ -21,6 +21,35 @@ fn execute_envelope_routes_delivery_send_locally() {
 }
 
 #[test]
+fn execute_envelope_routes_delivery_cancel_locally() {
+    let app = Client::new(MockBackend::new());
+    app.start(Config::testing_default()).expect("start");
+
+    let response = app
+        .command(
+            "app.delivery.cancel",
+            serde_json::json!({
+                "message_id": "msg-cancel"
+            }),
+        )
+        .expect("delivery cancel");
+
+    assert_eq!(response.operation_id.as_str(), "app.delivery.cancel");
+    assert_eq!(
+        response.payload.get("message_id").and_then(|value| value.as_str()),
+        Some("msg-cancel")
+    );
+    assert_eq!(
+        response.payload.get("result").and_then(|value| value.as_str()),
+        Some("accepted")
+    );
+    assert!(
+        response.payload.get("command").is_none(),
+        "cancel should not fall through to the generic remote-command path"
+    );
+}
+
+#[test]
 fn execute_envelope_routes_custom_commands_via_remote_command_backend() {
     let backend = MockBackend::new();
     backend.queue_remote_command_result(Ok(crate::domain::RemoteCommandResponse {

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -881,6 +881,9 @@ Scoped release evidence is split as follows:
   cancellation through both `ZmqPipelineBackendClient::cancel` and
   `app.delivery.cancel` envelope execution, preserving daemon cancellation
   outcomes without raw RPC envelopes.
+- The native SDK app facade now routes `app.delivery.cancel` locally through
+  `Client::cancel_delivery`, preserving typed cancellation results for app
+  callers instead of falling through to generic remote-command dispatch.
 - `app.delivery.cancel` now cancels queued/pre-handoff outbound work before
   bridge delivery, persists `receipt_status = cancelled`, records delivery
   trace and event state, exposes cancel metadata through raw and envelope SDK

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -448,6 +448,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   mapping `sdk_status_v2` into `DeliverySnapshot`, so direct-chat delivery
   status reports `sent` as terminal only until
   `sdk.capability.receipt_terminality` is negotiated.
+- The native SDK app facade now routes `app.delivery.cancel` locally through
+  `Client::cancel_delivery`, preserving typed cancellation results for app
+  callers instead of falling through to generic remote-command dispatch.
 - The typed ZeroMQ SDK backend preserves daemon-reported retry-attempt counts
   and reason codes when mapping `sdk_status_v2` into `DeliverySnapshot`, so
   direct-chat restart and retry recovery state remains visible to REM/RCH over


### PR DESCRIPTION
## Summary
- add native SDK app facade cancellation via `Client::cancel_delivery`
- route `app.delivery.cancel` envelopes locally instead of generic remote-command dispatch
- add focused app envelope regression coverage and update LXMF parity docs

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p lxmf-sdk app::node::node_tests::execute_envelope_routes_delivery -- --nocapture`
- `cargo clippy -p lxmf-sdk --all-targets --all-features --no-deps -- -D warnings`
- `tools/scripts/check-boundaries.sh`

## Notes
- Separate from external-client evidence. Columba gate was attempted locally but blocked because the checkout no longer exposes `python/reticulum_wrapper.py` for the current harness layout.
