### PR TITLE
ci: install nextest for release readiness

### DIFF
--- a/.github/workflows/leader-readiness.yml
+++ b/.github/workflows/leader-readiness.yml
@@ -24,7 +24,7 @@ jobs:
           components: miri
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-deny,cargo-audit
+          tool: cargo-deny,cargo-audit,cargo-nextest
       - name: Leader-grade readiness certification
         run: cargo xtask ci --stage leader-readiness-check
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
The leader-readiness stage invokes cargo nextest but the tag and manual workflow runner did not install it. Add cargo-nextest to the existing taiki-e tool bootstrap.\n\nExact-main failure: https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/29136450738