### PR TITLE
Fix Windows Rust 1.97 clippy gates

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup_parts/module_prelude.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup_parts/module_prelude.rs
@@ -345,18 +345,16 @@ pub(super) async fn startup_configured_interfaces(
                         }
                         LocalTcpSidecarStartup::Failed => {}
                     }
-                } else {
-                    if let Some(seed) = startup_tcp_server_record(
-                        index,
-                        iface,
-                        &label,
-                        selected_tcp_server,
-                        server_iface,
-                        &mut configured_interfaces[index],
-                        &mut startup_failures,
-                    ) {
-                        seeded_hot_apply_interfaces.push(seed);
-                    }
+                } else if let Some(seed) = startup_tcp_server_record(
+                    index,
+                    iface,
+                    &label,
+                    selected_tcp_server,
+                    server_iface,
+                    &mut configured_interfaces[index],
+                    &mut startup_failures,
+                ) {
+                    seeded_hot_apply_interfaces.push(seed);
                 }
                 if selected_tcp_server.selected_index == Some(index) {
                     if let Some(active_iface) = server_iface {
@@ -708,6 +706,7 @@ fn startup_tcp_server_record(
     })
 }
 
+#[cfg_attr(not(unix), allow(dead_code))]
 enum LocalUnixStartup {
     Active,
     Attached(AddressHash),

--- a/crates/libs/rns-transport/src/iface/tcp_client.rs
+++ b/crates/libs/rns-transport/src/iface/tcp_client.rs
@@ -367,6 +367,7 @@ pub(crate) fn backbone_hdlc_watchdog() -> HdlcStreamWatchdog {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg_attr(not(unix), allow(dead_code))]
 pub(crate) async fn run_hdlc_stream<R, W>(
     label: String,
     iface_address: crate::hash::AddressHash,


### PR DESCRIPTION
## Summary
- mark the Unix-only HDLC wrapper and local Unix startup variants as target-scoped dead code on Windows
- apply Rust 1.97's collapsible `else if` suggestion without changing startup behavior
- unblock the repository-wide all-features clippy stage on Windows

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- `git diff --check`