### PR TITLE
Resolve missing LXMF destination identities before send

### DIFF
--- a/crates/libs/lxmf-runtime/src/delivery.rs
+++ b/crates/libs/lxmf-runtime/src/delivery.rs
@@ -70,7 +70,13 @@ pub(crate) async fn send(
     request: &SendRequest,
 ) -> Result<InProcessSendReport, SdkError> {
     let requested_destination = parse_hash(&request.destination)?;
-    let remote = resolve_destination(context.transport, requested_destination, "delivery").await?;
+    let remote = resolve_destination(
+        context.transport,
+        requested_destination,
+        "delivery",
+        context.link_connect_timeout,
+    )
+    .await?;
     let wire = encode_wire(context.identity, context.source_destination, &remote, request)?;
     let message_id = MessageId(hex::encode(
         WireMessage::unpack(&wire)
@@ -152,7 +158,13 @@ async fn send_propagated(
         .transpose()?
         .or(context.propagation_relay)
         .ok_or_else(|| transport_error("no propagation relay selected"))?;
-    let relay = resolve_destination(context.transport, relay_hash, "propagation").await?;
+    let relay = resolve_destination(
+        context.transport,
+        relay_hash,
+        "propagation",
+        context.link_connect_timeout,
+    )
+    .await?;
     let recipient = lxmf_core::identity::Identity::new_from_slices(
         remote.identity.public_key_bytes(),
         remote.identity.verifying_key_bytes(),
@@ -222,15 +234,22 @@ fn encode_wire(
         .map_err(|err| internal(format!("failed to encode LXMF message: {err}")))
 }
 
-async fn resolve_destination(
+pub(crate) async fn resolve_destination(
     transport: &Transport,
     hash: AddressHash,
     aspect: &str,
+    timeout: Duration,
 ) -> Result<DestinationDesc, SdkError> {
-    let identity = transport
-        .destination_identity(&hash)
-        .await
-        .ok_or_else(|| transport_error(format!("destination identity unavailable for {hash}")))?;
+    let identity = if let Some(identity) = transport.destination_identity(&hash).await {
+        identity
+    } else {
+        transport.await_path(&hash, timeout, None).await;
+        transport.destination_identity(&hash).await.ok_or_else(|| {
+            transport_error(format!(
+                "destination identity unavailable for {hash} after path resolution"
+            ))
+        })?
+    };
     Ok(DestinationDesc { identity, name: DestinationName::new("lxmf", aspect), address_hash: hash })
 }
 

--- a/crates/libs/lxmf-runtime/src/tests.rs
+++ b/crates/libs/lxmf-runtime/src/tests.rs
@@ -16,7 +16,7 @@ use tokio::sync::broadcast;
 
 use crate::delivery::{
     forced_representation, request_link_attempts, request_link_timeout, request_resource_timeout,
-    requested_method,
+    requested_method, resolve_destination,
 };
 use crate::link_delivery::await_resource_completion;
 use crate::{
@@ -70,6 +70,33 @@ fn accepted_result_uses_short_link_timeout_unless_overridden() {
 
     request.extensions.insert(EXT_LINK_CONNECT_TIMEOUT_MS.to_owned(), json!(75_000));
     assert_eq!(request_link_timeout(&request, Duration::from_secs(20)), Duration::from_secs(75));
+}
+
+#[tokio::test]
+async fn missing_destination_identity_requests_path_before_failing() {
+    let identity = rns_transport::identity::PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new(
+        "lxmf-runtime-identity-resolution-test",
+        &identity,
+        true,
+    ));
+    let mut iface = transport.iface_manager().lock().await.new_channel(4);
+    let unknown = AddressHash::new([0x44; rns_transport::hash::ADDRESS_HASH_SIZE]);
+
+    let error =
+        match resolve_destination(&transport, unknown, "delivery", Duration::from_millis(55)).await
+        {
+            Ok(_) => panic!("unknown destination must remain unavailable"),
+            Err(error) => error,
+        };
+
+    assert_eq!(error.category, lxmf_sdk::ErrorCategory::Transport);
+    assert!(error.message.contains("after path resolution"));
+    let path_request = iface.tx_channel.try_recv().expect("path request must be broadcast");
+    assert_eq!(
+        &path_request.packet.data.as_slice()[..rns_transport::hash::ADDRESS_HASH_SIZE],
+        unknown.as_slice()
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- request a normal Reticulum path when an LXMF recipient or propagation relay identity is not cached
- wait up to the configured link timeout for the announce identity before encoding the message
- preserve a transport error when discovery completes without an identity

## Verification
- `cargo test -p lxmf-runtime`
- `cargo clippy -p lxmf-runtime --all-targets -- -D warnings`
- regression test confirms a path request is broadcast before failure