### PR TITLE
Fix some bugs that would potentially allow crypto side channel timing attacks

### DIFF
--- a/crates/libs/rns-core/src/crypt/fernet.rs
+++ b/crates/libs/rns-core/src/crypt/fernet.rs
@@ -187,21 +187,9 @@ impl<R: CryptoRngCore + Copy> Fernet<R> {
 
         hmac.update(&token_data[..token_data.len() - HMAC_OUT_SIZE]);
 
-        let actual_tag = hmac.finalize().into_bytes();
+        hmac.verify_slice(expected_tag).map_err(|_| RnsError::IncorrectSignature)?;
 
-        let valid = expected_tag
-            .iter()
-            .zip(actual_tag.as_slice())
-            .map(|(x, y)| x.cmp(y))
-            .find(|&ord| ord != cmp::Ordering::Equal)
-            .unwrap_or(actual_tag.len().cmp(&expected_tag.len()))
-            == cmp::Ordering::Equal;
-
-        if valid {
-            Ok(VerifiedToken(token_data))
-        } else {
-            Err(RnsError::IncorrectSignature)
-        }
+        Ok(VerifiedToken(token_data))
     }
 
     pub fn decrypt<'a, 'b>(

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_auth_http.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_auth_http.rs
@@ -188,16 +188,27 @@ impl RpcDaemon {
                     let signed_payload = zeroize::Zeroizing::new(format!(
                         "iss={issuer};aud={audience};jti={jti};sub={subject};iat={iat};exp={exp}"
                     ));
-                    let expected_signature = zeroize::Zeroizing::new(Self::token_signature(
-                        shared_secret.as_str(),
-                        signed_payload.as_str(),
-                    ));
-                    if signature != expected_signature.as_str() {
-                        return Err(RpcError::new(
+                    let signature_bytes = hex::decode(signature).map_err(|_| {
+                        RpcError::new(
+                            "SDK_SECURITY_TOKEN_INVALID".to_string(),
+                            "token signature is invalid".to_string(),
+                        )
+                    })?;
+                    let mut mac =
+                        hmac::Hmac::<sha2::Sha256>::new_from_slice(shared_secret.as_bytes())
+                            .map_err(|_| {
+                                RpcError::new(
+                                    "SDK_SECURITY_TOKEN_INVALID".to_string(),
+                                    "token authentication failed".to_string(),
+                                )
+                            })?;
+                    mac.update(signed_payload.as_bytes());
+                    mac.verify_slice(&signature_bytes).map_err(|_| {
+                        RpcError::new(
                             "SDK_SECURITY_TOKEN_INVALID".to_string(),
                             "token signature does not match runtime policy".to_string(),
-                        ));
-                    }
+                        )
+                    })?;
                     if issuer != expected_issuer || audience != expected_audience {
                         return Err(RpcError::new(
                             "SDK_SECURITY_TOKEN_INVALID".to_string(),

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_capabilities.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_capabilities.rs
@@ -106,6 +106,7 @@ impl RpcDaemon {
         Some(claims)
     }
 
+    #[cfg(test)]
     pub(super) fn token_signature(secret: &str, payload: &str) -> String {
         let mut mac = hmac::Hmac::<sha2::Sha256>::new_from_slice(secret.as_bytes())
             .expect("HMAC key length is valid for HMAC-SHA256");

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/negotiate_security_parts/sdk_negotiate_v2_selects_contract_an.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/negotiate_security_parts/sdk_negotiate_v2_selects_contract_an.rs
@@ -417,4 +417,13 @@
             .authorize_http_request(&tampered_headers, Some("10.5.6.7"))
             .expect_err("tampered signature should be rejected");
         assert_eq!(tampered.code, "SDK_SECURITY_TOKEN_INVALID");
+        assert_eq!(tampered.message, "token signature does not match runtime policy");
+
+        let malformed_headers =
+            vec![("authorization".to_string(), format!("Bearer {valid_payload};sig=not-hex"))];
+        let malformed = daemon
+            .authorize_http_request(&malformed_headers, Some("10.5.6.7"))
+            .expect_err("malformed signature should be rejected");
+        assert_eq!(malformed.code, "SDK_SECURITY_TOKEN_INVALID");
+        assert_eq!(malformed.message, "token signature is invalid");
     }

--- a/crates/libs/rns-transport/src/crypt/fernet.rs
+++ b/crates/libs/rns-transport/src/crypt/fernet.rs
@@ -187,21 +187,9 @@ impl<R: CryptoRngCore + Copy> Fernet<R> {
 
         hmac.update(&token_data[..token_data.len() - HMAC_OUT_SIZE]);
 
-        let actual_tag = hmac.finalize().into_bytes();
+        hmac.verify_slice(expected_tag).map_err(|_| RnsError::IncorrectSignature)?;
 
-        let valid = expected_tag
-            .iter()
-            .zip(actual_tag.as_slice())
-            .map(|(x, y)| x.cmp(y))
-            .find(|&ord| ord != cmp::Ordering::Equal)
-            .unwrap_or(actual_tag.len().cmp(&expected_tag.len()))
-            == cmp::Ordering::Equal;
-
-        if valid {
-            Ok(VerifiedToken(token_data))
-        } else {
-            Err(RnsError::IncorrectSignature)
-        }
+        Ok(VerifiedToken(token_data))
     }
 
     pub fn decrypt<'a, 'b>(
@@ -266,21 +254,9 @@ impl CachedFernet {
 
         hmac.update(&token_data[..token_data.len() - HMAC_OUT_SIZE]);
 
-        let actual_tag = hmac.finalize().into_bytes();
+        hmac.verify_slice(expected_tag).map_err(|_| RnsError::IncorrectSignature)?;
 
-        let valid = expected_tag
-            .iter()
-            .zip(actual_tag.as_slice())
-            .map(|(x, y)| x.cmp(y))
-            .find(|&ord| ord != cmp::Ordering::Equal)
-            .unwrap_or(actual_tag.len().cmp(&expected_tag.len()))
-            == cmp::Ordering::Equal;
-
-        if valid {
-            Ok(VerifiedToken(token_data))
-        } else {
-            Err(RnsError::IncorrectSignature)
-        }
+        Ok(VerifiedToken(token_data))
     }
 
     pub fn decrypt<'a, 'b>(


### PR DESCRIPTION
## Summary

I had some issues with how reticulum handles some of the cryptography in the Python implementation and decided to take a look here. As these are very simply fixed, I wrote a small patch.

The main issue is that when you are comparing two arrays of bytes to each other and exit earlier, this allows for consecutive brute forcing of the secret. Suppose the following situation: Eve wants to log into Alice's server but doesn't know the password. She tries different ones and suddenly notices that the response from Alice is coming back at different speeds. Indeed, suppose we have [g, o, o, d, p, a, s, s , w, o, r, d] as the array that Alice is checking against. Then Eve first submits 'a' and checks it to any other character like 'b'. She checks it against all other bytes she knows until 'g'. For this one byte it is the case that Alice takes a very short time longer to say "no." This is how Eve knows the first byte has been correctly guessed: Alice did not stop at comparing the first byte, but at the second one. Now Eve saves the byte and does the same with the next byte until she cracks the password.

In my patch I replace the manual comparisons I found in this crate with the ones provided by the libraries themselves (in the hopes that the cryptographers there correctly implement it). A review should be trivial.

## Type
- [ ] breaking
- [ ] refactor
- [ ] reliability
- [x] security
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `make test`
- [x] `make test-all` (optional compatibility pass)
- [x] `make test-full-targets` (optional full-target parity check)
- [x] `cargo doc --workspace --no-deps`
- [x] `cargo deny check`
- [x] `cargo audit`

## Compatibility
- [x] Updated compatibility matrix / contract docs (if needed)
