### PR TITLE
Split transport job tests below module gate

### DIFF
--- a/crates/libs/rns-transport/src/transport/jobs.rs
+++ b/crates/libs/rns-transport/src/transport/jobs.rs
@@ -481,29 +481,4 @@ pub(super) async fn manage_transport(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn link_check_delay_uses_retry_deadline_when_sooner_than_default_sweep() {
-        let now = std::time::Instant::now();
-        let deadline = now + Duration::from_millis(150);
-
-        assert_eq!(link_check_delay_from_deadline(now, Some(deadline)), Duration::from_millis(150));
-    }
-
-    #[test]
-    fn link_check_delay_clamps_overdue_retries_to_minimum_delay() {
-        let now = std::time::Instant::now();
-        let deadline = now - Duration::from_millis(5);
-
-        assert_eq!(link_check_delay_from_deadline(now, Some(deadline)), MIN_LINKS_CHECK_DELAY);
-    }
-
-    #[test]
-    fn link_check_delay_keeps_default_sweep_without_pending_retries() {
-        let now = std::time::Instant::now();
-
-        assert_eq!(link_check_delay_from_deadline(now, None), INTERVAL_LINKS_CHECK);
-    }
-}
+include!("jobs_parts/tests.rs");

--- a/crates/libs/rns-transport/src/transport/jobs_parts/tests.rs
+++ b/crates/libs/rns-transport/src/transport/jobs_parts/tests.rs
@@ -1,0 +1,26 @@
+mod tests {
+    use super::*;
+
+    #[test]
+    fn link_check_delay_uses_retry_deadline_when_sooner_than_default_sweep() {
+        let now = std::time::Instant::now();
+        let deadline = now + Duration::from_millis(150);
+
+        assert_eq!(link_check_delay_from_deadline(now, Some(deadline)), Duration::from_millis(150));
+    }
+
+    #[test]
+    fn link_check_delay_clamps_overdue_retries_to_minimum_delay() {
+        let now = std::time::Instant::now();
+        let deadline = now - Duration::from_millis(5);
+
+        assert_eq!(link_check_delay_from_deadline(now, Some(deadline)), MIN_LINKS_CHECK_DELAY);
+    }
+
+    #[test]
+    fn link_check_delay_keeps_default_sweep_without_pending_retries() {
+        let now = std::time::Instant::now();
+
+        assert_eq!(link_check_delay_from_deadline(now, None), INTERVAL_LINKS_CHECK);
+    }
+}


### PR DESCRIPTION
## Summary
- move the transport job timing tests into `jobs_parts/tests.rs`
- keep production behavior unchanged while reducing `transport/jobs.rs` below the 500-line module budget
- restore the repository module-size gate on current `main`

## Validation
- `cargo test -p reticulum-rs-transport link_check_delay_ -- --nocapture`
- `tools/scripts/check-module-size.sh`
- `cargo fmt --all -- --check`
- `git diff --check`