### PR TITLE
Fix reticulumd's direct-backchannel LinkIdentify consumer left behind by #478

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/direct_backchannel.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/direct_backchannel.rs
@@ -1,4 +1,3 @@
-use ed25519_dalek::Signature;
 use rns_transport::destination::link::{Link, LinkStatus};
 use rns_transport::destination::DestinationName;
 use rns_transport::hash::AddressHash;
@@ -62,23 +61,6 @@ impl DirectBackchannelLinks {
     }
 }
 
-pub(super) fn parse_link_identify_payload(
-    payload: &[u8],
-    link_id: &AddressHash,
-) -> Result<Identity, &'static str> {
-    if payload.len() < 32 + 32 + 64 {
-        return Err("payload too short");
-    }
-    let identity = Identity::new_from_slices(&payload[..32], &payload[32..64]);
-    let signature =
-        Signature::from_slice(&payload[64..128]).map_err(|_| "invalid signature bytes")?;
-    let mut signed = Vec::with_capacity(16 + 64);
-    signed.extend_from_slice(link_id.as_slice());
-    signed.extend_from_slice(&payload[..64]);
-    identity.verify(&signed, &signature).map_err(|_| "signature verification failed")?;
-    Ok(identity)
-}
-
 fn delivery_destination_hash_for_identity(identity: &Identity) -> AddressHash {
     let name = DestinationName::new("lxmf", "delivery");
     let hash = sha2::Sha256::new()
@@ -98,46 +80,6 @@ mod tests {
     use rns_transport::identity::PrivateIdentity;
     use rns_transport::iface::IfaceRole;
     use rns_transport::transport::TransportConfig;
-
-    #[test]
-    fn parses_valid_link_identify_payload() {
-        let identity = PrivateIdentity::new_from_rand(OsRng);
-        let link_id = AddressHash::new([9u8; 16]);
-        let mut public_key = Vec::new();
-        public_key.extend_from_slice(identity.as_identity().public_key.as_bytes());
-        public_key.extend_from_slice(identity.as_identity().verifying_key.as_bytes());
-        let mut signed = Vec::new();
-        signed.extend_from_slice(link_id.as_slice());
-        signed.extend_from_slice(&public_key);
-        let signature = identity.sign(&signed);
-        let mut payload = public_key;
-        payload.extend_from_slice(signature.to_bytes().as_slice());
-
-        let parsed = parse_link_identify_payload(&payload, &link_id).expect("valid payload");
-
-        assert_eq!(parsed.address_hash, identity.as_identity().address_hash);
-    }
-
-    #[test]
-    fn rejects_link_identify_payload_signed_for_other_link() {
-        let identity = PrivateIdentity::new_from_rand(OsRng);
-        let signed_link_id = AddressHash::new([9u8; 16]);
-        let checked_link_id = AddressHash::new([8u8; 16]);
-        let mut public_key = Vec::new();
-        public_key.extend_from_slice(identity.as_identity().public_key.as_bytes());
-        public_key.extend_from_slice(identity.as_identity().verifying_key.as_bytes());
-        let mut signed = Vec::new();
-        signed.extend_from_slice(signed_link_id.as_slice());
-        signed.extend_from_slice(&public_key);
-        let signature = identity.sign(&signed);
-        let mut payload = public_key;
-        payload.extend_from_slice(signature.to_bytes().as_slice());
-
-        match parse_link_identify_payload(&payload, &checked_link_id) {
-            Ok(_) => panic!("link id is part of the signature"),
-            Err(error) => assert_eq!(error, "signature verification failed"),
-        }
-    }
 
     #[test]
     fn records_identified_link_by_lxmf_delivery_destination() {

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_routing.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_routing.rs
@@ -146,7 +146,11 @@ fn destination_hash(destination: &AddressHash) -> [u8; 16] {
     hash
 }
 
-fn is_lxmf_delivery_destination(destination: &DestinationDesc) -> bool {
+// `pub(super)` — the direct-backchannel `PeerIdentified` consumer in
+// `module_core.rs` (included into this same `inbound_worker` module via
+// `include!`) needs this to gate which links get cached as a peer's
+// delivery backchannel (see its call site's doc comment for why).
+pub(super) fn is_lxmf_delivery_destination(destination: &DestinationDesc) -> bool {
     destination.name.hash == DestinationName::new("lxmf", "delivery").hash
 }
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker_parts/module_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker_parts/module_core.rs
@@ -1,7 +1,7 @@
 use reticulum_daemon::receipt_bridge::ReceiptEvent;
 
 use crate::bridge::emit_receipt_event;
-use crate::direct_backchannel::{parse_link_identify_payload, DirectBackchannelLinks};
+use crate::direct_backchannel::DirectBackchannelLinks;
 
 use rns_rpc::{RpcDaemon, RpcRequest};
 
@@ -287,6 +287,42 @@ fn spawn_packet_inbound_worker(
     control: PropagationControlContext,
     direct_backchannel_links: Option<DirectBackchannelLinks>,
 ) {
+    // meshage fork — `LinkIdentify` packets stopped surfacing as plain
+    // `received_data_events()` payloads once #477 gave them their own
+    // dedicated `LinkEvent::PeerIdentified` event (matching upstream
+    // Python Reticulum's own separate identify handling), so the direct
+    // backchannel cache has to be populated from that event directly
+    // instead — the crate now hands back an already-parsed, already-
+    // signature-verified `Identity`, so this no longer needs its own
+    // `parse_link_identify_payload` reimplementation. A backchannel link
+    // can be either side's outbound link to the other, so both event
+    // streams are covered, mirroring how `Transport::new`'s own
+    // `spawn_link_data_forwarder` covers both directions. See #477's
+    // review discussion.
+    if let Some(backchannel_links) = direct_backchannel_links.clone() {
+        for mut rx in [transport.in_link_events(), transport.out_link_events()] {
+            let backchannel_links = backchannel_links.clone();
+            tokio::spawn(async move {
+                loop {
+                    match rx.recv().await {
+                        Ok(event) => {
+                            if let LinkEvent::PeerIdentified(identity) = event.event {
+                                backchannel_links.record_identified_link(&identity, event.id);
+                                log::debug!(
+                                    "[daemon-rx] direct backchannel available destination={} link={}",
+                                    identity.address_hash,
+                                    event.id
+                                );
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    }
+                }
+            });
+        }
+    }
+
     let daemon_inbound = daemon;
     let inbound_transport = transport;
     tokio::spawn(async move {
@@ -352,29 +388,6 @@ fn spawn_packet_inbound_worker(
                             continue;
                         }
                         InboundLxmfDestination::Delivery(destination) => {
-                            if event.context == Some(PacketContext::LinkIdentify) {
-                                if let Some(backchannel_links) = direct_backchannel_links.as_ref() {
-                                    match parse_link_identify_payload(data, &event.destination) {
-                                        Ok(identity) => {
-                                            backchannel_links
-                                                .record_identified_link(&identity, event.destination);
-                                            log::debug!(
-                                                "[daemon-rx] direct backchannel available destination={} link={}",
-                                                identity.address_hash,
-                                                event.destination
-                                            );
-                                        }
-                                        Err(err) => {
-                                            log::warn!(
-                                                "[daemon-rx] invalid direct backchannel identify link={} err={}",
-                                                event.destination,
-                                                err
-                                            );
-                                        }
-                                    }
-                                }
-                                continue;
-                            }
                             delivery_events::accept_delivery_packet(
                                 daemon_inbound.as_ref(),
                                 inbound_transport.as_ref(),

--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker_parts/module_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_worker_parts/module_core.rs
@@ -281,6 +281,25 @@ fn handle_outbound_resource_failure(
     }
 }
 
+/// Whether the link identified by `link_id` is anchored on an
+/// `lxmf/delivery` destination — the direct-backchannel cache should only
+/// ever be populated from delivery links, never `lxmf/propagation`/
+/// `propagation.control` ones (see `spawn_packet_inbound_worker`'s
+/// `PeerIdentified` consumer for why). Checks in-links then out-links,
+/// mirroring `routing::resolve_resource_destination`'s own lookup order;
+/// an unresolvable `link_id` (already closed/evicted) is treated as
+/// not-delivery, fail-closed rather than caching on a guess.
+async fn is_delivery_backchannel_link(transport: &Transport, link_id: &AddressHash) -> bool {
+    let link = match transport.find_in_link(link_id).await {
+        Some(link) => Some(link),
+        None => transport.find_out_link(link_id).await,
+    };
+    match link {
+        Some(link) => routing::is_lxmf_delivery_destination(link.lock().await.destination()),
+        None => false,
+    }
+}
+
 fn spawn_packet_inbound_worker(
     daemon: Arc<RpcDaemon>,
     transport: Arc<Transport>,
@@ -299,14 +318,36 @@ fn spawn_packet_inbound_worker(
     // streams are covered, mirroring how `Transport::new`'s own
     // `spawn_link_data_forwarder` covers both directions. See #477's
     // review discussion.
+    //
+    // `PeerIdentified` fires for ANY link, not just delivery ones — a peer
+    // also sends `LinkIdentify` on `lxmf/propagation`/`propagation.control`
+    // links (e.g. `bridge_remote_request.rs`, propagation download flows).
+    // The old inline-packet path only ever recorded a backchannel entry
+    // after `resolve_packet_destination` had resolved to
+    // `InboundLxmfDestination::Delivery`; that filter has to be
+    // reconstructed here by resolving the actual `Link` this event came
+    // from and checking its destination aspect, or a propagation/control
+    // link gets cached as if it were the peer's delivery backchannel — a
+    // later direct send would then reuse that link and the receiver would
+    // resolve the payload as propagation/control instead of delivery
+    // (flagged in Codex review; see PR #477 discussion).
     if let Some(backchannel_links) = direct_backchannel_links.clone() {
         for mut rx in [transport.in_link_events(), transport.out_link_events()] {
             let backchannel_links = backchannel_links.clone();
+            let link_transport = transport.clone();
             tokio::spawn(async move {
                 loop {
                     match rx.recv().await {
                         Ok(event) => {
                             if let LinkEvent::PeerIdentified(identity) = event.event {
+                                if !is_delivery_backchannel_link(&link_transport, &event.id).await {
+                                    log::debug!(
+                                        "[daemon-rx] skipping non-delivery backchannel identify destination={} link={}",
+                                        identity.address_hash,
+                                        event.id
+                                    );
+                                    continue;
+                                }
                                 backchannel_links.record_identified_link(&identity, event.id);
                                 log::debug!(
                                     "[daemon-rx] direct backchannel available destination={} link={}",
@@ -410,4 +451,67 @@ fn spawn_packet_inbound_worker(
             }
         }
     });
+}
+
+#[cfg(test)]
+mod backchannel_link_classification_tests {
+    use super::is_delivery_backchannel_link;
+    use rand_core::OsRng;
+    use rns_transport::destination::{DestinationDesc, DestinationName};
+    use rns_transport::identity::PrivateIdentity;
+    use rns_transport::transport::{Transport, TransportConfig};
+
+    // Regression test for the Codex-flagged backchannel-caching bug in
+    // PR #477: `PeerIdentified` fires for any link (delivery, propagation,
+    // AND propagation.control), but only a delivery link's identify
+    // should ever get cached as a peer's direct-delivery backchannel — a
+    // propagation/control link cached under the same key would later get
+    // reused for a direct delivery send, and the receiver would resolve
+    // the payload as propagation/control instead of delivery. This drives
+    // two real outbound links (one of each aspect) through an in-process
+    // `Transport` — no identify handshake needed, since the gate only
+    // inspects the link's own destination, not identify state.
+    #[tokio::test]
+    async fn only_a_delivery_aspect_link_is_treated_as_a_delivery_backchannel() {
+        let local_identity = PrivateIdentity::new_from_rand(OsRng);
+        let transport = Transport::new(TransportConfig::new(
+            "backchannel-classification-test",
+            &local_identity,
+            true,
+        ));
+
+        let delivery_peer = PrivateIdentity::new_from_rand(OsRng);
+        let delivery_destination = DestinationDesc {
+            identity: *delivery_peer.as_identity(),
+            address_hash: *delivery_peer.address_hash(),
+            name: DestinationName::new("lxmf", "delivery"),
+        };
+        let delivery_link = transport.link(delivery_destination).await;
+        let delivery_link_id = *delivery_link.lock().await.id();
+
+        let control_peer = PrivateIdentity::new_from_rand(OsRng);
+        let control_destination = DestinationDesc {
+            identity: *control_peer.as_identity(),
+            address_hash: *control_peer.address_hash(),
+            name: DestinationName::new("lxmf", "propagation.control"),
+        };
+        let control_link = transport.link(control_destination).await;
+        let control_link_id = *control_link.lock().await.id();
+
+        assert!(is_delivery_backchannel_link(&transport, &delivery_link_id).await);
+        assert!(!is_delivery_backchannel_link(&transport, &control_link_id).await);
+    }
+
+    #[tokio::test]
+    async fn an_unresolvable_link_id_is_not_treated_as_a_delivery_backchannel() {
+        let local_identity = PrivateIdentity::new_from_rand(OsRng);
+        let transport = Transport::new(TransportConfig::new(
+            "backchannel-classification-unresolvable-test",
+            &local_identity,
+            true,
+        ));
+        let bogus_link_id = rns_transport::hash::AddressHash::new([7u8; 16]);
+
+        assert!(!is_delivery_backchannel_link(&transport, &bogus_link_id).await);
+    }
 }


### PR DESCRIPTION
Fixes the last unaddressed piece of #476.

## What happened

This PR originally restored `Link::identify_packet` and the dedicated
`PacketContext::LinkIdentify` dispatch arm dropped by the #302 module
split (see #476). While it was open, #478 ("Builds on #477") landed
directly on `main` — it independently restored the same
`rns-transport`-side behavior (with additional hardening: `note_inbound`
moved after validation, NaN/range-checked RTT, exact-match keepalive
framing, etc.) and also fixed one of the two `reticulumd` consumers that
depended on the old behavior (`inbound_control_parts`'s
`identified_peer_links` map, used to gate propagation-control requests).

That superseded this PR's first commit entirely and created a merge
conflict against `main`, since both touched the same files. Rebasing
onto current `main` and dropping the now-redundant `rns-transport`
changes turned up a real, live gap: **#478 never fixed the *second*
consumer**, `inbound_worker_parts::spawn_packet_inbound_worker`'s direct
backchannel cache (`direct_backchannel.rs`). That code still expected a
`LinkIdentify` payload to arrive as a generic `LinkEvent::Data`, which
`#478`'s own transport-side fix means never happens anymore — so on
current `main`, the direct-backchannel link cache used for fast-path
DIRECT delivery replies is silently never populated.

## What this PR now does

Ports forward just the still-needed half of this branch's original
second commit:

- `inbound_worker_parts::spawn_packet_inbound_worker` now reads
  `LinkEvent::PeerIdentified` directly from `Transport::in_link_events()`
  / `out_link_events()`, covering both link directions (mirroring how
  `Transport::new`'s own `spawn_link_data_forwarder` covers both).
- `direct_backchannel.rs` drops its own now-redundant
  `parse_link_identify_payload` reimplementation (and its tests) in favor
  of the identity the crate already parsed and signature-verified.
- `inbound_control_parts/module_core.rs` is left untouched — #478's
  fix there is already correct and is not touched by this PR.

## Verification

- `cargo test -p reticulumd --bin reticulumd` — 485 passed, 0 failed
  (including `direct_backchannel::tests::*` and
  `inbound_worker::routing::tests::outbound_delivery_link_backchannel_resolves_to_local_delivery_destination`)
- `cargo test -p reticulum_daemon --lib` — 28 passed, 0 failed
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p reticulumd --all-targets --all-features --no-deps -- -D warnings` — clean
- `tools/scripts/check-module-size.sh` / `tools/scripts/check-boundaries.sh` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)