### PR TITLE
Cover tunnel path restore status

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/tests_parts/bootstrap_restores_path_cache.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/tests_parts/bootstrap_restores_path_cache.rs
@@ -407,6 +407,30 @@ fn bootstrap_reports_path_table_restore_error_in_daemon_status() {
     assert_eq!(restore_status["error"].as_str(), Some("decode path table"));
 }
 
+#[test]
+fn bootstrap_reports_tunnel_table_restore_error_in_daemon_status() {
+    let temp = TempDir::new().expect("temp dir");
+    let db_path = temp.path().join("reticulum.db");
+    fs::write(temp.path().join("tunnels"), b"not-msgpack-tunnel-table")
+        .expect("write corrupt tunnel table");
+    let runtime =
+        tokio::runtime::Builder::new_current_thread().enable_all().build().expect("runtime");
+
+    let context = runtime.block_on(async {
+        bootstrap::bootstrap(test_args(
+            db_path.clone(),
+            None,
+            Some("127.0.0.1:0".to_string()),
+            false,
+        ))
+        .await
+    });
+
+    let restore_status = path_table_restore_runtime_status(&context.daemon);
+    assert_eq!(restore_status["status"].as_str(), Some("error"));
+    assert_eq!(restore_status["error"].as_str(), Some("decode tunnel table"));
+}
+
 fn append_corrupt_cache_path_row(
     storage_path: &std::path::Path,
     destination: AddressHash,

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -133,7 +133,8 @@ Scoped release evidence is split as follows:
   `request_path` RPC after restart, that restored cached-announce identity keys
   are persisted for daemon announce-identity lookup, and daemon status reports
   `_runtime.reticulum.path_table_restore.status` as `ok` or `error` so corrupt
-  `destination_table` state remains observable without making startup fatal.
+  `destination_table` and `tunnels` state remain observable without making
+  startup fatal.
 - Reticulum path-table persistence now writes only routes with cached announce
   material and restore hardens Python-format active and tunnel path-table rows
   by ignoring stale/expired path rows, so restart bootstrap cannot revive
@@ -146,7 +147,8 @@ Scoped release evidence is split as follows:
   active/tunnel cached-announce rows alongside the existing malformed-cache
   daemon evidence.
   Malformed `destination_table` and `tunnels` files remain observable daemon
-  restore errors.
+  restore errors, with focused daemon bootstrap/status coverage for each
+  Python-format table.
 - Shared-instance clients skip local Reticulum path-table save and restore
   work, matching Python's shared-instance bootstrap/persistence boundary.
 - Tunnel-only restored announces are retained as cache material so paths

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -351,8 +351,9 @@ announce material, and restore ignores stale/expired Python-format active and
 tunnel path-table rows before reintroducing resolver/cache state.
 Malformed per-entry cached announce files and cached announces whose decoded
 destination does not match the active/tunnel path row are skipped without
-poisoning other valid restored routes, while malformed `destination_table` or
-`tunnels` files still surface as daemon restore errors.
+poisoning other valid restored routes, while malformed `destination_table` and
+`tunnels` files surface as daemon restore errors through focused bootstrap/status
+coverage.
 Shared-instance clients now skip local path-table save and restore work like
 Python Reticulum.
 Tunnel-only restored announces are also retained as cache material, so paths


### PR DESCRIPTION
## Summary

- add daemon bootstrap/status regression coverage for malformed Python-format `tunnels` restore files
- document that both `destination_table` and `tunnels` restore errors surface through `_runtime.reticulum.path_table_restore`

## Impact

This closes a small Reticulum resolver/bootstrap observability gap. Corrupt tunnel path-table state remains non-fatal at daemon startup while still being visible in daemon status, matching the existing malformed `destination_table` behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p reticulumd bootstrap_reports_tunnel_table_restore_error_in_daemon_status`
- `cargo test -p reticulum-rs-transport reticulum_tunnel_table_restore_skips_malformed_cached_announce_entry`
