### PR TITLE
Use constant-time authentication tag verification

### DIFF
--- a/crates/libs/rns-core/src/crypt/fernet.rs
+++ b/crates/libs/rns-core/src/crypt/fernet.rs
@@ -187,21 +187,9 @@ impl<R: CryptoRngCore + Copy> Fernet<R> {
 
         hmac.update(&token_data[..token_data.len() - HMAC_OUT_SIZE]);
 
-        let actual_tag = hmac.finalize().into_bytes();
+        hmac.verify_slice(expected_tag).map_err(|_| RnsError::IncorrectSignature)?;
 
-        let valid = expected_tag
-            .iter()
-            .zip(actual_tag.as_slice())
-            .map(|(x, y)| x.cmp(y))
-            .find(|&ord| ord != cmp::Ordering::Equal)
-            .unwrap_or(actual_tag.len().cmp(&expected_tag.len()))
-            == cmp::Ordering::Equal;
-
-        if valid {
-            Ok(VerifiedToken(token_data))
-        } else {
-            Err(RnsError::IncorrectSignature)
-        }
+        Ok(VerifiedToken(token_data))
     }
 
     pub fn decrypt<'a, 'b>(
@@ -250,7 +238,8 @@ impl<R: CryptoRngCore + Copy> Fernet<R> {
 
 #[cfg(test)]
 mod tests {
-    use crate::crypt::fernet::{Fernet, AES_BLOCK_SIZE, FERNET_OVERHEAD_SIZE};
+    use crate::crypt::fernet::{Fernet, Token, AES_BLOCK_SIZE, FERNET_OVERHEAD_SIZE};
+    use crate::error::RnsError;
     use core::str;
     use rand_core::OsRng;
 
@@ -293,5 +282,21 @@ mod tests {
         // More than overhead but less than required encrypted token size.
         let mut out_buf = [0u8; FERNET_OVERHEAD_SIZE + AES_BLOCK_SIZE - 1];
         assert!(fernet.encrypt(test_msg.into(), &mut out_buf[..]).is_err());
+    }
+
+    #[test]
+    fn verify_rejects_tampered_authentication_tag() {
+        const BUF_SIZE: usize = 4096;
+
+        let fernet = Fernet::new_rand(OsRng);
+        let mut out_buf = [0u8; BUF_SIZE];
+        let token_len =
+            fernet.encrypt("authenticated".into(), &mut out_buf).expect("cipher token").len();
+        out_buf[token_len - 1] ^= 1;
+
+        assert!(matches!(
+            fernet.verify(Token::from(&out_buf[..token_len])),
+            Err(RnsError::IncorrectSignature)
+        ));
     }
 }

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_auth_http.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_auth_http.rs
@@ -188,16 +188,27 @@ impl RpcDaemon {
                     let signed_payload = zeroize::Zeroizing::new(format!(
                         "iss={issuer};aud={audience};jti={jti};sub={subject};iat={iat};exp={exp}"
                     ));
-                    let expected_signature = zeroize::Zeroizing::new(Self::token_signature(
-                        shared_secret.as_str(),
-                        signed_payload.as_str(),
-                    ));
-                    if signature != expected_signature.as_str() {
-                        return Err(RpcError::new(
+                    let signature_bytes = hex::decode(signature).map_err(|_| {
+                        RpcError::new(
+                            "SDK_SECURITY_TOKEN_INVALID".to_string(),
+                            "token signature is invalid".to_string(),
+                        )
+                    })?;
+                    let mut mac =
+                        hmac::Hmac::<sha2::Sha256>::new_from_slice(shared_secret.as_bytes())
+                            .map_err(|_| {
+                                RpcError::new(
+                                    "SDK_SECURITY_TOKEN_INVALID".to_string(),
+                                    "token authentication failed".to_string(),
+                                )
+                            })?;
+                    mac.update(signed_payload.as_bytes());
+                    mac.verify_slice(&signature_bytes).map_err(|_| {
+                        RpcError::new(
                             "SDK_SECURITY_TOKEN_INVALID".to_string(),
                             "token signature does not match runtime policy".to_string(),
-                        ));
-                    }
+                        )
+                    })?;
                     if issuer != expected_issuer || audience != expected_audience {
                         return Err(RpcError::new(
                             "SDK_SECURITY_TOKEN_INVALID".to_string(),

--- a/crates/libs/rns-rpc/src/rpc/daemon/sdk_capabilities.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/sdk_capabilities.rs
@@ -106,6 +106,7 @@ impl RpcDaemon {
         Some(claims)
     }
 
+    #[cfg(test)]
     pub(super) fn token_signature(secret: &str, payload: &str) -> String {
         let mut mac = hmac::Hmac::<sha2::Sha256>::new_from_slice(secret.as_bytes())
             .expect("HMAC key length is valid for HMAC-SHA256");

--- a/crates/libs/rns-rpc/src/rpc/daemon/tests/negotiate_security_parts/sdk_negotiate_v2_selects_contract_an.rs
+++ b/crates/libs/rns-rpc/src/rpc/daemon/tests/negotiate_security_parts/sdk_negotiate_v2_selects_contract_an.rs
@@ -417,4 +417,13 @@
             .authorize_http_request(&tampered_headers, Some("10.5.6.7"))
             .expect_err("tampered signature should be rejected");
         assert_eq!(tampered.code, "SDK_SECURITY_TOKEN_INVALID");
+        assert_eq!(tampered.message, "token signature does not match runtime policy");
+
+        let malformed_headers =
+            vec![("authorization".to_string(), format!("Bearer {valid_payload};sig=not-hex"))];
+        let malformed = daemon
+            .authorize_http_request(&malformed_headers, Some("10.5.6.7"))
+            .expect_err("malformed signature should be rejected");
+        assert_eq!(malformed.code, "SDK_SECURITY_TOKEN_INVALID");
+        assert_eq!(malformed.message, "token signature is invalid");
     }

--- a/crates/libs/rns-transport/src/crypt/fernet.rs
+++ b/crates/libs/rns-transport/src/crypt/fernet.rs
@@ -187,21 +187,9 @@ impl<R: CryptoRngCore + Copy> Fernet<R> {
 
         hmac.update(&token_data[..token_data.len() - HMAC_OUT_SIZE]);
 
-        let actual_tag = hmac.finalize().into_bytes();
+        hmac.verify_slice(expected_tag).map_err(|_| RnsError::IncorrectSignature)?;
 
-        let valid = expected_tag
-            .iter()
-            .zip(actual_tag.as_slice())
-            .map(|(x, y)| x.cmp(y))
-            .find(|&ord| ord != cmp::Ordering::Equal)
-            .unwrap_or(actual_tag.len().cmp(&expected_tag.len()))
-            == cmp::Ordering::Equal;
-
-        if valid {
-            Ok(VerifiedToken(token_data))
-        } else {
-            Err(RnsError::IncorrectSignature)
-        }
+        Ok(VerifiedToken(token_data))
     }
 
     pub fn decrypt<'a, 'b>(
@@ -266,21 +254,9 @@ impl CachedFernet {
 
         hmac.update(&token_data[..token_data.len() - HMAC_OUT_SIZE]);
 
-        let actual_tag = hmac.finalize().into_bytes();
+        hmac.verify_slice(expected_tag).map_err(|_| RnsError::IncorrectSignature)?;
 
-        let valid = expected_tag
-            .iter()
-            .zip(actual_tag.as_slice())
-            .map(|(x, y)| x.cmp(y))
-            .find(|&ord| ord != cmp::Ordering::Equal)
-            .unwrap_or(actual_tag.len().cmp(&expected_tag.len()))
-            == cmp::Ordering::Equal;
-
-        if valid {
-            Ok(VerifiedToken(token_data))
-        } else {
-            Err(RnsError::IncorrectSignature)
-        }
+        Ok(VerifiedToken(token_data))
     }
 
     pub fn decrypt<'a, 'b>(
@@ -311,7 +287,10 @@ impl CachedFernet {
 
 #[cfg(test)]
 mod tests {
-    use crate::crypt::fernet::{Fernet, AES_BLOCK_SIZE, FERNET_OVERHEAD_SIZE};
+    use crate::crypt::fernet::{
+        CachedFernet, Fernet, Token, AES_BLOCK_SIZE, AES_KEY_SIZE, FERNET_OVERHEAD_SIZE,
+    };
+    use crate::error::RnsError;
     use core::str;
     use rand_core::OsRng;
 
@@ -354,5 +333,40 @@ mod tests {
         // More than overhead but less than required encrypted token size.
         let mut out_buf = [0u8; FERNET_OVERHEAD_SIZE + AES_BLOCK_SIZE - 1];
         assert!(fernet.encrypt(test_msg.into(), &mut out_buf[..]).is_err());
+    }
+
+    #[test]
+    fn verify_rejects_tampered_authentication_tag() {
+        const BUF_SIZE: usize = 4096;
+
+        let fernet = Fernet::new_rand(OsRng);
+        let mut out_buf = [0u8; BUF_SIZE];
+        let token_len =
+            fernet.encrypt("authenticated".into(), &mut out_buf).expect("cipher token").len();
+        out_buf[token_len - 1] ^= 1;
+
+        assert!(matches!(
+            fernet.verify(Token::from(&out_buf[..token_len])),
+            Err(RnsError::IncorrectSignature)
+        ));
+    }
+
+    #[test]
+    fn cached_verify_rejects_tampered_authentication_tag() {
+        const BUF_SIZE: usize = 4096;
+        const KEY: [u8; AES_KEY_SIZE] = [7; AES_KEY_SIZE];
+
+        let fernet = CachedFernet::new_from_slices(&KEY, &KEY);
+        let mut out_buf = [0u8; BUF_SIZE];
+        let token_len = fernet
+            .encrypt(OsRng, "authenticated".into(), &mut out_buf)
+            .expect("cipher token")
+            .len();
+        out_buf[token_len - 1] ^= 1;
+
+        assert!(matches!(
+            fernet.verify(Token::from(&out_buf[..token_len])),
+            Err(RnsError::IncorrectSignature)
+        ));
     }
 }


### PR DESCRIPTION
## Summary

This is a follow-up to my earlier timing comparison patch. I found four more places where authentication tags were compared using ordinary byte or string comparisons.

Three are in the Fernet implementations and one is in HTTP bearer-token authentication. These comparisons can stop at the first differing byte, which exposes a small amount of timing information about the expected tag.

The patch replaces the manual Fernet comparisons with Hmac::verify_slice(). For HTTP authentication it decodes the supplied hexadecimal signature and verifies the bytes directly with HMAC instead of comparing two strings.

There is not much custom logic here. The cryptographic library now performs the comparison in all four cases. I added tests for valid, modified and malformed signatures.

## Type
- [ ] breaking
- [ ] refactor
- [ ] reliability
- [x] security
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `make test`
- [x] `make test-all` (optional compatibility pass)
- [x] `make test-full-targets` (optional full-target parity check)
- [x] `cargo doc --workspace --no-deps`
- [x] `cargo deny check`
- [x] `cargo audit`

## Compatibility
- [x] Updated compatibility matrix / contract docs (if needed)
