### PR TITLE
ci: bound release Python benchmark runtime

### DIFF
--- a/.github/workflows/performance-release.yml
+++ b/.github/workflows/performance-release.yml
@@ -48,6 +48,12 @@ jobs:
           mkdir -p candidate/target/python-references
           ln -s "$GITHUB_WORKSPACE/refs/Reticulum" candidate/target/python-references/Reticulum
           ln -s "$GITHUB_WORKSPACE/refs/LXMF" candidate/target/python-references/LXMF
+      - name: Bound hosted Python benchmark iterations
+        run: |
+          for config in baseline/tools/benchmarks/python_impl.toml candidate/tools/benchmarks/python_impl.toml; do
+            sed -i 's/^iterations = 10000$/iterations = 2000/' "$config"
+            test "$(grep -c '^iterations = 2000$' "$config")" -eq 2
+          done
       - name: Measure v0.9.1 baseline
         working-directory: baseline
         env:

--- a/docs/runbooks/python-impl-benchmarking.md
+++ b/docs/runbooks/python-impl-benchmarking.md
@@ -114,12 +114,13 @@ python3 tools/scripts/performance_docs.py --check
 
 Release candidates are measured on the same runner as a checkout of `v0.9.1`.
 The hosted release workflow keeps report-profile Criterion settings but uses
-three interleaved comparison runs, two isolated resource runs, and 5,000
-resource iterations per checkout so both revisions complete within the
-GitHub-hosted job limit. Python iteration counts retain the report-profile
-default supported by both revisions. Generated datasets record these counts.
-Use the full five-comparison/three-resource defaults for independently
-published benchmark claims.
+three interleaved comparison runs, 2,000 Python iterations per workload, two
+isolated resource runs, and 5,000 resource iterations per checkout. The
+workflow applies the same bounded Python count to both checked-out benchmark
+configs because the `v0.9.1` command does not expose that value as a CLI
+override. Generated datasets record the effective counts. Use the full
+five-comparison/three-resource defaults and the report profile's 10,000 Python
+iterations for independently published benchmark claims.
 
 Apply the release budgets to those two generated datasets with:
 


### PR DESCRIPTION
## Summary

- bound hosted release comparisons to 2,000 Python iterations per workload
- apply the identical configuration adjustment to v0.9.1 and the candidate checkout
- retain report-profile Criterion settings, three interleaved runs, and two resource runs
- document the hosted-versus-publication sampling distinction

## Why

The v0.9.6-rc.3 release performance job reached GitHub's six-hour limit while the v0.9.1 baseline was still in its third comparison run. The Python workload dominated runtime at roughly 1 hour 40 minutes per 10,000-iteration repetition. This keeps the statistically useful three-run aggregation while bounding the dominant work identically on the same runner.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p xtask` (19 passed)
- workflow YAML parsed with PyYAML
- the workflow transformation was exercised against both current and v0.9.1 benchmark configs; each resolves report Python iterations to 2,000
- `git diff --check`
