### PR TITLE
Expose receipt event stage metadata

### DIFF
--- a/crates/apps/reticulumd/src/receipt_bridge.rs
+++ b/crates/apps/reticulumd/src/receipt_bridge.rs
@@ -19,6 +19,7 @@ pub struct ReceiptEvent {
     pub delivery_kind: Option<String>,
     pub bytes: Option<usize>,
     pub link_id: Option<String>,
+    pub stage: Option<String>,
 }
 
 impl ReceiptEvent {
@@ -33,6 +34,7 @@ impl ReceiptEvent {
             delivery_kind: None,
             bytes: None,
             link_id: None,
+            stage: None,
         }
     }
 
@@ -71,6 +73,11 @@ impl ReceiptEvent {
         self
     }
 
+    pub fn with_stage(mut self, stage: impl Into<String>) -> Self {
+        self.stage = Some(stage.into());
+        self
+    }
+
     fn rpc_params(&self) -> serde_json::Value {
         let mut params = serde_json::json!({
             "message_id": self.message_id,
@@ -97,6 +104,9 @@ impl ReceiptEvent {
             }
             if let Some(link_id) = &self.link_id {
                 map.insert("link_id".to_string(), serde_json::json!(link_id));
+            }
+            if let Some(stage) = &self.stage {
+                map.insert("stage".to_string(), serde_json::json!(stage));
             }
         }
         params
@@ -127,7 +137,8 @@ impl ReceiptHandler for ReceiptBridge {
         };
         let event = ReceiptEvent::new(message_id, "delivered")
             .with_packet_hash(hex::encode(receipt.message_id))
-            .with_delivery_kind("transport-receipt");
+            .with_delivery_kind("transport-receipt")
+            .with_stage("transport_receipt");
         if let Err(err) = self.tx.try_send(event) {
             log::warn!("[daemon] dropped delivery receipt event: {err}");
         }

--- a/crates/apps/reticulumd/tests/receipt_worker.rs
+++ b/crates/apps/reticulumd/tests/receipt_worker.rs
@@ -106,7 +106,8 @@ fn receipt_event_preserves_router_metadata_in_sdk_payload() {
             .with_method("direct")
             .with_delivery_kind("link-packet")
             .with_bytes(128)
-            .with_link_id("link-1"),
+            .with_link_id("link-1")
+            .with_stage("transport_receipt"),
     )
     .expect("handle receipt");
 
@@ -119,6 +120,7 @@ fn receipt_event_preserves_router_metadata_in_sdk_payload() {
     assert_eq!(payload["delivery_kind"], json!("link-packet"));
     assert_eq!(payload["bytes"], json!(128));
     assert_eq!(payload["link_id"], json!("link-1"));
+    assert_eq!(payload["stage"], json!("transport_receipt"));
 }
 
 #[test]

--- a/crates/libs/lxmf-sdk/src/app/events.rs
+++ b/crates/libs/lxmf-sdk/src/app/events.rs
@@ -4,7 +4,6 @@ use crate::event::{Severity as RawSeverity, SubscriptionStart as RawSubscription
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
-
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
@@ -111,6 +110,7 @@ pub struct DeliveryLifecycleDetails {
     pub method: Option<String>,
     pub bytes: Option<u64>,
     pub link_id: Option<String>,
+    pub stage: Option<String>,
     pub reason: Option<String>,
 }
 
@@ -274,6 +274,7 @@ fn delivery_lifecycle_details(payload: &JsonValue) -> DeliveryLifecycleDetails {
         method: json_str(payload, "method"),
         bytes: payload.get("bytes").and_then(JsonValue::as_u64),
         link_id: json_str(payload, "link_id"),
+        stage: json_str(payload, "stage"),
         reason: json_str(payload, "reason").or_else(|| json_str(payload, "detail")),
     }
 }
@@ -489,7 +490,6 @@ pub fn map_event_batch(batch: RawEventBatch, profile_id: &str) -> EventBatch {
         dropped_count: batch.dropped_count,
     }
 }
-
 #[cfg(feature = "sdk-async")]
 pub fn subscription_cursor(subscription: &EventSubscription) -> Option<crate::EventCursor> {
     subscription.cursor.clone()

--- a/crates/libs/lxmf-sdk/src/app/events_tests.rs
+++ b/crates/libs/lxmf-sdk/src/app/events_tests.rs
@@ -230,7 +230,8 @@ fn maps_receipt_event_to_lifecycle_details() {
                 "packet_hash": "packet-1",
                 "resource_hash": "resource-1",
                 "bytes": 128,
-                "link_id": "link-1"
+                "link_id": "link-1",
+                "stage": "transport_receipt"
             }),
         ),
         "desktop_default",
@@ -249,4 +250,5 @@ fn maps_receipt_event_to_lifecycle_details() {
     assert_eq!(details.resource_hash.as_deref(), Some("resource-1"));
     assert_eq!(details.bytes, Some(128));
     assert_eq!(details.link_id.as_deref(), Some("link-1"));
+    assert_eq!(details.stage.as_deref(), Some("transport_receipt"));
 }

--- a/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/handle_rpc_legacy_message_delivery.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/dispatch_legacy_messages_parts/rpcdaemon_sections/handle_rpc_legacy_message_delivery.rs
@@ -119,6 +119,7 @@ impl RpcDaemon {
                     delivery_kind,
                     bytes,
                     link_id,
+                    stage,
                 } = parsed;
                 let (status, updated, delivered_ticket_destination) = {
                     let _status_guard = self
@@ -183,6 +184,9 @@ impl RpcDaemon {
                 }
                 if let Some(link_id) = link_id {
                     payload.insert("link_id".into(), json!(link_id));
+                }
+                if let Some(stage) = stage {
+                    payload.insert("stage".into(), json!(stage));
                 }
                 let payload = JsonValue::Object(payload);
                 let event = RpcEvent { event_type: "receipt".into(), payload: payload.clone() };

--- a/crates/libs/rns-rpc/src/rpc/params/core.rs
+++ b/crates/libs/rns-rpc/src/rpc/params/core.rs
@@ -16,6 +16,8 @@ struct RecordReceiptParams {
     bytes: Option<u64>,
     #[serde(default)]
     link_id: Option<String>,
+    #[serde(default)]
+    stage: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1041,6 +1041,10 @@ Scoped release evidence is split as follows:
   receipt status, signature/stamp metadata, drop reason, and lifecycle state
   without requiring REM/RCH clients to parse raw event JSON for normal message
   and status UI.
+- Receipt lifecycle events now preserve handler/bridge stage provenance in the
+  pollable SDK payload and typed app lifecycle helper, so transport-origin
+  delivery receipts can be distinguished from other receipt publishers without
+  raw JSON parsing.
 - RPC-layer propagation rejects for ignored destination hashes now emit bounded
   `inbound_dropped` events before returning `PermissionDenied` from
   `propagation_ingest` and remote fetch/download/sync imports. The events use

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -923,6 +923,9 @@ Workspace paths are used for navigation. `crates/libs/lxmf-core` publishes as
   preserving message IDs, peer/source identity, destination hashes, raw LXMF
   bytes, signature/stamp metadata, drop reason, receipt status, and lifecycle
   state without requiring normal client UI flows to decode raw event JSON.
+- Receipt lifecycle events preserve handler/bridge stage provenance in both
+  the pollable SDK payload and typed app lifecycle helper, so transport-origin
+  delivery receipts remain distinguishable without raw event JSON parsing.
 - Focused propagated local-delivery tests cover ignored-source delivery-policy
   rejections emitting bounded raw `inbound_dropped` events with
   `delivery_kind = "propagation"` while preserving Python-style no-store


### PR DESCRIPTION
## Summary
- preserve receipt handler/bridge stage provenance through `record_receipt` event payloads
- tag transport-origin delivery receipt events with `stage = "transport_receipt"`
- expose receipt stage in typed SDK app delivery lifecycle details and update LXMF parity docs

## Validation
- cargo fmt --all -- --check
- cargo test -p reticulumd --test receipt_worker -- --nocapture
- cargo test -p lxmf-sdk maps_receipt_event_to_lifecycle_details -- --nocapture
- cargo test -p reticulumd --test code_quality_issue_369
- tools/scripts/check-boundaries.sh
- git diff --check