### PR TITLE
Hot-apply UDP forward_ip shared port

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply_parts/record_hot_apply.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/interface_hot_apply_parts/record_hot_apply.rs
@@ -213,8 +213,18 @@ fn udp_forward_addr(record: &InterfaceRecord) -> Option<String> {
 }
 
 fn udp_forward_addr_result(record: &InterfaceRecord) -> Result<Option<String>, io::Error> {
-    let host = setting_str(record, "target_host").or_else(|| setting_str(record, "forward_ip"));
-    let port = setting_u64(record, "target_port").or_else(|| setting_u64(record, "forward_port"));
+    let target_host = setting_str(record, "target_host");
+    let forward_ip = setting_str(record, "forward_ip");
+    let host = target_host.or(forward_ip);
+    let port = setting_u64(record, "target_port")
+        .or_else(|| setting_u64(record, "forward_port"))
+        .or_else(|| {
+            if target_host.is_none() && forward_ip.is_some() {
+                record.port.map(u64::from)
+            } else {
+                None
+            }
+        });
     let (host, port) = match (host, port) {
         (Some(host), Some(port)) => (host, port),
         (None, None) => return Ok(None),

--- a/crates/apps/reticulumd/src/bin/reticulumd/tests/interface_hot_apply.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests/interface_hot_apply.rs
@@ -1,7 +1,8 @@
 use super::{
-    apply_hot_apply_interface_records, refresh_hot_apply_tcp_listener_runtime_status_once,
-    refresh_hot_apply_udp_runtime_status_once, HotApplyUdpRefresh, InterfaceHotApplyBridge,
-    InterfaceManager, InterfaceMutationBridge, InterfaceRecord, ManagedHotApplyInterface,
+    apply_hot_apply_interface_records, mark_udp_record_runtime_status,
+    refresh_hot_apply_tcp_listener_runtime_status_once, refresh_hot_apply_udp_runtime_status_once,
+    HotApplyUdpRefresh, InterfaceHotApplyBridge, InterfaceManager, InterfaceMutationBridge,
+    InterfaceRecord, ManagedHotApplyInterface,
 };
 use rand_core::OsRng;
 use rns_rpc::{RpcDaemon, RpcRequest};
@@ -59,6 +60,14 @@ fn udp_peer_record(
     record.settings = Some(json!({
         "target_host": target_host,
         "target_port": target_port
+    }));
+    record
+}
+
+fn udp_forward_ip_record(name: &str, host: &str, port: u16, forward_ip: &str) -> InterfaceRecord {
+    let mut record = udp_record(name, host, port);
+    record.settings = Some(json!({
+        "forward_ip": forward_ip,
     }));
     record
 }
@@ -465,6 +474,23 @@ async fn hot_apply_spawns_udp_unicast_peer_with_runtime_metadata() {
     assert_eq!(
         udp_status.get("forward_addr").and_then(|value| value.as_str()),
         Some("127.0.0.1:4242")
+    );
+}
+
+#[test]
+fn hot_apply_udp_forward_ip_uses_shared_port_for_runtime_metadata() {
+    let mut record = udp_forward_ip_record("udp-peer", "127.0.0.1", 4242, "127.0.0.2");
+
+    mark_udp_record_runtime_status(&mut record, None);
+
+    let runtime =
+        record.settings.as_ref().and_then(|value| value.get("_runtime")).expect("runtime metadata");
+    let udp_status =
+        runtime.get("udp").and_then(|value| value.get("status")).expect("udp runtime status");
+    assert_eq!(udp_status.get("role").and_then(|value| value.as_str()), Some("peer"));
+    assert_eq!(
+        udp_status.get("forward_addr").and_then(|value| value.as_str()),
+        Some("127.0.0.2:4242")
     );
 }
 

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/interface_mutation_helpers.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/interface_mutation_helpers.rs
@@ -186,10 +186,18 @@ impl RpcDaemon {
         if iface.port.is_none() || Self::interface_setting_str(iface, "device").is_some() {
             return false;
         }
-        let target_host = Self::interface_setting_str(iface, "target_host")
-            .or_else(|| Self::interface_setting_str(iface, "forward_ip"));
+        let native_target_host = Self::interface_setting_str(iface, "target_host");
+        let forward_ip = Self::interface_setting_str(iface, "forward_ip");
+        let target_host = native_target_host.or(forward_ip);
         let target_port = Self::interface_setting_u64(iface, "target_port")
-            .or_else(|| Self::interface_setting_u64(iface, "forward_port"));
+            .or_else(|| Self::interface_setting_u64(iface, "forward_port"))
+            .or_else(|| {
+                if native_target_host.is_none() && forward_ip.is_some() {
+                    iface.port.map(u64::from)
+                } else {
+                    None
+                }
+            });
         if target_host.is_some() ^ target_port.is_some() {
             return false;
         }

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/interface_mutation_policy.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/interface_mutation_policy.rs
@@ -488,6 +488,46 @@
     }
 
     #[test]
+    fn set_interfaces_hot_applies_udp_forward_ip_with_shared_port() {
+        let daemon = RpcDaemon::test_instance();
+        let bridge = std::sync::Arc::new(RecordingInterfaceMutationBridge::new());
+        daemon.set_interface_mutation_bridge(bridge.clone());
+
+        let response = daemon
+            .handle_rpc(rpc_request(
+                37,
+                "set_interfaces",
+                json!({
+                    "interfaces": [{
+                        "type": "udp",
+                        "enabled": true,
+                        "host": "127.0.0.1",
+                        "port": 4242,
+                        "name": "udp-peer",
+                        "settings": {
+                            "forward_ip": "127.0.0.2"
+                        }
+                    }]
+                }),
+            ))
+            .expect("set_interfaces response");
+
+        assert!(response.error.is_none(), "unexpected error: {response:?}");
+        let applied = bridge.applied();
+        assert_eq!(applied.len(), 1);
+        let iface = &applied[0][0];
+        assert_eq!(iface.name.as_deref(), Some("udp-peer"));
+        assert_eq!(iface.port, Some(4242));
+        assert_eq!(
+            iface.settings
+                .as_ref()
+                .and_then(|settings| settings.get("forward_ip"))
+                .and_then(|value| value.as_str()),
+            Some("127.0.0.2")
+        );
+    }
+
+    #[test]
     fn set_interfaces_reports_device_udp_requires_restart() {
         let daemon = RpcDaemon::test_instance();
 
@@ -828,6 +868,50 @@
         assert_eq!(
             bridge.applied(),
             vec![vec![udp_interface("udp-mcast", "239.255.0.1", 4248)]]
+        );
+    }
+
+    #[test]
+    fn reload_config_hot_applies_udp_forward_ip_with_shared_port() {
+        let daemon = RpcDaemon::test_instance();
+        daemon.replace_interfaces(vec![udp_interface("udp-peer", "127.0.0.1", 4242)]);
+        let bridge = std::sync::Arc::new(RecordingInterfaceMutationBridge::new());
+        daemon.set_interface_mutation_bridge(bridge.clone());
+
+        let response = daemon
+            .handle_rpc(rpc_request(
+                36,
+                "reload_config",
+                json!({
+                    "interfaces": [{
+                        "type": "udp",
+                        "enabled": true,
+                        "host": "127.0.0.1",
+                        "port": 4242,
+                        "name": "udp-peer",
+                        "settings": {
+                            "forward_ip": "127.0.0.2"
+                        }
+                    }]
+                }),
+            ))
+            .expect("reload_config response");
+
+        assert!(response.error.is_none(), "unexpected reload error: {response:?}");
+        let result = response.result.expect("result");
+        assert_eq!(result["hot_applied_legacy_tcp_only"], json!(false));
+        assert_eq!(result["hot_applied_interface_mutation"], json!(true));
+        let applied = bridge.applied();
+        assert_eq!(applied.len(), 1);
+        let iface = &applied[0][0];
+        assert_eq!(iface.name.as_deref(), Some("udp-peer"));
+        assert_eq!(iface.port, Some(4242));
+        assert_eq!(
+            iface.settings
+                .as_ref()
+                .and_then(|settings| settings.get("forward_ip"))
+                .and_then(|value| value.as_str()),
+            Some("127.0.0.2")
         );
     }
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -441,9 +441,10 @@ Scoped release evidence is split as follows:
   network services. `set_interfaces` and `reload_config` now hot-apply explicit
   loopback TCP server listeners, including the local `localhost` hostname,
   alongside TCP clients and explicit UDP
-  listener, peer, and multicast-bind records, with tests proving
+  listener, peer, multicast-bind, and Python-style shared-port forward-peer
+  records, with tests proving
   `device`-bound, non-local, and broader TCP server listener shapes stay
-  restart-required or invalid, UDP `device`-bound, partial-target,
+  restart-required or invalid, UDP `device`-bound, native partial-target,
   out-of-range-target, and multicast-forward shapes remain restart-required or
   invalid, and duplicate TCP server or UDP binds are rejected before mutation.
   Hot-applied explicit TCP server records attach live daemon/RPC

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -141,16 +141,17 @@ placeholders:
   strict startup, bound loopback status, and malformed-datagram
   `bytes_rx`/`decode_errors` telemetry without external network services.
   Runtime interface mutation now hot-applies explicit loopback TCP server
-  listeners, including `localhost`, plus explicit UDP listener, peer, and
-  multicast-bind records through `set_interfaces` and `reload_config`, while
+  listeners, including `localhost`, plus explicit UDP listener, peer,
+  multicast-bind, and Python-style shared-port forward-peer records through
+  `set_interfaces` and `reload_config`, while
   `device`-bound, non-local, and broader TCP server listener shapes, plus UDP
-  `device`-bound, partial-target, out-of-range-target, and multicast-forward
-  records, remain restart-required or invalid. Duplicate TCP server and UDP
-  binds are rejected before mutation. Hot-applied explicit TCP server records
-  attach live daemon/RPC `_runtime.tcp.listener_status` metadata, hot-applied
-  explicit UDP records attach the runtime iface and refresh live daemon/RPC
-  `_runtime.udp.status` counters under focused software tests; multicast-bind
-  hot-apply uses the transport peer-routing helper.
+  `device`-bound, native partial-target, out-of-range-target, and
+  multicast-forward records, remain restart-required or invalid. Duplicate TCP
+  server and UDP binds are rejected before mutation. Hot-applied explicit TCP
+  server records attach live daemon/RPC `_runtime.tcp.listener_status`
+  metadata, hot-applied explicit UDP records attach the runtime iface and
+  refresh live daemon/RPC `_runtime.udp.status` counters under focused software
+  tests; multicast-bind hot-apply uses the transport peer-routing helper.
 - Serial now refreshes live daemon/RPC status with open/reconnect, HDLC frame,
   packet, byte, EOF, queue, decode, serialize, read, and write-error counters.
   Serial KISS and AX.25 KISS retain Python-compatible AX.25 UI header wrapping


### PR DESCRIPTION
## Summary
- make runtime UDP hot-apply treat Python-style `forward_ip` plus shared `port` as a complete forward peer target
- keep native `target_host` without a target port on the existing restart-required path
- add RPC mutation and runtime metadata regressions, and update Reticulum parity docs

## Validation
- cargo test -p reticulum-rs-rpc udp -- --nocapture
- cargo test -p reticulumd --bin reticulumd hot_apply -- --nocapture
- cargo test -p reticulumd --test config reticulum_udp_shared_port_defaults_forward_port_when_forward_ip_is_present -- --nocapture
- cargo fmt --all -- --check
- git diff --check