### PR TITLE
Bound RPC connections and secure the Unix socket

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop.rs
@@ -7,4 +7,7 @@ include!("rpc_loop_parts/module_core.rs");
 
 include!("rpc_loop_parts/network_listeners.rs");
 
+#[cfg(unix)]
+include!("rpc_loop_parts/unix_socket.rs");
+
 include!("rpc_loop_parts/read_http_request.rs");

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop.rs
@@ -5,4 +5,6 @@ mod rpc_access_log;
 
 include!("rpc_loop_parts/module_core.rs");
 
+include!("rpc_loop_parts/network_listeners.rs");
+
 include!("rpc_loop_parts/read_http_request.rs");

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/module_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/module_core.rs
@@ -119,8 +119,7 @@ pub(super) async fn run_rpc_loop_until(
 
 #[cfg(unix)]
 async fn run_unix_rpc_loop(path: PathBuf, daemon: Arc<RpcDaemon>, mut shutdown: ShutdownReceiver) {
-    prepare_rpc_unix_socket_path(&path).expect("prepare rpc unix socket path");
-    let listener = UnixListener::bind(&path).expect("bind rpc unix socket");
+    let listener = bind_private_rpc_unix_listener(&path).expect("bind private rpc unix socket");
     log::info!("reticulumd listening on unix:{}", path.display());
     let peer_addr = SocketAddr::from(([127, 0, 0, 1], 0));
 
@@ -142,33 +141,6 @@ async fn run_unix_rpc_loop(path: PathBuf, daemon: Arc<RpcDaemon>, mut shutdown: 
         }
     }
     cleanup_rpc_unix_socket_path(&path).expect("cleanup rpc unix socket path");
-}
-
-#[cfg(unix)]
-fn prepare_rpc_unix_socket_path(path: &Path) -> io::Result<()> {
-    if let Ok(metadata) = std::fs::metadata(path) {
-        use std::os::unix::fs::FileTypeExt;
-        if metadata.file_type().is_socket() {
-            std::fs::remove_file(path)?;
-        } else {
-            return Err(io::Error::new(
-                io::ErrorKind::AlreadyExists,
-                format!("refusing to remove non-socket rpc unix path {}", path.display()),
-            ));
-        }
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn cleanup_rpc_unix_socket_path(path: &Path) -> io::Result<()> {
-    if let Ok(metadata) = std::fs::metadata(path) {
-        use std::os::unix::fs::FileTypeExt;
-        if metadata.file_type().is_socket() {
-            std::fs::remove_file(path)?;
-        }
-    }
-    Ok(())
 }
 
 #[cfg(not(unix))]

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/module_core.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/module_core.rs
@@ -29,7 +29,7 @@ use tokio::net::UnixListener;
 
 use tokio::net::{TcpListener, TcpStream};
 
-use tokio::sync::watch;
+use tokio::sync::{watch, OwnedSemaphorePermit, Semaphore};
 
 use tokio::time::{timeout, Duration};
 
@@ -41,7 +41,11 @@ use x509_parser::extensions::ParsedExtension;
 
 use x509_parser::prelude::{FromDer, GeneralName, X509Certificate};
 
-const RPC_READ_TIMEOUT: Duration = Duration::from_secs(5);
+const RPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+const RPC_TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+const RPC_MAX_REMOTE_CONNECTIONS: usize = 128;
 
 const RPC_MAX_HEADER_BYTES: usize = 16 * 1024;
 
@@ -113,33 +117,6 @@ pub(super) async fn run_rpc_loop_until(
     }
 }
 
-async fn run_plain_rpc_loop(
-    addr: SocketAddr,
-    daemon: Arc<RpcDaemon>,
-    mut shutdown: ShutdownReceiver,
-) {
-    let listener = TcpListener::bind(addr).await.expect("bind rpc listener");
-    println!("{}", rpc_ready_line("http", addr));
-
-    loop {
-        tokio::select! {
-            shutdown_result = shutdown.changed() => {
-                if shutdown_result.is_err() || *shutdown.borrow() {
-                    log::info!("[daemon] rpc tcp listener shutting down");
-                    break;
-                }
-            }
-            accepted = listener.accept() => {
-                let (stream, peer_addr) = accepted.expect("accept rpc socket");
-                let daemon = daemon.clone();
-                tokio::spawn(async move {
-                    handle_connection(stream, peer_addr, daemon.as_ref(), None).await;
-                });
-            }
-        }
-    }
-}
-
 #[cfg(unix)]
 async fn run_unix_rpc_loop(path: PathBuf, daemon: Arc<RpcDaemon>, mut shutdown: ShutdownReceiver) {
     prepare_rpc_unix_socket_path(&path).expect("prepare rpc unix socket path");
@@ -200,54 +177,6 @@ async fn run_unix_rpc_loop(path: PathBuf, _daemon: Arc<RpcDaemon>, _shutdown: Sh
         "[daemon] ignoring --rpc-unix {} because Unix sockets are not supported on this platform",
         path.display()
     );
-}
-
-async fn run_tls_rpc_loop(
-    addr: SocketAddr,
-    daemon: Arc<RpcDaemon>,
-    config: RpcTlsConfig,
-    mut shutdown: ShutdownReceiver,
-) {
-    let tls_server = build_tls_server_config(&config).expect("build rpc tls server config");
-    let acceptor = TlsAcceptor::from(tls_server);
-    let listener = TcpListener::bind(addr).await.expect("bind tls rpc listener");
-    println!("{}", rpc_ready_line("https", addr));
-
-    loop {
-        tokio::select! {
-            shutdown_result = shutdown.changed() => {
-                if shutdown_result.is_err() || *shutdown.borrow() {
-                    log::info!("[daemon] rpc tls listener shutting down");
-                    break;
-                }
-            }
-            accepted = listener.accept() => {
-                let (stream, peer_addr) = accepted.expect("accept tls rpc socket");
-                let daemon = daemon.clone();
-                let acceptor = acceptor.clone();
-                tokio::spawn(async move {
-                    match acceptor.accept(stream).await {
-                        Ok(tls_stream) => {
-                            let transport_auth = extract_transport_auth(&tls_stream);
-                            handle_connection(
-                                tls_stream,
-                                peer_addr,
-                                daemon.as_ref(),
-                                Some(transport_auth),
-                            )
-                            .await;
-                        }
-                        Err(err) => {
-                            log::error!(
-                                "[daemon] rpc tls handshake failed peer={} err={}",
-                                peer_addr, err
-                            );
-                        }
-                    }
-                });
-            }
-        }
-    }
 }
 
 #[tracing::instrument(name = "rpc_conn", skip(stream, daemon, transport_auth))]

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/network_listeners.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/network_listeners.rs
@@ -1,0 +1,110 @@
+fn reserve_remote_connection(
+    permits: &Arc<Semaphore>,
+) -> Result<OwnedSemaphorePermit, tokio::sync::TryAcquireError> {
+    Arc::clone(permits).try_acquire_owned()
+}
+
+async fn run_plain_rpc_loop(
+    addr: SocketAddr,
+    daemon: Arc<RpcDaemon>,
+    mut shutdown: ShutdownReceiver,
+) {
+    let listener = TcpListener::bind(addr).await.expect("bind rpc listener");
+    let connection_permits = Arc::new(Semaphore::new(RPC_MAX_REMOTE_CONNECTIONS));
+    println!("{}", rpc_ready_line("http", addr));
+
+    loop {
+        tokio::select! {
+            shutdown_result = shutdown.changed() => {
+                if shutdown_result.is_err() || *shutdown.borrow() {
+                    log::info!("[daemon] rpc tcp listener shutting down");
+                    break;
+                }
+            }
+            accepted = listener.accept() => {
+                let (stream, peer_addr) = accepted.expect("accept rpc socket");
+                let Ok(connection_permit) =
+                    reserve_remote_connection(&connection_permits)
+                else {
+                    log::debug!(
+                        "[daemon-rpc] rejecting rpc connection at capacity peer={peer_addr}"
+                    );
+                    continue;
+                };
+                let daemon = daemon.clone();
+                tokio::spawn(async move {
+                    let _connection_permit = connection_permit;
+                    handle_connection(stream, peer_addr, daemon.as_ref(), None).await;
+                });
+            }
+        }
+    }
+}
+
+async fn run_tls_rpc_loop(
+    addr: SocketAddr,
+    daemon: Arc<RpcDaemon>,
+    config: RpcTlsConfig,
+    mut shutdown: ShutdownReceiver,
+) {
+    let tls_server = build_tls_server_config(&config).expect("build rpc tls server config");
+    let acceptor = TlsAcceptor::from(tls_server);
+    let listener = TcpListener::bind(addr).await.expect("bind tls rpc listener");
+    let connection_permits = Arc::new(Semaphore::new(RPC_MAX_REMOTE_CONNECTIONS));
+    println!("{}", rpc_ready_line("https", addr));
+
+    loop {
+        tokio::select! {
+            shutdown_result = shutdown.changed() => {
+                if shutdown_result.is_err() || *shutdown.borrow() {
+                    log::info!("[daemon] rpc tls listener shutting down");
+                    break;
+                }
+            }
+            accepted = listener.accept() => {
+                let (stream, peer_addr) = accepted.expect("accept tls rpc socket");
+                let Ok(connection_permit) =
+                    reserve_remote_connection(&connection_permits)
+                else {
+                    log::debug!(
+                        "[daemon-rpc] rejecting tls rpc connection at capacity peer={peer_addr}"
+                    );
+                    continue;
+                };
+                let daemon = daemon.clone();
+                let acceptor = acceptor.clone();
+                tokio::spawn(async move {
+                    let _connection_permit = connection_permit;
+                    match timeout(
+                        RPC_TLS_HANDSHAKE_TIMEOUT,
+                        acceptor.accept(stream),
+                    )
+                    .await
+                    {
+                        Ok(Ok(tls_stream)) => {
+                            let transport_auth = extract_transport_auth(&tls_stream);
+                            handle_connection(
+                                tls_stream,
+                                peer_addr,
+                                daemon.as_ref(),
+                                Some(transport_auth),
+                            )
+                            .await;
+                        }
+                        Ok(Err(err)) => {
+                            log::error!(
+                                "[daemon] rpc tls handshake failed peer={} err={}",
+                                peer_addr, err
+                            );
+                        }
+                        Err(_) => {
+                            log::warn!(
+                                "[daemon] rpc tls handshake timed out peer={peer_addr}"
+                            );
+                        }
+                    }
+                });
+            }
+        }
+    }
+}

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/read_http_request.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/read_http_request.rs
@@ -2,14 +2,31 @@ async fn read_http_request<S>(stream: &mut S) -> io::Result<Vec<u8>>
 where
     S: AsyncRead + Unpin,
 {
+    read_http_request_with_timeout(stream, RPC_REQUEST_TIMEOUT).await
+}
+
+async fn read_http_request_with_timeout<S>(
+    stream: &mut S,
+    request_timeout: Duration,
+) -> io::Result<Vec<u8>>
+where
+    S: AsyncRead + Unpin,
+{
+    timeout(request_timeout, read_http_request_inner(stream))
+        .await
+        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "rpc read timed out"))?
+}
+
+async fn read_http_request_inner<S>(stream: &mut S) -> io::Result<Vec<u8>>
+where
+    S: AsyncRead + Unpin,
+{
     let mut buffer = Vec::new();
     let mut expected_len: Option<usize> = None;
 
     loop {
         let mut chunk = [0_u8; 4096];
-        let read = timeout(RPC_READ_TIMEOUT, stream.read(&mut chunk))
-            .await
-            .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "rpc read timed out"))??;
+        let read = stream.read(&mut chunk).await?;
         if read == 0 {
             break;
         }
@@ -270,6 +287,47 @@ mod rpc_loop_tests {
             assert_eq!(err.kind(), io::ErrorKind::InvalidData);
             assert!(err.to_string().contains("maximum size"));
         });
+    }
+
+    #[test]
+    fn read_http_request_enforces_total_deadline_across_reads() {
+        let runtime =
+            tokio::runtime::Builder::new_current_thread().enable_all().build().expect("runtime");
+        runtime.block_on(async {
+            let (mut client, mut server) = duplex(4096);
+            let writer = tokio::spawn(async move {
+                for byte in b"GET /rpc HTTP/1.1\r\n" {
+                    if client.write_all(&[*byte]).await.is_err() {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(40)).await;
+                }
+            });
+
+            let err =
+                read_http_request_with_timeout(&mut server, Duration::from_millis(75))
+                    .await
+                    .expect_err("slow request should exceed its total deadline");
+            assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+            writer.abort();
+        });
+    }
+
+    #[test]
+    fn remote_connection_budget_recovers_when_a_connection_finishes() {
+        let permits = Arc::new(Semaphore::new(1));
+        let permit =
+            reserve_remote_connection(&permits).expect("first connection should be admitted");
+        assert!(
+            reserve_remote_connection(&permits).is_err(),
+            "connection above the configured limit should be rejected"
+        );
+
+        drop(permit);
+        assert!(
+            reserve_remote_connection(&permits).is_ok(),
+            "finishing a connection should restore listener capacity"
+        );
     }
 
     #[test]

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/read_http_request.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/read_http_request.rs
@@ -418,6 +418,69 @@ mod rpc_loop_tests {
 
     #[cfg(unix)]
     #[test]
+    fn rpc_unix_socket_is_private_at_creation_under_permissive_umask() {
+        const CHILD_MARKER: &str = "RETICULUMD_RPC_UMASK_TEST_CHILD";
+
+        if std::env::var_os(CHILD_MARKER).is_none() {
+            let executable = std::env::current_exe().expect("current test executable");
+            let status = std::process::Command::new("sh")
+                .arg("-c")
+                .arg("umask 000; exec \"$1\" \"$2\" --nocapture")
+                .arg("sh")
+                .arg(executable)
+                .arg("rpc_unix_socket_is_private_at_creation_under_permissive_umask")
+                .env(CHILD_MARKER, "1")
+                .status()
+                .expect("run permissive-umask test child");
+            assert!(status.success(), "permissive-umask test child failed");
+            return;
+        }
+
+        use std::os::unix::fs::PermissionsExt;
+
+        let runtime =
+            tokio::runtime::Builder::new_current_thread().enable_all().build().expect("runtime");
+        runtime.block_on(async {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let path = temp.path().join("reticulumd.sock");
+            let listener = bind_private_rpc_unix_listener_with_pre_publish(
+                &path,
+                |staging_path| {
+                    assert!(
+                        !path.exists(),
+                        "final socket must not exist before private publication"
+                    );
+                    assert!(
+                        std::os::unix::net::UnixStream::connect(&path).is_err(),
+                        "final socket must not be connectable before private publication"
+                    );
+                    let socket_mode =
+                        std::fs::metadata(staging_path)?.permissions().mode() & 0o777;
+                    assert_eq!(socket_mode, RPC_UNIX_SOCKET_MODE);
+                    let staging_mode =
+                        std::fs::metadata(staging_path.parent().expect("staging parent"))?
+                            .permissions()
+                            .mode()
+                            & 0o777;
+                    assert_eq!(staging_mode, RPC_UNIX_STAGING_DIR_MODE);
+                    Ok(())
+                },
+            )
+            .expect("bind private socket");
+
+            let mode =
+                std::fs::metadata(&path).expect("socket metadata").permissions().mode() & 0o777;
+            assert_eq!(mode, RPC_UNIX_SOCKET_MODE);
+            std::os::unix::net::UnixStream::connect(&path)
+                .expect("connect after private publication");
+
+            drop(listener);
+            cleanup_rpc_unix_socket_path(&path).expect("cleanup socket");
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn unix_rpc_loop_removes_stale_socket_and_cleans_up_on_shutdown() {
         let runtime =
             tokio::runtime::Builder::new_current_thread().enable_all().build().expect("runtime");

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/read_http_request.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/read_http_request.rs
@@ -380,6 +380,44 @@ mod rpc_loop_tests {
 
     #[cfg(unix)]
     #[test]
+    fn prepare_rpc_unix_socket_path_refuses_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let target = temp.path().join("target");
+        let path = temp.path().join("reticulumd.sock");
+        std::fs::write(&target, b"target").expect("write target");
+        symlink(&target, &path).expect("create symlink");
+
+        let err = prepare_rpc_unix_socket_path(&path).expect_err("symlink rejected");
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        assert!(path.is_symlink());
+        assert!(target.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rpc_unix_socket_is_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let runtime =
+            tokio::runtime::Builder::new_current_thread().enable_all().build().expect("runtime");
+        runtime.block_on(async {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let path = temp.path().join("reticulumd.sock");
+            let listener = bind_private_rpc_unix_listener(&path).expect("bind private socket");
+
+            let mode =
+                std::fs::metadata(&path).expect("socket metadata").permissions().mode() & 0o777;
+            assert_eq!(mode, RPC_UNIX_SOCKET_MODE);
+
+            drop(listener);
+            cleanup_rpc_unix_socket_path(&path).expect("cleanup socket");
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn unix_rpc_loop_removes_stale_socket_and_cleans_up_on_shutdown() {
         let runtime =
             tokio::runtime::Builder::new_current_thread().enable_all().build().expect("runtime");

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/unix_socket.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/unix_socket.rs
@@ -1,34 +1,91 @@
 const RPC_UNIX_SOCKET_MODE: u32 = 0o600;
+const RPC_UNIX_STAGING_DIR_MODE: u32 = 0o700;
 
 fn bind_private_rpc_unix_listener(path: &Path) -> io::Result<UnixListener> {
+    bind_private_rpc_unix_listener_with_pre_publish(path, |_| Ok(()))
+}
+
+fn bind_private_rpc_unix_listener_with_pre_publish(
+    path: &Path,
+    before_publish: impl FnOnce(&Path) -> io::Result<()>,
+) -> io::Result<UnixListener> {
     use std::os::unix::fs::PermissionsExt;
 
     prepare_rpc_unix_socket_path(path)?;
-    let listener = UnixListener::bind(path)?;
-    if let Err(permission_error) = std::fs::set_permissions(
-        path,
-        std::fs::Permissions::from_mode(RPC_UNIX_SOCKET_MODE),
-    ) {
-        drop(listener);
-        return match cleanup_rpc_unix_socket_path(path) {
-            Ok(()) => Err(io::Error::new(
-                permission_error.kind(),
-                format!(
-                    "failed to secure rpc unix socket {}: {permission_error}",
-                    path.display()
-                ),
-            )),
-            Err(cleanup_error) => Err(io::Error::new(
-                permission_error.kind(),
-                format!(
-                    "failed to secure rpc unix socket {}: {permission_error}; \
-                     failed to remove insecure socket: {cleanup_error}",
-                    path.display()
-                ),
-            )),
-        };
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "rpc unix socket path has no file name")
+    })?;
+    let staging_dir = create_private_rpc_unix_staging_dir(parent, file_name)?;
+    let staging_path = staging_dir.join("socket");
+
+    let result = (|| {
+        let listener = UnixListener::bind(&staging_path)?;
+        std::fs::set_permissions(
+            &staging_path,
+            std::fs::Permissions::from_mode(RPC_UNIX_SOCKET_MODE),
+        )?;
+        before_publish(&staging_path)?;
+
+        // The hard link publishes an already-private socket atomically and fails
+        // instead of replacing a path created after prepare_rpc_unix_socket_path().
+        std::fs::hard_link(&staging_path, path)?;
+        Ok(listener)
+    })();
+
+    if staging_path.exists() {
+        let _ = std::fs::remove_file(&staging_path);
     }
-    Ok(listener)
+    if let Err(error) = std::fs::remove_dir(&staging_dir) {
+        if error.kind() != io::ErrorKind::NotFound {
+            log::warn!(
+                "failed to remove private rpc unix staging directory {}: {error}",
+                staging_dir.display()
+            );
+        }
+    }
+
+    result
+}
+
+fn create_private_rpc_unix_staging_dir(
+    parent: &Path,
+    file_name: &std::ffi::OsStr,
+) -> io::Result<PathBuf> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_STAGING_ID: AtomicU64 = AtomicU64::new(0);
+
+    for _ in 0..128 {
+        let id = NEXT_STAGING_ID.fetch_add(1, Ordering::Relaxed);
+        let staging_dir = parent.join(format!(
+            ".{}.rpc-stage-{}-{id}",
+            file_name.to_string_lossy(),
+            std::process::id()
+        ));
+        let mut builder = std::fs::DirBuilder::new();
+        builder.mode(RPC_UNIX_STAGING_DIR_MODE);
+        match builder.create(&staging_dir) {
+            Ok(()) => {
+                if let Err(error) = std::fs::set_permissions(
+                    &staging_dir,
+                    std::fs::Permissions::from_mode(RPC_UNIX_STAGING_DIR_MODE),
+                ) {
+                    let _ = std::fs::remove_dir(&staging_dir);
+                    return Err(error);
+                }
+                return Ok(staging_dir);
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "unable to create private rpc unix socket staging directory",
+    ))
 }
 
 fn prepare_rpc_unix_socket_path(path: &Path) -> io::Result<()> {

--- a/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/unix_socket.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/rpc_loop_parts/unix_socket.rs
@@ -1,0 +1,57 @@
+const RPC_UNIX_SOCKET_MODE: u32 = 0o600;
+
+fn bind_private_rpc_unix_listener(path: &Path) -> io::Result<UnixListener> {
+    use std::os::unix::fs::PermissionsExt;
+
+    prepare_rpc_unix_socket_path(path)?;
+    let listener = UnixListener::bind(path)?;
+    if let Err(permission_error) = std::fs::set_permissions(
+        path,
+        std::fs::Permissions::from_mode(RPC_UNIX_SOCKET_MODE),
+    ) {
+        drop(listener);
+        return match cleanup_rpc_unix_socket_path(path) {
+            Ok(()) => Err(io::Error::new(
+                permission_error.kind(),
+                format!(
+                    "failed to secure rpc unix socket {}: {permission_error}",
+                    path.display()
+                ),
+            )),
+            Err(cleanup_error) => Err(io::Error::new(
+                permission_error.kind(),
+                format!(
+                    "failed to secure rpc unix socket {}: {permission_error}; \
+                     failed to remove insecure socket: {cleanup_error}",
+                    path.display()
+                ),
+            )),
+        };
+    }
+    Ok(listener)
+}
+
+fn prepare_rpc_unix_socket_path(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::FileTypeExt;
+
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_socket() => std::fs::remove_file(path),
+        Ok(_) => Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("refusing to remove non-socket rpc unix path {}", path.display()),
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn cleanup_rpc_unix_socket_path(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::FileTypeExt;
+
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_socket() => std::fs::remove_file(path),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}

--- a/docs/runbooks/reticulumd-operational-deployment.md
+++ b/docs/runbooks/reticulumd-operational-deployment.md
@@ -28,7 +28,16 @@ curl --unix-socket /tmp/lxmf-rpc.sock http://localhost/metrics
 
 The daemon removes an existing socket at the configured path only when the path
 is actually a Unix socket. It refuses to remove regular files or directories.
-On graceful shutdown, the listener exits and removes the socket path.
+The socket is explicitly restricted to mode `0600`, independent of the process
+umask. On graceful shutdown, the listener exits and removes the socket path.
+
+The default `/tmp` location preserves compatibility with existing clients.
+Because `/tmp` is shared, another local user can reserve that pathname before
+the daemon starts and prevent startup. The socket mode prevents other users
+from opening connections after permission hardening completes. Production
+services should place the socket in a private runtime directory, such as
+`/run/reticulumd`, with directory mode `0700`. The daemon does not change
+permissions on a caller-provided parent directory.
 
 ## Optional TCP Deployment
 
@@ -86,6 +95,7 @@ Wants=network-online.target
 Type=simple
 ExecStart=/usr/local/bin/reticulumd --rpc-unix /run/reticulumd/lxmf-rpc.sock
 RuntimeDirectory=reticulumd
+RuntimeDirectoryMode=0700
 Restart=on-failure
 RestartSec=2
 KillSignal=SIGINT


### PR DESCRIPTION
## Summary

I took a look at how the RPC listeners handle connections and found two fairly simple issues.

For TCP and TLS, every accepted connection starts a new task without any upper bound. The five-second timeout was also applied to each individual read instead of the complete request. This means a client can keep a connection alive by slowly sending data, and enough clients can eventually consume all available tasks or file descriptors. TLS handshakes had the same issue and could remain open indefinitely.

The local Unix socket also relied on the process umask for its permissions. Since the default socket is placed in /tmp and local connections are trusted without further authentication, I don't think this should be left to the environment.
This patch limits remote RPC connections to 128, applies a total request deadline, adds a TLS handshake deadline, and explicitly sets the Unix socket to mode 0600. It also rejects symlink socket paths and cleans up if the permissions cannot be applied.

The changes have regression tests and pass the existing reticulumd tests and clippy checks.

## Type
- [ ] breaking
- [ ] refactor
- [ ] reliability
- [x] security
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `make test`
- [x] `make test-all` (optional compatibility pass)
- [x] `make test-full-targets` (optional full-target parity check)
- [x] `cargo doc --workspace --no-deps`
- [x] `cargo deny check`
- [x] `cargo audit`

## Compatibility
- [x] Updated compatibility matrix / contract docs (if needed)
