### PR TITLE
Fix v0.9.6 release blockers

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_cancel.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_cancel.rs
@@ -2,22 +2,41 @@ use super::*;
 
 impl DeliveryTask {
     pub(super) fn abort_if_cancelled(&self, stage: &str) -> bool {
-        let status = match self.daemon.message_receipt_status(&self.message_id) {
+        self.abort_for_status_result(stage, self.daemon.message_receipt_status(&self.message_id))
+    }
+
+    pub(super) fn abort_for_status_result(
+        &self,
+        stage: &str,
+        status: Result<Option<String>, std::io::Error>,
+    ) -> bool {
+        let status = match status {
             Ok(status) => status,
             Err(error) => {
                 log::error!(
                     "[daemon-delivery] receipt status lookup failed message_id={} stage={stage}: {error}",
                     self.message_id
                 );
-                emit_receipt_event(
-                    &self.receipt_tx,
+                let persisted = crate::receipt_events::persist_receipt_update(
+                    self.daemon.as_ref(),
                     ReceiptEvent::new(
                         self.message_id.clone(),
                         format!("failed: receipt status lookup: {error}"),
                     )
                     .with_stage(stage),
+                    &self.receipt_map,
+                    &self.outbound_resource_map,
                 );
-                return true;
+                return match persisted {
+                    Ok(()) => true,
+                    Err(persist_error) => {
+                        log::error!(
+                            "[daemon-delivery] failed to persist receipt lookup failure message_id={} stage={stage}: {persist_error}; continuing because no terminal state was established",
+                            self.message_id
+                        );
+                        false
+                    }
+                };
             }
         };
         if !Self::is_cancelled_status(status.as_deref()) {

--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests_parts/module_prelude.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_delivery_task_tests_parts/module_prelude.rs
@@ -148,6 +148,36 @@ async fn abort_if_cancelled_reads_persisted_daemon_status() {
 }
 
 #[tokio::test]
+async fn receipt_lookup_error_persists_terminal_status_without_receipt_queue() {
+    let message_id = "propagation-cost-lookup-message";
+    let store = MessagesStore::in_memory().expect("store");
+    store
+        .insert_message(&MessageRecord {
+            id: message_id.to_string(),
+            source: "source".to_string(),
+            destination: "00000000000000000000000000000000".to_string(),
+            title: String::new(),
+            content: String::new(),
+            timestamp: 0,
+            direction: "out".to_string(),
+            fields: None,
+            receipt_status: Some("sending".to_string()),
+        })
+        .expect("insert message");
+    let daemon = Arc::new(RpcDaemon::with_store(store, "lookup-error-node".to_string()));
+    let task = delivery_task_for_propagation_cost_lookup(daemon.clone());
+
+    assert!(task.abort_for_status_result(
+        "test",
+        Err(std::io::Error::other("synthetic receipt lookup failure")),
+    ));
+    assert_eq!(
+        daemon.message_receipt_status(message_id).expect("receipt status"),
+        Some("failed: receipt status lookup: synthetic receipt lookup failure".to_string())
+    );
+}
+
+#[tokio::test]
 async fn tracked_outbound_resource_cancel_sends_resource_cancel_frame() {
     let message_id = "cancel-active-resource";
     let store = MessagesStore::in_memory().expect("store");

--- a/crates/apps/reticulumd/src/bin/reticulumd/receipt_events.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/receipt_events.rs
@@ -38,22 +38,30 @@ pub(super) fn handle_receipt_update(
     outbound_resource_map: &OutboundResourceMap,
 ) {
     let message_id = event.message_id.clone();
+    if let Err(err) = persist_receipt_update(daemon, event, receipt_map, outbound_resource_map) {
+        log_delivery_trace(&message_id, "-", "receipt-persist", &format!("failed err={err}"));
+    }
+}
+
+pub(crate) fn persist_receipt_update(
+    daemon: &RpcDaemon,
+    event: ReceiptEvent,
+    receipt_map: &Arc<Mutex<HashMap<String, String>>>,
+    outbound_resource_map: &OutboundResourceMap,
+) -> Result<(), std::io::Error> {
+    let message_id = event.message_id.clone();
     let status = event.status.clone();
     let detail = format!("status={status}");
     log_delivery_trace(&message_id, "-", "receipt-update", &detail);
     let delivery_state = ReceiptDeliveryState::from_status(&status);
-    let result = handle_receipt_event(daemon, event);
-    if let Err(err) = result {
-        let detail = format!("persist-failed err={err}");
-        log_delivery_trace(&message_id, "-", "receipt-persist", &detail);
-        return;
-    }
+    handle_receipt_event(daemon, event)?;
 
     if delivery_state.should_prune_correlations() {
         prune_receipt_mappings_for_message(receipt_map, &message_id);
         prune_outbound_resource_mappings_for_message(outbound_resource_map, &message_id);
     }
     log_delivery_trace(&message_id, "-", "receipt-persist", "ok");
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/propagation.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/propagation.rs
@@ -96,7 +96,7 @@ impl ZmqPipelineBackendClient {
 
     pub fn propagation_recovery_state(&self) -> Result<PropagationRecoveryStateResult, SdkError> {
         let status = self.propagation_status()?;
-        PropagationRecoveryStateResult::from_propagation(status.propagation).map_err(|error| {
+        PropagationRecoveryStateResult::try_from_propagation(status.propagation).map_err(|error| {
             SdkError::new(
                 code::INTERNAL,
                 ErrorCategory::Internal,

--- a/crates/libs/lxmf-sdk/src/domain_parts/propagationlocalpayload.rs
+++ b/crates/libs/lxmf-sdk/src/domain_parts/propagationlocalpayload.rs
@@ -166,7 +166,7 @@ impl<'de> Deserialize<'de> for PropagationIngestResult {
         D: serde::Deserializer<'de>,
     {
         let raw = RawPropagationIngestResult::deserialize(deserializer)?;
-        let recovery_state = PropagationRecoveryStateResult::from_propagation(
+        let recovery_state = PropagationRecoveryStateResult::try_from_propagation(
             raw.propagation.clone(),
         )
         .map_err(serde::de::Error::custom)?;
@@ -219,7 +219,7 @@ impl<'de> Deserialize<'de> for PropagationFetchResult {
         D: serde::Deserializer<'de>,
     {
         let raw = RawPropagationFetchResult::deserialize(deserializer)?;
-        let recovery_state = PropagationRecoveryStateResult::from_propagation(
+        let recovery_state = PropagationRecoveryStateResult::try_from_propagation(
             raw.propagation.clone(),
         )
         .map_err(serde::de::Error::custom)?;

--- a/crates/libs/lxmf-sdk/src/domain_parts/propagationrecoverystate.rs
+++ b/crates/libs/lxmf-sdk/src/domain_parts/propagationrecoverystate.rs
@@ -78,7 +78,103 @@ pub struct PropagationRecoveryStateResult {
 }
 
 impl PropagationRecoveryStateResult {
-    pub fn from_propagation(propagation: JsonValue) -> Result<Self, String> {
+    /// Projects propagation metadata using the compatibility behavior exposed
+    /// before v0.9.6. Malformed optional fields are treated as absent so
+    /// existing callers retain the original infallible API.
+    pub fn from_propagation(propagation: JsonValue) -> Self {
+        let state_name = json_string(&propagation, "state_name").ok().flatten();
+        let sync_state =
+            json_u64(&propagation, "sync_state").ok().flatten().unwrap_or(0) as u32;
+        let failure_kind = json_string(&propagation, "failure_kind")
+            .ok()
+            .flatten()
+            .or_else(|| match state_name.as_deref() {
+                Some("no_access") => Some("no_access".to_string()),
+                Some("timeout") => Some("timeout".to_string()),
+                _ => None,
+            });
+        let timed_out =
+            failure_kind.as_deref() == Some("timeout") || state_name.as_deref() == Some("timeout");
+        let access_denied = json_bool(&propagation, "access_denied")
+            .ok()
+            .flatten()
+            .unwrap_or(false)
+            || state_name.as_deref() == Some("no_access")
+            || sync_state == 0xf4
+            || matches!(
+                failure_kind.as_deref(),
+                Some("access_denied" | "access-denied" | "no_access")
+            );
+        Self {
+            enabled: json_bool(&propagation, "enabled").ok().flatten().unwrap_or(false),
+            selected_node: json_string(&propagation, "selected_node").ok().flatten(),
+            sync_state,
+            state_name,
+            sync_progress: json_f64(&propagation, "sync_progress").ok().flatten(),
+            last_sync_started: json_i64(&propagation, "last_sync_started").ok().flatten(),
+            last_sync_completed: json_i64(&propagation, "last_sync_completed").ok().flatten(),
+            last_sync_error: json_string(&propagation, "last_sync_error").ok().flatten(),
+            failure_kind,
+            timed_out,
+            access_denied,
+            next_sync_attempt: json_i64(&propagation, "next_sync_attempt").ok().flatten(),
+            retry_count: json_u64(&propagation, "retry_count").ok().flatten().unwrap_or(0),
+            queue_depth: json_u64(&propagation, "queue_depth").ok().flatten().unwrap_or(0),
+            timestamp: json_i64(&propagation, "timestamp").ok().flatten(),
+            auth_required: json_bool(&propagation, "auth_required").ok().flatten().unwrap_or(false),
+            store_root: json_string(&propagation, "store_root").ok().flatten(),
+            target_cost: json_u64(&propagation, "target_cost").ok().flatten(),
+            stamp_cost_flexibility: json_u64(&propagation, "stamp_cost_flexibility")
+                .ok()
+                .flatten(),
+            message_storage_limit_mb: json_u64(&propagation, "message_storage_limit_mb")
+                .ok()
+                .flatten(),
+            delivery_limit: json_u64(&propagation, "delivery_limit").ok().flatten(),
+            propagation_limit: json_u64(&propagation, "propagation_limit").ok().flatten(),
+            autopeer: json_bool(&propagation, "autopeer").ok().flatten(),
+            autopeer_maxdepth: json_u64(&propagation, "autopeer_maxdepth").ok().flatten(),
+            static_peers: remote_transfer_json_string_array(&propagation, "static_peers"),
+            sync_limit: json_u64(&propagation, "sync_limit").ok().flatten(),
+            max_peers: json_u64(&propagation, "max_peers").ok().flatten(),
+            from_static_only: json_bool(&propagation, "from_static_only").ok().flatten(),
+            retain_synced_on_node: json_bool(&propagation, "retain_synced_on_node")
+                .ok()
+                .flatten(),
+            peering_cost: json_u64(&propagation, "peering_cost").ok().flatten(),
+            remote_peering_cost_max: json_u64(&propagation, "remote_peering_cost_max")
+                .ok()
+                .flatten(),
+            control_allowed: remote_transfer_json_string_array(&propagation, "control_allowed"),
+            total_ingested: json_u64(&propagation, "total_ingested")
+                .ok()
+                .flatten()
+                .unwrap_or(0),
+            last_ingest_count: json_u64(&propagation, "last_ingest_count")
+                .ok()
+                .flatten()
+                .unwrap_or(0),
+            client_propagation_messages_received: json_u64(
+                &propagation,
+                "client_propagation_messages_received",
+            )
+            .ok()
+            .flatten()
+            .unwrap_or(0),
+            client_propagation_messages_served: json_u64(
+                &propagation,
+                "client_propagation_messages_served",
+            )
+            .ok()
+            .flatten()
+            .unwrap_or(0),
+            propagation,
+        }
+    }
+
+    /// Strictly projects propagation metadata and reports malformed typed
+    /// fields instead of silently treating them as absent.
+    pub fn try_from_propagation(propagation: JsonValue) -> Result<Self, String> {
         macro_rules! field {
             ($getter:ident, $key:literal) => {
                 $getter(&propagation, $key)
@@ -220,7 +316,7 @@ mod propagation_recovery_state_tests {
 
     #[test]
     fn recovery_state_accepts_absent_and_null_optional_fields() {
-        let state = PropagationRecoveryStateResult::from_propagation(json!({
+        let state = PropagationRecoveryStateResult::try_from_propagation(json!({
             "enabled": true,
             "selected_node": null,
             "static_peers": null
@@ -234,22 +330,35 @@ mod propagation_recovery_state_tests {
 
     #[test]
     fn recovery_state_rejects_malformed_typed_fields() {
-        let error = PropagationRecoveryStateResult::from_propagation(json!({
+        let error = PropagationRecoveryStateResult::try_from_propagation(json!({
             "queue_depth": "many"
         }))
         .expect_err("invalid queue depth");
         assert!(error.contains("queue_depth"));
 
-        let error = PropagationRecoveryStateResult::from_propagation(json!({
+        let error = PropagationRecoveryStateResult::try_from_propagation(json!({
             "sync_state": u64::from(u32::MAX) + 1
         }))
         .expect_err("overflowing sync state");
         assert!(error.contains("sync_state"));
 
-        let error = PropagationRecoveryStateResult::from_propagation(json!({
+        let error = PropagationRecoveryStateResult::try_from_propagation(json!({
             "static_peers": ["peer-a", 42]
         }))
         .expect_err("invalid static peer entry");
         assert!(error.contains("static_peers"));
+    }
+
+    #[test]
+    fn compatibility_recovery_state_keeps_infallible_projection() {
+        let state = PropagationRecoveryStateResult::from_propagation(json!({
+            "enabled": true,
+            "queue_depth": "many",
+            "static_peers": ["peer-a", 42]
+        }));
+
+        assert!(state.enabled);
+        assert_eq!(state.queue_depth, 0);
+        assert_eq!(state.static_peers, vec!["peer-a".to_string()]);
     }
 }

--- a/crates/libs/lxmf-sdk/src/domain_parts/propagationremote.rs
+++ b/crates/libs/lxmf-sdk/src/domain_parts/propagationremote.rs
@@ -297,7 +297,7 @@ impl<'de> Deserialize<'de> for PropagationAcknowledgeSyncResult {
         D: serde::Deserializer<'de>,
     {
         let raw = RawPropagationAcknowledgeSyncResult::deserialize(deserializer)?;
-        let recovery_state = PropagationRecoveryStateResult::from_propagation(
+        let recovery_state = PropagationRecoveryStateResult::try_from_propagation(
             raw.propagation.clone(),
         )
         .map_err(serde::de::Error::custom)?;
@@ -329,7 +329,7 @@ impl<'de> Deserialize<'de> for PropagationStatusResult {
         D: serde::Deserializer<'de>,
     {
         let raw = RawPropagationStatusResult::deserialize(deserializer)?;
-        let recovery_state = PropagationRecoveryStateResult::from_propagation(
+        let recovery_state = PropagationRecoveryStateResult::try_from_propagation(
             raw.propagation.clone(),
         )
         .map_err(serde::de::Error::custom)?;

--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -8,8 +8,8 @@
     },
     {
       "path": "docs/contracts/baselines/lxmf-sdk-public-api.txt",
-      "bytes": 394578,
-      "sha256": "3f8484de68f4153dd11cd24901c580a541ba73a150430dbeb822c31276cab93e"
+      "bytes": 394828,
+      "sha256": "409b5ac39eda1b7ba8c569e280d100898d026a2c83b8638da167c9df35330189"
     },
     {
       "path": "docs/contracts/baselines/schema-client-generation-baseline.json",

--- a/docs/contracts/baselines/lxmf-sdk-public-api.txt
+++ b/docs/contracts/baselines/lxmf-sdk-public-api.txt
@@ -1181,7 +1181,8 @@ pub lxmf_sdk::domain::PropagationRecoveryStateResult::timed_out: bool
 pub lxmf_sdk::domain::PropagationRecoveryStateResult::timestamp: core::option::Option<i64>
 pub lxmf_sdk::domain::PropagationRecoveryStateResult::total_ingested: u64
 impl lxmf_sdk::domain::PropagationRecoveryStateResult
-pub fn lxmf_sdk::domain::PropagationRecoveryStateResult::from_propagation(propagation: serde_json::value::Value) -> core::result::Result<Self, alloc::string::String>
+pub fn lxmf_sdk::domain::PropagationRecoveryStateResult::from_propagation(propagation: serde_json::value::Value) -> Self
+pub fn lxmf_sdk::domain::PropagationRecoveryStateResult::try_from_propagation(propagation: serde_json::value::Value) -> core::result::Result<Self, alloc::string::String>
 #[non_exhaustive] pub struct lxmf_sdk::domain::PropagationRemoteClientStats
 pub lxmf_sdk::domain::PropagationRemoteClientStats::received: core::option::Option<u64>
 pub lxmf_sdk::domain::PropagationRemoteClientStats::served: core::option::Option<u64>
@@ -3115,7 +3116,8 @@ pub lxmf_sdk::PropagationRecoveryStateResult::timed_out: bool
 pub lxmf_sdk::PropagationRecoveryStateResult::timestamp: core::option::Option<i64>
 pub lxmf_sdk::PropagationRecoveryStateResult::total_ingested: u64
 impl lxmf_sdk::domain::PropagationRecoveryStateResult
-pub fn lxmf_sdk::domain::PropagationRecoveryStateResult::from_propagation(propagation: serde_json::value::Value) -> core::result::Result<Self, alloc::string::String>
+pub fn lxmf_sdk::domain::PropagationRecoveryStateResult::from_propagation(propagation: serde_json::value::Value) -> Self
+pub fn lxmf_sdk::domain::PropagationRecoveryStateResult::try_from_propagation(propagation: serde_json::value::Value) -> core::result::Result<Self, alloc::string::String>
 #[non_exhaustive] pub struct lxmf_sdk::PropagationRemoteClientStats
 pub lxmf_sdk::PropagationRemoteClientStats::received: core::option::Option<u64>
 pub lxmf_sdk::PropagationRemoteClientStats::served: core::option::Option<u64>

--- a/docs/release-notes-v0.9.6.md
+++ b/docs/release-notes-v0.9.6.md
@@ -60,9 +60,10 @@ candidate commit.
   result with `?` or attach local context with `map_err`. The existing
   `new_from_slices` signature remains source-compatible for typed/invariant
   conversions.
-- `PropagationRecoveryStateResult::from_propagation` now returns `Result` so
+- `PropagationRecoveryStateResult::try_from_propagation` returns `Result` so
   callers can distinguish an absent optional field from a malformed typed
-  response.
+  response. The existing infallible `from_propagation` method remains
+  source-compatible for callers that need the pre-v0.9.6 best-effort behavior.
 
 ## Release evidence
 


### PR DESCRIPTION
## Summary

- restore the source-compatible infallible `PropagationRecoveryStateResult::from_propagation` API
- add `try_from_propagation` for strict typed-field validation and use it in SDK response decoding
- persist receipt-status lookup failures synchronously before a delivery task terminates
- refresh the interop artifact manifest for the corrected SDK API baseline

## Why

PR #485 changed the return type of an existing public SDK method during a patch release, which would break existing source consumers. It also routed receipt lookup failures through a bounded best-effort event queue and then stopped delivery, so a dropped event could leave the persisted message status nonterminal.

## Impact

Existing SDK callers retain the pre-0.9.6 best-effort projection behavior. Callers and internal decoders that need malformed-versus-absent distinction can use the new strict method. Delivery tasks now stop on a receipt lookup error only after the terminal failure status has been persisted; if persistence itself fails, delivery continues instead of claiming a terminal state that was never established.

## Validation

- `cargo xtask release-check` (passed on `90be9673`)
- full workspace tests, clippy, formatting, SDK API, architecture, module-size, security, Miri, Loom, local E2E, mesh/soak, reproducible-build, and embedded-footprint stages passed within the release gate
- regenerated manifest independently matches the SDK API baseline: 394828 bytes, SHA-256 `409b5ac39eda1b7ba8c569e280d100898d026a2c83b8638da167c9df35330189`

## Hosted release evidence

This PR is labeled `run-full-CI` so the pinned Python-reference interoperability workflow runs on the exact PR head SHA. Do not cut `v0.9.6-rc.1` until required hosted checks, including Python interoperability, pass.
