### PR TITLE
Add in-process LXMF runtime backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,6 +1589,23 @@ name = "lxmf-reference"
 version = "0.7.1"
 
 [[package]]
+name = "lxmf-runtime"
+version = "0.7.1"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "lxmf-sdk",
+ "lxmf-wire",
+ "rand_core 0.6.4",
+ "reticulum-rs-transport",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "lxmf-sdk"
 version = "0.7.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/libs/rns-embedded-runtime",
   "crates/libs/lxmf-core",
   "crates/libs/lxmf-sdk",
+  "crates/libs/lxmf-runtime",
   "crates/libs/reticulum-rs",
   "crates/libs/rns-core",
   "crates/libs/rns-transport",
@@ -29,6 +30,7 @@ default-members = [
   "crates/libs/rns-embedded-runtime",
   "crates/libs/lxmf-core",
   "crates/libs/lxmf-sdk",
+  "crates/libs/lxmf-runtime",
   "crates/libs/reticulum-rs",
   "crates/libs/rns-core",
   "crates/libs/rns-transport",
@@ -56,6 +58,9 @@ allowed_library_edges = [
   "lxmf->lxmf-wire",
   "lxmf-sdk->lxmf-wire",
   "lxmf-sdk->reticulum-rs-rpc",
+  "lxmf-runtime->lxmf-sdk",
+  "lxmf-runtime->lxmf-wire",
+  "lxmf-runtime->reticulum-rs-transport",
   "reticulum-rs->reticulum-rs-core",
   "reticulum-rs->reticulum-rs-rpc",
   "reticulum-rs->reticulum-rs-transport",
@@ -95,6 +100,7 @@ criterion = "0.5"
 lxmf = { version = "0.7.1", path = "crates/libs/lxmf" }
 lxmf-core = { package = "lxmf-wire", version = "0.7.1", path = "crates/libs/lxmf-core" }
 lxmf-sdk = { version = "0.7.1", path = "crates/libs/lxmf-sdk" }
+lxmf-runtime = { version = "0.7.1", path = "crates/libs/lxmf-runtime" }
 reticulum-rs = { version = "0.7.1", path = "crates/libs/reticulum-rs" }
 rns-core = { package = "reticulum-rs-core", version = "0.7.1", path = "crates/libs/rns-core" }
 rns-rpc = { package = "reticulum-rs-rpc", version = "0.7.1", path = "crates/libs/rns-rpc" }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ LXMF-rs/
 │   │   ├── lxmf/
 │   │   ├── lxmf-core/
 │   │   ├── lxmf-sdk/
+│   │   ├── lxmf-runtime/
 │   │   ├── reticulum-rs/
 │   │   ├── rns-core/
 │   │   ├── rns-embedded-core/
@@ -84,6 +85,7 @@ migration-era crates are not kept in the repository surface.
 - `lxmf-wire` (`crates/libs/lxmf-core`): message/payload/identity primitives.
 - `lxmf`: umbrella crate for `lxmf-sdk` and `lxmf-wire`.
 - `lxmf-sdk`: host-facing client API (`start/send/cancel/status/configure/poll/snapshot/shutdown`).
+- `lxmf-runtime`: in-process `SdkBackend` over Reticulum transport for embedded host applications.
 - `rns-embedded-runtime`: node-centric embedded runtime facade with lifecycle, event, and managed `std` driver support.
 - `rns-embedded-ffi`: C ABI for embedded/manual-tick compatibility and the v1 node-centric API.
 - `rns-embedded-core`: shared embedded/runtime types and fixtures.

--- a/crates/libs/lxmf-runtime/Cargo.toml
+++ b/crates/libs/lxmf-runtime/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "lxmf-runtime"
+version = "0.7.1"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "In-process LXMF SDK backend over the Reticulum transport runtime."
+readme = "../../../README.md"
+documentation = "https://docs.rs/lxmf-runtime"
+keywords = ["lxmf", "reticulum", "runtime", "sdk"]
+categories = ["network-programming"]
+
+[dependencies]
+base64.workspace = true
+hex.workspace = true
+lxmf-core.workspace = true
+lxmf-sdk = { version = "0.7.1", path = "../lxmf-sdk", default-features = false, features = ["std"] }
+rand_core = { workspace = true, features = ["getrandom"] }
+rmp-serde.workspace = true
+rns-transport.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/libs/lxmf-runtime/src/backend.rs
+++ b/crates/libs/lxmf-runtime/src/backend.rs
@@ -1,0 +1,185 @@
+use std::sync::{Arc, Mutex};
+
+use lxmf_sdk::{
+    Ack, CancelResult, ConfigPatch, DeliverySnapshot, DeliveryState, EventBatch, EventCursor,
+    MessageId, NegotiationRequest, NegotiationResponse, RuntimeSnapshot, SdkBackend, SdkError,
+    SendRequest, Severity, ShutdownMode,
+};
+use rns_transport::hash::AddressHash;
+use serde_json::{json, Value as JsonValue};
+
+use crate::config::InProcessBackendConfig;
+use crate::delivery::{
+    request_link_attempts, request_link_timeout, request_resource_timeout, InProcessSendReport,
+    SendContext,
+};
+use crate::state::{internal_error, BackendState};
+
+#[derive(Clone)]
+pub struct InProcessBackend {
+    config: Arc<InProcessBackendConfig>,
+    state: Arc<Mutex<BackendState>>,
+    propagation_relay: Arc<Mutex<Option<AddressHash>>>,
+}
+
+impl InProcessBackend {
+    pub fn new(config: InProcessBackendConfig) -> Self {
+        let state = BackendState::new(config.runtime_id.clone(), config.limits);
+        let propagation_relay = Arc::new(Mutex::new(config.propagation_relay));
+        Self { config: Arc::new(config), state: Arc::new(Mutex::new(state)), propagation_relay }
+    }
+
+    pub fn send_report(
+        &self,
+        message_id: &MessageId,
+    ) -> Result<Option<InProcessSendReport>, SdkError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| internal_error("in-process backend state poisoned"))?
+            .send_report(&message_id.0))
+    }
+
+    pub fn set_propagation_relay(&self, relay: Option<AddressHash>) -> Result<(), SdkError> {
+        *self
+            .propagation_relay
+            .lock()
+            .map_err(|_| internal_error("in-process propagation relay state poisoned"))? = relay;
+        Ok(())
+    }
+
+    pub fn record_delivery(
+        &self,
+        message_id: &MessageId,
+        state: DeliveryState,
+        reason: Option<String>,
+    ) -> Result<(), SdkError> {
+        self.state
+            .lock()
+            .map_err(|_| internal_error("in-process backend state poisoned"))?
+            .record_delivery(&message_id.0, state, reason)
+    }
+
+    pub fn record_event(
+        &self,
+        event_type: &str,
+        severity: Severity,
+        payload: JsonValue,
+    ) -> Result<(), SdkError> {
+        self.state
+            .lock()
+            .map_err(|_| internal_error("in-process backend state poisoned"))?
+            .record_event(event_type, severity, payload)
+    }
+}
+
+impl SdkBackend for InProcessBackend {
+    fn negotiate(&self, _req: NegotiationRequest) -> Result<NegotiationResponse, SdkError> {
+        let runtime_id = self
+            .state
+            .lock()
+            .map_err(|_| internal_error("in-process backend state poisoned"))?
+            .runtime_id()
+            .to_owned();
+        serde_json::from_value(json!({
+            "runtime_id": runtime_id,
+            "active_contract_version": 2,
+            "effective_capabilities": [
+                "sdk.capability.event_stream",
+                "sdk.capability.cursor_replay",
+                "sdk.capability.receipt_terminality",
+                "sdk.capability.config_revision_cas",
+                "reticulum.capability.raw_bytes",
+                "reticulum.capability.msgpack_fields"
+            ],
+            "effective_limits": {
+                "max_poll_events": 128,
+                "max_event_bytes": 65536,
+                "max_batch_bytes": 1048576,
+                "max_extension_keys": 16,
+                "idempotency_ttl_ms": 43200000
+            },
+            "contract_release": lxmf_sdk::CONTRACT_RELEASE,
+            "schema_namespace": lxmf_sdk::SCHEMA_NAMESPACE,
+        }))
+        .map_err(|err| internal_error(format!("invalid negotiation response: {err}")))
+    }
+
+    fn send(&self, request: SendRequest) -> Result<MessageId, SdkError> {
+        let link_timeout = request_link_timeout(&request, self.config.link_connect_timeout);
+        let link_attempts = request_link_attempts(&request, self.config.link_connect_attempts);
+        let resource_timeout =
+            request_resource_timeout(&request, self.config.resource_transfer_timeout);
+        let context = SendContext {
+            transport: &self.config.transport,
+            identity: &self.config.identity,
+            source_destination: self.config.source_destination,
+            propagation_relay: *self
+                .propagation_relay
+                .lock()
+                .map_err(|_| internal_error("in-process propagation relay state poisoned"))?,
+            link_connect_timeout: link_timeout,
+            link_connect_attempts: link_attempts,
+            resource_transfer_timeout: resource_timeout,
+        };
+        let result = self.config.runtime_handle.block_on(crate::delivery::send(context, &request));
+        match result {
+            Ok(report) => {
+                let message_id = report.message_id.clone();
+                self.state
+                    .lock()
+                    .map_err(|_| internal_error("in-process backend state poisoned"))?
+                    .record_send(report)?;
+                Ok(message_id)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    fn cancel(&self, _id: MessageId) -> Result<CancelResult, SdkError> {
+        Ok(CancelResult::Unsupported)
+    }
+
+    fn status(&self, id: MessageId) -> Result<Option<DeliverySnapshot>, SdkError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| internal_error("in-process backend state poisoned"))?
+            .status(&id))
+    }
+
+    fn configure(&self, _expected_revision: u64, _patch: ConfigPatch) -> Result<Ack, SdkError> {
+        let revision = self
+            .state
+            .lock()
+            .map_err(|_| internal_error("in-process backend state poisoned"))?
+            .advance_config_revision();
+        make_ack(Some(revision))
+    }
+
+    fn poll_events(&self, cursor: Option<EventCursor>, max: usize) -> Result<EventBatch, SdkError> {
+        self.state
+            .lock()
+            .map_err(|_| internal_error("in-process backend state poisoned"))?
+            .poll(cursor.as_ref(), max)
+    }
+
+    fn snapshot(&self) -> Result<RuntimeSnapshot, SdkError> {
+        self.state
+            .lock()
+            .map_err(|_| internal_error("in-process backend state poisoned"))?
+            .snapshot()
+    }
+
+    fn shutdown(&self, _mode: ShutdownMode) -> Result<Ack, SdkError> {
+        make_ack(None)
+    }
+}
+
+fn make_ack(revision: Option<u64>) -> Result<Ack, SdkError> {
+    serde_json::from_value(json!({
+        "accepted": true,
+        "revision": revision,
+    }))
+    .map_err(|err| internal_error(format!("invalid acknowledgement: {err}")))
+}

--- a/crates/libs/lxmf-runtime/src/config.rs
+++ b/crates/libs/lxmf-runtime/src/config.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use rns_transport::hash::AddressHash;
+use rns_transport::identity::PrivateIdentity;
+use rns_transport::transport::Transport;
+use tokio::runtime::Handle;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InProcessBackendLimits {
+    pub event_retention: usize,
+    pub delivery_retention: usize,
+    pub send_report_retention: usize,
+}
+
+impl Default for InProcessBackendLimits {
+    fn default() -> Self {
+        Self { event_retention: 2_048, delivery_retention: 1_024, send_report_retention: 512 }
+    }
+}
+
+#[derive(Clone)]
+pub struct InProcessBackendConfig {
+    pub runtime_id: String,
+    pub runtime_handle: Handle,
+    pub transport: Arc<Transport>,
+    pub identity: PrivateIdentity,
+    pub source_destination: AddressHash,
+    pub propagation_relay: Option<AddressHash>,
+    pub link_connect_timeout: Duration,
+    pub link_connect_attempts: usize,
+    pub resource_transfer_timeout: Duration,
+    pub limits: InProcessBackendLimits,
+}
+
+impl InProcessBackendConfig {
+    pub fn new(
+        runtime_id: impl Into<String>,
+        runtime_handle: Handle,
+        transport: Arc<Transport>,
+        identity: PrivateIdentity,
+        source_destination: AddressHash,
+    ) -> Self {
+        Self {
+            runtime_id: runtime_id.into(),
+            runtime_handle,
+            transport,
+            identity,
+            source_destination,
+            propagation_relay: None,
+            link_connect_timeout: Duration::from_secs(20),
+            link_connect_attempts: 3,
+            resource_transfer_timeout: Duration::from_secs(120),
+            limits: InProcessBackendLimits::default(),
+        }
+    }
+}

--- a/crates/libs/lxmf-runtime/src/delivery.rs
+++ b/crates/libs/lxmf-runtime/src/delivery.rs
@@ -1,0 +1,395 @@
+use std::time::Duration;
+
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine as _;
+use lxmf_core::{decide_delivery, Message, MessageMethod, TransportMethod, WireMessage};
+use lxmf_sdk::{MessageId, SdkError, SendRequest};
+use rand_core::OsRng;
+use rns_transport::destination::{DestinationDesc, DestinationName};
+use rns_transport::hash::AddressHash;
+use rns_transport::identity::PrivateIdentity;
+use rns_transport::packet::{
+    ContextFlag, DestinationType, Header, HeaderType, IfacFlag, Packet, PacketContext,
+    PacketDataBuffer, PacketType, PropagationType, LXMF_MAX_PAYLOAD,
+};
+use rns_transport::transport::{SendPacketOutcome, Transport};
+use serde_json::Value as JsonValue;
+
+use crate::link_delivery::send_link_payload;
+use crate::{
+    EXT_ACCEPTED_RESULT_ACK, EXT_DIRECT_PACKET_MAX_WIRE_BYTES, EXT_FIELDS_BASE64,
+    EXT_LINK_CONNECT_TIMEOUT_MS, EXT_PROPAGATION_RELAY_HEX, EXT_RAW_BYTES_BASE64, EXT_SEND_MODE,
+    EXT_USE_PROPAGATION_NODE,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeliveryMethod {
+    Opportunistic,
+    Direct,
+    Propagated,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeliveryRepresentation {
+    Packet,
+    Resource,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeliveryOutcome {
+    SentDirect,
+    SentBroadcast,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InProcessSendReport {
+    pub message_id: MessageId,
+    pub resolved_destination: String,
+    pub method: DeliveryMethod,
+    pub representation: DeliveryRepresentation,
+    pub outcome: DeliveryOutcome,
+    pub relay_destination: Option<String>,
+    pub receipt_hash: Option<String>,
+}
+
+pub(crate) struct SendContext<'a> {
+    pub transport: &'a Transport,
+    pub identity: &'a PrivateIdentity,
+    pub source_destination: AddressHash,
+    pub propagation_relay: Option<AddressHash>,
+    pub link_connect_timeout: Duration,
+    pub link_connect_attempts: usize,
+    pub resource_transfer_timeout: Duration,
+}
+
+pub(crate) async fn send(
+    context: SendContext<'_>,
+    request: &SendRequest,
+) -> Result<InProcessSendReport, SdkError> {
+    let requested_destination = parse_hash(&request.destination)?;
+    let remote = resolve_destination(context.transport, requested_destination, "delivery").await?;
+    let wire = encode_wire(context.identity, context.source_destination, &remote, request)?;
+    let message_id = MessageId(hex::encode(
+        WireMessage::unpack(&wire)
+            .map_err(|err| internal(format!("failed to decode encoded LXMF message: {err}")))?
+            .message_id(),
+    ));
+    let mut desired_method = requested_method(request)?;
+    if matches!(desired_method, TransportMethod::Opportunistic)
+        && request_uses_auto_mode(request)
+        && context.transport.delivery_link_available(&remote.address_hash).await
+    {
+        desired_method = TransportMethod::Direct;
+    }
+    let decision = decide_delivery(desired_method, false, wire.len())
+        .map_err(|err| validation(format!("failed to select delivery representation: {err}")))?;
+    let representation =
+        forced_representation(request, decision.method, decision.representation, wire.len());
+
+    match decision.method {
+        TransportMethod::Opportunistic => {
+            send_opportunistic(context.transport, remote.address_hash, &wire, message_id).await
+        }
+        TransportMethod::Direct => {
+            send_link_payload(
+                context.transport,
+                remote,
+                &wire,
+                message_id,
+                DeliveryMethod::Direct,
+                representation,
+                context.link_connect_timeout,
+                context.link_connect_attempts,
+                context.resource_transfer_timeout,
+                None,
+            )
+            .await
+        }
+        TransportMethod::Propagated => {
+            send_propagated(context, request, &remote, &wire, message_id).await
+        }
+        TransportMethod::Paper => Err(validation("paper delivery is not supported in-process")),
+    }
+}
+
+async fn send_opportunistic(
+    transport: &Transport,
+    destination: AddressHash,
+    wire: &[u8],
+    message_id: MessageId,
+) -> Result<InProcessSendReport, SdkError> {
+    let packet = data_packet(destination, PropagationType::Transport, wire)?;
+    let receipt_hash = hex::encode(packet.hash().to_bytes());
+    let outcome =
+        ensure_sent(transport.send_packet_with_outcome(packet).await, "opportunistic send")?;
+    Ok(InProcessSendReport {
+        message_id,
+        resolved_destination: destination.to_hex_string(),
+        method: DeliveryMethod::Opportunistic,
+        representation: DeliveryRepresentation::Packet,
+        outcome,
+        relay_destination: None,
+        receipt_hash: Some(receipt_hash),
+    })
+}
+
+async fn send_propagated(
+    context: SendContext<'_>,
+    request: &SendRequest,
+    remote: &DestinationDesc,
+    wire: &[u8],
+    message_id: MessageId,
+) -> Result<InProcessSendReport, SdkError> {
+    let relay_hash = request
+        .extensions
+        .get(EXT_PROPAGATION_RELAY_HEX)
+        .and_then(JsonValue::as_str)
+        .map(parse_hash)
+        .transpose()?
+        .or(context.propagation_relay)
+        .ok_or_else(|| transport_error("no propagation relay selected"))?;
+    let relay = resolve_destination(context.transport, relay_hash, "propagation").await?;
+    let recipient = lxmf_core::identity::Identity::new_from_slices(
+        remote.identity.public_key_bytes(),
+        remote.identity.verifying_key_bytes(),
+    );
+    let propagated = WireMessage::unpack(wire)
+        .and_then(|message| {
+            message
+                .pack_propagation_with_options_and_rng(
+                    &recipient,
+                    crate::state::now_ms() as f64 / 1000.0,
+                    Some(&[0_u8; 32]),
+                    OsRng,
+                )
+                .map(|(payload, _)| payload)
+        })
+        .map_err(|err| internal(format!("failed to encode propagated LXMF payload: {err}")))?;
+    let representation = if propagated.len() > LXMF_MAX_PAYLOAD {
+        MessageMethod::Resource
+    } else {
+        MessageMethod::Packet
+    };
+    send_link_payload(
+        context.transport,
+        relay,
+        &propagated,
+        message_id,
+        DeliveryMethod::Propagated,
+        representation,
+        context.link_connect_timeout,
+        context.link_connect_attempts,
+        context.resource_transfer_timeout,
+        Some(remote.address_hash.to_hex_string()),
+    )
+    .await
+}
+
+fn encode_wire(
+    identity: &PrivateIdentity,
+    source: AddressHash,
+    remote: &DestinationDesc,
+    request: &SendRequest,
+) -> Result<Vec<u8>, SdkError> {
+    let content = decode_required_base64(request, EXT_RAW_BYTES_BASE64, "content_base64")?;
+    let fields = request
+        .extensions
+        .get(EXT_FIELDS_BASE64)
+        .and_then(JsonValue::as_str)
+        .map(|value| BASE64_STANDARD.decode(value).map_err(|_| validation("invalid fields base64")))
+        .transpose()?
+        .map(|bytes| {
+            rmp_serde::from_slice(&bytes).map_err(|_| validation("invalid msgpack fields"))
+        })
+        .transpose()?;
+    let title = request.payload.get("title").and_then(JsonValue::as_str).unwrap_or_default();
+    let mut message = Message::new();
+    message.source_hash = Some(copy_hash(source));
+    message.destination_hash = Some(copy_hash(remote.address_hash));
+    message.set_content_from_bytes(&content);
+    message.set_title_from_string(title);
+    message.fields = fields;
+    let signer = lxmf_core::identity::PrivateIdentity::from_private_key_bytes(
+        &identity.to_private_key_bytes(),
+    )
+    .map_err(|err| internal(format!("invalid local identity: {err:?}")))?;
+    message
+        .to_wire(Some(&signer))
+        .map_err(|err| internal(format!("failed to encode LXMF message: {err}")))
+}
+
+async fn resolve_destination(
+    transport: &Transport,
+    hash: AddressHash,
+    aspect: &str,
+) -> Result<DestinationDesc, SdkError> {
+    let identity = transport
+        .destination_identity(&hash)
+        .await
+        .ok_or_else(|| transport_error(format!("destination identity unavailable for {hash}")))?;
+    Ok(DestinationDesc { identity, name: DestinationName::new("lxmf", aspect), address_hash: hash })
+}
+
+pub(crate) fn requested_method(request: &SendRequest) -> Result<TransportMethod, SdkError> {
+    if request
+        .extensions
+        .get(EXT_USE_PROPAGATION_NODE)
+        .and_then(JsonValue::as_bool)
+        .unwrap_or(false)
+    {
+        return Ok(TransportMethod::Propagated);
+    }
+    let value = request
+        .extensions
+        .get(EXT_SEND_MODE)
+        .and_then(JsonValue::as_str)
+        .or(request.delivery_method.as_deref())
+        .unwrap_or("auto")
+        .to_ascii_lowercase();
+    match value.as_str() {
+        "auto" | "opportunistic" => Ok(TransportMethod::Opportunistic),
+        "direct" | "directonly" | "direct_only" => Ok(TransportMethod::Direct),
+        "propagated" | "propagationonly" | "propagation_only" => Ok(TransportMethod::Propagated),
+        _ => Err(validation(format!("unsupported delivery method: {value}"))),
+    }
+}
+
+fn request_uses_auto_mode(request: &SendRequest) -> bool {
+    request
+        .extensions
+        .get(EXT_SEND_MODE)
+        .and_then(JsonValue::as_str)
+        .or(request.delivery_method.as_deref())
+        .is_none_or(|value| value.eq_ignore_ascii_case("auto"))
+}
+
+pub(crate) fn forced_representation(
+    request: &SendRequest,
+    method: TransportMethod,
+    representation: MessageMethod,
+    wire_len: usize,
+) -> MessageMethod {
+    if matches!(method, TransportMethod::Direct)
+        && request
+            .extensions
+            .get(EXT_DIRECT_PACKET_MAX_WIRE_BYTES)
+            .and_then(JsonValue::as_u64)
+            .is_some_and(|limit| wire_len as u64 > limit)
+    {
+        MessageMethod::Resource
+    } else {
+        representation
+    }
+}
+
+pub(crate) fn request_link_timeout(request: &SendRequest, fallback: Duration) -> Duration {
+    let accepted = request
+        .extensions
+        .get(EXT_ACCEPTED_RESULT_ACK)
+        .and_then(JsonValue::as_bool)
+        .unwrap_or(false);
+    request
+        .extensions
+        .get(EXT_LINK_CONNECT_TIMEOUT_MS)
+        .and_then(JsonValue::as_u64)
+        .map(Duration::from_millis)
+        .unwrap_or_else(|| if accepted { Duration::from_secs(5) } else { fallback })
+        .clamp(Duration::from_millis(1), Duration::from_secs(120))
+}
+
+pub(crate) fn request_link_attempts(request: &SendRequest, fallback: usize) -> usize {
+    if request.extensions.get(EXT_ACCEPTED_RESULT_ACK).and_then(JsonValue::as_bool).unwrap_or(false)
+    {
+        1
+    } else {
+        fallback.max(1)
+    }
+}
+
+pub(crate) fn request_resource_timeout(request: &SendRequest, fallback: Duration) -> Duration {
+    if request.extensions.get(EXT_ACCEPTED_RESULT_ACK).and_then(JsonValue::as_bool).unwrap_or(false)
+    {
+        Duration::from_secs(8)
+    } else {
+        fallback
+    }
+}
+
+fn decode_required_base64(
+    request: &SendRequest,
+    extension: &str,
+    payload_key: &str,
+) -> Result<Vec<u8>, SdkError> {
+    let value = request
+        .extensions
+        .get(extension)
+        .and_then(JsonValue::as_str)
+        .or_else(|| request.payload.get(payload_key).and_then(JsonValue::as_str))
+        .ok_or_else(|| validation("missing raw payload"))?;
+    BASE64_STANDARD.decode(value).map_err(|_| validation("invalid payload base64"))
+}
+
+fn data_packet(
+    destination: AddressHash,
+    propagation_type: PropagationType,
+    payload: &[u8],
+) -> Result<Packet, SdkError> {
+    Ok(Packet {
+        header: Header {
+            ifac_flag: IfacFlag::Open,
+            header_type: HeaderType::Type1,
+            context_flag: ContextFlag::Unset,
+            propagation_type,
+            destination_type: DestinationType::Single,
+            packet_type: PacketType::Data,
+            hops: 0,
+        },
+        ifac: None,
+        destination,
+        transport: None,
+        context: PacketContext::None,
+        data: PacketDataBuffer::new_from_slice(payload),
+    })
+}
+
+fn parse_hash(value: &str) -> Result<AddressHash, SdkError> {
+    let value = value.trim();
+    if value.len() != 32 || !value.chars().all(|character| character.is_ascii_hexdigit()) {
+        return Err(validation("invalid destination hash"));
+    }
+    AddressHash::new_from_hex_string(value).map_err(|_| validation("invalid destination hash"))
+}
+
+fn copy_hash(hash: AddressHash) -> [u8; 16] {
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(hash.as_slice());
+    bytes
+}
+
+fn ensure_sent(outcome: SendPacketOutcome, action: &str) -> Result<DeliveryOutcome, SdkError> {
+    match outcome {
+        SendPacketOutcome::SentDirect => Ok(DeliveryOutcome::SentDirect),
+        SendPacketOutcome::SentBroadcast => Ok(DeliveryOutcome::SentBroadcast),
+        _ => Err(transport_error(format!("{action} failed: {outcome:?}"))),
+    }
+}
+
+fn validation(message: impl Into<String>) -> SdkError {
+    SdkError::new(
+        lxmf_sdk::error_code::VALIDATION_INVALID_ARGUMENT,
+        lxmf_sdk::ErrorCategory::Validation,
+        message,
+    )
+    .with_user_actionable(true)
+}
+
+pub(crate) fn transport_error(message: impl Into<String>) -> SdkError {
+    SdkError::new(lxmf_sdk::error_code::INTERNAL, lxmf_sdk::ErrorCategory::Transport, message)
+}
+
+fn internal(message: impl Into<String>) -> SdkError {
+    crate::state::internal_error(message)
+}

--- a/crates/libs/lxmf-runtime/src/lib.rs
+++ b/crates/libs/lxmf-runtime/src/lib.rs
@@ -1,0 +1,26 @@
+//! In-process [`lxmf_sdk::SdkBackend`] implementation over Reticulum transport.
+
+// The public backend trait fixes `SdkError` as the error type, so boxing it in
+// this adapter would make the implementation incompatible with the SDK.
+#![allow(clippy::result_large_err)]
+
+mod backend;
+mod config;
+mod delivery;
+mod link_delivery;
+mod state;
+#[cfg(test)]
+mod tests;
+
+pub use backend::InProcessBackend;
+pub use config::{InProcessBackendConfig, InProcessBackendLimits};
+pub use delivery::{DeliveryMethod, DeliveryOutcome, DeliveryRepresentation, InProcessSendReport};
+
+pub const EXT_ACCEPTED_RESULT_ACK: &str = "reticulum.accepted_result_ack";
+pub const EXT_DIRECT_PACKET_MAX_WIRE_BYTES: &str = "reticulum.direct_packet_max_wire_bytes";
+pub const EXT_FIELDS_BASE64: &str = "reticulum.fields_base64";
+pub const EXT_LINK_CONNECT_TIMEOUT_MS: &str = "reticulum.link_connect_timeout_ms";
+pub const EXT_PROPAGATION_RELAY_HEX: &str = "reticulum.propagation_relay_hex";
+pub const EXT_RAW_BYTES_BASE64: &str = "reticulum.raw_bytes_base64";
+pub const EXT_SEND_MODE: &str = "reticulum.send_mode";
+pub const EXT_USE_PROPAGATION_NODE: &str = "reticulum.use_propagation_node";

--- a/crates/libs/lxmf-runtime/src/link_delivery.rs
+++ b/crates/libs/lxmf-runtime/src/link_delivery.rs
@@ -1,0 +1,125 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use lxmf_core::MessageMethod;
+use lxmf_sdk::{MessageId, SdkError};
+use rns_transport::delivery::{await_link_activation, send_on_link, LinkSendResult};
+use rns_transport::destination::link::Link;
+use rns_transport::destination::DestinationDesc;
+use rns_transport::resource::ResourceEventKind;
+use rns_transport::transport::Transport;
+use tokio::sync::Mutex;
+
+use crate::delivery::{
+    transport_error, DeliveryMethod, DeliveryOutcome, DeliveryRepresentation, InProcessSendReport,
+};
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "transport send contract keeps routing and timeout choices explicit"
+)]
+pub(crate) async fn send_link_payload(
+    transport: &Transport,
+    destination: DestinationDesc,
+    payload: &[u8],
+    message_id: MessageId,
+    method: DeliveryMethod,
+    representation: MessageMethod,
+    link_timeout: Duration,
+    link_attempts: usize,
+    resource_timeout: Duration,
+    propagated_recipient: Option<String>,
+) -> Result<InProcessSendReport, SdkError> {
+    let resolved_destination = destination.address_hash.to_hex_string();
+    let link = activate_link(transport, destination, link_timeout, link_attempts).await?;
+    let mut resource_events = transport.resource_events();
+    let (actual_representation, receipt_hash) = if matches!(representation, MessageMethod::Resource)
+    {
+        let link_id = *link.lock().await.id();
+        let resource_hash = transport
+            .send_resource(&link_id, payload.to_vec(), None)
+            .await
+            .map_err(|err| transport_error(format!("resource send failed: {err:?}")))?;
+        await_resource_completion(&mut resource_events, resource_hash, resource_timeout).await?;
+        (DeliveryRepresentation::Resource, None)
+    } else {
+        match send_on_link(transport, &link, payload)
+            .await
+            .map_err(|err| transport_error(format!("link send failed: {err}")))?
+        {
+            LinkSendResult::Packet(packet) => {
+                (DeliveryRepresentation::Packet, Some(hex::encode(packet.hash().to_bytes())))
+            }
+            LinkSendResult::Resource(resource_hash) => {
+                await_resource_completion(&mut resource_events, resource_hash, resource_timeout)
+                    .await?;
+                (DeliveryRepresentation::Resource, None)
+            }
+        }
+    };
+    Ok(InProcessSendReport {
+        message_id,
+        resolved_destination: propagated_recipient.unwrap_or(resolved_destination.clone()),
+        method,
+        representation: actual_representation,
+        outcome: DeliveryOutcome::SentDirect,
+        relay_destination: matches!(method, DeliveryMethod::Propagated)
+            .then_some(resolved_destination),
+        receipt_hash,
+    })
+}
+
+async fn activate_link(
+    transport: &Transport,
+    destination: DestinationDesc,
+    timeout: Duration,
+    attempts: usize,
+) -> Result<Arc<Mutex<Link>>, SdkError> {
+    let mut last_error = None;
+    for _ in 0..attempts.max(1) {
+        let link = transport.link(destination).await;
+        match await_link_activation(transport, &link, timeout).await {
+            Ok(()) => return Ok(link),
+            Err(error) => {
+                last_error = Some(error);
+                transport.reset_out_link(&destination.address_hash).await;
+            }
+        }
+    }
+    Err(transport_error(format!(
+        "link activation failed: {}",
+        last_error.map_or_else(|| "no attempts made".to_owned(), |error| error.to_string())
+    )))
+}
+
+pub(crate) async fn await_resource_completion(
+    events: &mut tokio::sync::broadcast::Receiver<rns_transport::resource::ResourceEvent>,
+    resource_hash: rns_transport::hash::Hash,
+    timeout: Duration,
+) -> Result<(), SdkError> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(transport_error("resource transfer timed out"));
+        }
+        match tokio::time::timeout(remaining, events.recv()).await {
+            Ok(Ok(event)) if event.hash != resource_hash => continue,
+            Ok(Ok(event)) => match event.kind {
+                ResourceEventKind::OutboundComplete => return Ok(()),
+                ResourceEventKind::OutboundFailed => {
+                    return Err(transport_error("resource transfer failed"))
+                }
+                ResourceEventKind::OutboundCancelled => {
+                    return Err(transport_error("resource transfer cancelled"))
+                }
+                _ => continue,
+            },
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
+                return Err(transport_error("resource event stream closed"));
+            }
+            Err(_) => return Err(transport_error("resource transfer timed out")),
+        }
+    }
+}

--- a/crates/libs/lxmf-runtime/src/state.rs
+++ b/crates/libs/lxmf-runtime/src/state.rs
@@ -1,0 +1,227 @@
+use std::collections::{HashMap, VecDeque};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use lxmf_sdk::{
+    DeliverySnapshot, DeliveryState, EventBatch, EventCursor, MessageId, RuntimeSnapshot,
+    RuntimeState, SdkError, SdkEvent, Severity,
+};
+use serde_json::{json, Value as JsonValue};
+
+use crate::config::InProcessBackendLimits;
+use crate::delivery::InProcessSendReport;
+
+pub(crate) struct BackendState {
+    runtime_id: String,
+    config_revision: u64,
+    events: VecDeque<SdkEvent>,
+    deliveries: HashMap<String, DeliverySnapshot>,
+    send_reports: HashMap<String, InProcessSendReport>,
+    send_report_order: VecDeque<String>,
+    limits: InProcessBackendLimits,
+}
+
+impl BackendState {
+    pub(crate) fn new(runtime_id: String, limits: InProcessBackendLimits) -> Self {
+        Self {
+            runtime_id,
+            config_revision: 1,
+            events: VecDeque::new(),
+            deliveries: HashMap::new(),
+            send_reports: HashMap::new(),
+            send_report_order: VecDeque::new(),
+            limits,
+        }
+    }
+
+    pub(crate) fn runtime_id(&self) -> &str {
+        &self.runtime_id
+    }
+
+    pub(crate) fn advance_config_revision(&mut self) -> u64 {
+        self.config_revision = self.config_revision.saturating_add(1);
+        self.config_revision
+    }
+
+    pub(crate) fn send_report(&self, message_id: &str) -> Option<InProcessSendReport> {
+        self.send_reports.get(message_id).cloned()
+    }
+
+    pub(crate) fn record_send(&mut self, report: InProcessSendReport) -> Result<(), SdkError> {
+        let message_id = report.message_id.0.clone();
+        self.record_delivery(&message_id, DeliveryState::Sent, None)?;
+        self.send_reports.insert(message_id.clone(), report.clone());
+        self.send_report_order.retain(|item| item != &message_id);
+        self.send_report_order.push_back(message_id.clone());
+        while self.send_report_order.len() > self.limits.send_report_retention {
+            if let Some(evicted) = self.send_report_order.pop_front() {
+                self.send_reports.remove(&evicted);
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn status(&self, id: &MessageId) -> Option<DeliverySnapshot> {
+        self.deliveries.get(&id.0).cloned()
+    }
+
+    pub(crate) fn poll(
+        &self,
+        cursor: Option<&EventCursor>,
+        max: usize,
+    ) -> Result<EventBatch, SdkError> {
+        let cursor_seq = cursor.and_then(|value| value.0.parse::<u64>().ok()).unwrap_or(0);
+        let events = self
+            .events
+            .iter()
+            .filter(|event| event.seq_no > cursor_seq)
+            .take(max)
+            .cloned()
+            .collect::<Vec<_>>();
+        let high_watermark = self.last_seq_no();
+        let next_cursor = events.last().map(|event| event.seq_no).unwrap_or(high_watermark);
+        serde_json::from_value(json!({
+            "events": events,
+            "next_cursor": next_cursor.to_string(),
+            "dropped_count": 0,
+            "snapshot_high_watermark_seq_no": high_watermark,
+            "extensions": {},
+        }))
+        .map_err(|err| internal_error(format!("invalid event batch: {err}")))
+    }
+
+    pub(crate) fn snapshot(&self) -> Result<RuntimeSnapshot, SdkError> {
+        let in_flight = self.deliveries.values().filter(|item| !item.terminal).count() as u64;
+        serde_json::from_value(json!({
+            "runtime_id": self.runtime_id,
+            "state": RuntimeState::Running,
+            "active_contract_version": 2,
+            "event_stream_position": self.last_seq_no(),
+            "config_revision": self.config_revision,
+            "queued_messages": 0,
+            "in_flight_messages": in_flight,
+        }))
+        .map_err(|err| internal_error(format!("invalid runtime snapshot: {err}")))
+    }
+
+    pub(crate) fn record_delivery(
+        &mut self,
+        id: &str,
+        state: DeliveryState,
+        reason: Option<String>,
+    ) -> Result<(), SdkError> {
+        let attempts = self.deliveries.get(id).map_or(1, |item| item.attempts.saturating_add(1));
+        let terminal = matches!(
+            state,
+            DeliveryState::Delivered
+                | DeliveryState::Failed
+                | DeliveryState::Cancelled
+                | DeliveryState::Expired
+                | DeliveryState::Rejected
+                | DeliveryState::Unknown
+        );
+        let snapshot = serde_json::from_value(json!({
+            "message_id": id,
+            "state": state,
+            "terminal": terminal,
+            "last_updated_ms": now_ms(),
+            "attempts": attempts,
+            "reason_code": reason,
+        }))
+        .map_err(|err| internal_error(format!("invalid delivery snapshot: {err}")))?;
+        self.deliveries.insert(id.to_owned(), snapshot);
+        self.prune_deliveries();
+        self.push_event(
+            "lxmf.delivery.updated",
+            if matches!(
+                state,
+                DeliveryState::Failed | DeliveryState::Rejected | DeliveryState::Expired
+            ) {
+                Severity::Warn
+            } else {
+                Severity::Info
+            },
+            json!({
+                "message_id": id,
+                "state": format!("{state:?}").to_ascii_lowercase(),
+                "reason": reason,
+            }),
+        )
+    }
+
+    pub(crate) fn record_event(
+        &mut self,
+        event_type: &str,
+        severity: Severity,
+        payload: JsonValue,
+    ) -> Result<(), SdkError> {
+        self.push_event(event_type, severity, payload)
+    }
+
+    fn prune_deliveries(&mut self) {
+        if self.deliveries.len() <= self.limits.delivery_retention {
+            return;
+        }
+        let mut candidates = self
+            .deliveries
+            .iter()
+            .map(|(id, item)| (id.clone(), !item.terminal, item.last_updated_ms))
+            .collect::<Vec<_>>();
+        candidates.sort_by_key(|(_, active, updated)| (*active, *updated));
+        for (id, _, _) in candidates {
+            if self.deliveries.len() <= self.limits.delivery_retention {
+                break;
+            }
+            self.deliveries.remove(&id);
+        }
+    }
+
+    fn push_event(
+        &mut self,
+        event_type: &str,
+        severity: Severity,
+        payload: JsonValue,
+    ) -> Result<(), SdkError> {
+        let seq_no = self.last_seq_no().saturating_add(1);
+        let event = serde_json::from_value(json!({
+            "event_id": format!("{}-{seq_no}", self.runtime_id),
+            "runtime_id": self.runtime_id,
+            "stream_id": "lxmf-runtime",
+            "seq_no": seq_no,
+            "contract_version": 2,
+            "ts_ms": now_ms(),
+            "event_type": event_type,
+            "severity": severity,
+            "source_component": "lxmf-runtime",
+            "operation_id": null,
+            "message_id": payload.get("message_id").and_then(JsonValue::as_str),
+            "peer_id": payload.get("destination_hex").and_then(JsonValue::as_str),
+            "correlation_id": null,
+            "trace_id": null,
+            "payload": payload,
+            "extensions": {},
+        }))
+        .map_err(|err| internal_error(format!("invalid runtime event: {err}")))?;
+        self.events.push_back(event);
+        while self.events.len() > self.limits.event_retention {
+            self.events.pop_front();
+        }
+        Ok(())
+    }
+
+    fn last_seq_no(&self) -> u64 {
+        self.events.back().map_or(0, |event| event.seq_no)
+    }
+}
+
+pub(crate) fn internal_error(message: impl Into<String>) -> SdkError {
+    SdkError::new(lxmf_sdk::error_code::INTERNAL, lxmf_sdk::ErrorCategory::Internal, message)
+}
+
+pub(crate) fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}

--- a/crates/libs/lxmf-runtime/src/tests.rs
+++ b/crates/libs/lxmf-runtime/src/tests.rs
@@ -1,0 +1,153 @@
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use lxmf_core::{MessageMethod, TransportMethod};
+use lxmf_sdk::{DeliveryState, MessageId, SdkBackend, SendRequest, Severity};
+use rand_core::OsRng;
+use rns_transport::destination::{DestinationName, SingleInputDestination};
+use rns_transport::hash::{AddressHash, Hash};
+use rns_transport::resource::{ResourceEvent, ResourceEventKind};
+use rns_transport::transport::{Transport, TransportConfig};
+use serde_json::json;
+use tokio::sync::broadcast;
+
+use crate::delivery::{
+    forced_representation, request_link_attempts, request_link_timeout, request_resource_timeout,
+    requested_method,
+};
+use crate::link_delivery::await_resource_completion;
+use crate::{
+    InProcessBackend, InProcessBackendConfig, EXT_ACCEPTED_RESULT_ACK,
+    EXT_DIRECT_PACKET_MAX_WIRE_BYTES, EXT_LINK_CONNECT_TIMEOUT_MS,
+};
+
+fn request() -> SendRequest {
+    SendRequest::new(
+        "00112233445566778899aabbccddeeff",
+        "ffeeddccbbaa99887766554433221100",
+        json!({"content_base64": "aGVsbG8="}),
+    )
+}
+
+#[test]
+fn rnode_wire_budget_forces_direct_resource_representation() {
+    let mut request = request();
+    request.extensions =
+        BTreeMap::from([(EXT_DIRECT_PACKET_MAX_WIRE_BYTES.to_owned(), json!(145))]);
+
+    assert_eq!(
+        forced_representation(&request, TransportMethod::Direct, MessageMethod::Packet, 146,),
+        MessageMethod::Resource
+    );
+    assert_eq!(
+        forced_representation(&request, TransportMethod::Direct, MessageMethod::Packet, 145,),
+        MessageMethod::Packet
+    );
+}
+
+#[test]
+fn explicit_unknown_delivery_method_is_rejected() {
+    let mut request = request();
+    request.delivery_method = Some("teleport".to_owned());
+
+    let error = requested_method(&request).expect_err("unknown mode must fail");
+    assert_eq!(error.category, lxmf_sdk::ErrorCategory::Validation);
+}
+
+#[test]
+fn accepted_result_uses_short_link_timeout_unless_overridden() {
+    let mut request = request();
+    request.extensions.insert(EXT_ACCEPTED_RESULT_ACK.to_owned(), json!(true));
+    assert_eq!(request_link_timeout(&request, Duration::from_secs(20)), Duration::from_secs(5));
+    assert_eq!(request_link_attempts(&request, 3), 1);
+    assert_eq!(
+        request_resource_timeout(&request, Duration::from_secs(120)),
+        Duration::from_secs(8)
+    );
+
+    request.extensions.insert(EXT_LINK_CONNECT_TIMEOUT_MS.to_owned(), json!(75_000));
+    assert_eq!(request_link_timeout(&request, Duration::from_secs(20)), Duration::from_secs(75));
+}
+
+#[tokio::test]
+async fn resource_send_only_succeeds_after_matching_outbound_completion() {
+    let (sender, mut receiver) = broadcast::channel(4);
+    let expected_hash = Hash::new_from_slice(b"expected");
+    sender
+        .send(ResourceEvent {
+            hash: Hash::new_from_slice(b"other"),
+            link_id: AddressHash::new_from_slice(b"link"),
+            kind: ResourceEventKind::OutboundComplete,
+        })
+        .expect("queue unrelated completion");
+    sender
+        .send(ResourceEvent {
+            hash: expected_hash,
+            link_id: AddressHash::new_from_slice(b"link"),
+            kind: ResourceEventKind::OutboundComplete,
+        })
+        .expect("queue matching completion");
+
+    await_resource_completion(&mut receiver, expected_hash, Duration::from_secs(1))
+        .await
+        .expect("matching completion acknowledges resource send");
+}
+
+#[tokio::test]
+async fn resource_failure_is_not_reported_as_success() {
+    let (sender, mut receiver) = broadcast::channel(2);
+    let expected_hash = Hash::new_from_slice(b"expected");
+    sender
+        .send(ResourceEvent {
+            hash: expected_hash,
+            link_id: AddressHash::new_from_slice(b"link"),
+            kind: ResourceEventKind::OutboundFailed,
+        })
+        .expect("queue failure");
+
+    let error = await_resource_completion(&mut receiver, expected_hash, Duration::from_secs(1))
+        .await
+        .expect_err("failed resource must fail send");
+    assert_eq!(error.category, lxmf_sdk::ErrorCategory::Transport);
+}
+
+#[tokio::test]
+async fn delivery_updates_drive_status_snapshot_and_events() {
+    let identity = rns_transport::identity::PrivateIdentity::new_from_rand(OsRng);
+    let transport = std::sync::Arc::new(Transport::new(TransportConfig::new(
+        "lxmf-runtime-state-test",
+        &identity,
+        true,
+    )));
+    let source =
+        SingleInputDestination::new(identity.clone(), DestinationName::new("lxmf", "delivery"))
+            .desc
+            .address_hash;
+    let backend = InProcessBackend::new(InProcessBackendConfig::new(
+        "runtime-test",
+        tokio::runtime::Handle::current(),
+        transport,
+        identity,
+        source,
+    ));
+    let message_id = MessageId("message-1".to_owned());
+
+    backend
+        .record_delivery(&message_id, DeliveryState::InFlight, None)
+        .expect("record in-flight delivery");
+    assert_eq!(backend.snapshot().expect("snapshot").in_flight_messages, 1);
+
+    backend
+        .record_delivery(&message_id, DeliveryState::Delivered, None)
+        .expect("record delivered state");
+    let status = backend.status(message_id).expect("status query").expect("delivery status");
+    assert!(status.terminal);
+    assert_eq!(status.state, DeliveryState::Delivered);
+    assert_eq!(backend.snapshot().expect("snapshot").in_flight_messages, 0);
+    backend
+        .record_event("reticulum.packet_received", Severity::Info, json!({"bytes": 3}))
+        .expect("record transport event");
+    let events = backend.poll_events(None, 16).expect("events").events;
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[2].event_type, "reticulum.packet_received");
+}

--- a/crates/libs/rns-transport/src/transport/links_parts/transport_sections/reset_out_link.rs
+++ b/crates/libs/rns-transport/src/transport/links_parts/transport_sections/reset_out_link.rs
@@ -1,4 +1,34 @@
 impl Transport {
+    /// Reports whether the LXMF router can reuse a direct or backchannel link.
+    ///
+    /// This mirrors Python LXMRouter membership semantics while excluding
+    /// links that have already reached the closed state.
+    pub async fn delivery_link_available(&self, destination: &AddressHash) -> bool {
+        let (out_link, in_links) = {
+            let handler = self.handler.lock().await;
+            (
+                handler.out_links.get(destination).cloned(),
+                handler.in_links.values().cloned().collect::<Vec<_>>(),
+            )
+        };
+
+        if let Some(link) = out_link {
+            if link.lock().await.status() != LinkStatus::Closed {
+                return true;
+            }
+        }
+
+        for link in in_links {
+            let link = link.lock().await;
+            if link.destination().address_hash == *destination && link.status() != LinkStatus::Closed
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+
 
     pub async fn reset_out_link(&self, destination: &AddressHash) {
         let removed = {

--- a/crates/libs/rns-transport/src/transport/tests_parts/transport_register_channel_handler_d.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/transport_register_channel_handler_d.rs
@@ -437,3 +437,50 @@ async fn new_unicast_iface_in(transport: &Transport) -> AddressHash {
     let channel = mgr.new_channel(16);
     *channel.address()
 }
+#[tokio::test]
+async fn delivery_link_available_tracks_python_router_direct_and_backchannel_maps() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let config = TransportConfig::new("test", &local_identity, true);
+    let transport = Transport::new(config);
+    let handler = transport.get_handler();
+
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination = crate::destination::DestinationDesc {
+        identity,
+        address_hash: identity.address_hash,
+        name: DestinationName::new("lxmf", "delivery"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(8);
+    let outbound = Arc::new(Mutex::new(Link::new(destination, tx.clone())));
+
+    assert!(!transport.delivery_link_available(&destination.address_hash).await);
+
+    handler.lock().await.out_links.insert(destination.address_hash, outbound.clone());
+    assert!(
+        transport.delivery_link_available(&destination.address_hash).await,
+        "pending direct links count as available like Python LXMRouter.direct_links membership"
+    );
+
+    outbound.lock().await.close();
+    assert!(
+        !transport.delivery_link_available(&destination.address_hash).await,
+        "closed direct links must not leak availability while awaiting cleanup"
+    );
+
+    let inbound_request = Link::new(destination, tx.clone()).request();
+    let inbound =
+        Link::new_from_request(&inbound_request, signer.sign_key().clone(), destination, tx)
+            .expect("link request should parse");
+    let inbound = Arc::new(Mutex::new(inbound));
+    let inbound_id = *inbound.lock().await.id();
+    handler.lock().await.in_links.insert(inbound_id, inbound.clone());
+
+    assert!(
+        transport.delivery_link_available(&destination.address_hash).await,
+        "backchannel links count as available like Python LXMRouter.backchannel_links membership"
+    );
+
+    inbound.lock().await.close();
+    assert!(!transport.delivery_link_available(&destination.address_hash).await);
+}

--- a/docs/runbooks/crates-io-publish-plan.md
+++ b/docs/runbooks/crates-io-publish-plan.md
@@ -72,6 +72,7 @@ not have to rewrite `use` paths just to complete the package rename.
 | `lxmf-reference` | `lxmf-reference` | `lxmf_reference` | GitHub release version | yes |
 | `lxmf-core` | `lxmf-wire` | `lxmf_core` | GitHub release version | yes |
 | `lxmf-sdk` | `lxmf-sdk` | `lxmf_sdk` | GitHub release version | yes |
+| `lxmf-runtime` | `lxmf-runtime` | `lxmf_runtime` | GitHub release version | yes |
 | `rns-core` | `reticulum-rs-core` | `rns_core` | GitHub release version | yes |
 | `rns-transport` | `reticulum-rs-transport` | `rns_transport` | GitHub release version | yes |
 | `rns-rpc` | `reticulum-rs-rpc` | `rns_rpc` | GitHub release version | yes |
@@ -195,13 +196,14 @@ Recommended order:
 7. `reticulum-rs-transport`
 8. `reticulum-rs-rpc`
 9. `lxmf-sdk`
-10. `rns-embedded-mininode`
-11. `lxmf-embedded-mini`
-12. `reticulum-rs`
-13. `lxmf`
-14. `lxmf-cli`
-15. `reticulumd`
-16. `rns-tools`
+10. `lxmf-runtime`
+11. `rns-embedded-mininode`
+12. `lxmf-embedded-mini`
+13. `reticulum-rs`
+14. `lxmf`
+15. `lxmf-cli`
+16. `reticulumd`
+17. `rns-tools`
 Reason:
 
 - `reticulum-rs-rpc` and `lxmf-sdk` share pinned compatibility metadata through
@@ -211,6 +213,7 @@ Reason:
 - `rns-embedded-ffi` depends on `rns-embedded-core` and `rns-embedded-runtime`
 - `reticulum-rs-transport` depends on `reticulum-rs-core`
 - `lxmf-sdk` depends on `reticulum-rs-rpc`
+- `lxmf-runtime` depends on `lxmf-sdk`, `lxmf-wire`, and `reticulum-rs-transport`
 - `rns-embedded-mininode` depends on `lxmf-wire` and `reticulum-rs-core`
 - facade crates should only publish after the underlying components are live
 - command crates publish last after their library dependencies are live

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -37,10 +37,11 @@ The project is best described by capability level:
 
 The v0.7.0 release thread is SDK-first: REM/RCH-facing delivery, discovery,
 identity, saved-peer, paper, history, conversation, cancellation, and
-propagation workflows should keep moving onto the existing `lxmf-sdk`
-`ZmqPipelineBackendClient` surface. This is an in-place improvement of the
-current SDK/backend client. It is not a compatibility layer, adapter, shim, or
-new parallel SDK surface.
+propagation workflows should keep moving onto the existing `lxmf-sdk` surface.
+Daemon consumers use `ZmqPipelineBackendClient`; embedded host applications can
+use `lxmf-runtime::InProcessBackend` over their existing Reticulum transport.
+Both implement the same `SdkBackend` contract. This is not a compatibility
+layer, shim, or parallel SDK surface.
 
 Scoped release evidence is split as follows:
 

--- a/xtask/src/main_parts/interop_baseline_path.rs
+++ b/xtask/src/main_parts/interop_baseline_path.rs
@@ -228,6 +228,10 @@ const WAVE1_PUBLIC_CRATES: &[PublishedCrate] = &[
     },
     PublishedCrate { package: "reticulum-rs-rpc", manifest_path: "crates/libs/rns-rpc/Cargo.toml" },
     PublishedCrate { package: "lxmf-sdk", manifest_path: "crates/libs/lxmf-sdk/Cargo.toml" },
+    PublishedCrate {
+        package: "lxmf-runtime",
+        manifest_path: "crates/libs/lxmf-runtime/Cargo.toml",
+    },
 ];
 
 const FACADE_PUBLIC_CRATES: &[PublishedCrate] = &[


### PR DESCRIPTION
## Summary
- add the published `lxmf-runtime` workspace crate implementing `lxmf_sdk::SdkBackend` over an in-process Reticulum `Transport`
- support raw/message-field encoding, opportunistic/direct/propagated delivery, reference-compatible direct/backchannel reuse, packet/resource selection, bounded link retries, resource-completion acknowledgement, delivery status, event polling, snapshots, and typed failures
- expose bounded retention/configuration, mutable propagation relay selection, and typed send reports for embedded hosts such as REM
- extract the transport-level `delivery_link_available` primitive from draft #409 with its reference-semantics regression
- update workspace boundaries, roadmap, README, publication order, and release metadata

## Reliability evidence
- RNode wire payloads above the configured 145-byte budget are forced onto resource delivery
- resource sends return success only after the matching `OutboundComplete` event
- outbound failure/cancellation/timeout remain typed transport failures
- Auto mode reuses live direct and inbound backchannel links before opportunistic fallback
- accepted-result sends use one bounded link attempt and an 8-second resource timeout
- no RPC or ZMQ backend features are pulled into `lxmf-runtime`

## Validation
- `cargo xtask ci` (complete PR-core gate: pass)
- workspace nextest: 2,061/2,061 passed
- `cargo test --workspace --tests --no-fail-fast`
- `cargo test -p lxmf-runtime` (6 passed)
- focused transport direct/backchannel regression
- strict crate clippy with `-D warnings`
- architecture boundary and module-size gates
- publish dry-run/package check (12 files, 26.3 KiB compressed)
- cargo-deny and RustSec audit (repository allowlist only)

This is the reusable backend prerequisite. REM cutover will be a separate REM PR and will remove its compatibility backend in that change rather than maintain two runtime paths.