### PR TITLE
Expose typed inbound LXMF metadata

### DIFF
--- a/crates/libs/lxmf-sdk/src/app/events.rs
+++ b/crates/libs/lxmf-sdk/src/app/events.rs
@@ -1,6 +1,11 @@
 #[cfg(feature = "sdk-async")]
 use crate::event::{EventBatch as RawEventBatch, EventSubscription, SdkEvent};
 use crate::event::{Severity as RawSeverity, SubscriptionStart as RawSubscriptionStart};
+#[path = "events_details.rs"]
+mod events_details;
+pub use events_details::{
+    DeliveryLifecycleDetails, InboundDropDetails, InboundMessageDetails, StreamGapDetails,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
@@ -57,61 +62,6 @@ impl From<RawSubscriptionStart> for SubscriptionStart {
             RawSubscriptionStart::Snapshot => Self::Snapshot,
         }
     }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct StreamGapDetails {
-    pub expected_seq_no: Option<u64>,
-    pub observed_seq_no: Option<u64>,
-    pub dropped_count: u64,
-    pub recovery_required: bool,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct InboundMessageDetails {
-    pub message_id: Option<String>,
-    pub source_hash: Option<String>,
-    pub destination_hash: Option<String>,
-    pub delivery_kind: Option<String>,
-    pub lxmf_bytes_hex: Option<String>,
-    pub receipt_status: Option<String>,
-    pub signature_checked: Option<bool>,
-    pub signature_status: Option<String>,
-    pub stamp_status: Option<String>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct InboundDropDetails {
-    pub reason: Option<String>,
-    pub delivery_kind: Option<String>,
-    pub raw_destination_hash: Option<String>,
-    pub resolved_destination_hash: Option<String>,
-    pub source_hash: Option<String>,
-    pub destination_hash: Option<String>,
-    pub dropped_message_id: Option<String>,
-    pub payload_mode: Option<String>,
-    pub bytes_len: Option<u64>,
-    pub detail: Option<String>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct DeliveryLifecycleDetails {
-    pub state: Option<String>,
-    pub from: Option<String>,
-    pub to: Option<String>,
-    pub receipt_status: Option<String>,
-    pub delivery_kind: Option<String>,
-    pub packet_hash: Option<String>,
-    pub resource_hash: Option<String>,
-    pub peer: Option<String>,
-    pub method: Option<String>,
-    pub bytes: Option<u64>,
-    pub link_id: Option<String>,
-    pub reason: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -186,11 +136,11 @@ pub struct EventBatch {
 impl Event {
     pub fn inbound_message_details(&self) -> Option<InboundMessageDetails> {
         matches!(self.kind, EventKind::InboundMessageReceived)
-            .then(|| inbound_message_details(&self.details))
+            .then(|| events_details::inbound_message_details(&self.details))
     }
     pub fn inbound_drop_details(&self) -> Option<InboundDropDetails> {
         matches!(self.kind, EventKind::InboundMessageDropped)
-            .then(|| inbound_drop_details(&self.details))
+            .then(|| events_details::inbound_drop_details(&self.details))
     }
     pub fn delivery_lifecycle_details(&self) -> Option<DeliveryLifecycleDetails> {
         matches!(
@@ -202,79 +152,7 @@ impl Event {
                 | EventKind::MessageFailed
                 | EventKind::MessageCancelled
         )
-        .then(|| delivery_lifecycle_details(&self.details))
-    }
-}
-fn json_str(value: &JsonValue, key: &str) -> Option<String> {
-    value.get(key)?.as_str().map(ToOwned::to_owned)
-}
-
-fn nested_json_str(value: &JsonValue, path: &[&str]) -> Option<String> {
-    let mut current = value;
-    for key in path {
-        current = current.get(*key)?;
-    }
-    current.as_str().map(ToOwned::to_owned)
-}
-
-fn nested_json_bool(value: &JsonValue, path: &[&str]) -> Option<bool> {
-    let mut current = value;
-    for key in path {
-        current = current.get(*key)?;
-    }
-    current.as_bool()
-}
-
-fn inbound_message_details(payload: &JsonValue) -> InboundMessageDetails {
-    let message = payload.get("message").unwrap_or(payload);
-    InboundMessageDetails {
-        message_id: json_str(message, "id").or_else(|| json_str(payload, "message_id")),
-        source_hash: json_str(message, "source").or_else(|| json_str(payload, "source_hash")),
-        destination_hash: json_str(message, "destination")
-            .or_else(|| json_str(payload, "destination_hash")),
-        delivery_kind: json_str(payload, "delivery_kind"),
-        lxmf_bytes_hex: json_str(payload, "lxmf_bytes_hex"),
-        receipt_status: json_str(message, "receipt_status")
-            .or_else(|| json_str(payload, "receipt_status")),
-        signature_checked: nested_json_bool(message, &["fields", "_lxmf", "signature_checked"]),
-        signature_status: nested_json_str(message, &["fields", "_lxmf", "signature_status"]),
-        stamp_status: nested_json_str(message, &["fields", "_lxmf", "stamp_status"]),
-    }
-}
-
-fn inbound_drop_details(payload: &JsonValue) -> InboundDropDetails {
-    InboundDropDetails {
-        reason: json_str(payload, "reason"),
-        delivery_kind: json_str(payload, "delivery_kind"),
-        raw_destination_hash: json_str(payload, "raw_destination_hash"),
-        resolved_destination_hash: json_str(payload, "resolved_destination_hash"),
-        source_hash: json_str(payload, "source_hash"),
-        destination_hash: json_str(payload, "destination_hash"),
-        dropped_message_id: json_str(payload, "dropped_message_id"),
-        payload_mode: json_str(payload, "payload_mode"),
-        bytes_len: payload.get("bytes_len").and_then(JsonValue::as_u64),
-        detail: json_str(payload, "detail"),
-    }
-}
-
-fn delivery_lifecycle_details(payload: &JsonValue) -> DeliveryLifecycleDetails {
-    let message = payload.get("message").unwrap_or(payload);
-    DeliveryLifecycleDetails {
-        state: json_str(payload, "state")
-            .or_else(|| normalized_receipt_state(payload).ok().flatten()),
-        from: json_str(payload, "from"),
-        to: json_str(payload, "to"),
-        receipt_status: json_str(message, "receipt_status")
-            .or_else(|| json_str(payload, "receipt_status"))
-            .or_else(|| json_str(payload, "status")),
-        delivery_kind: json_str(payload, "delivery_kind"),
-        packet_hash: json_str(payload, "packet_hash"),
-        resource_hash: json_str(payload, "resource_hash"),
-        peer: json_str(payload, "peer").or_else(|| json_str(payload, "peer_id")),
-        method: json_str(payload, "method"),
-        bytes: payload.get("bytes").and_then(JsonValue::as_u64),
-        link_id: json_str(payload, "link_id"),
-        reason: json_str(payload, "reason").or_else(|| json_str(payload, "detail")),
+        .then(|| events_details::delivery_lifecycle_details(&self.details))
     }
 }
 
@@ -287,19 +165,6 @@ fn payload_state(payload: &JsonValue, key: &str) -> Result<Option<String>, &'sta
             .ok_or("payload field is not a string")
             .map(|s| Some(s.trim().to_ascii_lowercase())),
     }
-}
-
-fn normalized_receipt_state(payload: &JsonValue) -> Result<Option<String>, &'static str> {
-    let status_val = payload
-        .get("message")
-        .and_then(|message| message.get("receipt_status").or_else(|| message.get("status")))
-        .or_else(|| payload.get("receipt_status"))
-        .or_else(|| payload.get("status"))
-        .or_else(|| payload.get("state"))
-        .or_else(|| payload.get("receipt").and_then(|receipt| receipt.get("status")));
-    let Some(status_val) = status_val else { return Ok(None) };
-    let status = status_val.as_str().ok_or("receipt status is not a string")?;
-    Ok(Some(status.split(':').next().unwrap_or(status).trim().to_ascii_lowercase()))
 }
 
 #[cfg(feature = "sdk-async")]
@@ -444,7 +309,7 @@ pub fn map_sdk_event(event: SdkEvent, profile_id: &str) -> Event {
         "sdk_security_rate_limited" => EventKind::SecurityActionRequired,
         "runtime_shutdown_requested" => EventKind::RuntimeStopped,
         "outbound" | "receipt" => map_delivery_state(
-            normalized_receipt_state(&event.payload)
+            events_details::normalized_receipt_state(&event.payload)
                 .ok()
                 .flatten()
                 .unwrap_or_else(|| "unknown".to_owned())

--- a/crates/libs/lxmf-sdk/src/app/events_details.rs
+++ b/crates/libs/lxmf-sdk/src/app/events_details.rs
@@ -1,0 +1,174 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct StreamGapDetails {
+    pub expected_seq_no: Option<u64>,
+    pub observed_seq_no: Option<u64>,
+    pub dropped_count: u64,
+    pub recovery_required: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct InboundMessageDetails {
+    pub message_id: Option<String>,
+    pub source_hash: Option<String>,
+    pub destination_hash: Option<String>,
+    pub delivery_kind: Option<String>,
+    pub lxmf_bytes_hex: Option<String>,
+    pub receipt_status: Option<String>,
+    pub signature_checked: Option<bool>,
+    pub signature_valid: Option<bool>,
+    pub signature_status: Option<String>,
+    pub stamp_checked: Option<bool>,
+    pub stamp_valid: Option<bool>,
+    pub stamp_status: Option<String>,
+    pub propagation_stamp_checked: Option<bool>,
+    pub propagation_stamp_valid: Option<bool>,
+    pub method: Option<u64>,
+    pub transport_encrypted: Option<bool>,
+    pub transport_encryption: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct InboundDropDetails {
+    pub reason: Option<String>,
+    pub delivery_kind: Option<String>,
+    pub raw_destination_hash: Option<String>,
+    pub resolved_destination_hash: Option<String>,
+    pub source_hash: Option<String>,
+    pub destination_hash: Option<String>,
+    pub dropped_message_id: Option<String>,
+    pub payload_mode: Option<String>,
+    pub bytes_len: Option<u64>,
+    pub detail: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DeliveryLifecycleDetails {
+    pub state: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub receipt_status: Option<String>,
+    pub delivery_kind: Option<String>,
+    pub packet_hash: Option<String>,
+    pub resource_hash: Option<String>,
+    pub peer: Option<String>,
+    pub method: Option<String>,
+    pub bytes: Option<u64>,
+    pub link_id: Option<String>,
+    pub reason: Option<String>,
+}
+
+fn json_str(value: &JsonValue, key: &str) -> Option<String> {
+    value.get(key)?.as_str().map(ToOwned::to_owned)
+}
+
+fn nested_json<'a>(value: &'a JsonValue, path: &[&str]) -> Option<&'a JsonValue> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    Some(current)
+}
+
+fn nested_json_str(value: &JsonValue, path: &[&str]) -> Option<String> {
+    nested_json(value, path)?.as_str().map(ToOwned::to_owned)
+}
+
+fn nested_json_bool(value: &JsonValue, path: &[&str]) -> Option<bool> {
+    nested_json(value, path)?.as_bool()
+}
+
+fn nested_json_u64(value: &JsonValue, path: &[&str]) -> Option<u64> {
+    nested_json(value, path)?.as_u64()
+}
+
+pub(super) fn inbound_message_details(payload: &JsonValue) -> InboundMessageDetails {
+    let message = payload.get("message").unwrap_or(payload);
+    InboundMessageDetails {
+        message_id: json_str(message, "id").or_else(|| json_str(payload, "message_id")),
+        source_hash: json_str(message, "source").or_else(|| json_str(payload, "source_hash")),
+        destination_hash: json_str(message, "destination")
+            .or_else(|| json_str(payload, "destination_hash")),
+        delivery_kind: json_str(payload, "delivery_kind"),
+        lxmf_bytes_hex: json_str(payload, "lxmf_bytes_hex"),
+        receipt_status: json_str(message, "receipt_status")
+            .or_else(|| json_str(payload, "receipt_status")),
+        signature_checked: nested_json_bool(message, &["fields", "_lxmf", "signature_checked"]),
+        signature_valid: nested_json_bool(message, &["fields", "_lxmf", "signature_valid"]),
+        signature_status: nested_json_str(message, &["fields", "_lxmf", "signature_status"]),
+        stamp_checked: nested_json_bool(message, &["fields", "_lxmf", "stamp_checked"]),
+        stamp_valid: nested_json_bool(message, &["fields", "_lxmf", "stamp_valid"]),
+        stamp_status: nested_json_str(message, &["fields", "_lxmf", "stamp_status"]),
+        propagation_stamp_checked: nested_json_bool(
+            message,
+            &["fields", "_lxmf", "propagation_stamp_checked"],
+        ),
+        propagation_stamp_valid: nested_json_bool(
+            message,
+            &["fields", "_lxmf", "propagation_stamp_valid"],
+        ),
+        method: nested_json_u64(message, &["fields", "_lxmf", "method"]),
+        transport_encrypted: nested_json_bool(message, &["fields", "_lxmf", "transport_encrypted"]),
+        transport_encryption: nested_json_str(
+            message,
+            &["fields", "_lxmf", "transport_encryption"],
+        ),
+    }
+}
+
+pub(super) fn inbound_drop_details(payload: &JsonValue) -> InboundDropDetails {
+    InboundDropDetails {
+        reason: json_str(payload, "reason"),
+        delivery_kind: json_str(payload, "delivery_kind"),
+        raw_destination_hash: json_str(payload, "raw_destination_hash"),
+        resolved_destination_hash: json_str(payload, "resolved_destination_hash"),
+        source_hash: json_str(payload, "source_hash"),
+        destination_hash: json_str(payload, "destination_hash"),
+        dropped_message_id: json_str(payload, "dropped_message_id"),
+        payload_mode: json_str(payload, "payload_mode"),
+        bytes_len: payload.get("bytes_len").and_then(JsonValue::as_u64),
+        detail: json_str(payload, "detail"),
+    }
+}
+
+pub(super) fn delivery_lifecycle_details(payload: &JsonValue) -> DeliveryLifecycleDetails {
+    let message = payload.get("message").unwrap_or(payload);
+    DeliveryLifecycleDetails {
+        state: json_str(payload, "state")
+            .or_else(|| normalized_receipt_state(payload).ok().flatten()),
+        from: json_str(payload, "from"),
+        to: json_str(payload, "to"),
+        receipt_status: json_str(message, "receipt_status")
+            .or_else(|| json_str(payload, "receipt_status"))
+            .or_else(|| json_str(payload, "status")),
+        delivery_kind: json_str(payload, "delivery_kind"),
+        packet_hash: json_str(payload, "packet_hash"),
+        resource_hash: json_str(payload, "resource_hash"),
+        peer: json_str(payload, "peer").or_else(|| json_str(payload, "peer_id")),
+        method: json_str(payload, "method"),
+        bytes: payload.get("bytes").and_then(JsonValue::as_u64),
+        link_id: json_str(payload, "link_id"),
+        reason: json_str(payload, "reason").or_else(|| json_str(payload, "detail")),
+    }
+}
+
+pub(super) fn normalized_receipt_state(
+    payload: &JsonValue,
+) -> Result<Option<String>, &'static str> {
+    let status_val = payload
+        .get("message")
+        .and_then(|message| message.get("receipt_status").or_else(|| message.get("status")))
+        .or_else(|| payload.get("receipt_status"))
+        .or_else(|| payload.get("status"))
+        .or_else(|| payload.get("state"))
+        .or_else(|| payload.get("receipt").and_then(|receipt| receipt.get("status")));
+    let Some(status_val) = status_val else { return Ok(None) };
+    let status = status_val.as_str().ok_or("receipt status is not a string")?;
+    Ok(Some(status.split(':').next().unwrap_or(status).trim().to_ascii_lowercase()))
+}

--- a/crates/libs/lxmf-sdk/src/app/events_tests.rs
+++ b/crates/libs/lxmf-sdk/src/app/events_tests.rs
@@ -131,8 +131,16 @@ fn maps_inbound_success_to_typed_details() {
                     "fields": {
                         "_lxmf": {
                             "signature_checked": true,
+                            "signature_valid": true,
                             "signature_status": "verified",
-                            "stamp_status": "accepted"
+                            "stamp_checked": true,
+                            "stamp_valid": true,
+                            "stamp_status": "accepted",
+                            "propagation_stamp_checked": true,
+                            "propagation_stamp_valid": false,
+                            "method": 2,
+                            "transport_encrypted": true,
+                            "transport_encryption": "Curve25519"
                         }
                     }
                 }
@@ -152,8 +160,16 @@ fn maps_inbound_success_to_typed_details() {
     assert_eq!(details.lxmf_bytes_hex.as_deref(), Some("aabbcc"));
     assert_eq!(details.receipt_status.as_deref(), Some("received"));
     assert_eq!(details.signature_checked, Some(true));
+    assert_eq!(details.signature_valid, Some(true));
     assert_eq!(details.signature_status.as_deref(), Some("verified"));
+    assert_eq!(details.stamp_checked, Some(true));
+    assert_eq!(details.stamp_valid, Some(true));
     assert_eq!(details.stamp_status.as_deref(), Some("accepted"));
+    assert_eq!(details.propagation_stamp_checked, Some(true));
+    assert_eq!(details.propagation_stamp_valid, Some(false));
+    assert_eq!(details.method, Some(2));
+    assert_eq!(details.transport_encrypted, Some(true));
+    assert_eq!(details.transport_encryption.as_deref(), Some("Curve25519"));
 }
 
 #[test]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1041,6 +1041,10 @@ Scoped release evidence is split as follows:
   receipt status, signature/stamp metadata, drop reason, and lifecycle state
   without requiring REM/RCH clients to parse raw event JSON for normal message
   and status UI.
+- Typed inbound message helpers now expose the richer handler metadata already
+  carried in raw inbound events: signature validity, stamp validity,
+  propagation stamp validity, LXMF method, and direct transport encryption
+  fields.
 - RPC-layer propagation rejects for ignored destination hashes now emit bounded
   `inbound_dropped` events before returning `PermissionDenied` from
   `propagation_ingest` and remote fetch/download/sync imports. The events use

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -923,6 +923,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   preserving message IDs, peer/source identity, destination hashes, raw LXMF
   bytes, signature/stamp metadata, drop reason, receipt status, and lifecycle
   state without requiring normal client UI flows to decode raw event JSON.
+- Typed inbound message helpers now expose the richer handler metadata already
+  carried in raw inbound events: signature validity, stamp validity,
+  propagation stamp validity, LXMF method, and direct transport encryption
+  fields.
 - Focused propagated local-delivery tests cover ignored-source delivery-policy
   rejections emitting bounded raw `inbound_dropped` events with
   `delivery_kind = "propagation"` while preserving Python-style no-store


### PR DESCRIPTION
## Summary
- split SDK app event detail mapping into a private helper module so the event facade stays under the module-size policy
- expose typed inbound LXMF handler metadata for signature validity, stamp validity, propagation stamp validity, method, and transport encryption fields
- document the typed inbound metadata parity increment in the roadmap and LXMF parity matrix

## Validation
- cargo fmt --all -- --check
- cargo test -p lxmf-sdk app::events::tests::maps_inbound_success_to_typed_details -- --nocapture
- cargo clippy -p lxmf-sdk --all-targets --all-features --no-deps -- -D warnings
- tools/scripts/check-boundaries.sh
- git diff --check