### PR TITLE
Expose propagation drop context in app events

### DIFF
--- a/crates/libs/lxmf-sdk/src/app/events.rs
+++ b/crates/libs/lxmf-sdk/src/app/events.rs
@@ -87,6 +87,9 @@ pub struct InboundMessageDetails {
 pub struct InboundDropDetails {
     pub reason: Option<String>,
     pub delivery_kind: Option<String>,
+    pub operation: Option<String>,
+    pub transient_id: Option<String>,
+    pub peer: Option<String>,
     pub raw_destination_hash: Option<String>,
     pub resolved_destination_hash: Option<String>,
     pub source_hash: Option<String>,
@@ -208,7 +211,6 @@ impl Event {
 fn json_str(value: &JsonValue, key: &str) -> Option<String> {
     value.get(key)?.as_str().map(ToOwned::to_owned)
 }
-
 fn nested_json_str(value: &JsonValue, path: &[&str]) -> Option<String> {
     let mut current = value;
     for key in path {
@@ -216,7 +218,6 @@ fn nested_json_str(value: &JsonValue, path: &[&str]) -> Option<String> {
     }
     current.as_str().map(ToOwned::to_owned)
 }
-
 fn nested_json_bool(value: &JsonValue, path: &[&str]) -> Option<bool> {
     let mut current = value;
     for key in path {
@@ -224,7 +225,6 @@ fn nested_json_bool(value: &JsonValue, path: &[&str]) -> Option<bool> {
     }
     current.as_bool()
 }
-
 fn inbound_message_details(payload: &JsonValue) -> InboundMessageDetails {
     let message = payload.get("message").unwrap_or(payload);
     InboundMessageDetails {
@@ -241,11 +241,13 @@ fn inbound_message_details(payload: &JsonValue) -> InboundMessageDetails {
         stamp_status: nested_json_str(message, &["fields", "_lxmf", "stamp_status"]),
     }
 }
-
 fn inbound_drop_details(payload: &JsonValue) -> InboundDropDetails {
     InboundDropDetails {
         reason: json_str(payload, "reason"),
         delivery_kind: json_str(payload, "delivery_kind"),
+        operation: json_str(payload, "operation"),
+        transient_id: json_str(payload, "transient_id"),
+        peer: json_str(payload, "peer").or_else(|| json_str(payload, "peer_id")),
         raw_destination_hash: json_str(payload, "raw_destination_hash"),
         resolved_destination_hash: json_str(payload, "resolved_destination_hash"),
         source_hash: json_str(payload, "source_hash"),
@@ -256,7 +258,6 @@ fn inbound_drop_details(payload: &JsonValue) -> InboundDropDetails {
         detail: json_str(payload, "detail"),
     }
 }
-
 fn delivery_lifecycle_details(payload: &JsonValue) -> DeliveryLifecycleDetails {
     let message = payload.get("message").unwrap_or(payload);
     DeliveryLifecycleDetails {

--- a/crates/libs/lxmf-sdk/src/app/events_tests.rs
+++ b/crates/libs/lxmf-sdk/src/app/events_tests.rs
@@ -164,6 +164,9 @@ fn maps_inbound_drop_to_typed_details() {
             json!({
                 "reason": "payload_too_short",
                 "delivery_kind": "propagation",
+                "operation": "remote_fetch",
+                "transient_id": "transient-drop-1",
+                "peer": "peer-propagation",
                 "raw_destination_hash": "sha256:raw",
                 "resolved_destination_hash": "sha256:resolved",
                 "source_hash": "sha256:source",
@@ -179,10 +182,13 @@ fn maps_inbound_drop_to_typed_details() {
 
     assert!(matches!(mapped.kind, EventKind::InboundMessageDropped));
     assert_eq!(mapped.metadata.message_id.as_deref(), Some("msg-drop-1"));
-    assert_eq!(mapped.metadata.peer_id.as_deref(), Some("sha256:source"));
+    assert_eq!(mapped.metadata.peer_id.as_deref(), Some("peer-propagation"));
     let details = mapped.inbound_drop_details().expect("drop details");
     assert_eq!(details.reason.as_deref(), Some("payload_too_short"));
     assert_eq!(details.delivery_kind.as_deref(), Some("propagation"));
+    assert_eq!(details.operation.as_deref(), Some("remote_fetch"));
+    assert_eq!(details.transient_id.as_deref(), Some("transient-drop-1"));
+    assert_eq!(details.peer.as_deref(), Some("peer-propagation"));
     assert_eq!(details.raw_destination_hash.as_deref(), Some("sha256:raw"));
     assert_eq!(details.resolved_destination_hash.as_deref(), Some("sha256:resolved"));
     assert_eq!(details.source_hash.as_deref(), Some("sha256:source"));

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1041,6 +1041,9 @@ Scoped release evidence is split as follows:
   receipt status, signature/stamp metadata, drop reason, and lifecycle state
   without requiring REM/RCH clients to parse raw event JSON for normal message
   and status UI.
+- Typed inbound drop helpers now also preserve propagation drop context fields,
+  including operation, transient ID, and peer, so remote fetch/download/sync
+  duplicate and reject events stay actionable without raw event JSON parsing.
 - RPC-layer propagation rejects for ignored destination hashes now emit bounded
   `inbound_dropped` events before returning `PermissionDenied` from
   `propagation_ingest` and remote fetch/download/sync imports. The events use

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -923,6 +923,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   preserving message IDs, peer/source identity, destination hashes, raw LXMF
   bytes, signature/stamp metadata, drop reason, receipt status, and lifecycle
   state without requiring normal client UI flows to decode raw event JSON.
+- Typed inbound drop helpers now also preserve propagation drop context fields,
+  including operation, transient ID, and peer, so remote fetch/download/sync
+  duplicate and reject events stay actionable without raw event JSON parsing.
 - Focused propagated local-delivery tests cover ignored-source delivery-policy
   rejections emitting bounded raw `inbound_dropped` events with
   `delivery_kind = "propagation"` while preserving Python-style no-store


### PR DESCRIPTION
## Summary
- add typed `operation`, `transient_id`, and `peer` fields to SDK app inbound drop details
- preserve propagation drop context for remote fetch/download/sync duplicate and reject events without raw JSON parsing
- update LXMF parity docs for the handler/event projection slice

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p lxmf-sdk app::events::tests::maps_inbound_drop_to_typed_details -- --nocapture`
- `cargo clippy -p lxmf-sdk --all-targets --all-features --no-deps -- -D warnings`
- `tools/scripts/check-boundaries.sh`

## Notes
- `crates/libs/lxmf-sdk/src/app/events.rs` is exactly 500 LOC after this change, matching the current module-size policy.
