### PR TITLE
Document 100-node scale test results

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -66,6 +66,22 @@ These matched sender workloads use the same two-node loopback TCP topology with 
 | Loopback TCP propagated delivery | warm | 256 | 721.21 ms | 7858.45 ms | 10.90x | 890.08 ms | 7873.64 ms | 3.440s | 6.480s | 80.4 MiB | 80.2 MiB | 3.49% | 0.07% |
 | Loopback TCP resource delivery | warm | 16384 | 513.15 ms | 817.19 ms | 1.59x | 596.14 ms | 836.28 ms | 4.670s | 1.870s | 80.4 MiB | 80.4 MiB | 0.99% | 0.57% |
 
+## 100-node chain scale tests
+
+Exploratory single-host scale results are stored in [`docs/performance/100-node-chain-2026-07-20.json`](performance/100-node-chain-2026-07-20.json). Each run created `100` nodes in a linear chain over `99` simulated media at `1` Mbit/s, a `500`-byte MTU, `1` ms propagation per medium, and `0.0%` configured loss. The `98` interior nodes acted as transports.
+
+After a `60`-second route warm-up, the endpoints sent `3` concurrent `256`-byte opportunistic messages in each direction. RTT columns report p50 across delivered samples; a dash means no sample was delivered. Readiness required all 100 nodes to be running, connected, and addressed.
+
+| Composition | Ready | n0 -> n99 p50 | n99 -> n0 p50 | Delivered | Media TX | Result |
+|---|---:|---:|---:|---:|---:|---:|
+| 100 Python | 1.761 s | 25.180 s (Python -> Python) | - (Python -> Python) | 3/6 | 35,662 | fail |
+| 50 Python / 50 Rust | 1.517 s | 0.456 s (Python -> Rust) | 0.770 s (Rust -> Python) | 6/6 | 4,411 | pass |
+| 100 Rust | 0.253 s | 0.112 s (Rust -> Rust) | 0.192 s (Rust -> Rust) | 6/6 | 1,368 | pass |
+
+The all-Python reverse direction delivered `0/3` samples, logged `SENDFAIL noidentity`, and reached the `121`-second action timeout; the missing RTT is not zero.
+
+These are single runs per composition, not a repeated benchmark distribution. The simulator and all nodes shared one host, so scheduler and simulator overhead affect the measurements. The Rust binary came from LXMF-rs `f6f8407f0645ec251efdb9dc37149aaea78ce8e9`; the Python references were Reticulum `15320e4d2cfabb143c1db20ca887e275fd521585` and LXMF `727830cefda83d9c6e3982b48675425f3f988f9c`. The reticulated harness working tree contained uncommitted changes, so these results are exploratory evidence rather than a release threshold.
+
 ## Limitations
 
 - Scheduler noise, CPU frequency changes, and host background work affect tails and resource readings.

--- a/docs/performance/100-node-chain-2026-07-20.json
+++ b/docs/performance/100-node-chain-2026-07-20.json
@@ -1,0 +1,107 @@
+{
+  "environment": {
+    "generated_at_utc": "2026-07-20T18:46:39Z",
+    "lxmf_rs_dirty": false,
+    "lxmf_rs_revision": "f6f8407f0645ec251efdb9dc37149aaea78ce8e9",
+    "platform": "Linux-7.0.0-27-generic-x86_64-with-glibc2.43",
+    "python_lxmf_revision": "727830cefda83d9c6e3982b48675425f3f988f9c",
+    "python_rns_revision": "15320e4d2cfabb143c1db20ca887e275fd521585",
+    "python_version": "3.12.13",
+    "reticulated_dirty": true,
+    "reticulated_revision": "3aa991d3e443184cc3f94ade23abda7c78bb637e",
+    "rust_binary_sha256": "05463e5d3701da757e07c07b7f3d7639986685ada2d8711c2cda5d3aa4577ab6"
+  },
+  "runs": [
+    {
+      "composition": "python",
+      "forward": {
+        "delivered": 3,
+        "destination_implementation": "Python",
+        "p50_seconds": 25.180237702006707,
+        "p95_seconds": 25.226097325998126,
+        "samples": 3,
+        "source_implementation": "Python"
+      },
+      "label": "100 Python",
+      "media_tx": 35662,
+      "raw_report_sha256": "69eb90d956c14fe203b8619f3779e407adb82b5c139347477b318b1974b60e31",
+      "ready_seconds": 1.761,
+      "reverse": {
+        "delivered": 0,
+        "destination_implementation": "Python",
+        "failure": "SENDFAIL noidentity",
+        "p50_seconds": null,
+        "p95_seconds": null,
+        "samples": 3,
+        "source_implementation": "Python",
+        "timeout_seconds": 120.501
+      },
+      "status": "fail"
+    },
+    {
+      "composition": "mixed",
+      "forward": {
+        "delivered": 3,
+        "destination_implementation": "Rust",
+        "p50_seconds": 0.45646748000581283,
+        "p95_seconds": 0.45687731899670325,
+        "samples": 3,
+        "source_implementation": "Python"
+      },
+      "label": "50 Python / 50 Rust",
+      "media_tx": 4411,
+      "raw_report_sha256": "ac55a775de0b9d69ea3039517612c73e2c0e7c136960446dea747c248ab8ac6a",
+      "ready_seconds": 1.517,
+      "reverse": {
+        "delivered": 3,
+        "destination_implementation": "Python",
+        "p50_seconds": 0.7701579489948926,
+        "p95_seconds": 0.7769938900019042,
+        "samples": 3,
+        "source_implementation": "Rust"
+      },
+      "status": "pass"
+    },
+    {
+      "composition": "rust",
+      "forward": {
+        "delivered": 3,
+        "destination_implementation": "Rust",
+        "p50_seconds": 0.11188276200846303,
+        "p95_seconds": 0.115015613992,
+        "samples": 3,
+        "source_implementation": "Rust"
+      },
+      "label": "100 Rust",
+      "media_tx": 1368,
+      "raw_report_sha256": "1d57b5ce0433929056886646c5ca5a51ae1d85a9ac8e7ea734ba5b5c398d26f9",
+      "ready_seconds": 0.253,
+      "reverse": {
+        "delivered": 3,
+        "destination_implementation": "Rust",
+        "p50_seconds": 0.19163855598890223,
+        "p95_seconds": 0.1931110020086635,
+        "samples": 3,
+        "source_implementation": "Rust"
+      },
+      "status": "pass"
+    }
+  ],
+  "scenario": {
+    "bitrate_bps": 1000000,
+    "configured_loss": 0.0,
+    "delivery_mode": "opportunistic",
+    "media": 99,
+    "mtu_bytes": 500,
+    "nodes": 100,
+    "payload_bytes": 256,
+    "propagation_seconds": 0.001,
+    "route_hops": 99,
+    "route_warmup_seconds": 60,
+    "samples_per_direction": 3,
+    "topology": "linear-chain",
+    "topology_seed": 20260720,
+    "transport_nodes": 98
+  },
+  "schema_version": 1
+}

--- a/tools/scripts/performance_docs.py
+++ b/tools/scripts/performance_docs.py
@@ -14,6 +14,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[2]
 README = ROOT / "README.md"
 PAGE = ROOT / "docs/performance.md"
+SCALE_DATASET = ROOT / "docs/performance/100-node-chain-2026-07-20.json"
 START = "<!-- performance-summary:start -->"
 END = "<!-- performance-summary:end -->"
 PYTHON_INTEROP_WORKFLOW = ROOT / ".github/workflows/python-interop.yml"
@@ -86,6 +87,73 @@ def fmt_ns(value: float) -> str:
     return f"{value:.0f} ns"
 
 
+def fmt_seconds(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.3f} s"
+
+
+def scale_test_section(data: dict[str, Any]) -> list[str]:
+    scenario = data["scenario"]
+    lines = [
+        "## 100-node chain scale tests",
+        "",
+        "Exploratory single-host scale results are stored in "
+        "[`docs/performance/100-node-chain-2026-07-20.json`](performance/100-node-chain-2026-07-20.json). "
+        f"Each run created `{scenario['nodes']}` nodes in a linear chain over `{scenario['media']}` simulated media "
+        f"at `{scenario['bitrate_bps'] // 1_000_000}` Mbit/s, a `{scenario['mtu_bytes']}`-byte MTU, "
+        f"`{scenario['propagation_seconds'] * 1_000:.0f}` ms propagation per medium, and "
+        f"`{scenario['configured_loss']:.1%}` configured loss. "
+        f"The `{scenario['transport_nodes']}` interior nodes acted as transports.",
+        "",
+        f"After a `{scenario['route_warmup_seconds']:.0f}`-second route warm-up, the endpoints sent "
+        f"`{scenario['samples_per_direction']}` concurrent `{scenario['payload_bytes']}`-byte "
+        f"{scenario['delivery_mode']} messages in each direction. RTT columns report p50 across delivered samples; "
+        f"a dash means no sample was delivered. Readiness required all {scenario['nodes']} nodes to be running, "
+        "connected, and addressed.",
+        "",
+        "| Composition | Ready | n0 -> n99 p50 | n99 -> n0 p50 | Delivered | Media TX | Result |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for run in data["runs"]:
+        forward = run["forward"]
+        reverse = run["reverse"]
+        delivered = forward["delivered"] + reverse["delivered"]
+        samples = forward["samples"] + reverse["samples"]
+        forward_label = (
+            f"{fmt_seconds(forward['p50_seconds'])} "
+            f"({forward['source_implementation']} -> {forward['destination_implementation']})"
+        )
+        reverse_label = (
+            f"{fmt_seconds(reverse['p50_seconds'])} "
+            f"({reverse['source_implementation']} -> {reverse['destination_implementation']})"
+        )
+        lines.append(
+            f"| {run['label']} | {fmt_seconds(run['ready_seconds'])} | {forward_label} | {reverse_label} | "
+            f"{delivered}/{samples} | {run['media_tx']:,} | {run['status']} |"
+        )
+    python_run = next((run for run in data["runs"] if run["composition"] == "python"), None)
+    if python_run is None:
+        raise ValueError("100-node scale dataset is missing the all-Python run")
+    environment = data["environment"]
+    lines.extend(
+        [
+            "",
+            "The all-Python reverse direction delivered `0/3` samples, logged "
+            f"`{python_run['reverse']['failure']}`, and reached the "
+            f"`{python_run['reverse']['timeout_seconds']:.0f}`-second action timeout; the missing RTT is not zero.",
+            "",
+            "These are single runs per composition, not a repeated benchmark distribution. The simulator and all nodes "
+            "shared one host, so scheduler and simulator overhead affect the measurements. The Rust binary came from "
+            f"LXMF-rs `{environment['lxmf_rs_revision']}`; the Python references were Reticulum "
+            f"`{environment['python_rns_revision']}` and LXMF `{environment['python_lxmf_revision']}`. "
+            "The reticulated harness working tree contained uncommitted changes, so these results are exploratory "
+            "evidence rather than a release threshold.",
+        ]
+    )
+    return lines
+
+
 def summary_section(data: dict[str, Any], release: str) -> str:
     env = data["environment"]
     rows = data["comparisons"][:4]
@@ -112,7 +180,7 @@ def summary_section(data: dict[str, Any], release: str) -> str:
     return "\n".join(lines)
 
 
-def performance_page(data: dict[str, Any], release: str) -> str:
+def performance_page(data: dict[str, Any], release: str, scale_data: dict[str, Any]) -> str:
     env = data["environment"]
     lines = [
         "# Performance",
@@ -201,6 +269,7 @@ def performance_page(data: dict[str, Any], release: str) -> str:
             )
     else:
         lines.append("No E2E measurements are present; release publication must add the report before making whole-delivery claims.")
+    lines.extend(["", *scale_test_section(scale_data)])
     lines.extend(
         [
             "",
@@ -255,8 +324,9 @@ def main() -> int:
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         data = load(target)
+        scale_data = load(SCALE_DATASET)
         verify_workflow_refs(data)
-        expected_page = performance_page(data, args.release)
+        expected_page = performance_page(data, args.release, scale_data)
         expected_readme = replace_marked(README.read_text(encoding="utf-8"), summary_section(data, args.release))
         if args.check:
             if not PAGE.is_file() or PAGE.read_text(encoding="utf-8") != expected_page:


### PR DESCRIPTION
## Summary

- add the all-Python, 50/50 mixed, and all-Rust 100-node chain results to `docs/performance.md`
- record the test inputs and source-report hashes in a compact performance dataset
- keep the generated performance page reproducible through `performance_docs.py`
- report the all-Python reverse-direction timeout and `SENDFAIL noidentity` outcome without suppressing it

## Test setup

Each single-host run used a 100-node linear chain with 99 simulated media and 98 interior transport nodes. After a 60-second route warm-up, the endpoints sent three concurrent 256-byte opportunistic messages in each direction.

## Impact

Readers can compare readiness, bidirectional p50 delivery latency, delivered samples, and media transmissions across the Python, mixed, and Rust compositions. The page explicitly labels these as exploratory single-run evidence because the reticulated harness working tree contained uncommitted changes.

## Validation

- `python3 tools/scripts/performance_docs.py --check`
- `python3 -m json.tool docs/performance/100-node-chain-2026-07-20.json`
- `python3 -m py_compile tools/scripts/performance_docs.py`
- verified every curated status, readiness, media TX, sample count, delivery count, p50, p95, implementation direction, and raw-report SHA-256 against the three source reports
- `git diff --check origin/main...HEAD`
