### PR TITLE
Fix Rust 1.97 xtask clippy

### DIFF
--- a/xtask/src/client_codegen_parts/generate_openapi_spec.rs
+++ b/xtask/src/client_codegen_parts/generate_openapi_spec.rs
@@ -218,7 +218,7 @@ fn generate_openapi_spec(
     };
 
     let mut spec = spec;
-    for (_name, schema) in spec.components.schemas.iter_mut() {
+    for schema in spec.components.schemas.values_mut() {
         sanitize_component_self_references(schema);
     }
     promote_inline_component_property(


### PR DESCRIPTION
## Summary

- iterate directly over OpenAPI schema values in the xtask generator
- restore the workspace Clippy gate under Rust 1.97

## Root cause

Rust 1.97 now reports `clippy::for_kv_map` for the unused map key binding. Because CI uses `-D warnings`, this blocked otherwise unrelated pull requests, including #398.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p xtask --all-targets --all-features --no-deps -- -D warnings`
- `git diff --check`