### PR TITLE
Back off after a connection dies immediately, not just when connect() fails outright

### DIFF
--- a/crates/libs/rns-transport/src/iface/tcp_client.rs
+++ b/crates/libs/rns-transport/src/iface/tcp_client.rs
@@ -1062,6 +1062,19 @@ impl TcpClient {
 
             log::info!("disconnected from <{}>", addr);
 
+            // A deliberate shutdown requested during those first couple of
+            // seconds (context.cancel/iface_stop already cancelled) is not
+            // evidence of an unstable peer — it's the reason
+            // run_hdlc_stream_with_runtime just returned in the first
+            // place. Falling through to the loop's own top-of-iteration
+            // check breaks cleanly without polluting failed_connect_attempts
+            // or runtime status with a spurious "treating as a failed
+            // attempt" — a hot-reload or daemon shutdown that lands inside
+            // MIN_STABLE_CONNECTION shouldn't look like a flaky connection.
+            if context.cancel.is_cancelled() || iface_stop.is_cancelled() {
+                break;
+            }
+
             // A stream that died moments after connecting is treated as a
             // failed attempt (backoff + counts toward `max_reconnect_tries`),
             // same as an outright `connect()` failure just above — otherwise
@@ -1336,6 +1349,52 @@ mod tests {
             "expected at least one 5s backoff sleep once the storm was established, only took {:?}",
             started_at.elapsed()
         );
+    }
+
+    // Regression test for review feedback on the MIN_STABLE_CONNECTION fix
+    // above (PR #494): a deliberate shutdown request (iface_stop/
+    // context.cancel already cancelled) that lands inside the
+    // MIN_STABLE_CONNECTION window is not evidence of an unstable peer —
+    // it's the reason the stream loop just returned. Without the fix, a
+    // hot-reload or daemon shutdown shortly after connecting would show up
+    // as a spurious "reconnecting"/failed-attempt status right before
+    // going to "closed".
+    #[tokio::test]
+    async fn tcp_client_does_not_count_a_deliberate_shutdown_as_a_failed_attempt() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+
+        // Accept and hold the connection open for the task's lifetime —
+        // the disconnect in this test comes from cancelling iface_stop
+        // below, never from the peer closing its end.
+        let _accept_task = tokio::spawn(async move {
+            let mut streams = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                streams.push(stream);
+            }
+        });
+
+        let mut manager = InterfaceManager::new(8);
+        let client = TcpClient::new(addr.to_string()).with_connect_timeout(Duration::from_millis(200));
+        let runtime_status = client.runtime_status_handle();
+        let context = manager.new_context(client);
+        let iface_stop = context.channel.stop.clone();
+        let task = tokio::spawn(TcpClient::spawn(context));
+
+        // Well inside MIN_STABLE_CONNECTION, and long enough for the
+        // connection to have actually been established.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(runtime_status.to_json()["stream_state"].as_str(), Some("connected"));
+
+        iface_stop.cancel();
+        tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("tcp client should stop promptly once iface_stop is cancelled")
+            .expect("tcp client task should not panic");
+
+        let status = runtime_status.to_json();
+        assert_eq!(status["stream_state"].as_str(), Some("closed"));
+        assert_eq!(status["reconnect_attempts"].as_u64(), Some(0));
     }
 
     #[test]

--- a/crates/libs/rns-transport/src/iface/tcp_client.rs
+++ b/crates/libs/rns-transport/src/iface/tcp_client.rs
@@ -1375,7 +1375,8 @@ mod tests {
         });
 
         let mut manager = InterfaceManager::new(8);
-        let client = TcpClient::new(addr.to_string()).with_connect_timeout(Duration::from_millis(200));
+        let client =
+            TcpClient::new(addr.to_string()).with_connect_timeout(Duration::from_millis(200));
         let runtime_status = client.runtime_status_handle();
         let context = manager.new_context(client);
         let iface_stop = context.channel.stop.clone();

--- a/crates/libs/rns-transport/src/iface/tcp_client.rs
+++ b/crates/libs/rns-transport/src/iface/tcp_client.rs
@@ -21,6 +21,19 @@ use super::{Interface, InterfaceContext, InterfaceRxSender, InterfaceTxReceiver}
 // TCP packet tracing is kept off by default and gated by diagnostics env flags.
 const PACKET_TRACE: bool = false;
 const HDLC_KEEPALIVE_FRAME: &[u8] = &[0x7e, 0x7e];
+
+// A peer that accepts the TCP handshake and then resets/closes the
+// connection almost immediately used to bypass the reconnect backoff
+// entirely — `failed_connect_attempts` only ever incremented on an
+// outright `connect()` failure, so a connection that succeeds and then
+// dies moments later reset straight back to redialing with zero delay,
+// forever. Any stream that doesn't survive at least this long after
+// connecting is treated the same as a failed connect attempt for
+// backoff/counting purposes. Long enough that a real, working
+// connection's normal keepalive/traffic cadence never trips it; short
+// enough to catch "connected then instantly reset" within one or two
+// iterations rather than many.
+const MIN_STABLE_CONNECTION: Duration = Duration::from_secs(2);
 pub(crate) const HDLC_STREAM_EVENT_CHANNEL_CAPACITY: usize = 128;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -985,12 +998,15 @@ impl TcpClient {
             }
 
             let stream = stream.unwrap();
-            failed_connect_attempts = 0;
             runtime_status.lock().expect("tcp runtime status mutex poisoned").mark_connected();
             if let Err(err) = socket_tuning.apply_to_stream(&stream) {
                 log::warn!("failed to apply TCP socket tuning to <{}>: {}", addr, err);
             }
             let (read_stream, write_stream) = stream.into_split();
+            // `failed_connect_attempts` is NOT reset here anymore; it's
+            // only reset below once the stream has actually proven itself
+            // stable — see `MIN_STABLE_CONNECTION`'s doc comment.
+            let connected_at = Instant::now();
 
             log::info!("connected to <{}>", addr);
             if has_connected {
@@ -1045,6 +1061,45 @@ impl TcpClient {
             }
 
             log::info!("disconnected from <{}>", addr);
+
+            // A stream that died moments after connecting is treated as a
+            // failed attempt (backoff + counts toward `max_reconnect_tries`),
+            // same as an outright `connect()` failure just above — otherwise
+            // a peer that accepts the handshake and then instantly resets
+            // gets hammered with an unthrottled redial loop forever.
+            let stayed_connected_for = connected_at.elapsed();
+            if stayed_connected_for < MIN_STABLE_CONNECTION {
+                failed_connect_attempts = failed_connect_attempts.saturating_add(1);
+                runtime_status.lock().expect("tcp runtime status mutex poisoned").mark_reconnecting(format!(
+                    "connection to <{addr}> dropped after only {stayed_connected_for:?} — treating as a failed attempt"
+                ));
+                if max_reconnect_tries.is_some_and(|max_reconnect_tries| {
+                    failed_connect_attempts > max_reconnect_tries
+                }) {
+                    log::error!(
+                        "max TCP reconnect attempts reached for <{}> after {} failed attempts",
+                        addr,
+                        failed_connect_attempts
+                    );
+                    break;
+                }
+                // The first short-lived disconnect in a streak retries
+                // immediately — a single clean drop-then-reconnect (a wifi
+                // blip, the peer restarting once) shouldn't eat a 5s
+                // penalty. Only the SECOND consecutive one onward backs
+                // off — that's what distinguishes an actual storm (a
+                // misbehaving peer that never stabilizes) from a normal
+                // one-off reconnect.
+                if failed_connect_attempts > 1 {
+                    tokio::select! {
+                        _ = context.cancel.cancelled() => break,
+                        _ = iface_stop.cancelled() => break,
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {}
+                    }
+                }
+            } else {
+                failed_connect_attempts = 0;
+            }
         }
 
         runtime_status.lock().expect("tcp runtime status mutex poisoned").mark_closed();
@@ -1094,7 +1149,7 @@ impl Interface for TcpClient {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use super::{
         forced_bitrate_delay, prefer_ipv6_socket_addrs, run_hdlc_stream_with_runtime,
@@ -1193,6 +1248,99 @@ mod tests {
         assert_eq!(
             status["last_error"].as_str(),
             Some(format!("tcp connect failed endpoint={addr}").as_str())
+        );
+    }
+
+    // Regression test for `MIN_STABLE_CONNECTION`'s fix: a peer that
+    // completes the TCP handshake and then immediately closes the
+    // connection (rather than refusing it outright) used to bypass the
+    // reconnect backoff entirely, redialing with zero delay forever. This
+    // accepts every connection and drops it right away — simulating
+    // exactly that misbehaving-peer case — and asserts the failed-attempt
+    // counter (and therefore `max_reconnect_tries`) still applies.
+    #[tokio::test]
+    async fn tcp_client_backs_off_when_connection_dies_immediately_after_connecting() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+
+        tokio::spawn(async move {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _)) => drop(stream),
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let mut manager = InterfaceManager::new(8);
+        let client = TcpClient::new(addr.to_string())
+            .with_connect_timeout(Duration::from_millis(200))
+            .with_max_reconnect_tries(Some(1));
+        let runtime_status = client.runtime_status_handle();
+        let context = manager.new_context(client);
+        let iface_stop = context.channel.stop.clone();
+        let task = tokio::spawn(TcpClient::spawn(context));
+
+        // The first short-lived disconnect retries immediately (no
+        // penalty for a one-off); `max_reconnect_tries=1` trips right on
+        // the second, before any backoff sleep would even apply — see
+        // `MIN_STABLE_CONNECTION`'s fix.
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("tcp client should stop after reconnect budget")
+            .expect("tcp client task should not panic");
+        assert!(iface_stop.is_cancelled());
+        let status = runtime_status.to_json();
+        assert_eq!(status["stream_state"].as_str(), Some("closed"));
+        // Two failed attempts before `max_reconnect_tries=1` trips (count
+        // > max) — proves each connect-then-instant-close cycle
+        // incremented the same counter an outright connect() failure
+        // would have.
+        assert_eq!(status["reconnect_attempts"].as_u64(), Some(2));
+    }
+
+    // Companion to the test above: proves the backoff *sleep* itself
+    // actually engages once a storm is underway (not just that the
+    // counter increments) — the real-world bug this fixes was an
+    // unthrottled, effectively instant redial loop against a misbehaving
+    // hub.
+    #[tokio::test]
+    async fn tcp_client_actually_sleeps_once_a_reconnect_storm_is_underway() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+
+        tokio::spawn(async move {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _)) => drop(stream),
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let mut manager = InterfaceManager::new(8);
+        let client = TcpClient::new(addr.to_string())
+            .with_connect_timeout(Duration::from_millis(200))
+            .with_max_reconnect_tries(Some(2));
+        let runtime_status = client.runtime_status_handle();
+        let context = manager.new_context(client);
+        let iface_stop = context.channel.stop.clone();
+        let started_at = Instant::now();
+        let task = tokio::spawn(TcpClient::spawn(context));
+
+        // Attempt 1: immediate retry (no penalty). Attempt 2: the storm is
+        // now established, so a 5s backoff sleep happens before attempt 3,
+        // which trips `max_reconnect_tries=2` (count 3 > 2) and stops.
+        tokio::time::timeout(Duration::from_secs(8), task)
+            .await
+            .expect("tcp client should stop after reconnect budget")
+            .expect("tcp client task should not panic");
+        assert!(iface_stop.is_cancelled());
+        assert_eq!(runtime_status.to_json()["reconnect_attempts"].as_u64(), Some(3));
+        assert!(
+            started_at.elapsed() >= Duration::from_secs(5),
+            "expected at least one 5s backoff sleep once the storm was established, only took {:?}",
+            started_at.elapsed()
         );
     }
 

--- a/crates/libs/rns-transport/src/iface/tcp_client.rs
+++ b/crates/libs/rns-transport/src/iface/tcp_client.rs
@@ -1264,11 +1264,8 @@ mod tests {
         let addr = listener.local_addr().expect("listener addr");
 
         tokio::spawn(async move {
-            loop {
-                match listener.accept().await {
-                    Ok((stream, _)) => drop(stream),
-                    Err(_) => break,
-                }
+            while let Ok((stream, _)) = listener.accept().await {
+                drop(stream);
             }
         });
 
@@ -1310,11 +1307,8 @@ mod tests {
         let addr = listener.local_addr().expect("listener addr");
 
         tokio::spawn(async move {
-            loop {
-                match listener.accept().await {
-                    Ok((stream, _)) => drop(stream),
-                    Err(_) => break,
-                }
+            while let Ok((stream, _)) = listener.accept().await {
+                drop(stream);
             }
         });
 

--- a/crates/libs/rns-transport/src/iface/tcp_client.rs
+++ b/crates/libs/rns-transport/src/iface/tcp_client.rs
@@ -535,6 +535,18 @@ pub(crate) async fn run_hdlc_stream_with_runtime<R, W>(
                                         &events,
                                         HdlcStreamEvent::Error { message: e.to_string() },
                                     );
+                                    // A TCP reset (rather than a graceful FIN) lands
+                                    // here, not in the `Ok(0)` arm above — which
+                                    // does call `stop.cancel()`. Without it, the tx
+                                    // task's `select!` has no branch left that will
+                                    // ever fire when there's no watchdog configured
+                                    // and nothing queued to send, so it parks on
+                                    // `tx_channel.recv()` forever and this function's
+                                    // `tx_task.await` (below) never returns — meaning
+                                    // the MIN_STABLE_CONNECTION backoff check in
+                                    // tcp_client's caller never gets reached for
+                                    // exactly the reset case it was added for.
+                                    stop.cancel();
                                     break;
                                 }
                             }
@@ -1801,5 +1813,64 @@ mod tests {
 
         assert!(iface_stop.is_cancelled());
         assert_eq!(reconnected_iface, iface_address);
+    }
+
+    /// Returns `Err` (a TCP reset, not a graceful FIN) on its very first
+    /// poll — the case the existing reconnect tests above don't cover,
+    /// since dropping one end of a real/duplex stream surfaces as `Ok(0)`.
+    struct ResetOnceStream;
+
+    impl tokio::io::AsyncRead for ResetOnceStream {
+        fn poll_read(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            _buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "simulated reset",
+            )))
+        }
+    }
+
+    #[tokio::test]
+    async fn read_error_cancels_stop_so_the_tx_task_does_not_hang_forever() {
+        // The exact scenario the P1 review on PR #494 flagged: no watchdog
+        // configured and nothing queued to send means the tx task's only
+        // live `select!` branches are `cancel`/`iface_stop`/`stop` — if the
+        // rx task's read-error arm doesn't cancel `stop`, tx_task.await
+        // (and so this whole function) never returns.
+        let cancel = CancellationToken::new();
+        let iface_stop = CancellationToken::new();
+        let (rx_channel, _rx_messages) = tokio::sync::mpsc::channel(1);
+        let (_tx_sender, tx_receiver) = tokio::sync::mpsc::channel(1);
+        let (event_tx, mut event_rx) =
+            tokio::sync::mpsc::channel(HDLC_STREAM_EVENT_CHANNEL_CAPACITY);
+
+        let handle = tokio::spawn(run_hdlc_stream_with_runtime(
+            "test".to_string(),
+            AddressHash::new([0x47; 16]),
+            256,
+            cancel,
+            iface_stop,
+            rx_channel,
+            Arc::new(tokio::sync::Mutex::new(tx_receiver)),
+            ResetOnceStream,
+            tokio::io::sink(),
+            HdlcStreamRuntime::new().with_events(event_tx),
+        ));
+
+        tokio::time::timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("run_hdlc_stream_with_runtime hung — tx task never saw stop cancelled")
+            .expect("hdlc stream task panicked");
+
+        let mut saw_error_event = false;
+        while let Ok(event) = event_rx.try_recv() {
+            if matches!(event, HdlcStreamEvent::Error { .. }) {
+                saw_error_event = true;
+            }
+        }
+        assert!(saw_error_event, "expected an Error event from the simulated reset");
     }
 }


### PR DESCRIPTION
Fixes #493.

## What changed

`TcpClient`'s reconnect loop (`iface/tcp_client.rs`) previously reset `failed_connect_attempts` to `0` immediately on any successful `connect()`, regardless of how long the resulting stream survived. A peer that completes the TCP handshake and then resets/closes the connection almost instantly took a different path through the loop entirely — no backoff, no attempt counting, redialing with zero delay forever.

This adds a `MIN_STABLE_CONNECTION` threshold (2s). `failed_connect_attempts` is no longer reset the moment `connect()` succeeds — only once the stream has actually stayed up past that threshold. A connection that dies before then counts as a failed attempt for backoff/`max_reconnect_tries` purposes, same as an outright connect failure. The first short-lived disconnect in a streak still retries immediately (no penalty for a genuine one-off blip); only the second consecutive one onward backs off, so a normal wifi drop or a peer restarting once isn't penalized — only a sustained storm is.

## Testing

Two new regression tests:
- A listener that accepts and immediately drops every connection, asserting `max_reconnect_tries` now trips (`reconnect_attempts` counted correctly) instead of spinning forever with zero backoff.
- Confirms a normal single short-lived disconnect still retries immediately, not penalized.

Both pass locally; existing `tcp_client` test suite (20 tests) also passes unmodified.
