### PR TITLE
Rate limit failed RPC authentication attempts

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
@@ -214,21 +214,18 @@ fn authorize_zmq_envelope(
     {
         return Ok(());
     }
-    let auth = envelope.auth.as_ref().ok_or_else(|| {
-        RpcError::new("SDK_SECURITY_AUTH_REQUIRED", "zmq rpc envelope auth metadata is required")
-    })?;
-    if !auth.scheme.eq_ignore_ascii_case("bearer") {
-        return Err(RpcError::new(
-            "SDK_SECURITY_TOKEN_INVALID",
-            "zmq rpc auth metadata must use bearer scheme",
-        ));
-    }
-    let value = auth
-        .value
-        .strip_prefix("Bearer ")
-        .or_else(|| auth.value.strip_prefix("bearer "))
-        .unwrap_or(auth.value.as_str());
-    let headers = vec![("authorization".to_string(), format!("Bearer {value}"))];
+    let headers = match envelope.auth.as_ref() {
+        Some(auth) if auth.scheme.eq_ignore_ascii_case("bearer") => {
+            let value = auth
+                .value
+                .strip_prefix("Bearer ")
+                .or_else(|| auth.value.strip_prefix("bearer "))
+                .unwrap_or(auth.value.as_str());
+            vec![("authorization".to_string(), format!("Bearer {value}"))]
+        }
+        Some(_) => vec![("authorization".to_string(), "unsupported".to_string())],
+        None => Vec::new(),
+    };
     daemon.authorize_http_request(&headers, Some("0.0.0.0"))
 }
 
@@ -355,6 +352,51 @@ mod tests {
         let rpc = parse_rpc_frame(&response.envelope.payload).expect("rpc response");
         let error = rpc.error.expect("auth error");
         assert_eq!(error.code, "SDK_SECURITY_AUTH_REQUIRED");
+    }
+
+    #[test]
+    fn missing_zmq_auth_is_rate_limited_before_envelope_rejection() {
+        let daemon = token_auth_daemon();
+        let envelope = ZmqRpcEnvelope::request(
+            "session-missing-auth",
+            20,
+            "tcp://127.0.0.1:9101",
+            Vec::new(),
+            None,
+        );
+
+        for _ in 0..120 {
+            let error = authorize_zmq_envelope(&daemon, &envelope, true, true)
+                .expect_err("missing auth should be rejected");
+            assert_eq!(error.code, "SDK_SECURITY_AUTH_REQUIRED");
+        }
+        let limited = authorize_zmq_envelope(&daemon, &envelope, true, true)
+            .expect_err("repeated missing auth should be rate limited");
+        assert_eq!(limited.code, "SDK_SECURITY_RATE_LIMITED");
+    }
+
+    #[test]
+    fn invalid_zmq_auth_scheme_is_rate_limited_before_envelope_rejection() {
+        let daemon = token_auth_daemon();
+        let envelope = ZmqRpcEnvelope::request(
+            "session-invalid-scheme",
+            21,
+            "tcp://127.0.0.1:9101",
+            Vec::new(),
+            Some(rns_rpc::rpc::zmq::ZmqRpcAuthMetadata {
+                scheme: "basic".to_string(),
+                value: "not-a-bearer-token".to_string(),
+            }),
+        );
+
+        for _ in 0..120 {
+            let error = authorize_zmq_envelope(&daemon, &envelope, true, true)
+                .expect_err("invalid auth scheme should be rejected");
+            assert_eq!(error.code, "SDK_SECURITY_TOKEN_INVALID");
+        }
+        let limited = authorize_zmq_envelope(&daemon, &envelope, true, true)
+            .expect_err("repeated invalid auth scheme should be rate limited");
+        assert_eq!(limited.code, "SDK_SECURITY_RATE_LIMITED");
     }
 
     #[test]

--- a/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/zmq_rpc_loop.rs
@@ -214,18 +214,26 @@ fn authorize_zmq_envelope(
     {
         return Ok(());
     }
-    let headers = match envelope.auth.as_ref() {
-        Some(auth) if auth.scheme.eq_ignore_ascii_case("bearer") => {
-            let value = auth
-                .value
-                .strip_prefix("Bearer ")
-                .or_else(|| auth.value.strip_prefix("bearer "))
-                .unwrap_or(auth.value.as_str());
-            vec![("authorization".to_string(), format!("Bearer {value}"))]
-        }
-        Some(_) => vec![("authorization".to_string(), "unsupported".to_string())],
-        None => Vec::new(),
+    let Some(auth) = envelope.auth.as_ref() else {
+        daemon.enforce_pre_auth_ip_rate_limit("0.0.0.0")?;
+        return Err(RpcError::new(
+            "SDK_SECURITY_AUTH_REQUIRED",
+            "zmq rpc envelope auth metadata is required",
+        ));
     };
+    if !auth.scheme.eq_ignore_ascii_case("bearer") {
+        daemon.enforce_pre_auth_ip_rate_limit("0.0.0.0")?;
+        return Err(RpcError::new(
+            "SDK_SECURITY_TOKEN_INVALID",
+            "zmq rpc auth metadata must use bearer scheme",
+        ));
+    }
+    let value = auth
+        .value
+        .strip_prefix("Bearer ")
+        .or_else(|| auth.value.strip_prefix("bearer "))
+        .unwrap_or(auth.value.as_str());
+    let headers = vec![("authorization".to_string(), format!("Bearer {value}"))];
     daemon.authorize_http_request(&headers, Some("0.0.0.0"))
 }
 

--- a/crates/libs/lxmf-sdk/benches/sdk_client_paths_parts/sample_start_request.rs
+++ b/crates/libs/lxmf-sdk/benches/sdk_client_paths_parts/sample_start_request.rs
@@ -213,11 +213,18 @@ fn bench_slow_subscriber_memory(c: &mut Criterion) {
                             .await
                             .expect("stream should yield")
                             .expect("event should parse");
-                        let _ = stats.queued.fetch_update(
-                            Ordering::Relaxed,
-                            Ordering::Relaxed,
-                            |queued| Some(queued.saturating_sub(1)),
-                        );
+                        let mut queued = stats.queued.load(Ordering::Relaxed);
+                        loop {
+                            match stats.queued.compare_exchange_weak(
+                                queued,
+                                queued.saturating_sub(1),
+                                Ordering::Relaxed,
+                                Ordering::Relaxed,
+                            ) {
+                                Ok(_) => break,
+                                Err(current) => queued = current,
+                            }
+                        }
                         stats.observe();
                         observed = event.metadata.seq_no;
                         tokio::time::sleep(Duration::from_micros(50)).await;

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_auth_http.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_auth_http.rs
@@ -310,7 +310,7 @@ impl RpcDaemon {
     }
 
     #[allow(clippy::result_large_err)]
-    pub(super) fn enforce_pre_auth_ip_rate_limit(&self, source_ip: &str) -> Result<(), RpcError> {
+    pub fn enforce_pre_auth_ip_rate_limit(&self, source_ip: &str) -> Result<(), RpcError> {
         let (per_ip_limit, _) = self.sdk_rate_limits();
         if per_ip_limit == 0 {
             return Ok(());

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_auth_http.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_auth_http.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+pub(super) const SDK_RATE_LIMIT_MAX_IP_ENTRIES: usize = 4_096;
+pub(super) const SDK_RATE_LIMIT_MAX_IP_KEY_BYTES: usize = 64;
+pub(super) const SDK_RATE_LIMIT_OVERFLOW_IP: &str = "<overflow>";
+
 impl RpcDaemon {
     pub(super) fn response_meta(&self) -> JsonValue {
         let profile = self.sdk_profile.lock().expect("sdk_profile mutex poisoned").clone();
@@ -102,6 +106,8 @@ impl RpcDaemon {
                     "remote source is not allowed in local_only bind mode".to_string(),
                 ));
             }
+
+            self.enforce_pre_auth_ip_rate_limit(source_ip.as_str())?;
 
             let mut principal = "local".to_string();
             match auth_mode.as_str() {
@@ -280,7 +286,7 @@ impl RpcDaemon {
                 }
             }
 
-            self.enforce_rate_limits(source_ip.as_str(), principal.as_str())
+            self.enforce_authenticated_principal_rate_limit(source_ip.as_str(), principal.as_str())
         })();
 
         let elapsed_ms = auth_started.elapsed().as_millis() as u64;
@@ -288,56 +294,74 @@ impl RpcDaemon {
         result
     }
 
+    fn reset_expired_rate_limit_window(&self, now: u64) {
+        let mut window_started = self
+            .sdk_rate_window_started_ms
+            .lock()
+            .expect("sdk_rate_window_started_ms mutex poisoned");
+        if *window_started == 0 || now.saturating_sub(*window_started) >= 60_000 {
+            *window_started = now;
+            self.sdk_rate_ip_counts.lock().expect("sdk_rate_ip_counts mutex poisoned").clear();
+            self.sdk_rate_principal_counts
+                .lock()
+                .expect("sdk_rate_principal_counts mutex poisoned")
+                .clear();
+        }
+    }
+
     #[allow(clippy::result_large_err)]
-    pub(super) fn enforce_rate_limits(
+    pub(super) fn enforce_pre_auth_ip_rate_limit(&self, source_ip: &str) -> Result<(), RpcError> {
+        let (per_ip_limit, _) = self.sdk_rate_limits();
+        if per_ip_limit == 0 {
+            return Ok(());
+        }
+
+        self.reset_expired_rate_limit_window(now_millis_u64());
+        let mut counts = self.sdk_rate_ip_counts.lock().expect("sdk_rate_ip_counts mutex poisoned");
+        let source_key = if source_ip.len() <= SDK_RATE_LIMIT_MAX_IP_KEY_BYTES
+            && (counts.contains_key(source_ip)
+                || counts.len() < SDK_RATE_LIMIT_MAX_IP_ENTRIES.saturating_sub(1))
+        {
+            source_ip
+        } else {
+            SDK_RATE_LIMIT_OVERFLOW_IP
+        };
+        let count = counts.entry(source_key.to_string()).or_insert(0);
+        *count = count.saturating_add(1);
+        if *count > per_ip_limit {
+            let event = RpcEvent {
+                event_type: "sdk_security_rate_limited".to_string(),
+                payload: json!({
+                    "scope": "ip",
+                    "source_ip": source_ip,
+                    "principal": "unauthenticated",
+                    "limit": per_ip_limit,
+                    "count": *count,
+                }),
+            };
+            self.publish_event(event);
+            return Err(RpcError::new(
+                "SDK_SECURITY_RATE_LIMITED".to_string(),
+                "per-ip request rate limit exceeded".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn enforce_authenticated_principal_rate_limit(
         &self,
         source_ip: &str,
         principal: &str,
     ) -> Result<(), RpcError> {
-        let (per_ip_limit, per_principal_limit) = self.sdk_rate_limits();
-        if per_ip_limit == 0 && per_principal_limit == 0 {
+        let (_, per_principal_limit) = self.sdk_rate_limits();
+        if per_principal_limit == 0 {
             return Ok(());
         }
 
         let now = now_millis_u64();
-        {
-            let mut window_started = self
-                .sdk_rate_window_started_ms
-                .lock()
-                .expect("sdk_rate_window_started_ms mutex poisoned");
-            if *window_started == 0 || now.saturating_sub(*window_started) >= 60_000 {
-                *window_started = now;
-                self.sdk_rate_ip_counts.lock().expect("sdk_rate_ip_counts mutex poisoned").clear();
-                self.sdk_rate_principal_counts
-                    .lock()
-                    .expect("sdk_rate_principal_counts mutex poisoned")
-                    .clear();
-            }
-        }
-
-        if per_ip_limit > 0 {
-            let mut counts =
-                self.sdk_rate_ip_counts.lock().expect("sdk_rate_ip_counts mutex poisoned");
-            let count = counts.entry(source_ip.to_string()).or_insert(0);
-            *count = count.saturating_add(1);
-            if *count > per_ip_limit {
-                let event = RpcEvent {
-                    event_type: "sdk_security_rate_limited".to_string(),
-                    payload: json!({
-                        "scope": "ip",
-                        "source_ip": source_ip,
-                        "principal": principal,
-                        "limit": per_ip_limit,
-                        "count": *count,
-                    }),
-                };
-                self.publish_event(event);
-                return Err(RpcError::new(
-                    "SDK_SECURITY_RATE_LIMITED".to_string(),
-                    "per-ip request rate limit exceeded".to_string(),
-                ));
-            }
-        }
+        self.reset_expired_rate_limit_window(now);
 
         if per_principal_limit > 0 {
             let mut counts = self

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/negotiate_security_parts/sdk_negotiate_v2_accepts_mtls_auth_m.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/negotiate_security_parts/sdk_negotiate_v2_accepts_mtls_auth_m.rs
@@ -160,6 +160,95 @@
     }
 
     #[test]
+    fn sdk_security_failed_authentication_is_rate_limited_before_token_parsing() {
+        let daemon = RpcDaemon::test_instance();
+        let response = daemon
+            .handle_rpc(rpc_request(
+                25,
+                "sdk_negotiate_v2",
+                json!({
+                    "supported_contract_versions": [2],
+                    "requested_capabilities": [],
+                    "config": {
+                        "profile": "desktop-full",
+                        "bind_mode": "remote",
+                        "auth_mode": "token",
+                        "rpc_backend": {
+                            "token_auth": {
+                                "issuer": "test-issuer",
+                                "audience": "test-audience",
+                                "jti_cache_ttl_ms": 30_000,
+                                "clock_skew_ms": 0,
+                                "shared_secret": "test-secret"
+                            }
+                        }
+                    }
+                }),
+            ))
+            .expect("negotiate");
+        assert!(response.error.is_none());
+        let configured = daemon
+            .handle_rpc(rpc_request(
+                26,
+                "sdk_configure_v2",
+                json!({
+                    "expected_revision": 0,
+                    "patch": {
+                        "extensions": {
+                            "rate_limits": {
+                                "per_ip_per_minute": 2,
+                                "per_principal_per_minute": 10
+                            }
+                        }
+                    }
+                }),
+            ))
+            .expect("configure rate limits");
+        assert!(configured.error.is_none());
+
+        for _ in 0..2 {
+            let error = daemon
+                .authorize_http_request(&[], Some("10.5.6.7"))
+                .expect_err("missing credentials should fail");
+            assert_eq!(error.code, "SDK_SECURITY_AUTH_REQUIRED");
+        }
+        let limited = daemon
+            .authorize_http_request(&[], Some("10.5.6.7"))
+            .expect_err("repeated missing credentials should be throttled");
+        assert_eq!(limited.code, "SDK_SECURITY_RATE_LIMITED");
+        assert!(
+            daemon.sdk_rate_principal_counts
+                .lock()
+                .expect("sdk_rate_principal_counts mutex poisoned")
+                .is_empty(),
+            "failed authentication must not consume a principal quota"
+        );
+    }
+
+    #[test]
+    fn sdk_security_pre_authentication_ip_state_is_bounded() {
+        let daemon = RpcDaemon::test_instance();
+
+        for index in 0..super::sdk_auth_http::SDK_RATE_LIMIT_MAX_IP_ENTRIES + 128 {
+            let source_ip = format!("198.51.100.{index}");
+            let _ = daemon.enforce_pre_auth_ip_rate_limit(source_ip.as_str());
+        }
+        let oversized_source =
+            "x".repeat(super::sdk_auth_http::SDK_RATE_LIMIT_MAX_IP_KEY_BYTES + 1);
+        let _ = daemon.enforce_pre_auth_ip_rate_limit(oversized_source.as_str());
+
+        let counts =
+            daemon.sdk_rate_ip_counts.lock().expect("sdk_rate_ip_counts mutex poisoned");
+        assert!(counts.len() <= super::sdk_auth_http::SDK_RATE_LIMIT_MAX_IP_ENTRIES);
+        assert!(counts.contains_key(super::sdk_auth_http::SDK_RATE_LIMIT_OVERFLOW_IP));
+        assert!(
+            counts
+                .keys()
+                .all(|key| key.len() <= super::sdk_auth_http::SDK_RATE_LIMIT_MAX_IP_KEY_BYTES)
+        );
+    }
+
+    #[test]
     fn sdk_security_events_redact_sensitive_fields_by_default() {
         let daemon = RpcDaemon::test_instance();
         let _ = daemon.handle_rpc(rpc_request(


### PR DESCRIPTION
## Summary

I noticed that the RPC rate limiter was only called after authentication had succeeded.

This means the requests which actually need limiting (missing tokens, malformed tokens, bad signatures and replayed tokens) returned before consuming any rate-limit quota. A remote client could therefore make as many failed authentication attempts as it wanted.

This patch applies the per-IP limit before token or mTLS authentication and keeps the per-principal limit after successful authentication. Successful requests are still counted only once for each limit.

The IP table is capped at 4096 entries so an attacker cannot turn the limiter itself into an unbounded memory allocation. Excess sources share a fail-closed overflow bucket.

## Type
- [ ] breaking
- [ ] refactor
- [ ] reliability
- [x] security
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `make test`
- [x] `make test-all` (optional compatibility pass)
- [x] `make test-full-targets` (optional full-target parity check)
- [x] `cargo doc --workspace --no-deps`
- [x] `cargo deny check`
- [x] `cargo audit`

## Compatibility
- [x] Updated compatibility matrix / contract docs (if needed)
