### PR TITLE
Keep release benchmark CLI compatible with baseline

### DIFF
--- a/.github/workflows/performance-release.yml
+++ b/.github/workflows/performance-release.yml
@@ -55,7 +55,6 @@ jobs:
         run: >-
           cargo xtask python-impl-bench-report
           --compare-runs 3
-          --python-iterations 5000
           --resource-runs 2
           --resource-iterations 5000
       - name: Measure release candidate
@@ -65,7 +64,6 @@ jobs:
         run: >-
           cargo xtask python-impl-bench-report
           --compare-runs 3
-          --python-iterations 5000
           --resource-runs 2
           --resource-iterations 5000
       - name: Measure ZeroMQ and HTTP SDK transports

--- a/docs/runbooks/python-impl-benchmarking.md
+++ b/docs/runbooks/python-impl-benchmarking.md
@@ -115,10 +115,11 @@ python3 tools/scripts/performance_docs.py --check
 Release candidates are measured on the same runner as a checkout of `v0.9.1`.
 The hosted release workflow keeps report-profile Criterion settings but uses
 three interleaved comparison runs, two isolated resource runs, and 5,000
-Python/resource iterations per checkout so both revisions complete within the
-GitHub-hosted job limit. Generated datasets record these counts. Use the full
-five-comparison/three-resource defaults for independently published benchmark
-claims.
+resource iterations per checkout so both revisions complete within the
+GitHub-hosted job limit. Python iteration counts retain the report-profile
+default supported by both revisions. Generated datasets record these counts.
+Use the full five-comparison/three-resource defaults for independently
+published benchmark claims.
 
 Apply the release budgets to those two generated datasets with:
 


### PR DESCRIPTION
## Summary

- remove the candidate-only `--python-iterations` flag from both release benchmark invocations
- retain identical report-profile Python iteration counts across v0.9.1 and the candidate
- clarify the hosted sampling contract in the benchmark runbook

## Why

The v0.9.6-rc.2 performance run failed immediately because v0.9.1 predates the `--python-iterations` option. The remaining three overrides are present in both CLI versions.

## Validation

- inspected the v0.9.1 `PythonImplBenchReport` CLI definition
- `cargo xtask python-impl-bench-report --help`
- `cargo fmt --all -- --check`
- `cargo test -p xtask`
- workflow YAML parsed with Python/PyYAML
- `git diff --check`