### PR TITLE
Publish lxmf-runtime in the v0.8.0 crate train

### DIFF
--- a/.github/workflows/crates-io-publish.yml
+++ b/.github/workflows/crates-io-publish.yml
@@ -67,6 +67,7 @@ jobs:
             "crates/libs/rns-transport/Cargo.toml"
             "crates/libs/rns-rpc/Cargo.toml"
             "crates/libs/lxmf-sdk/Cargo.toml"
+            "crates/libs/lxmf-runtime/Cargo.toml"
             "crates/libs/rns-embedded-mininode/Cargo.toml"
             "crates/libs/lxmf-embedded-mini/Cargo.toml"
             "crates/libs/reticulum-rs/Cargo.toml"


### PR DESCRIPTION
## Summary

- add the documented public lxmf-runtime crate to the crates.io publication manifest order
- place it after lxmf-sdk and its other published dependencies

## Validation

- cargo package --locked --manifest-path crates/libs/lxmf-runtime/Cargo.toml --allow-dirty
- packaged crate verification succeeded using the published 0.8.0 dependency train
- the publish workflow is idempotent and skips the 16 crates already present when rerun