### PR TITLE
ci: bound release resource benchmark runtime

### DIFF
--- a/.github/workflows/performance-release.yml
+++ b/.github/workflows/performance-release.yml
@@ -62,7 +62,7 @@ jobs:
           cargo xtask python-impl-bench-report
           --compare-runs 3
           --resource-runs 2
-          --resource-iterations 5000
+          --resource-iterations 1000
       - name: Measure release candidate
         working-directory: candidate
         env:
@@ -71,7 +71,7 @@ jobs:
           cargo xtask python-impl-bench-report
           --compare-runs 3
           --resource-runs 2
-          --resource-iterations 5000
+          --resource-iterations 1000
       - name: Measure ZeroMQ and HTTP SDK transports
         working-directory: candidate
         run: |

--- a/docs/runbooks/python-impl-benchmarking.md
+++ b/docs/runbooks/python-impl-benchmarking.md
@@ -115,10 +115,12 @@ python3 tools/scripts/performance_docs.py --check
 Release candidates are measured on the same runner as a checkout of `v0.9.1`.
 The hosted release workflow keeps report-profile Criterion settings but uses
 three interleaved comparison runs, 2,000 Python iterations per workload, two
-isolated resource runs, and 5,000 resource iterations per checkout. The
+isolated resource runs, and a 1,000-iteration resource seed per checkout. The
 workflow applies the same bounded Python count to both checked-out benchmark
 configs because the `v0.9.1` command does not expose that value as a CLI
-override. Generated datasets record the effective counts. Use the full
+override. Resource iterations auto-scale upward per workload to preserve the
+report profile's 0.5-second minimum measurement duration. Generated datasets
+record the effective counts. Use the full
 five-comparison/three-resource defaults and the report profile's 10,000 Python
 iterations for independently published benchmark claims.
 


### PR DESCRIPTION
## Summary

- lower the hosted release resource seed from 5,000 to 1,000 iterations for both v0.9.1 and the candidate
- retain two isolated resource runs and per-workload auto-scaling to the report profile's 0.5-second minimum duration
- document the effective hosted sampling policy

## Why

The v0.9.6-rc.4 comparison completed both three-run core reports and SDK transport measurement, but reached GitHub's six-hour limit during matched E2E. Each core report took about 2h55. The remaining dominant cost is the two 5,000-iteration resource passes; reducing their seed symmetrically preserves the configured minimum-duration floor while recovering enough time for E2E, dataset generation, the regression gate, and artifact upload.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p xtask` (19 passed)
- workflow YAML parsed with PyYAML
- verified both baseline and candidate use `--resource-iterations 1000`
- `git diff --check`
