### PR TITLE
test: synchronize pinned-Python remote relay discovery

### DIFF
--- a/crates/apps/lxmf-cli/tests/python_lxmd_remote_relay_parts/module_prelude.rs
+++ b/crates/apps/lxmf-cli/tests/python_lxmd_remote_relay_parts/module_prelude.rs
@@ -144,13 +144,14 @@ fn rust_to_python_lxmd_relay_remote_path_e2e() {
         let sender_hash = status_hash(&sender_status)
             .unwrap_or_else(|| panic!("rust-sender delivery hash: {sender_status}"));
 
+        let delivery_started_at = Instant::now();
         rpc_call(recipient_rpc, "announce_now", None)?;
+        wait_for_known_path(sender_rpc, &recipient_hash)?;
 
         let message_id = format!(
             "python-relay-remote-{}",
             SystemTime::now().duration_since(UNIX_EPOCH).expect("time").as_millis()
         );
-        let delivery_started_at = Instant::now();
         rpc_call(
             sender_rpc,
             "send_message_v2",

--- a/crates/apps/lxmf-cli/tests/support/python_lxmd_remote_relay_parts/status_hash.rs
+++ b/crates/apps/lxmf-cli/tests/support/python_lxmd_remote_relay_parts/status_hash.rs
@@ -9,6 +9,33 @@ pub fn status_hash(status: &Value) -> Option<String> {
     None
 }
 
+pub fn wait_for_known_path(rpc_port: u16, destination: &str) -> Result<(), String> {
+    let deadline = Instant::now() + TEST_TIMEOUT;
+    let mut last_status = "path status was not queried".to_string();
+    while Instant::now() < deadline {
+        match rpc_call(
+            rpc_port,
+            "path_status",
+            Some(json!({ "destination": destination })),
+        ) {
+            Ok(status) => {
+                if status["known"].as_bool() == Some(true)
+                    || status["path_found"].as_bool() == Some(true)
+                {
+                    return Ok(());
+                }
+                last_status = status.to_string();
+            }
+            Err(err) => last_status = format!("rpc error: {err}"),
+        }
+        thread::sleep(WAIT_POLL_INTERVAL);
+    }
+
+    Err(format!(
+        "destination {destination} did not become reachable on rpc port {rpc_port}; last status: {last_status}"
+    ))
+}
+
 pub fn wait_for_inbound_message(rpc_port: u16, expected_content: &str) -> Result<(), String> {
     let deadline = Instant::now() + TEST_TIMEOUT;
     while Instant::now() < deadline {


### PR DESCRIPTION
The pinned-Python relay test could send immediately after an announce, before the sender had learned a route. This produced repeated five-minute delivery timeouts despite the same product tree passing earlier runs.\n\nWait for `path_status` to report the destination reachable, and measure the full announce/discovery/delivery interval. The exact failing test passed four consecutive local runs against pinned Reticulum `15320e4` and LXMF `727830c`.