### PR TITLE
Share structured LXMF announce metadata codec

### DIFF
--- a/crates/apps/reticulumd/src/announce_names.rs
+++ b/crates/apps/reticulumd/src/announce_names.rs
@@ -60,47 +60,15 @@ pub fn encode_delivery_announce_app_data_with_capabilities(
     stamp_cost: Option<u32>,
     capabilities: &[String],
 ) -> Result<Vec<u8>, AnnounceEncodeError> {
-    let normalized =
-        normalize_display_name(display_name).ok_or(AnnounceEncodeError::InvalidDisplayName)?;
-    let stamp_cost = stamp_cost
-        .filter(|cost| *cost > 0 && *cost < 255)
-        .map(rmpv::Value::from)
-        .unwrap_or(rmpv::Value::Nil);
-    let mut peer_data = vec![rmpv::Value::Binary(normalized.into_bytes()), stamp_cost];
-    let capabilities = normalize_capabilities(capabilities);
-    if !capabilities.is_empty() {
-        let caps =
-            rmpv::Value::Array(capabilities.into_iter().map(rmpv::Value::from).collect::<Vec<_>>());
-        let payload = rmpv::Value::Map(vec![
-            (rmpv::Value::from("app"), rmpv::Value::from("rch")),
-            (rmpv::Value::from("schema"), rmpv::Value::from(1)),
-            (rmpv::Value::from("caps"), caps),
-        ]);
-        peer_data.push(rmpv::Value::Binary(encode_msgpack(&payload, "delivery capabilities")?));
-    }
-    let peer_data = rmpv::Value::Array(peer_data);
-    Ok(encode_msgpack(&peer_data, "delivery announce")?)
+    lxmf::announce::encode_delivery_announce_app_data_with_capabilities(
+        display_name,
+        stamp_cost,
+        capabilities,
+    )
 }
 
 pub fn normalize_capabilities(capabilities: &[String]) -> Vec<String> {
-    let mut normalized = Vec::new();
-    for capability in capabilities {
-        let capability = capability.trim().to_ascii_lowercase();
-        if capability.is_empty()
-            || capability.chars().any(|ch| {
-                !(ch.is_ascii_lowercase()
-                    || ch.is_ascii_digit()
-                    || ch == '_'
-                    || ch == '-'
-                    || ch == '.')
-            })
-            || normalized.iter().any(|existing| existing == &capability)
-        {
-            continue;
-        }
-        normalized.push(capability);
-    }
-    normalized
+    lxmf::announce::normalize_announce_capabilities(capabilities)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/libs/lxmf-core/src/announce.rs
+++ b/crates/libs/lxmf-core/src/announce.rs
@@ -5,6 +5,13 @@ use core::fmt;
 
 use crate::constants::{PN_META_NAME, SF_COMPRESSION};
 
+mod delivery_metadata;
+
+pub use delivery_metadata::{
+    capabilities_from_delivery_app_data, encode_delivery_announce_app_data_with_capabilities,
+    normalize_announce_capabilities,
+};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AnnounceSlot {
     pub id: u8,

--- a/crates/libs/lxmf-core/src/announce/delivery_metadata.rs
+++ b/crates/libs/lxmf-core/src/announce/delivery_metadata.rs
@@ -66,19 +66,27 @@ pub fn capabilities_from_delivery_app_data(
     // Slot one is the standard stamp cost, but earlier REM builds placed their
     // capability map there. An integer/nil stamp never matches this decoder,
     // so scanning extensions from slot one preserves that deployed layout.
-    Ok(entries.iter().skip(1).find_map(capabilities_from_metadata_value).unwrap_or_default())
+    for entry in entries.iter().skip(1) {
+        if let Some(capabilities) = capabilities_from_metadata_value(entry)? {
+            return Ok(capabilities);
+        }
+    }
+    Ok(Vec::new())
 }
 
-fn capabilities_from_metadata_value(value: &Value) -> Option<Vec<String>> {
+fn capabilities_from_metadata_value(
+    value: &Value,
+) -> Result<Option<Vec<String>>, AnnounceDecodeError> {
     match value {
-        Value::Map(entries) => entries.iter().find_map(|(key, value)| {
+        Value::Map(entries) => Ok(entries.iter().find_map(|(key, value)| {
             matches!(key, Value::String(actual) if matches!(actual.as_str(), Some("caps" | "announce_capabilities")))
                 .then(|| capabilities_from_array(value))
-        }),
-        Value::Binary(bytes) => rmp_serde::from_slice::<Value>(bytes)
-            .ok()
-            .and_then(|nested| capabilities_from_metadata_value(&nested)),
-        _ => None,
+        })),
+        Value::Binary(bytes) => {
+            let nested = rmp_serde::from_slice::<Value>(bytes)?;
+            capabilities_from_metadata_value(&nested)
+        }
+        _ => Ok(None),
     }
 }
 
@@ -154,5 +162,20 @@ mod tests {
             capabilities_from_delivery_app_data(app_data.as_slice()).expect("legacy capabilities"),
             alloc::vec!["r3akt".to_string(), "telemetry".to_string()]
         );
+    }
+
+    #[test]
+    fn decoder_rejects_malformed_binary_capability_metadata() {
+        let malformed = Value::Array(alloc::vec![
+            Value::from("Malformed metadata"),
+            Value::Nil,
+            Value::Binary(alloc::vec![0xc1]),
+        ]);
+        let app_data = rmp_serde::to_vec(&malformed).expect("delivery announce msgpack");
+
+        assert!(matches!(
+            capabilities_from_delivery_app_data(app_data.as_slice()),
+            Err(AnnounceDecodeError::Msgpack(_))
+        ));
     }
 }

--- a/crates/libs/lxmf-core/src/announce/delivery_metadata.rs
+++ b/crates/libs/lxmf-core/src/announce/delivery_metadata.rs
@@ -1,0 +1,158 @@
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use rmpv::Value;
+
+use super::{normalize_display_name, AnnounceDecodeError, AnnounceEncodeError};
+
+const CAPABILITY_METADATA_APP: &str = "rch";
+const CAPABILITY_METADATA_SCHEMA: i64 = 1;
+
+pub fn normalize_announce_capabilities(capabilities: &[String]) -> Vec<String> {
+    let mut normalized = Vec::new();
+    for capability in capabilities {
+        let capability = capability.trim().to_ascii_lowercase();
+        if capability.is_empty()
+            || capability.chars().any(|ch| {
+                !(ch.is_ascii_lowercase()
+                    || ch.is_ascii_digit()
+                    || ch == '_'
+                    || ch == '-'
+                    || ch == '.')
+            })
+            || normalized.iter().any(|existing| existing == &capability)
+        {
+            continue;
+        }
+        normalized.push(capability);
+    }
+    normalized
+}
+
+pub fn encode_delivery_announce_app_data_with_capabilities(
+    display_name: &str,
+    stamp_cost: Option<u32>,
+    capabilities: &[String],
+) -> Result<Vec<u8>, AnnounceEncodeError> {
+    let normalized =
+        normalize_display_name(display_name).ok_or(AnnounceEncodeError::InvalidDisplayName)?;
+    let stamp_cost =
+        stamp_cost.filter(|cost| *cost > 0 && *cost < 255).map(Value::from).unwrap_or(Value::Nil);
+    let mut peer_data = alloc::vec![Value::Binary(normalized.into_bytes()), stamp_cost];
+    let capabilities = normalize_announce_capabilities(capabilities);
+    if !capabilities.is_empty() {
+        let caps = Value::Array(capabilities.into_iter().map(Value::from).collect());
+        let metadata = Value::Map(alloc::vec![
+            (Value::from("app"), Value::from(CAPABILITY_METADATA_APP)),
+            (Value::from("schema"), Value::from(CAPABILITY_METADATA_SCHEMA)),
+            (Value::from("caps"), caps),
+        ]);
+        let encoded_metadata = rmp_serde::to_vec(&metadata)?;
+        peer_data.push(Value::Binary(encoded_metadata));
+    }
+    rmp_serde::to_vec(&Value::Array(peer_data)).map_err(AnnounceEncodeError::from)
+}
+
+pub fn capabilities_from_delivery_app_data(
+    data: &[u8],
+) -> Result<Vec<String>, AnnounceDecodeError> {
+    if data.is_empty() {
+        return Ok(Vec::new());
+    }
+    let decoded: Value = rmp_serde::from_slice(data)?;
+    let Value::Array(entries) = decoded else {
+        return Ok(Vec::new());
+    };
+    // Slot one is the standard stamp cost, but earlier REM builds placed their
+    // capability map there. An integer/nil stamp never matches this decoder,
+    // so scanning extensions from slot one preserves that deployed layout.
+    Ok(entries.iter().skip(1).find_map(capabilities_from_metadata_value).unwrap_or_default())
+}
+
+fn capabilities_from_metadata_value(value: &Value) -> Option<Vec<String>> {
+    match value {
+        Value::Map(entries) => entries.iter().find_map(|(key, value)| {
+            matches!(key, Value::String(actual) if matches!(actual.as_str(), Some("caps" | "announce_capabilities")))
+                .then(|| capabilities_from_array(value))
+        }),
+        Value::Binary(bytes) => rmp_serde::from_slice::<Value>(bytes)
+            .ok()
+            .and_then(|nested| capabilities_from_metadata_value(&nested)),
+        _ => None,
+    }
+}
+
+fn capabilities_from_array(value: &Value) -> Vec<String> {
+    let Value::Array(values) = value else {
+        return Vec::new();
+    };
+    normalize_announce_capabilities(
+        &values
+            .iter()
+            .filter_map(|value| value.as_str().map(ToString::to_string))
+            .collect::<Vec<_>>(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::announce::{display_name_from_app_data, stamp_cost_from_app_data};
+
+    #[test]
+    fn structured_capabilities_preserve_standard_delivery_slots() {
+        let app_data = encode_delivery_announce_app_data_with_capabilities(
+            "Field Team One",
+            Some(17),
+            &[
+                "R3AKT".to_string(),
+                "emergencymessages".to_string(),
+                "rem.standard_lxmf_receipts.v1".to_string(),
+            ],
+        )
+        .expect("structured delivery announce");
+
+        assert_eq!(
+            display_name_from_app_data(Some(app_data.as_slice())),
+            Some("Field Team One".to_string())
+        );
+        assert_eq!(stamp_cost_from_app_data(Some(app_data.as_slice())), Some(17));
+        assert_eq!(
+            capabilities_from_delivery_app_data(app_data.as_slice()).expect("capability metadata"),
+            alloc::vec![
+                "r3akt".to_string(),
+                "emergencymessages".to_string(),
+                "rem.standard_lxmf_receipts.v1".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn delivery_announce_without_capabilities_keeps_python_shape() {
+        let app_data =
+            encode_delivery_announce_app_data_with_capabilities("Field Team Two", None, &[])
+                .expect("standard delivery announce");
+        let decoded: Value = rmp_serde::from_slice(app_data.as_slice()).expect("msgpack");
+        assert!(matches!(decoded, Value::Array(entries) if entries.len() == 2));
+        assert!(capabilities_from_delivery_app_data(app_data.as_slice())
+            .expect("empty capabilities")
+            .is_empty());
+    }
+
+    #[test]
+    fn decoder_accepts_legacy_rem_capabilities_in_stamp_slot() {
+        let legacy = Value::Array(alloc::vec![
+            Value::from("Legacy REM"),
+            Value::Map(alloc::vec![(
+                Value::from("caps"),
+                Value::Array(alloc::vec![Value::from("R3AKT"), Value::from("Telemetry")]),
+            )]),
+        ]);
+        let app_data = rmp_serde::to_vec(&legacy).expect("legacy msgpack");
+
+        assert_eq!(
+            capabilities_from_delivery_app_data(app_data.as_slice()).expect("legacy capabilities"),
+            alloc::vec!["r3akt".to_string(), "telemetry".to_string()]
+        );
+    }
+}

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -78,7 +78,11 @@ single-destination policy mutators alongside the broader Python convenience
 surface, reuses identified direct backchannels, preserves delivery-trace and
 opportunistic packet metadata, and resolves conversation display names from
 durable delivery announces even when delivery announces are intentionally not
-promoted to propagation peers. The `rnx` soak harness now discovers delivery
+promoted to propagation peers. Standard delivery announce encoding now has one
+shared core helper that preserves the Python-compatible display-name and stamp
+slots while placing optional application capability metadata in an extension
+slot, so applications do not need daemon-local or callsign-based encoders. The
+`rnx` soak harness now discovers delivery
 destinations from that durable announce surface, enables transport forwarding
 for mesh nodes, and requires full-mesh destination visibility before delivery.
 Inbound routing now resolves full-wire packets and resources received over an

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -665,6 +665,11 @@ traits. Row-level transport classification is generated in
 - Python-style `lxmd` `[lxmf] announce_interval` drives peer/delivery announce
   cadence separately from `[propagation] announce_interval`, which remains the
   propagation-node announce cadence.
+- Delivery announce application data uses the shared `lxmf-wire` structured
+  encoder/decoder: the Python-compatible display-name and stamp-cost positions
+  remain stable, while optional application capability strings occupy an
+  extension metadata slot. `reticulumd` and embedded consumers use the same
+  codec instead of encoding capabilities in callsigns or private text formats.
 - Outbound propagated delivery resolves selected propagation-node
   `propagation_stamp_cost` case-insensitively, so Python-style hash casing does
   not fall back to the default propagation stamp cost.


### PR DESCRIPTION
## Summary

- add a shared LXMF delivery-announce metadata encoder and decoder in `lxmf-wire`
- preserve the standard display-name and stamp-cost slots while carrying optional capability metadata in an extension slot
- retain decoding compatibility with the structured layout emitted by deployed REM versions
- make `reticulumd` use the shared codec instead of a daemon-local implementation

## Why

Applications were encoding capability information through private announce strings or local copies of the MsgPack layout. Centralizing the structured delivery metadata in LXMF-rs gives embedded clients a regular, interoperable API while preserving Python-compatible announce fields.

## Impact

Generic LXMF clients can continue reading the standard display name and stamp cost and ignore the extension. REM and other capability-aware clients can use the optional metadata without placing capabilities in callsigns.

## Validation

- `cargo test -p lxmf-wire`
- `cargo test -p reticulumd encodes_delivery_app_data_with_rch_capability_payload`
- `cargo clippy -p lxmf-wire -p reticulumd --all-targets -- -D warnings`
- `git diff --check origin/main...HEAD`
