### PR TITLE
Accept Windows executable name in rnsd help test

### DIFF
--- a/crates/apps/rns-tools/tests/rnsd_cli.rs
+++ b/crates/apps/rns-tools/tests/rnsd_cli.rs
@@ -11,7 +11,8 @@ fn rnsd_honors_reticulumd_bin_and_forwards_help_output() {
     assert!(output.status.success(), "status={:?}", output.status);
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Request Reticulum path discovery through daemon RPC."));
-    assert!(stdout.contains("Usage: rnpath-rs [OPTIONS] <DESTINATION_HASH>"));
+    let delegated_name = if cfg!(windows) { "rnpath-rs.exe" } else { "rnpath-rs" };
+    assert!(stdout.contains(&format!("Usage: {delegated_name} [OPTIONS] <DESTINATION_HASH>")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- expect Clap's `.exe` suffix in delegated `rnpath-rs` help output on Windows
- retain the exact Unix help expectation
- unblock the Windows `cargo test --workspace --tests` release stage

## Validation
- `cargo test -p rns-tools --test rnsd_cli -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`