### PR TITLE
Escape Windows paths in I2P TOML tests

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup_parts/module_prelude.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_interface_startup_parts/module_prelude.rs
@@ -2925,10 +2925,10 @@ interfaces = [
         let cfg = reticulum_daemon::config::DaemonConfig::from_toml(&format!(
             r#"
 interfaces = [
-  {{ type = "I2PInterface", enabled = true, name = "i2p-main", connectable = true, storagepath = "{}" }}
+  {{ type = "I2PInterface", enabled = true, name = "i2p-main", connectable = true, storagepath = {} }}
 ]
 "#,
-            root.to_string_lossy()
+            toml::Value::String(root.to_string_lossy().into_owned())
         ))
         .expect("parse i2p config");
         let args = test_args();
@@ -3101,12 +3101,12 @@ interfaces = [
         let cfg = reticulum_daemon::config::DaemonConfig::from_toml(&format!(
             r#"
 interfaces = [
-  {{ type = "I2PInterface", enabled = true, name = "i2p-main", connectable = true, sam_ip = "{}", sam_port = {}, storagepath = "{}" }}
+  {{ type = "I2PInterface", enabled = true, name = "i2p-main", connectable = true, sam_ip = "{}", sam_port = {}, storagepath = {} }}
 ]
 "#,
             sam_addr.ip(),
             sam_addr.port(),
-            root.to_string_lossy()
+            toml::Value::String(root.to_string_lossy().into_owned())
         ))
         .expect("parse i2p config");
         let args = test_args();


### PR DESCRIPTION
## Summary
- serialize Windows temporary paths as TOML string values in the two I2P startup metadata fixtures
- preserve the same cross-platform fixture semantics while escaping backslashes correctly
- unblock the Windows workspace nextest stage in `release-check`

## Validation
- `cargo test -p reticulumd --bin reticulumd i2p_startup_reports_ -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`