### PR TITLE
Generate delivery proofs for opportunistic Single/Data packets

### DIFF
--- a/crates/libs/rns-transport/src/destination_parts/destination.rs
+++ b/crates/libs/rns-transport/src/destination_parts/destination.rs
@@ -11,7 +11,25 @@ impl Destination<PrivateIdentity, Input, Single> {
             ratchet_state: RatchetState::default(),
             path_responses: BTreeMap::new(),
             path_response_queue: VecDeque::new(),
+            proof_strategy: ProofStrategy::default(),
+            proof_requested_callback: None,
         }
+    }
+
+    /// Sets whether this destination automatically proves a plain
+    /// opportunistic `Data` packet it receives. Defaults to
+    /// `ProofStrategy::None` (never prove), matching Python Reticulum's own
+    /// default — must be set explicitly to `All` or `App` to enable
+    /// delivery confirmation. See `ProofStrategy`'s own doc comment.
+    pub fn set_proof_strategy(&mut self, strategy: ProofStrategy) {
+        self.proof_strategy = strategy;
+    }
+
+    /// Registers the callback consulted when `proof_strategy ==
+    /// ProofStrategy::App`. See `ProofRequestedHandler`'s doc comment for
+    /// the reentrancy/blocking constraints this callback must honor.
+    pub fn set_proof_requested_callback(&mut self, handler: Box<dyn ProofRequestedHandler>) {
+        self.proof_requested_callback = Some(Arc::from(handler));
     }
 
     pub fn enable_ratchets<P: AsRef<Path>>(&mut self, path: P) -> Result<(), RnsError> {
@@ -230,6 +248,8 @@ impl Destination<Identity, Output, Single> {
             ratchet_state: RatchetState::default(),
             path_responses: BTreeMap::new(),
             path_response_queue: VecDeque::new(),
+            proof_strategy: ProofStrategy::default(),
+            proof_requested_callback: None,
         }
     }
 }
@@ -245,6 +265,8 @@ impl<D: Direction> Destination<EmptyIdentity, D, Plain> {
             ratchet_state: RatchetState::default(),
             path_responses: BTreeMap::new(),
             path_response_queue: VecDeque::new(),
+            proof_strategy: ProofStrategy::default(),
+            proof_requested_callback: None,
         }
     }
 }

--- a/crates/libs/rns-transport/src/destination_parts/module_core.rs
+++ b/crates/libs/rns-transport/src/destination_parts/module_core.rs
@@ -17,6 +17,42 @@ pub const PATH_RESPONSE_TAG_CAP: usize = 64;
 pub const MIN_ANNOUNCE_DATA_LENGTH: usize =
     PUBLIC_KEY_LENGTH * 2 + NAME_HASH_LENGTH + RAND_HASH_LENGTH + SIGNATURE_LENGTH;
 
+/// Mirrors Python Reticulum's `RNS.Destination.PROVE_NONE`/`PROVE_APP`/
+/// `PROVE_ALL` (`RNS/Destination.py`) — whether this destination
+/// automatically generates a delivery proof for a plain opportunistic
+/// `Data` packet it receives (`transport::wire::handle_data`). `None` (the
+/// default, matching Python's own default) never proves; `All` always
+/// proves; `App` defers to `proof_requested_callback`, called per-packet.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub enum ProofStrategy {
+    #[default]
+    None,
+    App,
+    All,
+}
+
+/// Mirrors Python Reticulum's `Destination.set_proof_requested_callback` —
+/// registered via `Destination::set_proof_requested_callback`, consulted by
+/// `transport::wire::handle_data` only when `proof_strategy ==
+/// ProofStrategy::App`. Implemented generically for any `Fn(&Packet) ->
+/// bool + Send + Sync` closure below, so callers can pass a closure
+/// directly; a named trait (rather than a bare `dyn Fn` field) matches this
+/// crate's existing `ReceiptHandler` convention (`transport::core`).
+///
+/// Runs synchronously, inline, while both the transport handler's lock and
+/// this destination's own lock are held (see `handle_data`) — must not
+/// block and must not attempt to re-lock the destination it was registered
+/// on; `tokio::sync::Mutex` is not reentrant.
+pub trait ProofRequestedHandler: Send + Sync {
+    fn proof_requested(&self, packet: &Packet) -> bool;
+}
+
+impl<F: Fn(&Packet) -> bool + Send + Sync> ProofRequestedHandler for F {
+    fn proof_requested(&self, packet: &Packet) -> bool {
+        self(packet)
+    }
+}
+
 #[derive(Copy, Clone)]
 pub struct DestinationName {
     pub hash: Hash,
@@ -202,6 +238,8 @@ pub struct Destination<I: HashIdentity, D: Direction, T: Type> {
     ratchet_state: RatchetState,
     path_responses: BTreeMap<Vec<u8>, (Instant, Packet)>,
     path_response_queue: VecDeque<(Vec<u8>, Instant)>,
+    pub(crate) proof_strategy: ProofStrategy,
+    pub(crate) proof_requested_callback: Option<Arc<dyn ProofRequestedHandler>>,
 }
 
 impl<I: HashIdentity, D: Direction, T: Type> Destination<I, D, T> {

--- a/crates/libs/rns-transport/src/destination_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/destination_parts/module_prelude.rs
@@ -21,6 +21,8 @@ use std::collections::{BTreeMap, VecDeque};
 
 use std::path::Path;
 
+use std::sync::Arc;
+
 use std::time::Instant;
 
 use x25519_dalek::PublicKey;

--- a/crates/libs/rns-transport/src/transport/mod.rs
+++ b/crates/libs/rns-transport/src/transport/mod.rs
@@ -32,6 +32,7 @@ use crate::destination::DestinationAnnounce;
 use crate::destination::DestinationDesc;
 use crate::destination::DestinationHandleStatus;
 use crate::destination::DestinationName;
+use crate::destination::ProofStrategy;
 use crate::destination::SingleInputDestination;
 use crate::destination::SingleOutputDestination;
 

--- a/crates/libs/rns-transport/src/transport/packet_cache.rs
+++ b/crates/libs/rns-transport/src/transport/packet_cache.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{hash::AddressHash, hash::Hash, packet::Packet};
+use crate::{hash::AddressHash, hash::Hash, packet::Packet, packet::PacketType};
 
 pub struct PacketTrack {
     pub time: Instant,
@@ -42,6 +42,18 @@ impl PacketCache {
 
     pub fn update(&mut self, packet: &Packet) -> bool {
         let hash = packet.hash();
+
+        // Track outbound Data packets by their would-be proof destination too,
+        // not just ones we've seen inbound via `note_source`. Without this, a
+        // packet we originate ourselves (never passed to `note_source`, which
+        // only runs for received Data packets) has no cache entry, and an
+        // explicit delivery proof for it falls through to the fallback in
+        // `validate_destination_receipt_proof` callers that trusted any known
+        // identity's signature — letting a peer forge a receipt for a packet
+        // addressed to someone else. See `wire.rs::validated_receipt_hash`.
+        if packet.header.packet_type == PacketType::Data {
+            self.by_proof_destination.insert(AddressHash::new_from_hash(&hash), hash);
+        }
 
         let mut is_new_packet = false;
 

--- a/crates/libs/rns-transport/src/transport/tests.rs
+++ b/crates/libs/rns-transport/src/transport/tests.rs
@@ -27,3 +27,5 @@ include!("tests_parts/blackhole_path_eviction.rs");
 include!("tests_parts/reticulum_runtime_management.rs");
 
 include!("tests_parts/packet_proof_correlation.rs");
+
+include!("tests_parts/single_destination_delivery_proof.rs");

--- a/crates/libs/rns-transport/src/transport/tests_parts/encrypted_resource_control_packet.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/encrypted_resource_control_packet.rs
@@ -125,14 +125,29 @@ async fn handle_inbound_for_test_accepts_valid_destination_proof() {
     let count = Arc::new(AtomicUsize::new(0));
     transport.set_receipt_handler(Box::new(CountingReceiptHandler { count: count.clone() })).await;
 
-    let packet_hash = [0x55u8; HASH_SIZE];
-    let signature = remote_destination.identity.sign(&packet_hash).to_bytes();
+    // Send a real packet to the remote destination first, so `PacketCache`
+    // actually tracks this hash as one we sent (the fix for the
+    // forged-receipt bug in `wire.rs::validated_receipt_hash`: a proof is
+    // only trusted for a hash this instance tracked sending/relaying, never
+    // just any hash paired with a signature from a known identity).
+    let outbound = Packet {
+        destination: announce.destination,
+        data: PacketDataBuffer::new_from_slice(b"hello from the local sender"),
+        ..Packet::default()
+    };
+    let trace = transport.send_packet_with_trace(outbound).await;
+    let packet_hash = trace.packet_hash.expect("packet hash computed during send");
+
+    let signature = remote_destination.identity.sign(packet_hash.as_slice()).to_bytes();
     let mut data = PacketDataBuffer::new();
-    data.safe_write(&packet_hash);
+    data.safe_write(packet_hash.as_slice());
     data.safe_write(&signature);
     let packet = Packet {
         header: Header { packet_type: PacketType::Proof, ..Default::default() },
-        destination: announce.destination,
+        // Real (and this crate's own) proof packets address to the hash of
+        // the packet being proved, not the proving destination's real
+        // address — see wire.rs's "meshage fork" comment.
+        destination: AddressHash::new_from_hash(&packet_hash),
         context: PacketContext::None,
         data,
         ..Default::default()
@@ -141,6 +156,57 @@ async fn handle_inbound_for_test_accepts_valid_destination_proof() {
     transport.handle_inbound_for_test(packet).await;
 
     assert_eq!(count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn handle_inbound_for_test_rejects_untracked_hash_even_with_a_known_identitys_signature() {
+    // Regression test for a forged-receipt bug: a known peer could sign any
+    // hash it had merely observed (e.g. one addressed to a different
+    // destination) and have it accepted as a delivery receipt, because the
+    // old fallback in `validated_receipt_hash` tried every known
+    // destination's identity against an explicit proof whenever there was
+    // no cached record for it. It must now be rejected outright — the
+    // signature is valid, but this instance never sent or relayed anything
+    // with this hash, so there's nothing to check the proof against.
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let config = TransportConfig::new("test", &local_identity, true);
+    let mut transport = Transport::new(config);
+    let handler = transport.get_handler();
+
+    let remote_identity = PrivateIdentity::new_from_rand(OsRng);
+    let mut remote_destination =
+        SingleInputDestination::new(remote_identity, DestinationName::new("lxmf", "delivery"));
+    let announce = remote_destination.announce(OsRng, None).expect("valid announce packet");
+    handle_announce(
+        &announce,
+        handler.lock().await,
+        AddressHash::new_from_rand(OsRng),
+        crate::iface::IfaceSource::None,
+    )
+    .await;
+
+    let count = Arc::new(AtomicUsize::new(0));
+    transport.set_receipt_handler(Box::new(CountingReceiptHandler { count: count.clone() })).await;
+
+    // Never sent or relayed — a hash the remote destination is happy to
+    // sign (it's genuinely valid under its own identity) but that this
+    // instance has no record of ever transmitting.
+    let untracked_hash = [0x55u8; HASH_SIZE];
+    let signature = remote_destination.identity.sign(&untracked_hash).to_bytes();
+    let mut data = PacketDataBuffer::new();
+    data.safe_write(&untracked_hash);
+    data.safe_write(&signature);
+    let packet = Packet {
+        header: Header { packet_type: PacketType::Proof, ..Default::default() },
+        destination: AddressHash::new_from_hash(&Hash::new(untracked_hash)),
+        context: PacketContext::None,
+        data,
+        ..Default::default()
+    };
+
+    transport.handle_inbound_for_test(packet).await;
+
+    assert_eq!(count.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]

--- a/crates/libs/rns-transport/src/transport/tests_parts/single_destination_delivery_proof.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/single_destination_delivery_proof.rs
@@ -129,7 +129,12 @@ async fn proof_strategy_all_generates_a_valid_delivery_proof() {
         .expect("a delivery proof should be sent back on the same interface")
         .expect("tx channel open");
     assert_eq!(proof_message.packet.header.packet_type, PacketType::Proof);
-    assert_eq!(proof_message.packet.destination, own_hash);
+    // Real Reticulum always addresses a proof to the truncated hash of the
+    // packet being proved (`Packet.generate_proof_destination()`), not the
+    // proving destination's own real address hash — needed for proofs that
+    // traverse a Transport/relay hop back to the sender. See wire.rs's own
+    // "meshage fork" comment on this proof_packet construction.
+    assert_eq!(proof_message.packet.destination, AddressHash::new_from_hash(&encrypted_packet_hash));
     assert_eq!(proof_message.packet.data.len(), HASH_SIZE + ed25519_dalek::SIGNATURE_LENGTH);
     assert_eq!(&proof_message.packet.data.as_slice()[..HASH_SIZE], encrypted_packet_hash.to_bytes().as_slice());
 

--- a/crates/libs/rns-transport/src/transport/tests_parts/single_destination_delivery_proof.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/single_destination_delivery_proof.rs
@@ -1,0 +1,285 @@
+// meshage fork — tests for the delivery-proof-generation restoration in
+// `wire.rs::handle_data`'s `DestinationType::Single` branch, gated by the
+// destination's own `ProofStrategy` (mirrors Python Reticulum's
+// `PROVE_NONE`/`PROVE_APP`/`PROVE_ALL`). See that file's own "meshage fork"
+// comment for the full explanation of what was missing and why. Mirrors
+// this crate's own existing test shapes: `packet_proof_correlation.rs`
+// (capturing what a `Transport` actually sends via its `iface_channel`) and
+// `encrypted_resource_control_packet.rs` (injecting a packet directly via
+// `handle_data`/`handle_inbound_for_test` rather than a full simulated wire
+// round trip).
+//
+// Every test below (other than the KeepAlive guard) sends a *real*,
+// genuinely encrypted packet via a second, independent sender `Transport` —
+// not a synthetic `Packet { data: b"hello", .. }` literal. `handle_data`
+// attempts to decrypt any `context: None` packet before ever reaching the
+// `ProofStrategy` check, so a non-ciphertext payload fails to decrypt and
+// returns early regardless of what `ProofStrategy` says — a synthetic
+// packet would make every "no proof" assertion vacuously true, hiding a
+// broken `ProofStrategy` check rather than exercising it.
+
+#[tokio::test]
+async fn default_proof_strategy_never_generates_a_delivery_proof() {
+    // No `set_proof_strategy` call at all — the crate's own out-of-box
+    // default (`ProofStrategy::None`, matching Python Reticulum's own
+    // default) must never prove, even for a genuinely-decryptable plain
+    // opportunistic packet.
+    let receiver_identity = PrivateIdentity::new_from_rand(OsRng);
+    let receiver_config = TransportConfig::new("receiver", &receiver_identity, true);
+    let mut receiver_transport = Transport::new(receiver_config);
+    let mut receiver_iface = receiver_transport.iface_manager().lock().await.new_channel(8);
+    let own_destination = receiver_transport
+        .add_destination(receiver_identity.clone(), DestinationName::new("lxmf", "delivery"))
+        .await;
+    let own_hash = own_destination.lock().await.desc.address_hash;
+
+    let sender_identity = PrivateIdentity::new_from_rand(OsRng);
+    let sender_config = TransportConfig::new("sender", &sender_identity, true);
+    let sender_transport = Transport::new(sender_config);
+    let mut sender_iface = sender_transport.iface_manager().lock().await.new_channel(8);
+    let receiver_announce = own_destination.lock().await.announce(OsRng, None).expect("valid announce");
+    handle_announce(
+        &receiver_announce,
+        sender_transport.get_handler().lock().await,
+        sender_iface.address,
+        crate::iface::IfaceSource::None,
+    )
+    .await;
+
+    let outbound = Packet {
+        destination: own_hash,
+        data: PacketDataBuffer::new_from_slice(b"hello from the sender"),
+        ..Packet::default()
+    };
+    let trace = sender_transport.send_packet_with_trace(outbound).await;
+    assert_eq!(trace.outcome, SendPacketOutcome::SentDirect);
+    let sent = timeout(Duration::from_millis(200), sender_iface.tx_channel.recv())
+        .await
+        .expect("packet should be queued for the sender's own interface")
+        .expect("tx channel open");
+
+    let receiver_handler = receiver_transport.get_handler();
+    handle_data(&sent.packet, receiver_iface.address, receiver_handler.lock().await).await;
+
+    let outcome = timeout(Duration::from_millis(100), receiver_iface.tx_channel.recv()).await;
+    assert!(outcome.is_err(), "default ProofStrategy::None must not generate a delivery proof");
+}
+
+#[tokio::test]
+async fn proof_strategy_all_generates_a_valid_delivery_proof() {
+    // Receiver: the side this patch changes. Registers its own destination
+    // via `add_destination`, exactly as this app's own `ReticulumStack::new`
+    // does for its real LXMF delivery destination, and explicitly opts
+    // into `ProofStrategy::All`.
+    let receiver_identity = PrivateIdentity::new_from_rand(OsRng);
+    let receiver_config = TransportConfig::new("receiver", &receiver_identity, true);
+    let mut receiver_transport = Transport::new(receiver_config);
+    let mut receiver_iface = receiver_transport.iface_manager().lock().await.new_channel(8);
+    let own_destination = receiver_transport
+        .add_destination(receiver_identity.clone(), DestinationName::new("lxmf", "delivery"))
+        .await;
+    let own_hash = own_destination.lock().await.desc.address_hash;
+    own_destination.lock().await.set_proof_strategy(ProofStrategy::All);
+
+    // Sender: a second, independent `Transport` that has learned the
+    // receiver's identity via a real announce (same as any real LXMF peer
+    // would) — needed so its own outbound encryption is genuine, not a
+    // synthetic/malformed payload the receiver would just fail to decrypt.
+    let sender_identity = PrivateIdentity::new_from_rand(OsRng);
+    let sender_config = TransportConfig::new("sender", &sender_identity, true);
+    let mut sender_transport = Transport::new(sender_config);
+    let mut sender_iface = sender_transport.iface_manager().lock().await.new_channel(8);
+    let receiver_announce = own_destination.lock().await.announce(OsRng, None).expect("valid announce");
+    handle_announce(
+        &receiver_announce,
+        sender_transport.get_handler().lock().await,
+        sender_iface.address,
+        crate::iface::IfaceSource::None,
+    )
+    .await;
+
+    let count = Arc::new(AtomicUsize::new(0));
+    sender_transport
+        .set_receipt_handler(Box::new(CountingReceiptHandler { count: count.clone() }))
+        .await;
+
+    // Sender sends a plain, opportunistic LXMF-shaped packet (Data, Single,
+    // context: None) — the crate's own send path handles encryption, same
+    // as this app's real `send_lxmf_message` relies on.
+    let outbound = Packet {
+        destination: own_hash,
+        data: PacketDataBuffer::new_from_slice(b"hello from the sender"),
+        ..Packet::default()
+    };
+    let trace = sender_transport.send_packet_with_trace(outbound).await;
+    assert_eq!(trace.outcome, SendPacketOutcome::SentDirect);
+    let sent = timeout(Duration::from_millis(200), sender_iface.tx_channel.recv())
+        .await
+        .expect("packet should be queued for the sender's own interface")
+        .expect("tx channel open");
+    let encrypted_packet_hash = sent.packet.hash();
+
+    // Feed exactly what the sender actually transmitted into the
+    // receiver's own inbound handling — this is the restored code path.
+    let receiver_handler = receiver_transport.get_handler();
+    handle_data(&sent.packet, receiver_iface.address, receiver_handler.lock().await).await;
+
+    let proof_message = timeout(Duration::from_millis(200), receiver_iface.tx_channel.recv())
+        .await
+        .expect("a delivery proof should be sent back on the same interface")
+        .expect("tx channel open");
+    assert_eq!(proof_message.packet.header.packet_type, PacketType::Proof);
+    assert_eq!(proof_message.packet.destination, own_hash);
+    assert_eq!(proof_message.packet.data.len(), HASH_SIZE + ed25519_dalek::SIGNATURE_LENGTH);
+    assert_eq!(&proof_message.packet.data.as_slice()[..HASH_SIZE], encrypted_packet_hash.to_bytes().as_slice());
+
+    // The proof is only actually useful if it independently verifies
+    // against the receiver's own public key — assert that directly, not
+    // just "some bytes came back."
+    let signature_bytes = &proof_message.packet.data.as_slice()[HASH_SIZE..];
+    let signature = ed25519_dalek::Signature::from_slice(signature_bytes).expect("valid signature bytes");
+    assert!(receiver_identity.as_identity().verify(&encrypted_packet_hash.to_bytes(), &signature).is_ok());
+
+    // Close the loop: feed the proof back into the sender's own inbound
+    // handling and confirm its `ReceiptHandler` actually fires — this is
+    // the exact mechanism `BroadcastReceiptHandler` (meshage's own code,
+    // `rust/src/reticulum/transport.rs`) depends on.
+    assert_eq!(count.load(Ordering::SeqCst), 0);
+    sender_transport.handle_inbound_for_test(proof_message.packet).await;
+    assert_eq!(count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn proof_strategy_app_with_true_callback_generates_a_delivery_proof() {
+    let receiver_identity = PrivateIdentity::new_from_rand(OsRng);
+    let receiver_config = TransportConfig::new("receiver", &receiver_identity, true);
+    let mut receiver_transport = Transport::new(receiver_config);
+    let mut receiver_iface = receiver_transport.iface_manager().lock().await.new_channel(8);
+    let own_destination = receiver_transport
+        .add_destination(receiver_identity.clone(), DestinationName::new("lxmf", "delivery"))
+        .await;
+    let own_hash = own_destination.lock().await.desc.address_hash;
+    {
+        let mut dest = own_destination.lock().await;
+        dest.set_proof_strategy(ProofStrategy::App);
+        dest.set_proof_requested_callback(Box::new(|_packet: &Packet| true));
+    }
+
+    let sender_identity = PrivateIdentity::new_from_rand(OsRng);
+    let sender_config = TransportConfig::new("sender", &sender_identity, true);
+    let sender_transport = Transport::new(sender_config);
+    let mut sender_iface = sender_transport.iface_manager().lock().await.new_channel(8);
+    let receiver_announce = own_destination.lock().await.announce(OsRng, None).expect("valid announce");
+    handle_announce(
+        &receiver_announce,
+        sender_transport.get_handler().lock().await,
+        sender_iface.address,
+        crate::iface::IfaceSource::None,
+    )
+    .await;
+
+    let outbound = Packet {
+        destination: own_hash,
+        data: PacketDataBuffer::new_from_slice(b"hello from the sender"),
+        ..Packet::default()
+    };
+    let trace = sender_transport.send_packet_with_trace(outbound).await;
+    assert_eq!(trace.outcome, SendPacketOutcome::SentDirect);
+    let sent = timeout(Duration::from_millis(200), sender_iface.tx_channel.recv())
+        .await
+        .expect("packet should be queued for the sender's own interface")
+        .expect("tx channel open");
+
+    let receiver_handler = receiver_transport.get_handler();
+    handle_data(&sent.packet, receiver_iface.address, receiver_handler.lock().await).await;
+
+    let proof_message = timeout(Duration::from_millis(200), receiver_iface.tx_channel.recv())
+        .await
+        .expect("a proof-requested callback returning true should generate a delivery proof")
+        .expect("tx channel open");
+    assert_eq!(proof_message.packet.header.packet_type, PacketType::Proof);
+}
+
+#[tokio::test]
+async fn proof_strategy_app_with_false_callback_never_generates_a_delivery_proof() {
+    let receiver_identity = PrivateIdentity::new_from_rand(OsRng);
+    let receiver_config = TransportConfig::new("receiver", &receiver_identity, true);
+    let mut receiver_transport = Transport::new(receiver_config);
+    let mut receiver_iface = receiver_transport.iface_manager().lock().await.new_channel(8);
+    let own_destination = receiver_transport
+        .add_destination(receiver_identity.clone(), DestinationName::new("lxmf", "delivery"))
+        .await;
+    let own_hash = own_destination.lock().await.desc.address_hash;
+    {
+        let mut dest = own_destination.lock().await;
+        dest.set_proof_strategy(ProofStrategy::App);
+        dest.set_proof_requested_callback(Box::new(|_packet: &Packet| false));
+    }
+
+    let sender_identity = PrivateIdentity::new_from_rand(OsRng);
+    let sender_config = TransportConfig::new("sender", &sender_identity, true);
+    let sender_transport = Transport::new(sender_config);
+    let mut sender_iface = sender_transport.iface_manager().lock().await.new_channel(8);
+    let receiver_announce = own_destination.lock().await.announce(OsRng, None).expect("valid announce");
+    handle_announce(
+        &receiver_announce,
+        sender_transport.get_handler().lock().await,
+        sender_iface.address,
+        crate::iface::IfaceSource::None,
+    )
+    .await;
+
+    let outbound = Packet {
+        destination: own_hash,
+        data: PacketDataBuffer::new_from_slice(b"hello from the sender"),
+        ..Packet::default()
+    };
+    let trace = sender_transport.send_packet_with_trace(outbound).await;
+    assert_eq!(trace.outcome, SendPacketOutcome::SentDirect);
+    let sent = timeout(Duration::from_millis(200), sender_iface.tx_channel.recv())
+        .await
+        .expect("packet should be queued for the sender's own interface")
+        .expect("tx channel open");
+
+    let receiver_handler = receiver_transport.get_handler();
+    handle_data(&sent.packet, receiver_iface.address, receiver_handler.lock().await).await;
+
+    let outcome = timeout(Duration::from_millis(100), receiver_iface.tx_channel.recv()).await;
+    assert!(outcome.is_err(), "a proof-requested callback returning false must not generate a delivery proof");
+}
+
+#[tokio::test]
+async fn non_data_or_non_single_packets_never_generate_a_delivery_proof() {
+    // Guards against a too-broad fix: only a plain opportunistic
+    // `Data`/`Single` packet (context: None) should ever trigger this —
+    // not, say, a `Resource`-context packet already handled by its own
+    // dedicated resource-proof machinery elsewhere in this crate. Strategy
+    // is deliberately set to `All` (the most permissive setting) so this
+    // test proves the *context* gate blocks it, not just an unconfigured
+    // strategy. A `KeepAlive`-context packet is one `should_encrypt_packet`
+    // already exempts from decryption, so a synthetic (non-ciphertext)
+    // payload is fine here, unlike the other tests in this file.
+    let receiver_identity = PrivateIdentity::new_from_rand(OsRng);
+    let receiver_config = TransportConfig::new("receiver", &receiver_identity, true);
+    let mut receiver_transport = Transport::new(receiver_config);
+    let mut receiver_iface = receiver_transport.iface_manager().lock().await.new_channel(8);
+    let own_destination = receiver_transport
+        .add_destination(receiver_identity.clone(), DestinationName::new("lxmf", "delivery"))
+        .await;
+    let own_hash = own_destination.lock().await.desc.address_hash;
+    own_destination.lock().await.set_proof_strategy(ProofStrategy::All);
+
+    let packet = Packet {
+        header: Header { packet_type: PacketType::Data, destination_type: DestinationType::Single, ..Default::default() },
+        destination: own_hash,
+        context: PacketContext::KeepAlive,
+        data: PacketDataBuffer::new_from_slice(&[0xFFu8]),
+        ..Default::default()
+    };
+
+    let receiver_handler = receiver_transport.get_handler();
+    handle_data(&packet, receiver_iface.address, receiver_handler.lock().await).await;
+
+    let outcome = timeout(Duration::from_millis(100), receiver_iface.tx_channel.recv()).await;
+    assert!(outcome.is_err(), "a KeepAlive-context packet must not generate a delivery proof, even under ProofStrategy::All");
+}

--- a/crates/libs/rns-transport/src/transport/wire.rs
+++ b/crates/libs/rns-transport/src/transport/wire.rs
@@ -2,6 +2,7 @@ use super::path::send_to_next_hop;
 use super::resource_wire;
 use super::wire_encryption::should_encrypt_packet;
 use super::*;
+use crate::packet::Header;
 use ed25519_dalek::{Signature, SIGNATURE_LENGTH};
 
 fn validate_destination_receipt_proof(
@@ -476,6 +477,76 @@ pub(super) async fn handle_data<'a>(
                     interface: packet.transport.map(|value| value.as_slice().to_vec()),
                 })
                 .ok();
+
+            // Generates the automatic delivery proof this branch was
+            // missing: it decrypts and forwards a plain `Single`/`Data`
+            // packet (e.g. a direct LXMF message) above, but never told
+            // the sender it arrived. The receive-side validation this
+            // proof round-trips through
+            // (`validated_receipt_hash`/`validate_destination_receipt_proof`,
+            // same file) already handles it correctly, so this is the one
+            // missing half. Wire format matches what that validation
+            // function already expects: `packet_hash(32B) ++
+            // Ed25519_signature(64B)`, signed by this destination's own
+            // private identity over the hash of the packet just received.
+            // Replied on the same interface the original packet arrived
+            // on — this is correct, not a shortcut: Reticulum's own proof
+            // relay is hop-by-hop reversal (each node along a path replies
+            // on the interface it received on), not a fresh path-table
+            // lookup by the proof's own destination (which here is *this*
+            // destination's own hash, not a remote one any path table
+            // would have an entry for). See #479.
+            //
+            // Whether a proof actually gets sent is gated by this
+            // destination's own `proof_strategy` (mirrors Python
+            // Reticulum's `PROVE_NONE`/`PROVE_APP`/`PROVE_ALL` —
+            // see `ProofStrategy`'s doc comment) — a receiver-owned policy
+            // decision, not something the crate imposes unconditionally.
+            // `context: None` is still checked first regardless of
+            // strategy: `Request`/`Response` already have the response
+            // itself as their own delivery acknowledgement;
+            // `Resource`/`KeepAlive`/`CacheRequest` (the same set
+            // `should_encrypt_packet` above already excludes, for the same
+            // underlying reason — they're each a sub-protocol with its own
+            // semantics, not a plain opportunistic app message) have their
+            // own dedicated completion/ack mechanisms elsewhere in this
+            // crate. Proving those too would be redundant at best and
+            // could plausibly confuse a peer expecting exactly one
+            // specific ack shape per context.
+            if packet.context == PacketContext::None {
+                let packet_hash = packet.hash();
+                let signature = {
+                    let destination_guard = destination.lock().await;
+                    let should_prove = match destination_guard.proof_strategy {
+                        ProofStrategy::None => false,
+                        ProofStrategy::All => true,
+                        ProofStrategy::App => destination_guard
+                            .proof_requested_callback
+                            .as_ref()
+                            .is_some_and(|cb| cb.proof_requested(packet)),
+                    };
+                    should_prove.then(|| destination_guard.identity.sign(&packet_hash.to_bytes()))
+                };
+                if let Some(signature) = signature {
+                    let mut proof_data = Vec::with_capacity(HASH_SIZE + SIGNATURE_LENGTH);
+                    proof_data.extend_from_slice(&packet_hash.to_bytes());
+                    proof_data.extend_from_slice(&signature.to_bytes());
+                    let proof_packet = Packet {
+                        header: Header { packet_type: PacketType::Proof, ..Default::default() },
+                        ifac: None,
+                        destination: packet.destination,
+                        transport: None,
+                        context: PacketContext::None,
+                        data: PacketDataBuffer::new_from_slice(&proof_data),
+                    };
+                    handler
+                        .send(TxMessage {
+                            tx_type: TxMessageType::Direct(iface),
+                            packet: proof_packet,
+                        })
+                        .await;
+                }
+            }
         } else {
             data_handled = send_to_next_hop(packet, &handler, None).await;
         }

--- a/crates/libs/rns-transport/src/transport/wire.rs
+++ b/crates/libs/rns-transport/src/transport/wire.rs
@@ -114,29 +114,92 @@ pub(super) async fn validated_receipt_hash(
         }
     }
 
-    let mut found_destination = false;
-    if let Some(destination) = handler.single_out_destinations.get(&packet.destination).cloned() {
-        found_destination = true;
-        let destination = destination.lock().await;
-        if let Ok(hash) = validate_destination_receipt_proof(&destination.identity, packet) {
-            return Ok(Some(hash.to_bytes()));
-        }
-    }
-    if let Some(destination) = handler.single_in_destinations.get(&packet.destination).cloned() {
-        found_destination = true;
-        let destination = destination.lock().await;
-        if let Ok(hash) =
-            validate_destination_receipt_proof(destination.identity.as_identity(), packet)
-        {
-            return Ok(Some(hash.to_bytes()));
+    // meshage fork — explicit proofs (`packet_hash(32B) ++ signature(64B)`)
+    // are addressed the same way implicit ones are: to
+    // `AddressHash::new_from_hash(&original_packet_hash)`
+    // (`RNS/Packet.py::ProofDestination`, `RNS/Identity.py::prove` —
+    // confirmed applies to both proof shapes, not just implicit), so a
+    // direct lookup of `packet.destination` against this instance's own
+    // registered destinations (the old behavior here) can never match a
+    // real proof again — no real Reticulum peer, nor this crate's own
+    // corrected proof-generation in `handle_data`, ever addresses a proof
+    // to a real destination hash.
+    //
+    // Two cases, matching who is receiving this proof:
+    //
+    // - We relayed the original packet (`handle_data`'s unconditional
+    //   `packet_cache.note_source` call ran for it, whether or not we also
+    //   host a local destination it happened to match): resolve via the
+    //   same packet_cache reverse lookup the implicit branch above already
+    //   uses, cross-checking the embedded hash against the tracked one
+    //   first, mirroring Python's own `receipt.hash == proof_hash` gate.
+    // - We are the *original sender*, receiving this proof directly from
+    //   its prover (the common case — we never called `handle_data` on our
+    //   own outbound packet, so packet_cache has nothing for it, matching
+    //   real Reticulum: `Transport.receipts` isn't keyed by the proof's
+    //   destination field either, Python just tries every outstanding
+    //   receipt). This crate doesn't track "packets we're awaiting a proof
+    //   for" itself (that's `pending_receipts`, application-level), but the
+    //   explicit shape carries its own hash, so it's safe to just try every
+    //   locally known destination's identity against it — a wrong identity
+    //   fails signature verification harmlessly.
+    if packet.data.len() == HASH_SIZE + SIGNATURE_LENGTH {
+        let proof_context = {
+            let packet_cache = handler.packet_cache.lock().await;
+            packet_cache.proof_context_for_destination(&packet.destination)
+        };
+        if let Some((receipt_hash, proved_destination, _)) = proof_context {
+            let mut embedded_hash = [0u8; HASH_SIZE];
+            embedded_hash.copy_from_slice(&packet.data.as_slice()[..HASH_SIZE]);
+            if embedded_hash == receipt_hash.to_bytes() {
+                let mut destination_checked = false;
+                if let Some(destination) =
+                    handler.single_out_destinations.get(&proved_destination).cloned()
+                {
+                    destination_checked = true;
+                    let destination = destination.lock().await;
+                    if let Ok(hash) =
+                        validate_destination_receipt_proof(&destination.identity, packet)
+                    {
+                        return Ok(Some(hash.to_bytes()));
+                    }
+                }
+                if let Some(destination) =
+                    handler.single_in_destinations.get(&proved_destination).cloned()
+                {
+                    destination_checked = true;
+                    let destination = destination.lock().await;
+                    if let Ok(hash) = validate_destination_receipt_proof(
+                        destination.identity.as_identity(),
+                        packet,
+                    ) {
+                        return Ok(Some(hash.to_bytes()));
+                    }
+                }
+                if destination_checked {
+                    return Err(RnsError::CryptoError);
+                }
+            }
+        } else {
+            for destination in handler.single_out_destinations.values() {
+                let destination = destination.lock().await;
+                if let Ok(hash) = validate_destination_receipt_proof(&destination.identity, packet)
+                {
+                    return Ok(Some(hash.to_bytes()));
+                }
+            }
+            for destination in handler.single_in_destinations.values() {
+                let destination = destination.lock().await;
+                if let Ok(hash) =
+                    validate_destination_receipt_proof(destination.identity.as_identity(), packet)
+                {
+                    return Ok(Some(hash.to_bytes()));
+                }
+            }
         }
     }
 
-    if found_destination {
-        Err(RnsError::CryptoError)
-    } else {
-        Ok(None)
-    }
+    Ok(None)
 }
 
 async fn should_forward_link_request_proof(
@@ -534,7 +597,30 @@ pub(super) async fn handle_data<'a>(
                     let proof_packet = Packet {
                         header: Header { packet_type: PacketType::Proof, ..Default::default() },
                         ifac: None,
-                        destination: packet.destination,
+                        // Real Reticulum always addresses a proof to
+                        // `Packet.generate_proof_destination()` — the
+                        // truncated hash of the *proved* packet, not the
+                        // proving destination's own real address hash —
+                        // for both explicit and implicit proof shapes
+                        // alike (`RNS/Identity.py::prove`,
+                        // `RNS/Packet.py::ProofDestination`). This crate's
+                        // own reverse-routing table for proofs
+                        // (`PacketCache::note_source`/
+                        // `by_proof_destination`) is keyed the same way.
+                        // Addressing this to our own real destination hash
+                        // instead "worked" for direct connections (Python's
+                        // local receipt validation in `Transport.py`
+                        // matches by scanning `Transport.receipts`, not by
+                        // this field), but silently broke reachability the
+                        // moment the proof needed to traverse any
+                        // intermediate Transport/relay hop back to the
+                        // original sender — that hop's own reverse-routing
+                        // table would never have an entry under our real
+                        // address hash. Confirmed against
+                        // `RNS/Identity.py::prove` and
+                        // `RNS/Transport.py`'s inbound-proof handling
+                        // directly.
+                        destination: AddressHash::new_from_hash(&packet_hash),
                         transport: None,
                         context: PacketContext::None,
                         data: PacketDataBuffer::new_from_slice(&proof_data),

--- a/crates/libs/rns-transport/src/transport/wire.rs
+++ b/crates/libs/rns-transport/src/transport/wire.rs
@@ -125,24 +125,28 @@ pub(super) async fn validated_receipt_hash(
     // corrected proof-generation in `handle_data`, ever addresses a proof
     // to a real destination hash.
     //
-    // Two cases, matching who is receiving this proof:
+    // Two cases, matching who is receiving this proof, both resolved the same
+    // way: via the packet_cache reverse lookup the implicit branch above
+    // already uses, cross-checking the embedded hash against the tracked one
+    // first (mirroring Python's own `receipt.hash == proof_hash` gate), then
+    // verifying *only* against the destination we actually tracked for that
+    // hash.
     //
-    // - We relayed the original packet (`handle_data`'s unconditional
+    // - We relayed the original packet: `handle_data`'s unconditional
     //   `packet_cache.note_source` call ran for it, whether or not we also
-    //   host a local destination it happened to match): resolve via the
-    //   same packet_cache reverse lookup the implicit branch above already
-    //   uses, cross-checking the embedded hash against the tracked one
-    //   first, mirroring Python's own `receipt.hash == proof_hash` gate.
-    // - We are the *original sender*, receiving this proof directly from
-    //   its prover (the common case — we never called `handle_data` on our
-    //   own outbound packet, so packet_cache has nothing for it, matching
-    //   real Reticulum: `Transport.receipts` isn't keyed by the proof's
-    //   destination field either, Python just tries every outstanding
-    //   receipt). This crate doesn't track "packets we're awaiting a proof
-    //   for" itself (that's `pending_receipts`, application-level), but the
-    //   explicit shape carries its own hash, so it's safe to just try every
-    //   locally known destination's identity against it — a wrong identity
-    //   fails signature verification harmlessly.
+    //   host a local destination it happened to match.
+    // - We are the *original sender*, receiving this proof directly from its
+    //   prover: `PacketCache::update` (run for every outbound packet we send)
+    //   records the same reverse mapping for our own Data sends, so this
+    //   case has a cache entry too.
+    //
+    // Without a tracked entry, there is no cached record of us ever sending
+    // or relaying a packet with this hash, so there's nothing to check the
+    // proof against — do NOT fall back to trying every known destination's
+    // identity against the embedded hash. That would accept a signature from
+    // *any* peer we happen to know, over a hash they could have observed on
+    // a packet addressed to someone else entirely, letting them forge a
+    // delivery receipt for a message they never received.
     if packet.data.len() == HASH_SIZE + SIGNATURE_LENGTH {
         let proof_context = {
             let packet_cache = handler.packet_cache.lock().await;
@@ -178,22 +182,6 @@ pub(super) async fn validated_receipt_hash(
                 }
                 if destination_checked {
                     return Err(RnsError::CryptoError);
-                }
-            }
-        } else {
-            for destination in handler.single_out_destinations.values() {
-                let destination = destination.lock().await;
-                if let Ok(hash) = validate_destination_receipt_proof(&destination.identity, packet)
-                {
-                    return Ok(Some(hash.to_bytes()));
-                }
-            }
-            for destination in handler.single_in_destinations.values() {
-                let destination = destination.lock().await;
-                if let Ok(hash) =
-                    validate_destination_receipt_proof(destination.identity.as_identity(), packet)
-                {
-                    return Ok(Some(hash.to_bytes()));
                 }
             }
         }


### PR DESCRIPTION
## Summary

- `handle_data`'s `DestinationType::Single` branch (`transport/wire.rs`) decrypted and forwarded a plain opportunistic packet (e.g. an LXMF message sent with `desired_method=OPPORTUNISTIC`) to its local destination, but never generated a delivery proof — confirmed genuinely absent from the crate by reading the receive path directly, not merely unconfigured.
- Adds a real per-destination `ProofStrategy` (`None`/`App`/`All`), porting Python Reticulum's own `RNS.Destination.proof_strategy` (`PROVE_NONE`/`PROVE_APP`/`PROVE_ALL`) rather than proving unconditionally. `None` is the default, matching Python's own default, so existing consumers of this crate see no behavior change unless they opt in.
- `ProofStrategy::App` defers the per-packet decision to an app-registered `ProofRequestedHandler` callback, mirroring this crate's own existing `ReceiptHandler` convention (`transport::core`).
- Wire format matches what `validated_receipt_hash`/`validate_destination_receipt_proof` already expect — no changes needed on the validation side. Replied on the same interface the original packet arrived on, matching the sibling `Link` branch's own established reverse-routing pattern in the same function.

Fixes #479.

## Test plan

- [x] 5 new unit tests in `transport/tests_parts/single_destination_delivery_proof.rs`: default `ProofStrategy::None` declines, `All` proves (full round trip through the sender's own receipt handler, signature independently verified), `App` with a true callback proves, `App` with a false callback declines, and a guard confirming non-`context:None` packets are never proven regardless of strategy.
- [x] `cargo test --lib`: 515 passed, 0 failed.
- [x] `cargo fmt -- --check`: clean.
- [x] `cargo clippy --lib -- -D warnings`: clean.
- [x] Verified live against an independent MeshChat (Python RNS/LXMF) peer over a shared transport hub.