### PR TITLE
Honor disabled Reticulum transport forwarding

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport.rs
@@ -44,7 +44,7 @@ use std::sync::{Arc, Mutex};
 
 const STREAM_RECONNECT_EVENT_CHANNEL_CAPACITY: usize = 32;
 
-pub(super) fn reticulum_transport_retransmit_enabled(daemon_config: Option<&DaemonConfig>) -> bool {
+pub(super) fn reticulum_transport_enabled(daemon_config: Option<&DaemonConfig>) -> bool {
     daemon_config.is_some_and(DaemonConfig::reticulum_transport_enabled)
 }
 
@@ -215,7 +215,7 @@ pub(super) async fn start_transport_and_interfaces(
         let transport_identity =
             rns_transport::identity_bridge::to_transport_private_identity(identity);
         let mut config = TransportConfig::new("daemon", &transport_identity, true);
-        config.set_retransmit(reticulum_transport_retransmit_enabled(daemon_config));
+        config.set_transport_enabled(reticulum_transport_enabled(daemon_config));
         let mut transport_instance = Transport::new(config);
         transport_instance
             .set_receipt_handler(Box::new(ReceiptBridge::new(receipt_map, receipt_tx.clone())))

--- a/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport_tests.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport_tests.rs
@@ -1,13 +1,11 @@
-use super::{
-    build_selected_tcp_server_adapter, reticulum_transport_retransmit_enabled, TcpServerSelection,
-};
+use super::{build_selected_tcp_server_adapter, reticulum_transport_enabled, TcpServerSelection};
 use rns_transport::iface::InterfaceManager;
 use std::sync::Arc;
 use std::time::Duration;
 
 #[test]
-fn reticulum_enable_transport_controls_daemon_retransmit() {
-    assert!(!reticulum_transport_retransmit_enabled(None));
+fn reticulum_enable_transport_controls_daemon_forwarding() {
+    assert!(!reticulum_transport_enabled(None));
 
     for (config, expected) in [
         ("", false),
@@ -17,7 +15,7 @@ fn reticulum_enable_transport_controls_daemon_retransmit() {
         let daemon_config =
             reticulum_daemon::config::DaemonConfig::from_toml(config).expect("parse daemon config");
 
-        assert_eq!(reticulum_transport_retransmit_enabled(Some(&daemon_config)), expected);
+        assert_eq!(reticulum_transport_enabled(Some(&daemon_config)), expected);
     }
 }
 

--- a/crates/apps/reticulumd/tests/transport_policy_evidence.rs
+++ b/crates/apps/reticulumd/tests/transport_policy_evidence.rs
@@ -1,4 +1,5 @@
 use rand_core::OsRng;
+use rns_transport::destination::link::Link;
 use rns_transport::destination::{DestinationName, SingleInputDestination};
 use rns_transport::hash::{AddressHash, ADDRESS_HASH_SIZE};
 use rns_transport::identity::PrivateIdentity;
@@ -14,6 +15,13 @@ fn retransmitting_transport(name: &str) -> Transport {
     let identity = PrivateIdentity::new_from_rand(OsRng);
     let mut config = TransportConfig::new(name, &identity, true);
     config.set_retransmit(true);
+    Transport::new(config)
+}
+
+fn non_transport_instance(name: &str) -> Transport {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let mut config = TransportConfig::new(name, &identity, true);
+    config.set_transport_enabled(false);
     Transport::new(config)
 }
 
@@ -115,6 +123,57 @@ async fn learn_remote_announce(
     feed_iface_packet(iface, announce.clone()).await;
     wait_for_known_path(transport, &destination).await;
     announce
+}
+
+fn link_request(destination: rns_transport::destination::DestinationDesc) -> Packet {
+    let (link_events, _keep) = tokio::sync::broadcast::channel(4);
+    Link::new(destination, link_events).request()
+}
+
+#[tokio::test]
+async fn disabled_transport_does_not_relay_known_path_link_requests() {
+    let app = non_transport_instance("issue-491-disabled-app");
+    let mut host_iface = new_probe_iface_with_mode(&app, InterfaceMode::AccessPoint).await;
+    let attacker_iface = new_probe_iface_with_mode(&app, InterfaceMode::AccessPoint).await;
+    let mut host_destination = SingleInputDestination::new(
+        PrivateIdentity::new_from_rand(OsRng),
+        DestinationName::new("lxmf", "issue-491-host"),
+    );
+    let mut announce = host_destination.announce(OsRng, None).expect("valid host announce");
+    announce.header.hops = 1;
+    let destination = announce.destination;
+
+    feed_iface_packet(&host_iface, announce).await;
+    wait_for_known_path(&app, &destination).await;
+    feed_iface_packet(&attacker_iface, link_request(host_destination.desc)).await;
+
+    assert_no_tx_within(
+        &mut host_iface,
+        "host-facing access-point interface on a disabled transport",
+        Duration::from_millis(250),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn disabled_transport_still_accepts_link_requests_for_local_destinations() {
+    let mut app = non_transport_instance("disabled-app-local-destination");
+    let local_destination = app
+        .add_destination(
+            PrivateIdentity::new_from_rand(OsRng),
+            DestinationName::new("lxmf", "disabled-app-local"),
+        )
+        .await;
+    let destination = local_destination.lock().await.desc;
+    let mut requester_iface = new_probe_iface_with_mode(&app, InterfaceMode::AccessPoint).await;
+
+    feed_iface_packet(&requester_iface, link_request(destination)).await;
+
+    let proof = recv_tx(&mut requester_iface, "local destination link proof").await;
+    assert!(
+        matches!(proof.tx_type, TxMessageType::Direct(iface) if iface == *requester_iface.address())
+    );
+    assert_eq!(proof.packet.context, PacketContext::LinkRequestProof);
 }
 
 fn fresh_announce(destination: &mut SingleInputDestination, hops: u8) -> Packet {

--- a/crates/libs/rns-transport/src/transport/config.rs
+++ b/crates/libs/rns-transport/src/transport/config.rs
@@ -7,7 +7,7 @@ impl TransportConfig {
             name: name.into(),
             identity: identity.clone(),
             broadcast,
-            retransmit: false,
+            transport_enabled: false,
             connected_to_shared_instance: false,
             announce_cache_capacity: 100_000,
             announce_retry_limit: 1,
@@ -22,8 +22,18 @@ impl TransportConfig {
         }
     }
 
+    /// Enables or disables forwarding traffic for remote destinations and links.
+    ///
+    /// This is the in-process equivalent of Reticulum's
+    /// `[reticulum] enable_transport` setting. Disabled transports still serve
+    /// their own destinations and locally owned links.
+    pub fn set_transport_enabled(&mut self, enabled: bool) {
+        self.transport_enabled = enabled;
+    }
+
+    /// Compatibility alias for callers that used the original transport-mode setter.
     pub fn set_retransmit(&mut self, retransmit: bool) {
-        self.retransmit = retransmit;
+        self.set_transport_enabled(retransmit);
     }
 
     pub fn set_connected_to_shared_instance(&mut self, connected: bool) {
@@ -82,7 +92,7 @@ impl Default for TransportConfig {
             name: "tp".into(),
             identity: PrivateIdentity::new_from_rand(OsRng),
             broadcast: false,
-            retransmit: false,
+            transport_enabled: false,
             connected_to_shared_instance: false,
             announce_cache_capacity: 100_000,
             announce_retry_limit: 1,
@@ -108,5 +118,16 @@ mod tests {
 
         assert_eq!(config.resource_retry_interval_secs, 2);
         assert_eq!(config.resource_retry_limit, 16);
+    }
+
+    #[test]
+    fn retransmit_setter_remains_a_transport_enabled_alias() {
+        let identity = PrivateIdentity::new_from_rand(OsRng);
+        let mut config = TransportConfig::new("test", &identity, true);
+
+        config.set_retransmit(true);
+        assert!(config.transport_enabled);
+        config.set_transport_enabled(false);
+        assert!(!config.transport_enabled);
     }
 }

--- a/crates/libs/rns-transport/src/transport/core.rs
+++ b/crates/libs/rns-transport/src/transport/core.rs
@@ -39,7 +39,7 @@ impl Transport {
         });
 
         let transport_id =
-            if config.retransmit { Some(*config.identity.address_hash()) } else { None };
+            if config.transport_enabled { Some(*config.identity.address_hash()) } else { None };
         let path_requests = PathRequests::new(
             config.name.as_str(),
             transport_id,

--- a/crates/libs/rns-transport/src/transport/handler.rs
+++ b/crates/libs/rns-transport/src/transport/handler.rs
@@ -379,8 +379,7 @@ impl TransportHandler {
     ///     outbound link (matched by id), or a forward in the `link_table`.
     ///   - Everything else (`LinkRequest` and single `Data`, both
     ///     `DestinationType::Single`) is accepted when the destination is a
-    ///     local input destination or has a known next hop — exactly
-    ///     `handle_link_request`'s destination/intermediate split.
+    ///     local input destination or, with transport enabled, a known next hop.
     pub(super) async fn should_learn_unicast_route(&self, packet: &Packet) -> bool {
         if packet.header.destination_type == DestinationType::Link {
             // `LinkId == AddressHash`, so the link id is `packet.destination`.
@@ -397,7 +396,8 @@ impl TransportHandler {
             false
         } else {
             self.single_in_destinations.contains_key(&packet.destination)
-                || self.path_table.next_hop_full(&packet.destination).is_some()
+                || self.config.transport_enabled
+                    && self.path_table.next_hop_full(&packet.destination).is_some()
         }
     }
 

--- a/crates/libs/rns-transport/src/transport/jobs.rs
+++ b/crates/libs/rns-transport/src/transport/jobs.rs
@@ -127,7 +127,8 @@ pub(super) async fn handle_check_links<'a>(mut handler: MutexGuard<'a, Transport
         match link.status() {
             LinkStatus::Closed => {
                 let destination = link.destination().address_hash;
-                let rediscover_closed_pending = !handler.config.retransmit && !link.was_activated();
+                let rediscover_closed_pending =
+                    !handler.config.transport_enabled && !link.was_activated();
                 links_to_remove.push(*link_entry.0);
                 closed_link_ids.push(*link.id());
                 if rediscover_closed_pending {
@@ -227,7 +228,7 @@ pub(super) async fn manage_transport(
     iface_messages_tx: broadcast::Sender<RxMessage>,
 ) {
     let cancel = handler_arc.lock().await.cancel.clone();
-    let retransmit = handler_arc.lock().await.config.retransmit;
+    let transport_enabled = handler_arc.lock().await.config.transport_enabled;
 
     let _packet_task = {
         let handler_arc = handler_arc.clone();
@@ -423,7 +424,7 @@ pub(super) async fn manage_transport(
                     },
                     _ = time::sleep(INTERVAL_ANNOUNCES_RETRANSMIT) => {
                         let guard = handler.lock().await;
-                        if retransmit {
+                        if transport_enabled {
                             retransmit_announces(guard).await;
                         } else {
                             release_held_announces(guard).await;

--- a/crates/libs/rns-transport/src/transport/jobs_parts/link_table_cleanup.rs
+++ b/crates/libs/rns-transport/src/transport/jobs_parts/link_table_cleanup.rs
@@ -25,7 +25,7 @@ pub(super) async fn handle_link_table_cleanup<'a>(mut handler: MutexGuard<'a, Tr
         }
 
         if should_mark_unresponsive {
-            if handler.config.retransmit {
+            if handler.config.transport_enabled {
                 let ingress_mode = handler.iface_manager.lock().await.mode(&expired.received_from);
                 if ingress_mode != Some(crate::iface::InterfaceMode::Boundary) {
                     handler.path_table.mark_path_unresponsive(&destination);

--- a/crates/libs/rns-transport/src/transport/mod.rs
+++ b/crates/libs/rns-transport/src/transport/mod.rs
@@ -174,7 +174,7 @@ pub struct TransportConfig {
     name: String,
     identity: PrivateIdentity,
     broadcast: bool,
-    retransmit: bool,
+    transport_enabled: bool,
     connected_to_shared_instance: bool,
     announce_cache_capacity: usize,
     announce_retry_limit: u8,

--- a/crates/libs/rns-transport/src/transport/path.rs
+++ b/crates/libs/rns-transport/src/transport/path.rs
@@ -116,6 +116,15 @@ pub(super) async fn send_to_next_hop<'a>(
     handler: &MutexGuard<'a, TransportHandler>,
     lookup: Option<AddressHash>,
 ) -> bool {
+    if !handler.config.transport_enabled {
+        log::debug!(
+            "[tp-diag] forward_next_hop_skip node={} dst={} reason=transport_disabled",
+            handler.config.name,
+            packet.destination
+        );
+        return false;
+    }
+
     let decision = route_inbound_packet(&handler.path_table, packet, lookup);
     let packet = decision.packet;
     let maybe_iface = decision.next_iface;
@@ -185,7 +194,7 @@ pub(super) async fn handle_path_request<'a>(
             return;
         }
 
-        if handler.config.retransmit {
+        if handler.config.transport_enabled {
             if let Some(entry) = handler.path_table.get(&request.destination) {
                 let next_hop = entry.received_from;
                 let learned_iface = entry.iface;
@@ -235,7 +244,7 @@ pub(super) async fn handle_path_request<'a>(
             }
         }
 
-        if handler.config.retransmit {
+        if handler.config.transport_enabled {
             let should_search_for_unknown = handler
                 .iface_manager
                 .lock()
@@ -342,6 +351,16 @@ pub(super) async fn handle_link_request_as_intermediate<'a>(
     packet: &Packet,
     mut handler: MutexGuard<'a, TransportHandler>,
 ) {
+    if !handler.config.transport_enabled {
+        log::debug!(
+            "[tp-diag] link_request_intermediate_skip node={} dst={} from_iface={} reason=transport_disabled",
+            handler.config.name,
+            packet.destination,
+            received_from
+        );
+        return;
+    }
+
     log::debug!(
         "[tp-diag] link_request_intermediate node={} dst={} from_iface={} next_hop={} next_iface={} packet={}",
         handler.config.name,
@@ -397,6 +416,12 @@ pub(super) async fn handle_link_request<'a>(
         log::trace!("tp({}): handle link request for {}", handler.config.name, packet.destination);
 
         handle_link_request_as_destination(destination, packet, iface, handler).await;
+    } else if !handler.config.transport_enabled {
+        log::trace!(
+            "tp({}): dropping transit link request to {} because transport forwarding is disabled",
+            handler.config.name,
+            packet.destination
+        );
     } else if let Some(entry) = handler.path_table.next_hop_full(&packet.destination) {
         log::trace!(
             "tp({}): handle link request for remote destination {}",

--- a/crates/libs/rns-transport/src/transport/resource_wire.rs
+++ b/crates/libs/rns-transport/src/transport/resource_wire.rs
@@ -37,16 +37,21 @@ pub(super) async fn handle_resource_proof(
         }
         handler.resource_response_packets = responses;
         publish_resource_events(&handler, events);
-    } else if let Some((packet, target_iface)) =
-        handler.link_table.handle_reverse_link_packet(&packet, iface)
-    {
-        log::debug!(
-            "[tp-diag] resource_proof_reverse_forward node={} link={} iface={}",
-            handler.config.name,
-            packet.destination,
-            target_iface
-        );
-        handler.send(TxMessage { tx_type: TxMessageType::Direct(target_iface), packet }).await;
+    } else {
+        let reverse_packet = if handler.config.transport_enabled {
+            handler.link_table.handle_reverse_link_packet(&packet, iface)
+        } else {
+            None
+        };
+        if let Some((packet, target_iface)) = reverse_packet {
+            log::debug!(
+                "[tp-diag] resource_proof_reverse_forward node={} link={} iface={}",
+                handler.config.name,
+                packet.destination,
+                target_iface
+            );
+            handler.send(TxMessage { tx_type: TxMessageType::Direct(target_iface), packet }).await;
+        }
     }
 }
 

--- a/crates/libs/rns-transport/src/transport/runtime_management.rs
+++ b/crates/libs/rns-transport/src/transport/runtime_management.rs
@@ -64,7 +64,7 @@ impl Transport {
     pub async fn save_packet_hashlist<P: AsRef<Path>>(&self, storage_path: P) -> io::Result<usize> {
         let hashes = {
             let handler = self.handler.lock().await;
-            if handler.config.retransmit {
+            if handler.config.transport_enabled {
                 handler
                     .packet_cache
                     .try_lock()

--- a/crates/libs/rns-transport/src/transport/tests_parts/encrypted_resource_control_packet.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/encrypted_resource_control_packet.rs
@@ -212,7 +212,8 @@ async fn handle_inbound_for_test_rejects_untracked_hash_even_with_a_known_identi
 #[tokio::test]
 async fn routed_destination_proof_forwards_back_to_packet_source() {
     let local_identity = PrivateIdentity::new_from_rand(OsRng);
-    let config = TransportConfig::new("test", &local_identity, true);
+    let mut config = TransportConfig::new("test", &local_identity, true);
+    config.set_transport_enabled(true);
     let transport = Transport::new(config);
     let handler = transport.get_handler();
     let mut source_iface = transport.iface_manager.lock().await.new_channel(8);
@@ -273,7 +274,8 @@ async fn routed_destination_proof_forwards_back_to_packet_source() {
 #[tokio::test]
 async fn routed_implicit_destination_proof_forwards_back_to_packet_source() {
     let local_identity = PrivateIdentity::new_from_rand(OsRng);
-    let config = TransportConfig::new("test", &local_identity, true);
+    let mut config = TransportConfig::new("test", &local_identity, true);
+    config.set_transport_enabled(true);
     let transport = Transport::new(config);
     let handler = transport.get_handler();
     let mut source_iface = transport.iface_manager.lock().await.new_channel(8);
@@ -801,7 +803,8 @@ async fn routed_link_resource_request_forwards_back_to_link_requester() {
 #[tokio::test]
 async fn routed_link_resource_proof_forwards_back_to_link_requester() {
     let local_identity = PrivateIdentity::new_from_rand(OsRng);
-    let config = TransportConfig::new("test", &local_identity, true);
+    let mut config = TransportConfig::new("test", &local_identity, true);
+    config.set_transport_enabled(true);
     let transport = Transport::new(config);
     let handler = transport.get_handler();
     let mut requester_iface = transport.iface_manager.lock().await.new_channel(8);
@@ -923,4 +926,62 @@ async fn routed_link_packet_proof_forwards_back_to_link_requester() {
     assert_eq!(sent.packet.destination, *outbound_link.id());
     assert_eq!(sent.packet.header.packet_type, PacketType::Proof);
     assert!(matches!(sent.packet.context, PacketContext::None | PacketContext::LinkProof));
+}
+
+#[tokio::test]
+async fn disabled_transport_does_not_forward_established_link_traffic() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let mut config = TransportConfig::new("disabled-transport", &local_identity, true);
+    config.set_transport_enabled(false);
+    let transport = Transport::new(config);
+    let handler = transport.get_handler();
+    let (mut requester_iface, next_hop_iface) = {
+        let iface_manager = transport.iface_manager();
+        let mut manager = iface_manager.lock().await;
+        let requester = manager.new_channel(8);
+        let next_hop = manager.new_channel(8);
+        (requester, *next_hop.address())
+    };
+    let received_from = *requester_iface.address();
+
+    let remote_destination = SingleInputDestination::new(
+        PrivateIdentity::new_from_rand(OsRng),
+        DestinationName::new("lxmf", "disabled-transit"),
+    );
+    let next_hop = AddressHash::new_from_rand(OsRng);
+    let (tx, _) = tokio::sync::broadcast::channel(4);
+    let mut outbound_link = Link::new(remote_destination.desc, tx.clone());
+    let request = outbound_link.request();
+    let mut inbound_link = Link::new_from_request(
+        &request,
+        remote_destination.sign_key().clone(),
+        remote_destination.desc,
+        tx,
+    )
+    .expect("link from request");
+    let link_request_proof = inbound_link.prove();
+    assert!(matches!(
+        outbound_link.handle_packet(&link_request_proof, next_hop_iface),
+        LinkHandleResult::Activated
+    ));
+
+    {
+        let mut guard = handler.lock().await;
+        guard.link_table.add(
+            &request,
+            request.destination,
+            received_from,
+            next_hop,
+            next_hop_iface,
+        );
+        assert!(guard.link_table.handle_proof(&link_request_proof).is_some());
+    }
+
+    let data_packet = outbound_link.data_packet(b"must not transit").expect("link data packet");
+    handle_data(&data_packet, next_hop_iface, handler.lock().await).await;
+
+    assert!(
+        timeout(Duration::from_millis(200), requester_iface.tx_channel.recv()).await.is_err(),
+        "disabled transport must not forward established-link data"
+    );
 }

--- a/crates/libs/rns-transport/src/transport/tests_parts/encrypted_resource_control_packet.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/encrypted_resource_control_packet.rs
@@ -876,7 +876,8 @@ async fn routed_link_resource_proof_forwards_back_to_link_requester() {
 #[tokio::test]
 async fn routed_link_packet_proof_forwards_back_to_link_requester() {
     let local_identity = PrivateIdentity::new_from_rand(OsRng);
-    let config = TransportConfig::new("test", &local_identity, true);
+    let mut config = TransportConfig::new("test", &local_identity, true);
+    config.set_transport_enabled(true);
     let transport = Transport::new(config);
     let handler = transport.get_handler();
     let mut requester_iface = transport.iface_manager.lock().await.new_channel(8);
@@ -983,5 +984,13 @@ async fn disabled_transport_does_not_forward_established_link_traffic() {
     assert!(
         timeout(Duration::from_millis(200), requester_iface.tx_channel.recv()).await.is_err(),
         "disabled transport must not forward established-link data"
+    );
+
+    let packet_proof = inbound_link.prove_packet(&data_packet);
+    handle_proof(packet_proof, handler, next_hop_iface).await;
+
+    assert!(
+        timeout(Duration::from_millis(200), requester_iface.tx_channel.recv()).await.is_err(),
+        "disabled transport must not forward established-link proofs"
     );
 }

--- a/crates/libs/rns-transport/src/transport/tests_parts/pending_out_link_rediscovery.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/pending_out_link_rediscovery.rs
@@ -287,6 +287,7 @@ async fn timed_out_routed_link_marks_one_hop_path_unresponsive_and_requests_redi
 async fn timed_out_routed_link_expires_one_hop_path_for_non_transport_boundary_ingress() {
     let local_identity = PrivateIdentity::new_from_rand(OsRng);
     let mut config = TransportConfig::new("client-instance", &local_identity, true);
+    config.set_transport_enabled(true);
     config.set_link_proof_timeout_secs(0);
     let transport = Transport::new(config);
     let handler = transport.get_handler();
@@ -342,6 +343,7 @@ async fn timed_out_routed_link_expires_one_hop_path_for_non_transport_boundary_i
         .expect("link request should forward to the current next-hop iface")
         .expect("tx channel open");
 
+    handler.lock().await.config.set_transport_enabled(false);
     tokio::time::sleep(Duration::from_millis(1)).await;
     super::jobs::handle_link_table_cleanup(handler.lock().await).await;
 

--- a/crates/libs/rns-transport/src/transport/wire.rs
+++ b/crates/libs/rns-transport/src/transport/wire.rs
@@ -6,23 +6,23 @@ use super::*;
 use crate::packet::Header;
 use ed25519_dalek::SIGNATURE_LENGTH;
 
-async fn should_forward_link_request_proof(
+async fn should_forward_link_table_proof(
     packet: &Packet,
     handler: &TransportHandler,
     iface: AddressHash,
 ) -> bool {
-    if packet.context != PacketContext::LinkRequestProof {
-        return true;
-    }
-
     if !handler.config.transport_enabled {
         log::debug!(
-            "[tp-diag] lrproof_forward_skip node={} reason=transport_disabled link={} iface={}",
+            "[tp-diag] link_proof_forward_skip node={} reason=transport_disabled link={} iface={}",
             handler.config.name,
             packet.destination,
             iface
         );
         return false;
+    }
+
+    if packet.context != PacketContext::LinkRequestProof {
+        return true;
     }
 
     let Some((original_destination, expected_iface)) =
@@ -163,7 +163,7 @@ pub(super) async fn handle_proof(
         }
     }
 
-    let maybe_packet = if should_forward_link_request_proof(&packet, &handler, iface).await {
+    let maybe_packet = if should_forward_link_table_proof(&packet, &handler, iface).await {
         handler.link_table.handle_proof(&packet)
     } else {
         None

--- a/crates/libs/rns-transport/src/transport/wire.rs
+++ b/crates/libs/rns-transport/src/transport/wire.rs
@@ -15,6 +15,16 @@ async fn should_forward_link_request_proof(
         return true;
     }
 
+    if !handler.config.transport_enabled {
+        log::debug!(
+            "[tp-diag] lrproof_forward_skip node={} reason=transport_disabled link={} iface={}",
+            handler.config.name,
+            packet.destination,
+            iface
+        );
+        return false;
+    }
+
     let Some((original_destination, expected_iface)) =
         handler.link_table.proof_validation_context(&packet.destination)
     else {
@@ -114,7 +124,7 @@ pub(super) async fn handle_proof(
                 None
             }
         };
-        if let Some(source_iface) = source_iface {
+        if let (true, Some(source_iface)) = (handler.config.transport_enabled, source_iface) {
             if source_iface != iface {
                 log::debug!(
                     "[tp-diag] destination_proof_reverse_forward node={} proof_dst={} source_iface={} ingress_iface={}",
@@ -184,7 +194,11 @@ pub(super) async fn handle_keepalive_response<'a>(
     if packet.context == PacketContext::KeepAlive
         && packet.data.as_slice()[0] == KEEP_ALIVE_RESPONSE
     {
-        let lookup = handler.link_table.handle_keepalive(packet);
+        let lookup = if handler.config.transport_enabled {
+            handler.link_table.handle_keepalive(packet)
+        } else {
+            None
+        };
 
         if let Some((propagated, iface)) = lookup {
             handler
@@ -251,8 +265,12 @@ pub(super) async fn handle_data<'a>(
             return;
         }
 
-        if let Some((packet, iface)) = handler.link_table.handle_reverse_link_packet(packet, iface)
-        {
+        let reverse_packet = if handler.config.transport_enabled {
+            handler.link_table.handle_reverse_link_packet(packet, iface)
+        } else {
+            None
+        };
+        if let Some((packet, iface)) = reverse_packet {
             log::debug!(
                 "[resource-diag] wire_resource_reverse_forward node={} link={} iface={}",
                 handler.config.name,
@@ -263,16 +281,18 @@ pub(super) async fn handle_data<'a>(
             return;
         }
 
-        let lookup = handler.link_table.original_destination(&packet.destination);
-        if lookup.is_some() {
-            let sent = send_to_next_hop(packet, &handler, lookup).await;
+        if handler.config.transport_enabled {
+            let lookup = handler.link_table.original_destination(&packet.destination);
+            if lookup.is_some() {
+                let sent = send_to_next_hop(packet, &handler, lookup).await;
 
-            log::trace!(
-                "tp({}): {} packet to remote link {}",
-                handler.config.name,
-                if sent { "forwarded" } else { "could not forward" },
-                packet.destination
-            );
+                log::trace!(
+                    "tp({}): {} packet to remote link {}",
+                    handler.config.name,
+                    if sent { "forwarded" } else { "could not forward" },
+                    packet.destination
+                );
+            }
         }
     }
 
@@ -461,7 +481,7 @@ pub(super) async fn handle_data<'a>(
                     }
                 }
             }
-        } else {
+        } else if handler.config.transport_enabled {
             data_handled = send_to_next_hop(packet, &handler, None).await;
         }
     }

--- a/docs/goals/issue-491-disable-transport-forwarding/GOAL.md
+++ b/docs/goals/issue-491-disable-transport-forwarding/GOAL.md
@@ -1,0 +1,10 @@
+# Goal: Disable Transit Forwarding
+
+Use Krypton Execution to execute `docs/goals/issue-491-disable-transport-forwarding/PLAN.md`.
+
+Core rules:
+- Treat PLAN.md as the source plan.
+- Preserve intent, ownership, contract, cutover, evidence, and kill criteria.
+- Do not add a new dominant path without deleting, redirecting, demoting, or shimming the displaced path.
+- Capture acceptance evidence from the target perspective.
+- Say "implemented but unproven" if that evidence cannot be captured.

--- a/docs/goals/issue-491-disable-transport-forwarding/PLAN.md
+++ b/docs/goals/issue-491-disable-transport-forwarding/PLAN.md
@@ -1,0 +1,43 @@
+# Disable Transit Forwarding Implementation Plan
+
+**Intent:** Make Rust `TransportConfig` expose and enforce the Python Reticulum `enable_transport = false` contract reported in issue #491.
+**Current Behavior:** `set_retransmit(false)` suppresses announce and path-request retransmission, but known-path Link Requests and established-link traffic can still cross the process between interfaces.
+**Expected Outcome:** A transport-disabled instance continues to serve local destinations and locally owned links but never relays traffic for remote destinations or transit links.
+**Target-Perspective Output:** An application operator can connect the process to trusted and untrusted networks and observe that a third party cannot activate or use a link through it when transport forwarding is disabled.
+**Truth Owner:** `TransportConfig::transport_enabled` in `crates/libs/rns-transport`.
+**Contract Boundary:** Daemon `[reticulum] enable_transport` and public `TransportConfig` configuration enter the inbound transport routing pipeline.
+**Cutover:** Replace the internal `retransmit` policy flag with `transport_enabled`; retain `set_retransmit` as a compatibility alias while directing new callers to `set_transport_enabled`.
+**Displaced Path:** Remove ungated remote forwarding from Link Request, proof, data, keepalive, and resource handlers.
+**Value Density:** One policy flag closes the security/correctness gap across every transit packet family without changing local application traffic.
+**Acceptance Evidence:** A two-interface regression recreates the issue #491 attacker/app/host boundary and proves no packet reaches the host-facing interface while local Link Requests still work; focused crate and daemon policy tests pass.
+**Evidence Lane:** Unit and simulated transport-boundary tests, followed by formatting, clippy, and workspace tests.
+**Kill Criteria:** No internal forwarding decision may use the old `retransmit` field or bypass the authoritative transit-policy check.
+**Architecture Slice:** Configuration in `transport/{mod,config,core}.rs`; inbound transit decisions in `transport/{path,wire,resource_wire}.rs`; daemon mapping in `bootstrap_transport.rs`; policy evidence in `transport_policy_evidence.rs`; parity status in `docs/status`.
+**Plan Review Gate:** Requires PRE review before execution.
+
+## Task 1: Establish the configuration contract
+
+- Files: `crates/libs/rns-transport/src/transport/mod.rs`, `config.rs`, `core.rs`, transport maintenance modules, and `crates/apps/reticulumd/src/bin/reticulumd/bootstrap_transport.rs`.
+- Allowed scope: Rename the internal policy to `transport_enabled`, add its explicit setter, and preserve the old setter as an alias.
+- Expected output: One source of truth for transport-instance behavior.
+- Verification: Focused config and daemon bootstrap tests.
+- Acceptance evidence: Both public setters produce identical transport-enabled state and daemon `enable_transport` selects it.
+- Parallel: No.
+
+## Task 2: Gate transit forwarding
+
+- Files: `crates/libs/rns-transport/src/transport/path.rs`, `wire.rs`, and `resource_wire.rs`.
+- Allowed scope: Gate only remote/transit sends; do not block local destinations, locally owned links, or their replies.
+- Expected output: Disabled instances cannot create transit link-table state or forward transit packets.
+- Verification: New focused transport tests plus existing routed-link/resource tests.
+- Acceptance evidence: Known-path Link Requests and established-link packets do not leave the second interface when disabled.
+- Parallel: No.
+
+## Task 3: Record parity and validate
+
+- Files: `crates/apps/reticulumd/tests/transport_policy_evidence.rs`, `docs/status/reticulum-parity-matrix.md`, and `docs/status/current-roadmap.md`.
+- Allowed scope: Add issue-shaped regression evidence and correct the parity claim.
+- Expected output: Repository status matches the implemented contract.
+- Verification: `cargo fmt --all -- --check`, focused package tests, workspace clippy, and workspace tests.
+- Acceptance evidence: The issue-shaped regression and full required checks pass on the final diff.
+- Parallel: No.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -43,6 +43,9 @@ accuracy, and release evidence rather than a new parity claim.
 Current candidate work includes link-context fan-out through each link's bound
 interface, packet-cache-correlated single-destination delivery proofs, real-link
 plain-resource routing evidence, and identified-peer propagation behavior.
+Transport-disabled runtimes now enforce Python's `enable_transport = false`
+contract across known-path Link Requests and established-link transit traffic
+without blocking locally hosted destinations.
 Fan-out now has additive reporting APIs that distinguish no matching link,
 complete delivery to interface queues, and partial packet-build or dispatch
 failure. Core and transport `RnsError` values implement the standard Rust error

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -1,6 +1,6 @@
 # Reticulum Parity Matrix
 
-Last reassessed: 2026-07-16
+Last reassessed: 2026-07-21
 
 This is the maintained row-level status for Python Reticulum compatibility.
 Repository-level posture and execution order live in
@@ -31,7 +31,7 @@ human-operated validation remain the explicit v1.0 boundary.
 | `RNS/Identity.py` | `crates/libs/rns-core` | complete | unit, pinned-python | Identity material, hashing, signing, encryption, recall, and key conversion. | No confirmed parity blocker. |
 | `RNS/Destination.py` | `crates/libs/rns-core`, `crates/libs/rns-transport` | complete | unit, pinned-python | Destination hashing, descriptors, announces, proof generation and validation, ratchets, and known-key stability checks. Single-destination Data delivery proofs are correlated through the packet cache before identity verification. | No confirmed parity blocker. |
 | `RNS/Packet.py` | `crates/libs/rns-core`, `crates/libs/rns-transport` | complete | unit, pinned-python | Framing, serialization, contexts, proofs, receipts, public post-encryption packet-hash correlation, explicit and implicit proof-destination correlation, Python-default link proof context, and header semantics. | No confirmed parity blocker. |
-| `RNS/Transport.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | complete | unit, simulated, pinned-python | Path and announce handling, path replacement/state/await semantics, routed links/resources/receipts/tunnels, next-hop bitrate/MTU/latency formulas, interface prioritization/detach/lookup, destination registration lifecycle, discovery and blackhole state, shared-instance behavior, packet filtering, Python-format forced disk packet cache and announce cleanup, MessagePack packet-hash/path/tunnel persistence, runtime jobs and graceful shutdown. Existing deterministic evidence also covers known-path response precedence, roaming suppression/grace, recursive discovery, link MTU signalling, restore/restart, scoped path requests, pacing, duplicate suppression, and bound-interface link fan-out with structured partial-failure reports. | No generated public-callable software gap remains in `Transport.py`; real carrier/public-network evidence remains separately bounded. |
+| `RNS/Transport.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | complete | unit, simulated, pinned-python | Path and announce handling, path replacement/state/await semantics, routed links/resources/receipts/tunnels, next-hop bitrate/MTU/latency formulas, interface prioritization/detach/lookup, destination registration lifecycle, discovery and blackhole state, shared-instance behavior, packet filtering, Python-format forced disk packet cache and announce cleanup, MessagePack packet-hash/path/tunnel persistence, runtime jobs and graceful shutdown. Existing deterministic evidence also covers known-path response precedence, roaming suppression/grace, recursive discovery, link MTU signalling, restore/restart, scoped path requests, pacing, duplicate suppression, bound-interface link fan-out with structured partial-failure reports, and `enable_transport = false` suppression of Link Request and established-link transit forwarding while local destinations remain reachable. | No generated public-callable software gap remains in `Transport.py`; real carrier/public-network evidence remains separately bounded. |
 | `RNS/Link.py` | `crates/libs/rns-transport` | complete | unit, pinned-python | Establishment, proof validation, bound-interface enforcement for data/channel fan-out, RTT-derived liveness, protocol close, and cleanup. | Continue live regression coverage; no confirmed blocker. |
 | `RNS/Resource.py` | `crates/libs/rns-transport` | complete | unit, simulated, pinned-python | Bounded receive allocation, advertisement validation, retries, adaptive fragment scheduling, timeout/failure events, cancellation, cleanup, and Python-shaped split-resource sequencing with original-hash preservation, ordered reassembly, per-segment completion metadata, and final whole-resource completion. | No confirmed software implementation blocker; physical-carrier evidence belongs to the interface rows. |
 | `RNS/Channel.py` | `crates/libs/rns-transport` | complete | unit, pinned-python | Channel packet handling, retry scheduling, buffering, ordered receive delivery, callback ordering/short-circuit/panic containment, delivery-on-proof, timeout retry, exhaustion cleanup, and live Rust/Python channel sequence tests. | No confirmed channel parity blocker. |
@@ -45,9 +45,11 @@ human-operated validation remain the explicit v1.0 boundary.
 
 ### Runtime and daemon compatibility
 
-- `[reticulum] enable_transport` now controls Reticulum retransmission
-  independently from interface startup, while `panic_on_interface_error`
-  remains a separate strict-startup policy.
+- `[reticulum] enable_transport` now controls the full Reticulum transport
+  contract independently from interface startup: disabled instances do not
+  retransmit announces/path responses or forward remote Link Requests and
+  established-link traffic, while local destinations remain reachable.
+  `panic_on_interface_error` remains a separate strict-startup policy.
 - Legacy daemon RPC now exposes `next_hop`, `next_hop_if_name`,
   `first_hop_timeout`, and `link_count`, and tracks blackholed identity
   list/add/remove state with Python-compatible malformed-input behavior and


### PR DESCRIPTION
## Summary

- make Reticulum's `enable_transport` setting the explicit source of truth for transport forwarding while preserving `set_retransmit` as a compatibility alias
- block known-path Link Requests, proofs, keepalives, established-link data, and resource traffic from transiting a disabled transport
- preserve local destinations and locally owned links, with regression coverage matching the two-interface topology from the issue
- update the Reticulum parity documentation to describe the enforced contract

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- `cargo test --workspace --tests`
- architecture boundary and module-size checks
- focused disabled-transport policy tests in `reticulumd` and `reticulum-rs-transport`

Fixes #491
