### PR TITLE
Bound release performance workflow runtime

### DIFF
--- a/.github/workflows/performance-release.yml
+++ b/.github/workflows/performance-release.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   same-runner-comparison:
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 360
     steps:
       - name: Resolve candidate ref
         id: candidate
@@ -52,12 +52,22 @@ jobs:
         working-directory: baseline
         env:
           PYTHONPATH: ${{ github.workspace }}/refs/Reticulum:${{ github.workspace }}/refs/LXMF
-        run: cargo xtask python-impl-bench-report
+        run: >-
+          cargo xtask python-impl-bench-report
+          --compare-runs 3
+          --python-iterations 5000
+          --resource-runs 2
+          --resource-iterations 5000
       - name: Measure release candidate
         working-directory: candidate
         env:
           PYTHONPATH: ${{ github.workspace }}/refs/Reticulum:${{ github.workspace }}/refs/LXMF
-        run: cargo xtask python-impl-bench-report
+        run: >-
+          cargo xtask python-impl-bench-report
+          --compare-runs 3
+          --python-iterations 5000
+          --resource-runs 2
+          --resource-iterations 5000
       - name: Measure ZeroMQ and HTTP SDK transports
         working-directory: candidate
         run: |

--- a/docs/runbooks/python-impl-benchmarking.md
+++ b/docs/runbooks/python-impl-benchmarking.md
@@ -113,6 +113,13 @@ python3 tools/scripts/performance_docs.py --check
 ```
 
 Release candidates are measured on the same runner as a checkout of `v0.9.1`.
+The hosted release workflow keeps report-profile Criterion settings but uses
+three interleaved comparison runs, two isolated resource runs, and 5,000
+Python/resource iterations per checkout so both revisions complete within the
+GitHub-hosted job limit. Generated datasets record these counts. Use the full
+five-comparison/three-resource defaults for independently published benchmark
+claims.
+
 Apply the release budgets to those two generated datasets with:
 
 ```bash


### PR DESCRIPTION
## Summary

- keep report-profile Criterion settings while using three comparison runs and two resource runs for hosted release evidence
- halve Python/resource iterations and extend the job ceiling to six hours
- document the hosted release sampling separately from full independent benchmark claims

## Why

The v0.9.6-rc.1 release performance run spent the full 180-minute timeout measuring only the v0.9.1 baseline. GitHub cancelled xtask before candidate measurement or artifact upload.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p xtask`
- workflow YAML parsed with Python/PyYAML
- `git diff --check`