### PR TITLE
test: reannounce during pinned-Python relay discovery

### DIFF
--- a/crates/apps/lxmf-cli/tests/python_lxmd_remote_relay_parts/module_prelude.rs
+++ b/crates/apps/lxmf-cli/tests/python_lxmd_remote_relay_parts/module_prelude.rs
@@ -145,8 +145,7 @@ fn rust_to_python_lxmd_relay_remote_path_e2e() {
             .unwrap_or_else(|| panic!("rust-sender delivery hash: {sender_status}"));
 
         let delivery_started_at = Instant::now();
-        rpc_call(recipient_rpc, "announce_now", None)?;
-        wait_for_known_path(sender_rpc, &recipient_hash)?;
+        wait_for_known_path(sender_rpc, recipient_rpc, &recipient_hash)?;
 
         let message_id = format!(
             "python-relay-remote-{}",

--- a/crates/apps/lxmf-cli/tests/support/python_lxmd_remote_relay_parts/status_hash.rs
+++ b/crates/apps/lxmf-cli/tests/support/python_lxmd_remote_relay_parts/status_hash.rs
@@ -9,12 +9,24 @@ pub fn status_hash(status: &Value) -> Option<String> {
     None
 }
 
-pub fn wait_for_known_path(rpc_port: u16, destination: &str) -> Result<(), String> {
+pub fn wait_for_known_path(
+    sender_rpc_port: u16,
+    announcer_rpc_port: u16,
+    destination: &str,
+) -> Result<(), String> {
     let deadline = Instant::now() + TEST_TIMEOUT;
+    let mut next_announce = Instant::now();
+    let mut last_announce_error = None;
     let mut last_status = "path status was not queried".to_string();
     while Instant::now() < deadline {
+        if Instant::now() >= next_announce {
+            if let Err(err) = rpc_call(announcer_rpc_port, "announce_now", None) {
+                last_announce_error = Some(err);
+            }
+            next_announce = Instant::now() + Duration::from_secs(5);
+        }
         match rpc_call(
-            rpc_port,
+            sender_rpc_port,
             "path_status",
             Some(json!({ "destination": destination })),
         ) {
@@ -32,7 +44,8 @@ pub fn wait_for_known_path(rpc_port: u16, destination: &str) -> Result<(), Strin
     }
 
     Err(format!(
-        "destination {destination} did not become reachable on rpc port {rpc_port}; last status: {last_status}"
+        "destination {destination} did not become reachable on rpc port {sender_rpc_port}; last status: {last_status}; last announce error: {}",
+        last_announce_error.as_deref().unwrap_or("none")
     ))
 }
 


### PR DESCRIPTION
The first delivery announce can be emitted while the simulated three-hop TCP topology is still converging. Re-announce every five seconds while waiting for `path_status`, then deliver only after the sender has a route.\n\nValidation: six consecutive focused runs against pinned Reticulum `15320e4` and LXMF `727830c`; targeted clippy passes with warnings denied.