### PR TITLE
Validate propagation get transient IDs

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation_parts/module_prelude.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation_parts/module_prelude.rs
@@ -61,7 +61,10 @@ pub(super) fn handle_message_get_request(
 
     let haves = match entries.get(1) {
         Some(value) if value.is_nil() => Vec::new(),
-        Some(rmpv::Value::Array(values)) => binary_id_list(values),
+        Some(rmpv::Value::Array(values)) => match validated_binary_id_list(values) {
+            Some(ids) => ids,
+            None => return ControlResponse::Code(error_invalid_data),
+        },
         _ => return ControlResponse::Code(error_invalid_data),
     };
     if !haves.is_empty() {
@@ -115,7 +118,10 @@ pub(super) fn handle_message_get_request(
     }
 
     let wants = match entries.first() {
-        Some(rmpv::Value::Array(values)) => binary_id_list(values),
+        Some(rmpv::Value::Array(values)) => match validated_binary_id_list(values) {
+            Some(ids) => ids,
+            None => return ControlResponse::Code(error_invalid_data),
+        },
         _ => return ControlResponse::Code(error_invalid_data),
     };
     let mut retryable_wants = Vec::with_capacity(wants.len());
@@ -298,10 +304,10 @@ pub(super) fn handle_offer_request(
     }
 }
 
-fn binary_id_list(values: &[rmpv::Value]) -> Vec<Vec<u8>> {
+fn validated_binary_id_list(values: &[rmpv::Value]) -> Option<Vec<Vec<u8>>> {
     values
         .iter()
-        .filter_map(|value| match value {
+        .map(|value| match value {
             rmpv::Value::Binary(bytes) if bytes.len() == 32 => Some(bytes.clone()),
             _ => None,
         })

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation_parts/test_validated_peer_links_sections/message_get_haves_clear_stale_unhand.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_control_propagation_parts/test_validated_peer_links_sections/message_get_haves_clear_stale_unhand.rs
@@ -379,7 +379,7 @@
     }
 
     #[test]
-    fn message_get_ignores_malformed_transient_ids_inside_lists_like_python() {
+    fn message_get_rejects_malformed_transient_ids_inside_lists() {
         let daemon = RpcDaemon::test_instance();
         let remote_private =
             rns_transport::identity::PrivateIdentity::new_from_rand(rand_core::OsRng);
@@ -425,9 +425,13 @@
             0xF1,
             0xF4,
         );
-        let ControlResponse::Rmpv(rmpv::Value::Array(messages)) = fetch_response else {
-            panic!("expected fetched message list");
-        };
-        assert_eq!(messages, vec![rmpv::Value::Binary(wanted_payload)]);
-        assert!(!daemon.has_propagation_payload(hex::encode(have).as_str()));
+        assert!(matches!(fetch_response, ControlResponse::Code(0xF4)));
+        assert!(
+            daemon.has_propagation_payload(hex::encode(wanted).as_str()),
+            "malformed message-get wants must not be silently filtered before serving payloads"
+        );
+        assert!(
+            daemon.has_propagation_payload(hex::encode(have).as_str()),
+            "malformed message-get haves must not be silently filtered before purging payloads"
+        );
     }

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1140,6 +1140,10 @@ Scoped release evidence is split as follows:
 - Inbound propagation offers now validate every offered transient ID before
   applying any source-accounting marks, so malformed mixed offers cannot leave
   partial received/completed queue state behind.
+- Inbound propagation message-get requests now validate every wanted and have
+  transient ID instead of silently filtering malformed entries, so malformed
+  mixed `/get` lists cannot fetch or purge queue state behind the rejected
+  request.
 - Inbound propagation offers now deduplicate validated offered transient IDs
   before building wanted-ID responses or applying source-accounting marks, so a
   duplicate offer cannot request or account the same payload more than once.

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -707,6 +707,10 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
 - Inbound propagation offers validate every offered transient ID before
   applying source-accounting marks, so malformed mixed offers cannot leave
   partial received/completed queue state behind.
+- Inbound propagation message-get requests validate every wanted and have
+  transient ID instead of silently filtering malformed entries, so malformed
+  mixed `/get` lists cannot fetch or purge queue state behind the rejected
+  request.
 - Inbound propagation offers deduplicate validated offered transient IDs before
   building wanted-ID responses or applying source-accounting marks, so duplicate
   offers cannot request or account the same payload more than once.


### PR DESCRIPTION
## Summary

- reject inbound propagation `/get` wanted/have entries unless every transient ID is a 32-byte binary value
- tighten the malformed-ID regression so mixed malformed lists no longer fetch or purge propagation payloads
- record the router/handler parity increment in the roadmap and LXMF parity matrix

## Root Cause

Inbound `/get` parsing reused a helper that filtered malformed transient IDs out of wanted/have lists, unlike the stricter `/offer` transient-ID validation path.

## Validation

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p reticulumd message_get -- --nocapture`
- `cargo test -p reticulumd --test code_quality_issue_369`
- `git diff --check`
