### PR TITLE
Prove inbound plain Resource delivery already works (#481 was already fixed)

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/inbound_routing.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/inbound_routing.rs
@@ -158,8 +158,8 @@ fn is_lxmf_propagation_link_destination(destination: &DestinationDesc) -> bool {
 mod tests {
     use super::{
         destination_for_outbound_link, is_lxmf_delivery_destination,
-        is_lxmf_propagation_link_destination, should_skip_resolved_control_payload,
-        InboundLxmfDestination,
+        is_lxmf_propagation_link_destination, resolve_resource_destination,
+        should_skip_resolved_control_payload, InboundLxmfDestination,
     };
     use rand_core::OsRng;
     use rns_transport::destination::{DestinationDesc, DestinationName};
@@ -227,6 +227,135 @@ mod tests {
         assert_eq!(
             destination_for_outbound_link(&remote_destination, Some(local_destination)),
             Some(InboundLxmfDestination::Delivery(local_destination))
+        );
+    }
+
+    // Live-reproduction check for PR #482 / issue #481: does a genuine
+    // plain (non-Request, non-Response) Resource transfer, completed over a
+    // real Link the sender opened to our own registered `lxmf.delivery`
+    // destination, actually resolve via THIS function the way
+    // `spawn_inbound_worker`'s pre-existing `resource_events()` consumer
+    // already relies on? No synthetic destination descriptors here — a
+    // real inbound Link, built the same way `handle_link_request_as_destination`
+    // builds one in production, carrying a real completed Resource transfer.
+    #[tokio::test]
+    async fn plain_resource_over_a_real_link_resolves_to_local_delivery_destination() {
+        use rns_transport::iface::{IfaceSource, RxMessage};
+        use rns_transport::resource::ResourceEventKind;
+        use rns_transport::transport::{Transport, TransportConfig};
+        use tokio::time::{timeout, Duration};
+
+        let receiver_identity = PrivateIdentity::new_from_rand(OsRng);
+        let mut receiver_transport =
+            Transport::new(TransportConfig::new("receiver", &receiver_identity, true));
+        let receiver_iface = receiver_transport.iface_manager().lock().await.new_channel(64);
+        let own_destination = receiver_transport
+            .add_destination(receiver_identity.clone(), DestinationName::new("lxmf", "delivery"))
+            .await;
+        let own_desc = own_destination.lock().await.desc;
+        let mut destination_hash = [0u8; 16];
+        destination_hash.copy_from_slice(own_desc.address_hash.as_slice());
+
+        let sender_identity = PrivateIdentity::new_from_rand(OsRng);
+        let sender_transport =
+            Transport::new(TransportConfig::new("sender", &sender_identity, true));
+        let sender_iface = sender_transport.iface_manager().lock().await.new_channel(64);
+
+        // Autonomously relay whatever each side transmits to the other, so
+        // the real Link handshake and Resource transfer run to completion
+        // exactly as they would over a real network — no manual packet
+        // stepping.
+        let (mut receiver_tx, receiver_rx_channel, receiver_addr) =
+            (receiver_iface.tx_channel, receiver_iface.rx_channel, receiver_iface.address);
+        let (mut sender_tx, sender_rx_channel, sender_addr) =
+            (sender_iface.tx_channel, sender_iface.rx_channel, sender_iface.address);
+        tokio::spawn({
+            let sender_rx_channel = sender_rx_channel.clone();
+            async move {
+                while let Some(msg) = receiver_tx.recv().await {
+                    let _ = sender_rx_channel
+                        .send(RxMessage {
+                            address: sender_addr,
+                            packet: msg.packet,
+                            source: IfaceSource::None,
+                        })
+                        .await;
+                }
+            }
+        });
+        tokio::spawn({
+            let receiver_rx_channel = receiver_rx_channel.clone();
+            async move {
+                while let Some(msg) = sender_tx.recv().await {
+                    let _ = receiver_rx_channel
+                        .send(RxMessage {
+                            address: receiver_addr,
+                            packet: msg.packet,
+                            source: IfaceSource::None,
+                        })
+                        .await;
+                }
+            }
+        });
+
+        let out_link = sender_transport.link(own_desc).await;
+        let link_id = *out_link.lock().await.id();
+        for _ in 0..200 {
+            if out_link.lock().await.status()
+                == rns_transport::destination::link::LinkStatus::Active
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            out_link.lock().await.status(),
+            rns_transport::destination::link::LinkStatus::Active,
+            "real Link handshake should complete over the relayed virtual ifaces"
+        );
+
+        // Large enough to force genuine multi-part chunking over the Link's
+        // MTU, matching the motivating "large message" scenario in #481 —
+        // not just a single-packet resource that might trivially round-trip
+        // regardless of whether the real chunked-transfer machinery works.
+        let payload: Vec<u8> = (0..20_000).map(|i| (i % 256) as u8).collect();
+        let mut resource_events = receiver_transport.resource_events();
+        sender_transport
+            .send_resource(&link_id, payload.clone(), None)
+            .await
+            .expect("plain resource send should succeed over the active link");
+
+        let event = timeout(Duration::from_secs(5), async {
+            loop {
+                let event = resource_events.recv().await.expect("resource event stream open");
+                if let ResourceEventKind::Complete(_) = &event.kind {
+                    return event;
+                }
+            }
+        })
+        .await
+        .expect("receiver should observe a real ResourceEventKind::Complete");
+
+        let ResourceEventKind::Complete(ref complete) = event.kind else { unreachable!() };
+        assert_eq!(
+            complete.data, payload,
+            "the full, untruncated large payload should have reassembled correctly"
+        );
+        assert!(!complete.is_request && !complete.is_response, "this is a plain resource send");
+
+        let resolved = resolve_resource_destination(
+            &receiver_transport,
+            &event.link_id,
+            Some(destination_hash),
+        )
+        .await;
+
+        assert_eq!(
+            resolved,
+            Some(InboundLxmfDestination::Delivery(destination_hash)),
+            "a plain Resource completed over a real Link to our own registered lxmf.delivery \
+             destination should resolve via resolve_resource_destination the same way \
+             spawn_inbound_worker's pre-existing resource_events() consumer already depends on"
         );
     }
 }


### PR DESCRIPTION
Fixes #481 — by confirming it was already fixed, not by adding new forwarding.

## What this PR originally did

Added `spawn_resource_data_forwarder` in `rns-transport`, forwarding any
plain (non-Request, non-Response) `ResourceEventKind::Complete` into
`received_data_events()`, mirroring `spawn_link_data_forwarder`. Codex's
review caught two real P1 bugs in that approach:

1. **Silent truncation.** `PacketDataBuffer::new_from_slice` caps at
   `PACKET_DATA_MAX` (256 KiB) with no error — any resource above that
   was silently truncated before reaching `received_data_events()`,
   corrupting exactly the large-message case #481 was about.
2. **Delivery-limit bypass.** Resources under that cap routed through
   `accept_delivery_packet`, which has no size check — bypassing
   `direct_delivery_resource_limit_exceeded`, the gate
   `accept_delivery_resource` already enforces for the same content.

## What actually happened

Issue #481 was diagnosed entirely from inside the `rns-transport` crate
("confirmed by reading transport/core.rs/resource.rs directly ... there
wasn't one \[consumer]") — without checking reticulumd's own
`resource_events()` consumer in `inbound_worker_parts/module_core.rs`,
added 2026-06-12 (weeks before this PR), which already calls
`accept_delivery_resource` for exactly this case: a plain resource
completing over a Link bound to a locally-registered `lxmf.delivery`
destination. That handler correctly size-checks and never truncates.

This PR's forwarder was racing that already-working path, not filling a
gap. Its own live verification ("confirmed it now arrives") couldn't
tell the two apart, because reticulumd already dedupes inbound messages
by ID — a message delivered via the pre-existing path and *redundantly*
re-delivered via this PR's buggy new path would look identical from the
outside.

## Verification

Built a real (non-synthetic) reproduction rather than trust static
analysis alone: two live `Transport`s wired together over in-memory
virtual interfaces, a genuine Link handshake, and a real 20,000-byte
plain Resource send forcing actual multi-part chunking — run against
current `main`, *without* this PR's forwarder. Result: the existing
consumer reassembled the full, untruncated payload and
`resolve_resource_destination` resolved it to the local delivery
destination exactly as `spawn_inbound_worker` already depends on. No
routing gap exists for this scenario.

## What this PR now does

- Drops `spawn_resource_data_forwarder` and its two synthetic-event unit
  tests entirely.
- Adds `plain_resource_over_a_real_link_resolves_to_local_delivery_destination`,
  a permanent end-to-end regression test proving the pre-existing path
  handles a real, large, chunked plain Resource correctly — so this stays
  proven regardless of future changes nearby.

## Test plan

- [x] `cargo test -p reticulumd --bin reticulumd` — 488 passed, 0 failed
- [x] `cargo test -p reticulum-rs-transport --lib` — 520 passed, 0 failed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p reticulumd --all-targets --all-features --no-deps -- -D warnings` — clean
- [x] `tools/scripts/check-module-size.sh` / `tools/scripts/check-boundaries.sh` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)