### PR TITLE
ci: install public API tool for release readiness

### DIFF
--- a/.github/workflows/leader-readiness.yml
+++ b/.github/workflows/leader-readiness.yml
@@ -24,7 +24,7 @@ jobs:
           components: miri
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-deny,cargo-audit,cargo-nextest
+          tool: cargo-deny,cargo-audit,cargo-nextest,cargo-public-api@0.50.2
       - name: Leader-grade readiness certification
         run: cargo xtask ci --stage leader-readiness-check
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
The aggregate leader-readiness stage runs the SDK public API drift gate, so its runner must install the same pinned cargo-public-api version used by CI and full CI.\n\nExact-main failure after all preceding release stages passed: https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/29136657499