### PR TITLE
Stop requiring an exact received_from match for direct (Type1) addressing

### DIFF
--- a/crates/libs/rns-transport/src/transport/path.rs
+++ b/crates/libs/rns-transport/src/transport/path.rs
@@ -83,10 +83,18 @@ pub(super) fn route_outbound_packet(
         return RouteDecision { packet: original_packet.clone(), next_iface: None };
     };
 
-    if entry.hops <= 1
-        && entry.received_from == original_packet.destination
-        && !connected_to_shared_instance
-    {
+    // Direct (Type1) addressing only requires that the destination is
+    // within one hop — it does not additionally require that its path was
+    // learned via a direct announce (`received_from == destination`).
+    // Confirmed via a byte-for-byte wire capture of a real NomadNet
+    // client's own successful LinkRequest: its path table recorded this
+    // exact shape (hops=1, received_from = the upstream hub's identity,
+    // not the destination's own hash — i.e. learned via a PathResponse,
+    // not a direct announce) and it still sent a plain Type1 LinkRequest,
+    // successfully. With exactly one physically-attached interface, there
+    // is no ambiguous next hop for Type2's explicit transport field to
+    // disambiguate, so `received_from` doesn't factor into this decision.
+    if entry.hops <= 1 && !connected_to_shared_instance {
         return RouteDecision { packet: original_packet.clone(), next_iface: Some(entry.iface) };
     }
 

--- a/crates/libs/rns-transport/src/transport/path_tests.rs
+++ b/crates/libs/rns-transport/src/transport/path_tests.rs
@@ -118,8 +118,17 @@ mod tests {
         assert_eq!(decision.packet.transport, Some(next_hop));
     }
 
+    // Confirmed via a byte-for-byte wire capture of a real NomadNet
+    // client's own successful LinkRequest against a real destination with
+    // this exact path-table shape (hops=1, received_from = the upstream
+    // hub's identity, not the destination's own hash — i.e. learned via a
+    // PathResponse, not a direct announce): it sent a plain Type1
+    // LinkRequest and it worked. With exactly one physically-attached
+    // interface there is no ambiguous next hop for Type2's explicit
+    // transport field to disambiguate, so `received_from` doesn't factor
+    // into this decision.
     #[test]
-    fn outbound_one_hop_transport_promotes_to_type2_transport() {
+    fn outbound_one_hop_via_relay_still_uses_type1() {
         let destination = AddressHash::new_from_hash(&Hash::new_from_slice(b"destination"));
         let iface = AddressHash::new_from_hash(&Hash::new_from_slice(b"iface"));
         let transport_hop = AddressHash::new_from_hash(&Hash::new_from_slice(b"transport_hop"));
@@ -136,9 +145,9 @@ mod tests {
         let decision = route_outbound_packet(&table, &packet, false);
 
         assert_eq!(decision.next_iface, Some(iface));
-        assert_eq!(decision.packet.header.header_type, HeaderType::Type2);
-        assert_eq!(decision.packet.header.propagation_type, PropagationType::Transport);
-        assert_eq!(decision.packet.transport, Some(transport_hop));
+        assert_eq!(decision.packet.header.header_type, HeaderType::Type1);
+        assert_eq!(decision.packet.header.propagation_type, PropagationType::Broadcast);
+        assert_eq!(decision.packet.transport, None);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #500.

## What changed

`route_outbound_packet` required both `hops <= 1` AND `entry.received_from == original_packet.destination` before addressing a destination directly (Type1). The second condition meant the path also had to be learned via a direct announce with zero intervening relays — which almost nothing reached through a Transport hub satisfies, since a path learned via a `PathResponse` (or any relayed announce) records `received_from` as the relaying node's own hash, not the destination's, even at `hops=1` or `0`.

This drops that extra condition, relying on hop count alone — matching what a real reference client actually does (see the linked issue for the wire-capture evidence: identical path-table shape, `hops=1` + `received_from` = a relay's hash, and the real client still sent Type1 successfully).

Genuinely multi-hop destinations are unaffected — `hops <= 1` still gates the decision, so a destination two or more hops away still correctly gets Type2-wrapped (unchanged, still covered by `outbound_multihop_promotes_to_type2_transport`).

## Testing

- `cargo test` — 542 passed, 0 failed (full workspace)
- `cargo clippy --lib --tests` — clean
- `cargo fmt --check` — clean on touched files
- `tools/scripts/check-module-size.sh` — ok
- Corrected the one test that encoded the old (incorrect) assumption, renamed to `outbound_one_hop_via_relay_still_uses_type1` to describe the actual scenario and expected behavior
- Verified live against a real destination previously affected by this bug: with this fix, a fresh, unforced fetch succeeds where it previously timed out waiting for a Proof that was never sent, because the LinkRequest never reached the hosting process in Type2-wrapped form

🤖 Generated with [Claude Code](https://claude.com/claude-code)