### PR TITLE
Replace rustls-pemfile with rustls-pki-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
  "lxmf-wire",
  "reticulum-rs-rpc",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "sha2",
@@ -2267,7 +2267,7 @@ dependencies = [
  "rmp-serde",
  "rmpv",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "sha2",
@@ -2452,19 +2452,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ tokio-serial = "5.4.4"
 tokio-stream = "0.1"
 zeromq = { version = "0.6.0", default-features = false, features = ["tokio-runtime", "tcp-transport"] }
 rustls = "0.23.23"
-rustls-pemfile = "2.2.0"
+rustls-pki-types = { version = "1.15", features = ["std"] }
 x509-parser = "0.16.0"
 rand_core = "0.6.4"
 x25519-dalek = "2.0.1"

--- a/crates/apps/reticulumd/Cargo.toml
+++ b/crates/apps/reticulumd/Cargo.toml
@@ -35,7 +35,7 @@ serde = { workspace = true }
 toml = { workspace = true }
 tokio-rustls = { workspace = true }
 rustls = { workspace = true }
-rustls-pemfile = { workspace = true }
+rustls-pki-types = { workspace = true }
 x509-parser = { workspace = true }
 zeromq = { workspace = true, optional = true }
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/module_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/module_core.rs
@@ -8,13 +8,13 @@ use rustls::server::WebPkiClientVerifier;
 
 use rustls::{RootCertStore, ServerConfig};
 
-use rustls_pemfile::private_key;
+use rustls_pki_types::pem::PemObject;
 
 use serde_json::json;
 
 use std::fs::File;
 
-use std::io::{self, BufReader};
+use std::io;
 
 use std::net::{IpAddr, SocketAddr};
 

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/read_http_request.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/read_http_request.rs
@@ -109,9 +109,9 @@ fn build_tls_server_config(config: &RpcTlsConfig) -> io::Result<std::sync::Arc<S
 
 fn load_cert_chain(path: &Path) -> io::Result<Vec<rustls::pki_types::CertificateDer<'static>>> {
     let file = File::open(path)?;
-    let mut reader = BufReader::new(file);
-    let certificates =
-        rustls_pemfile::certs(&mut reader).collect::<Result<Vec<_>, _>>().map_err(|err| {
+    let certificates = rustls::pki_types::CertificateDer::pem_reader_iter(file)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("failed to parse PEM certs from {}: {}", path.display(), err),
@@ -128,13 +128,15 @@ fn load_cert_chain(path: &Path) -> io::Result<Vec<rustls::pki_types::Certificate
 
 fn load_private_key(path: &Path) -> io::Result<rustls::pki_types::PrivateKeyDer<'static>> {
     let file = File::open(path)?;
-    let mut reader = BufReader::new(file);
-    let key = private_key(&mut reader).map_err(|err| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("failed to parse private key {}: {}", path.display(), err),
-        )
-    })?;
+    let key = rustls::pki_types::PrivateKeyDer::pem_reader_iter(file)
+        .next()
+        .transpose()
+        .map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to parse private key {}: {}", path.display(), err),
+            )
+        })?;
     key.ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidData,
@@ -230,6 +232,43 @@ mod rpc_loop_tests {
         let line = rpc_ready_line("http", "127.0.0.1:4242");
 
         assert!(line.contains("listening on http://127.0.0.1:4242"));
+    }
+
+    #[test]
+    fn tls_pem_loaders_accept_certificate_and_private_key_sections() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cert_path = temp.path().join("certificate.pem");
+        let key_path = temp.path().join("private-key.pem");
+        std::fs::write(
+            &cert_path,
+            b"-----BEGIN CERTIFICATE-----\nAQID\n-----END CERTIFICATE-----\n",
+        )
+        .expect("write certificate");
+        std::fs::write(
+            &key_path,
+            b"-----BEGIN PRIVATE KEY-----\nAQID\n-----END PRIVATE KEY-----\n",
+        )
+        .expect("write private key");
+
+        let certificates = load_cert_chain(&cert_path).expect("load certificate");
+        let private_key = load_private_key(&key_path).expect("load private key");
+
+        assert_eq!(certificates.len(), 1);
+        assert_eq!(certificates[0].as_ref(), &[1, 2, 3]);
+        assert_eq!(private_key.secret_der(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn tls_pem_loaders_report_files_without_matching_sections() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("empty.pem");
+        std::fs::write(&path, b"").expect("write empty PEM file");
+
+        let cert_error = load_cert_chain(&path).expect_err("empty certificate file rejected");
+        let key_error = load_private_key(&path).expect_err("empty private key file rejected");
+
+        assert!(cert_error.to_string().contains("no certificates found"));
+        assert!(key_error.to_string().contains("no private key found"));
     }
 
     #[test]

--- a/crates/libs/lxmf-sdk/Cargo.toml
+++ b/crates/libs/lxmf-sdk/Cargo.toml
@@ -16,7 +16,7 @@ lxmf-reference.workspace = true
 lxmf-core.workspace = true
 rns-rpc = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
-rustls-pemfile = { workspace = true, optional = true }
+rustls-pki-types = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
@@ -33,7 +33,7 @@ zeroize.workspace = true
 default = ["std", "sdk-async", "rpc-backend", "zmq-pipeline-backend"]
 std = []
 sdk-async = ["dep:tokio", "dep:tokio-stream"]
-rpc-backend = ["std", "dep:rns-rpc", "dep:rustls", "dep:rustls-pemfile", "dep:tokio-rustls"]
+rpc-backend = ["std", "dep:rns-rpc", "dep:rustls", "dep:rustls-pki-types", "dep:tokio-rustls"]
 zmq-pipeline-backend = ["std", "sdk-async", "dep:rns-rpc", "dep:zeromq"]
 embedded-alloc = []
 loom-tests = []

--- a/crates/libs/lxmf-sdk/benches/sdk_client_paths_parts/sample_start_request.rs
+++ b/crates/libs/lxmf-sdk/benches/sdk_client_paths_parts/sample_start_request.rs
@@ -213,11 +213,18 @@ fn bench_slow_subscriber_memory(c: &mut Criterion) {
                             .await
                             .expect("stream should yield")
                             .expect("event should parse");
-                        let _ = stats.queued.fetch_update(
-                            Ordering::Relaxed,
-                            Ordering::Relaxed,
-                            |queued| Some(queued.saturating_sub(1)),
-                        );
+                        let mut queued = stats.queued.load(Ordering::Relaxed);
+                        loop {
+                            match stats.queued.compare_exchange_weak(
+                                queued,
+                                queued.saturating_sub(1),
+                                Ordering::Relaxed,
+                                Ordering::Relaxed,
+                            ) {
+                                Ok(_) => break,
+                                Err(current) => queued = current,
+                            }
+                        }
                         stats.observe();
                         observed = event.metadata.seq_no;
                         tokio::time::sleep(Duration::from_micros(50)).await;

--- a/crates/libs/lxmf-sdk/fuzz/Cargo.lock
+++ b/crates/libs/lxmf-sdk/fuzz/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
  "lxmf-wire",
  "reticulum-rs-rpc",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "sha2",
@@ -1008,19 +1008,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]

--- a/crates/libs/lxmf-sdk/src/backend/rpc/transport_parts/module_prelude.rs
+++ b/crates/libs/lxmf-sdk/src/backend/rpc/transport_parts/module_prelude.rs
@@ -16,13 +16,13 @@ use rustls::pki_types::ServerName;
 
 use rustls::{ClientConfig, RootCertStore};
 
-use rustls_pemfile::private_key;
+use rustls_pki_types::pem::PemObject;
 
 use sha2::Sha256;
 
 use std::fs::File;
 
-use std::io::{self, BufReader, Read, Write};
+use std::io::{Read, Write};
 
 use std::net::{IpAddr, Shutdown, TcpStream};
 

--- a/crates/libs/lxmf-sdk/src/backend/rpc/transport_parts/rpcbackendclient_sections/call_rpc.rs
+++ b/crates/libs/lxmf-sdk/src/backend/rpc/transport_parts/rpcbackendclient_sections/call_rpc.rs
@@ -430,9 +430,8 @@ impl RpcBackendClient {
                 format!("failed to open mtls certificate chain {}: {}", path.display(), err),
             )
         })?;
-        let mut reader = BufReader::new(file);
-        let certificates = rustls_pemfile::certs(&mut reader)
-            .collect::<Result<Vec<_>, io::Error>>()
+        let certificates = rustls::pki_types::CertificateDer::pem_reader_iter(file)
+            .collect::<Result<Vec<_>, _>>()
             .map_err(|err| {
                 SdkError::new(
                     code::SECURITY_AUTH_REQUIRED,

--- a/crates/libs/lxmf-sdk/src/backend/rpc/transport_parts/rpcbackendclient_sections/load_private_key.rs
+++ b/crates/libs/lxmf-sdk/src/backend/rpc/transport_parts/rpcbackendclient_sections/load_private_key.rs
@@ -10,14 +10,16 @@ impl RpcBackendClient {
                 format!("failed to open mtls private key {}: {}", path.display(), err),
             )
         })?;
-        let mut reader = BufReader::new(file);
-        let key = private_key(&mut reader).map_err(|err| {
-            SdkError::new(
-                code::SECURITY_AUTH_REQUIRED,
-                ErrorCategory::Security,
-                format!("failed to parse mtls private key {}: {}", path.display(), err),
-            )
-        })?;
+        let key = rustls::pki_types::PrivateKeyDer::pem_reader_iter(file)
+            .next()
+            .transpose()
+            .map_err(|err| {
+                SdkError::new(
+                    code::SECURITY_AUTH_REQUIRED,
+                    ErrorCategory::Security,
+                    format!("failed to parse mtls private key {}: {}", path.display(), err),
+                )
+            })?;
         key.ok_or_else(|| {
             SdkError::new(
                 code::SECURITY_AUTH_REQUIRED,

--- a/deny.toml
+++ b/deny.toml
@@ -5,8 +5,6 @@ all-features = true
 version = 2
 yanked = "deny"
 ignore = [
-  # Temporary: rustls-pemfile is archived upstream while rustls-pki-types migration is tracked.
-  "RUSTSEC-2025-0134",
   # Temporary: idna / time / paste advisories are known upstream dependency issues on this branch.
   "RUSTSEC-2024-0421",
   "RUSTSEC-2024-0436",

--- a/docs/runbooks/release-readiness.md
+++ b/docs/runbooks/release-readiness.md
@@ -56,7 +56,7 @@ Current GitHub PR CI in `.github/workflows/ci.yml` enforces these jobs:
   - `cargo run -p xtask -- sdk-migration-check`
 - `security`
   - `cargo deny check bans licenses sources`
-  - `cargo audit --ignore RUSTSEC-2024-0421 --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2026-0009 --ignore RUSTSEC-2025-0134`
+  - `cargo audit --ignore RUSTSEC-2024-0421 --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2026-0009`
 
 `.github/workflows/python-interop.yml` is also a pull-request gate for pinned
 reference compatibility. It runs:

--- a/xtask/src/main_parts/interop_baseline_path.rs
+++ b/xtask/src/main_parts/interop_baseline_path.rs
@@ -139,7 +139,7 @@ const DAEMON_RELEASE_BINARIES: &[(&str, &str)] = &[
 ];
 
 const CARGO_AUDIT_IGNORE_ADVISORIES: &[&str] =
-    &["RUSTSEC-2024-0421", "RUSTSEC-2024-0436", "RUSTSEC-2026-0009", "RUSTSEC-2025-0134"];
+    &["RUSTSEC-2024-0421", "RUSTSEC-2024-0436", "RUSTSEC-2026-0009"];
 
 const SCHEMA_CLIENT_SMOKE_REPORT_PATH: &str = "target/interop/schema-client-smoke-report.txt";
 


### PR DESCRIPTION
## Summary

Contributor guide: `CONTRIBUTING.md`

## Type
- [ ] breaking
- [ ] refactor
- [ ] reliability
- [x] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `make test`
- [x] `make test-all` (optional compatibility pass)
- [x] `make test-full-targets` (optional full-target parity check)
- [x] `cargo doc --workspace --no-deps`
- [x] `cargo deny check`
- [x] `cargo audit`

## Compatibility
- [x] Updated compatibility matrix / contract docs (if needed)
