### PR TITLE
ci: install BLE dependencies for release readiness

### DIFF
--- a/.github/workflows/leader-readiness.yml
+++ b/.github/workflows/leader-readiness.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Linux BLE build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libdbus-1-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly


### PR DESCRIPTION
Fixes the tag-triggered leader readiness audit by installing the same Linux D-Bus development dependency already used by the standard CI, full CI, bundle, and crates publishing workflows.\n\nRC failure: https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/29136267218