### PR TITLE
Route send_to_*_links/send_channel_to_*_links via each Link's bound iface

### DIFF
--- a/crates/libs/rns-transport/src/transport/links_parts/transport_sections/reset_out_link.rs
+++ b/crates/libs/rns-transport/src/transport/links_parts/transport_sections/reset_out_link.rs
@@ -48,7 +48,19 @@ impl Transport {
         self.handler.lock().await.resource_manager.remove_link_state(link_id);
     }
 
-    pub(crate) async fn send_link_packet_on_bound_iface(
+    /// The correct way to send any packet addressed to an already-open
+    /// Link (`destination_type: Link` — identify, keepalive, channel,
+    /// plain data) rather than a fresh destination. `Transport::
+    /// send_packet`/`send_packet_with_outcome` route via the path table,
+    /// keyed by real announced destination hashes — never by a Link's own
+    /// ephemeral id, which is what a Link-context packet's `destination`
+    /// field actually holds. Public (not `pub(crate)`) specifically so a
+    /// downstream consumer building its own Link-context packet via
+    /// `Link::identify_packet`/`data_packet`/`channel_packet` — anything
+    /// this crate doesn't already wrap in a higher-level helper like
+    /// `crate::delivery::send_on_link_observed` — has a correct way to
+    /// send it at all.
+    pub async fn send_link_packet_on_bound_iface(
         &self,
         link: &Arc<Mutex<Link>>,
         packet: Packet,
@@ -102,171 +114,160 @@ impl Transport {
             .unwrap_or(crate::resource::DEFAULT_RESOURCE_INTERFACE_MTU)
     }
 
+    /// **Must route via each link's own bound interface, never
+    /// `TransportHandler::send_packet`.** That generic path resolves the
+    /// next hop through `route_outbound_packet`, which looks
+    /// `packet.destination` up in the path table — but a Link-context
+    /// packet (`data_packet`/`channel_packet`) sets `packet.destination` to
+    /// the link's own ephemeral id, which is never a path-table entry
+    /// (those come from real, announced destination-hash paths). For any
+    /// `Transport` configured with `broadcast: false` (the common case —
+    /// see `TransportConfig::new`'s own doc comment; a client that isn't
+    /// itself acting as a transport node has no reason to enable it), that
+    /// lookup miss falls straight through to `SendPacketOutcome::
+    /// DroppedNoRoute` with no broadcast fallback either — every packet
+    /// these six methods built was silently dropped before ever reaching
+    /// an interface. `send_link_packet_on_bound_iface` (below) is the
+    /// crate's own correct mechanism for this — already used by
+    /// `crate::delivery::send_on_link_observed` — but these six were never
+    /// wired to call it.
     pub async fn send_to_all_out_links(&self, payload: &[u8]) {
-        let packets = {
+        let pairs = {
             let handler = self.handler.lock().await;
-            let mut packets = Vec::new();
+            let mut pairs = Vec::new();
             for link in handler.out_links.values() {
-                let link = link.lock().await;
-                if link.status() == LinkStatus::Active {
-                    if let Ok(packet) = link.data_packet(payload) {
-                        packets.push(packet);
-                    }
+                let guard = link.lock().await;
+                if guard.status() != LinkStatus::Active {
+                    continue;
                 }
+                let Ok(packet) = guard.data_packet(payload) else { continue };
+                drop(guard);
+                pairs.push((link.clone(), packet));
             }
-            packets
+            pairs
         };
-        if packets.is_empty() {
-            return;
-        }
-        let mut handler = self.handler.lock().await;
-        for packet in packets {
-            handler.send_packet(packet).await;
+        for (link, packet) in pairs {
+            self.send_link_packet_on_bound_iface(&link, packet).await;
         }
     }
 
     pub async fn send_channel_to_all_out_links(&self, payload: &[u8]) {
-        let packets = {
+        let pairs = {
             let handler = self.handler.lock().await;
-            let mut packets = Vec::new();
+            let mut pairs = Vec::new();
             for link in handler.out_links.values() {
-                let link = link.lock().await;
-                if link.status() == LinkStatus::Active {
-                    if let Ok(packet) = link.channel_packet(payload) {
-                        packets.push(packet);
-                    }
+                let guard = link.lock().await;
+                if guard.status() != LinkStatus::Active {
+                    continue;
                 }
+                let Ok(packet) = guard.channel_packet(payload) else { continue };
+                drop(guard);
+                pairs.push((link.clone(), packet));
             }
-            packets
+            pairs
         };
-        if packets.is_empty() {
-            return;
-        }
-        let mut handler = self.handler.lock().await;
-        for packet in packets {
-            handler.send_packet(packet).await;
+        for (link, packet) in pairs {
+            self.send_link_packet_on_bound_iface(&link, packet).await;
         }
     }
 
     pub async fn send_to_out_links(&self, destination: &AddressHash, payload: &[u8]) {
-        let mut count = 0usize;
-        let packets = {
+        let pairs = {
             let handler = self.handler.lock().await;
-            let mut packets = Vec::new();
+            let mut pairs = Vec::new();
             for link in handler.out_links.values() {
-                let link = link.lock().await;
-                if link.destination().address_hash == *destination
-                    && link.status() == LinkStatus::Active
-                {
-                    if let Ok(packet) = link.data_packet(payload) {
-                        packets.push(packet);
-                    }
+                let guard = link.lock().await;
+                if guard.destination().address_hash != *destination || guard.status() != LinkStatus::Active {
+                    continue;
                 }
+                let Ok(packet) = guard.data_packet(payload) else { continue };
+                drop(guard);
+                pairs.push((link.clone(), packet));
             }
-            packets
+            pairs
         };
-        if !packets.is_empty() {
-            let mut handler = self.handler.lock().await;
-            for packet in packets {
-                handler.send_packet(packet).await;
-                count += 1;
-            }
-        }
 
-        if count == 0 {
+        if pairs.is_empty() {
             log::trace!("tp({}): no output links for {} destination", self.name, destination);
+            return;
+        }
+        for (link, packet) in pairs {
+            self.send_link_packet_on_bound_iface(&link, packet).await;
         }
     }
 
     pub async fn send_channel_to_out_links(&self, destination: &AddressHash, payload: &[u8]) {
-        let mut count = 0usize;
-        let packets = {
+        let pairs = {
             let handler = self.handler.lock().await;
-            let mut packets = Vec::new();
+            let mut pairs = Vec::new();
             for link in handler.out_links.values() {
-                let link = link.lock().await;
-                if link.destination().address_hash == *destination
-                    && link.status() == LinkStatus::Active
-                {
-                    if let Ok(packet) = link.channel_packet(payload) {
-                        packets.push(packet);
-                    }
+                let guard = link.lock().await;
+                if guard.destination().address_hash != *destination || guard.status() != LinkStatus::Active {
+                    continue;
                 }
+                let Ok(packet) = guard.channel_packet(payload) else { continue };
+                drop(guard);
+                pairs.push((link.clone(), packet));
             }
-            packets
+            pairs
         };
-        if !packets.is_empty() {
-            let mut handler = self.handler.lock().await;
-            for packet in packets {
-                handler.send_packet(packet).await;
-                count += 1;
-            }
-        }
 
-        if count == 0 {
+        if pairs.is_empty() {
             log::trace!("tp({}): no output links for {} destination", self.name, destination);
+            return;
+        }
+        for (link, packet) in pairs {
+            self.send_link_packet_on_bound_iface(&link, packet).await;
         }
     }
 
     pub async fn send_to_in_links(&self, destination: &AddressHash, payload: &[u8]) {
-        let mut count = 0usize;
-        let packets = {
+        let pairs = {
             let handler = self.handler.lock().await;
-            let mut packets = Vec::new();
+            let mut pairs = Vec::new();
             for link in handler.in_links.values() {
-                let link = link.lock().await;
-
-                if link.destination().address_hash == *destination
-                    && link.status() == LinkStatus::Active
-                {
-                    if let Ok(packet) = link.data_packet(payload) {
-                        packets.push(packet);
-                    }
+                let guard = link.lock().await;
+                if guard.destination().address_hash != *destination || guard.status() != LinkStatus::Active {
+                    continue;
                 }
+                let Ok(packet) = guard.data_packet(payload) else { continue };
+                drop(guard);
+                pairs.push((link.clone(), packet));
             }
-            packets
+            pairs
         };
-        if !packets.is_empty() {
-            let mut handler = self.handler.lock().await;
-            for packet in packets {
-                handler.send_packet(packet).await;
-                count += 1;
-            }
-        }
 
-        if count == 0 {
+        if pairs.is_empty() {
             log::trace!("tp({}): no input links for {} destination", self.name, destination);
+            return;
+        }
+        for (link, packet) in pairs {
+            self.send_link_packet_on_bound_iface(&link, packet).await;
         }
     }
 
     pub async fn send_channel_to_in_links(&self, destination: &AddressHash, payload: &[u8]) {
-        let mut count = 0usize;
-        let packets = {
+        let pairs = {
             let handler = self.handler.lock().await;
-            let mut packets = Vec::new();
+            let mut pairs = Vec::new();
             for link in handler.in_links.values() {
-                let link = link.lock().await;
-
-                if link.destination().address_hash == *destination
-                    && link.status() == LinkStatus::Active
-                {
-                    if let Ok(packet) = link.channel_packet(payload) {
-                        packets.push(packet);
-                    }
+                let guard = link.lock().await;
+                if guard.destination().address_hash != *destination || guard.status() != LinkStatus::Active {
+                    continue;
                 }
+                let Ok(packet) = guard.channel_packet(payload) else { continue };
+                drop(guard);
+                pairs.push((link.clone(), packet));
             }
-            packets
+            pairs
         };
-        if !packets.is_empty() {
-            let mut handler = self.handler.lock().await;
-            for packet in packets {
-                handler.send_packet(packet).await;
-                count += 1;
-            }
-        }
 
-        if count == 0 {
+        if pairs.is_empty() {
             log::trace!("tp({}): no input links for {} destination", self.name, destination);
+            return;
+        }
+        for (link, packet) in pairs {
+            self.send_link_packet_on_bound_iface(&link, packet).await;
         }
     }
 

--- a/crates/libs/rns-transport/src/transport/tests.rs
+++ b/crates/libs/rns-transport/src/transport/tests.rs
@@ -29,3 +29,5 @@ include!("tests_parts/reticulum_runtime_management.rs");
 include!("tests_parts/packet_proof_correlation.rs");
 
 include!("tests_parts/single_destination_delivery_proof.rs");
+
+include!("tests_parts/link_broadcast_helpers_route_via_bound_iface.rs");

--- a/crates/libs/rns-transport/src/transport/tests_parts/link_broadcast_helpers_route_via_bound_iface.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/link_broadcast_helpers_route_via_bound_iface.rs
@@ -1,0 +1,156 @@
+// Regression coverage for the bug fixed alongside this file: `send_to_*_links`/
+// `send_channel_to_*_links` built a correct Link-context packet but dispatched
+// it through `TransportHandler::send_packet`, which routes via
+// `route_outbound_packet`'s path-table lookup keyed by `packet.destination` —
+// for a Link-context packet that's the link's own ephemeral id, never a real
+// path-table entry, so for any `Transport` configured with `broadcast: false`
+// (the common client case — see `TransportConfig::new`) the packet silently
+// resolved to `SendPacketOutcome::DroppedNoRoute` and never reached an
+// interface. Confirmed against a downstream consumer's real third-party
+// NomadNet node before this fix (see the linked issue).
+//
+// Each test below builds a `Transport` with a *real* registered interface
+// channel and a manually-activated Link (mirroring
+// `transport_register_channel_handler_dispatches_inbound_channel_message`'s
+// existing shape for constructing an already-Active link without a full
+// path-discovery dance), then asserts the helper actually enqueues a
+// `TxMessage` on that same interface — not just that the call returns without
+// panicking, which the pre-fix code already did.
+
+use crate::iface::{IfaceRole, TxMessageType};
+
+fn activated_link_pair(destination: DestinationDesc, signer: &PrivateIdentity) -> (Link, Link) {
+    let (tx, _) = tokio::sync::broadcast::channel(8);
+    let mut outbound = Link::new(destination, tx.clone());
+    let request = outbound.request();
+    let mut inbound = Link::new_from_request(&request, signer.sign_key().clone(), destination, tx)
+        .expect("link request should parse");
+    let iface = AddressHash::new_from_rand(OsRng);
+    assert!(matches!(
+        outbound.handle_packet(&inbound.prove(), iface),
+        crate::destination::link::LinkHandleResult::Activated
+    ));
+    (outbound, inbound)
+}
+
+#[tokio::test]
+async fn send_to_out_links_reaches_the_links_bound_interface() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &local_identity, false));
+    let mut channel = transport.iface_manager().lock().await.new_channel_with_role(8, IfaceRole::Unicast);
+    let iface = *channel.address();
+
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination =
+        DestinationDesc { identity, address_hash: identity.address_hash, name: DestinationName::new("lxmf", "delivery") };
+    let (mut outbound, _inbound) = activated_link_pair(destination, &signer);
+    // The Active handshake above used a synthetic iface id, not the real
+    // registered `channel` — rebind to the real one so the send below has
+    // somewhere concrete to land, matching how a live handshake would set
+    // `ingress_iface` from whichever interface the proof actually arrived on.
+    outbound.set_ingress_iface(iface);
+    let link_id = *outbound.id();
+    transport.get_handler().lock().await.out_links.insert(destination.address_hash, Arc::new(Mutex::new(outbound)));
+
+    transport.send_to_out_links(&destination.address_hash, b"broadcast payload").await;
+
+    let sent = timeout(Duration::from_millis(200), channel.tx_channel.recv())
+        .await
+        .expect("send_to_out_links must deliver a TxMessage on the link's bound iface — it was silently dropped before this fix")
+        .expect("tx channel should not have closed");
+    assert_eq!(sent.tx_type, TxMessageType::Direct(iface));
+    assert_eq!(sent.packet.destination, link_id, "packet must be addressed to the link itself");
+}
+
+#[tokio::test]
+async fn send_channel_to_out_links_reaches_the_links_bound_interface() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &local_identity, false));
+    let mut channel = transport.iface_manager().lock().await.new_channel_with_role(8, IfaceRole::Unicast);
+    let iface = *channel.address();
+
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination =
+        DestinationDesc { identity, address_hash: identity.address_hash, name: DestinationName::new("lxmf", "delivery") };
+    let (mut outbound, _inbound) = activated_link_pair(destination, &signer);
+    outbound.set_ingress_iface(iface);
+    transport.get_handler().lock().await.out_links.insert(destination.address_hash, Arc::new(Mutex::new(outbound)));
+
+    transport.send_channel_to_out_links(&destination.address_hash, b"channel payload").await;
+
+    let sent = timeout(Duration::from_millis(200), channel.tx_channel.recv())
+        .await
+        .expect("send_channel_to_out_links must deliver a TxMessage on the link's bound iface")
+        .expect("tx channel should not have closed");
+    assert_eq!(sent.tx_type, TxMessageType::Direct(iface));
+    assert_eq!(sent.packet.context, PacketContext::Channel);
+}
+
+#[tokio::test]
+async fn send_to_in_links_reaches_the_links_bound_interface() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &local_identity, false));
+    let mut channel = transport.iface_manager().lock().await.new_channel_with_role(8, IfaceRole::Unicast);
+    let iface = *channel.address();
+
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination =
+        DestinationDesc { identity, address_hash: identity.address_hash, name: DestinationName::new("lxmf", "delivery") };
+    let (_outbound, mut inbound) = activated_link_pair(destination, &signer);
+    inbound.set_ingress_iface(iface);
+    let link_id = *inbound.id();
+    transport.get_handler().lock().await.in_links.insert(link_id, Arc::new(Mutex::new(inbound)));
+
+    transport.send_to_in_links(&destination.address_hash, b"broadcast to clients").await;
+
+    let sent = timeout(Duration::from_millis(200), channel.tx_channel.recv())
+        .await
+        .expect("send_to_in_links must deliver a TxMessage on the link's bound iface")
+        .expect("tx channel should not have closed");
+    assert_eq!(sent.tx_type, TxMessageType::Direct(iface));
+    assert_eq!(sent.packet.destination, link_id);
+}
+
+#[tokio::test]
+async fn send_to_all_out_links_skips_inactive_links_and_reaches_active_ones() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("test", &local_identity, false));
+    let mut channel = transport.iface_manager().lock().await.new_channel_with_role(8, IfaceRole::Unicast);
+    let iface = *channel.address();
+
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination =
+        DestinationDesc { identity, address_hash: identity.address_hash, name: DestinationName::new("lxmf", "delivery") };
+    let (mut outbound, _inbound) = activated_link_pair(destination, &signer);
+    outbound.set_ingress_iface(iface);
+    transport.get_handler().lock().await.out_links.insert(destination.address_hash, Arc::new(Mutex::new(outbound)));
+
+    // A second, never-activated (Pending) link must be skipped, not just
+    // silently dropped at send time — it should never even build a packet.
+    let other_signer = PrivateIdentity::new_from_rand(OsRng);
+    let other_identity = *other_signer.as_identity();
+    let other_destination = DestinationDesc {
+        identity: other_identity,
+        address_hash: other_identity.address_hash,
+        name: DestinationName::new("lxmf", "delivery"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(8);
+    let pending = Link::new(other_destination, tx);
+    transport.get_handler().lock().await.out_links.insert(other_destination.address_hash, Arc::new(Mutex::new(pending)));
+
+    transport.send_to_all_out_links(b"fan-out payload").await;
+
+    let sent = timeout(Duration::from_millis(200), channel.tx_channel.recv())
+        .await
+        .expect("send_to_all_out_links must deliver to the active link's bound iface")
+        .expect("tx channel should not have closed");
+    assert_eq!(sent.tx_type, TxMessageType::Direct(iface));
+
+    // Only the one Active link's packet should have been sent — nothing
+    // further should be queued.
+    assert!(timeout(Duration::from_millis(50), channel.tx_channel.recv()).await.is_err());
+}


### PR DESCRIPTION
Fixes #483.

## What changed

`send_to_all_out_links`, `send_channel_to_all_out_links`, `send_to_out_links`, `send_channel_to_out_links`, `send_to_in_links`, `send_channel_to_in_links` (`transport/links_parts/transport_sections/reset_out_link.rs`) built a correct Link-context packet but dispatched it through `TransportHandler::send_packet`, which routes via `route_outbound_packet`'s path-table lookup keyed by `packet.destination` — for a Link-context packet that's the link's own ephemeral id, never a path-table entry. For any `Transport` configured with `broadcast: false` (the ordinary client case), the packet silently resolved to `SendPacketOutcome::DroppedNoRoute` and never reached an interface — see #483 for the full trace.

Rewired all six to route through `send_link_packet_on_bound_iface` (this crate's own correct mechanism for an already-established Link, already used internally by `crate::delivery::send_on_link_observed`), collecting `(Arc<Mutex<Link>>, Packet)` pairs first so each send can resolve its own link's bound interface rather than the path table.

Also widens `send_link_packet_on_bound_iface` from `pub(crate)` to `pub` — a downstream consumer building its own Link-context packet via `Link::identify_packet`/`data_packet`/`channel_packet` for a context none of the higher-level helpers already cover has no other correct way to send it. This is what a downstream consumer (meshage) is using locally today via a vendored patch to fix the identical bug for `LinkIdentify` sends; this PR lets that patch eventually be dropped once released.

## Testing

New file `transport/tests_parts/link_broadcast_helpers_route_via_bound_iface.rs`, four tests:
- `send_to_out_links_reaches_the_links_bound_interface`
- `send_channel_to_out_links_reaches_the_links_bound_interface`
- `send_to_in_links_reaches_the_links_bound_interface`
- `send_to_all_out_links_skips_inactive_links_and_reaches_active_ones`

Each builds a `Transport` with a real registered interface channel and a manually-activated Link (mirroring the existing `transport_register_channel_handler_dispatches_inbound_channel_message` test's shape), then asserts the method actually enqueues a `TxMessage` on that same interface — not just that the call returns without panicking, which the pre-fix code already did silently.

Confirmed red against the pre-fix code (all four fail with a timeout waiting for the `TxMessage` that never arrives) before restoring the fix and confirming green.

```
cargo test -p reticulum-rs-transport --lib   # 530 passed, 0 failed
cargo clippy -p reticulum-rs-transport --all-targets   # clean
cargo check --workspace --all-targets   # clean
./tools/scripts/check-boundaries.sh   # boundary checks: ok
```