### PR TITLE
Write private key material using private and atomic files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomicwrites"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef1bb8d1b645fe38d51dfc331d720fb5fc2c94b440c76cc79c80ff265ca33e3"
+dependencies = [
+ "rustix 0.38.44",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +1522,12 @@ checksum = "2b23ac50abb8261cb38c6e2a7192d3302e0836dac1628f6a93b82b4fad185897"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2164,6 +2181,7 @@ name = "reticulum-rs-core"
 version = "0.9.6"
 dependencies = [
  "aes",
+ "atomicwrites",
  "cbc",
  "criterion",
  "crypto-common",
@@ -2425,6 +2443,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2432,7 +2463,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2773,7 +2804,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ rns-embedded-core = { version = "0.9.6", path = "crates/libs/rns-embedded-core" 
 rns-embedded-ffi = { version = "0.9.6", path = "crates/libs/rns-embedded-ffi" }
 rns-embedded-runtime = { version = "0.9.6", path = "crates/libs/rns-embedded-runtime" }
 anyhow = "1"
+atomicwrites = "0.4.4"
 clap = { version = "4.5.29", features = ["derive"] }
 clap_complete = "4.5"
 criterion = "0.5"

--- a/crates/libs/rns-core/Cargo.toml
+++ b/crates/libs/rns-core/Cargo.toml
@@ -29,6 +29,9 @@ serde_bytes.workspace = true
 sha2.workspace = true
 x25519-dalek = { workspace = true, features = ["static_secrets"] }
 
+[target.'cfg(windows)'.dependencies]
+atomicwrites.workspace = true
+
 [dev-dependencies]
 criterion.workspace = true
 log.workspace = true

--- a/crates/libs/rns-core/src/key_manager.rs
+++ b/crates/libs/rns-core/src/key_manager.rs
@@ -15,11 +15,22 @@ pub enum KeyPurpose {
     Custom(String),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StoredKey {
     pub key_id: String,
     pub purpose: KeyPurpose,
     pub material: Vec<u8>,
+}
+
+impl core::fmt::Debug for StoredKey {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("StoredKey")
+            .field("key_id", &self.key_id)
+            .field("purpose", &self.purpose)
+            .field("material", &"[REDACTED]")
+            .finish()
+    }
 }
 
 pub trait KeyManagerBackend {
@@ -81,7 +92,8 @@ pub struct FileKeyManager {
 impl FileKeyManager {
     pub fn new(root: impl Into<std::path::PathBuf>) -> Result<Self, RnsError> {
         let root = root.into();
-        std::fs::create_dir_all(&root).map_err(|_| RnsError::ConnectionError)?;
+        crate::secure_storage::ensure_private_directory(&root)
+            .map_err(|_| RnsError::ConnectionError)?;
         Ok(Self { root })
     }
 
@@ -111,10 +123,9 @@ impl KeyManagerBackend for FileKeyManager {
 
     fn put(&self, key: StoredKey) -> Result<(), RnsError> {
         let path = self.path_for_key(key.key_id.as_str())?;
-        let tmp_path = path.with_extension("tmp");
         let bytes = rmp_serde::to_vec_named(&key).map_err(|_| RnsError::PacketError)?;
-        std::fs::write(&tmp_path, bytes).map_err(|_| RnsError::ConnectionError)?;
-        std::fs::rename(&tmp_path, &path).map_err(|_| RnsError::ConnectionError)?;
+        crate::secure_storage::atomic_write_private(&path, &bytes)
+            .map_err(|_| RnsError::ConnectionError)?;
         Ok(())
     }
 

--- a/crates/libs/rns-core/src/lib.rs
+++ b/crates/libs/rns-core/src/lib.rs
@@ -13,6 +13,9 @@ pub mod key_manager;
 pub mod packet;
 pub mod ratchets;
 
+#[cfg(feature = "std")]
+#[doc(hidden)]
+pub mod secure_storage;
 pub mod serde;
 
 pub use destination::{group_decrypt, group_encrypt};

--- a/crates/libs/rns-core/src/secure_storage.rs
+++ b/crates/libs/rns-core/src/secure_storage.rs
@@ -36,12 +36,7 @@ pub fn atomic_write_private(path: &Path, contents: &[u8]) -> io::Result<()> {
     tmp_file.sync_all()?;
     drop(tmp_file);
 
-    #[cfg(windows)]
-    if path.exists() {
-        fs::remove_file(path)?;
-    }
-
-    fs::rename(cleanup.path(), path)?;
+    replace_private_temp(cleanup.path(), path)?;
     cleanup.disarm();
 
     #[cfg(unix)]
@@ -54,6 +49,16 @@ pub fn atomic_write_private(path: &Path, contents: &[u8]) -> io::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_private_temp(source: &Path, destination: &Path) -> io::Result<()> {
+    fs::rename(source, destination)
+}
+
+#[cfg(windows)]
+fn replace_private_temp(source: &Path, destination: &Path) -> io::Result<()> {
+    atomicwrites::replace_atomic(source, destination)
 }
 
 fn create_private_temp(path: &Path) -> io::Result<(PathBuf, File)> {
@@ -123,10 +128,12 @@ impl Drop for TempCleanup {
 
 #[cfg(test)]
 mod tests {
-    use super::{atomic_write_private, ensure_private_directory};
+    use super::atomic_write_private;
+    #[cfg(unix)]
+    use super::ensure_private_directory;
 
     #[test]
-    fn private_file_roundtrip_and_replace() {
+    fn private_file_roundtrip_and_atomically_replace_existing() {
         let temp = tempfile::tempdir().expect("tempdir");
         let path = temp.path().join("private").join("secret");
 
@@ -134,6 +141,28 @@ mod tests {
         atomic_write_private(&path, b"second").expect("replacement write");
 
         assert_eq!(std::fs::read(path).expect("read private file"), b"second");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn failed_windows_replacement_preserves_existing_secret() {
+        use std::fs::OpenOptions;
+        use std::os::windows::fs::OpenOptionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("secret");
+        atomic_write_private(&path, b"existing").expect("initial write");
+
+        let locked_file = OpenOptions::new()
+            .read(true)
+            .share_mode(0)
+            .open(&path)
+            .expect("lock destination against replacement");
+        let result = atomic_write_private(&path, b"replacement");
+        drop(locked_file);
+
+        assert!(result.is_err(), "replacement should fail while locked");
+        assert_eq!(std::fs::read(path).expect("read preserved secret"), b"existing");
     }
 
     #[cfg(unix)]

--- a/crates/libs/rns-core/src/secure_storage.rs
+++ b/crates/libs/rns-core/src/secure_storage.rs
@@ -1,0 +1,179 @@
+//! Private filesystem persistence helpers.
+
+use rand_core::{OsRng, RngCore};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+const PRIVATE_DIRECTORY_MODE: u32 = 0o700;
+#[cfg(unix)]
+const PRIVATE_FILE_MODE: u32 = 0o600;
+const TEMP_CREATE_ATTEMPTS: usize = 128;
+
+/// Creates a directory and restricts it to its owner on Unix.
+pub fn ensure_private_directory(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(PRIVATE_DIRECTORY_MODE))?;
+    }
+
+    Ok(())
+}
+
+/// Atomically replaces a private file using a randomized, exclusively-created sibling.
+pub fn atomic_write_private(path: &Path, contents: &[u8]) -> io::Result<()> {
+    if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        ensure_private_directory(parent)?;
+    }
+
+    let (tmp_path, mut tmp_file) = create_private_temp(path)?;
+    let mut cleanup = TempCleanup::new(tmp_path);
+    tmp_file.write_all(contents)?;
+    tmp_file.sync_all()?;
+    drop(tmp_file);
+
+    #[cfg(windows)]
+    if path.exists() {
+        fs::remove_file(path)?;
+    }
+
+    fs::rename(cleanup.path(), path)?;
+    cleanup.disarm();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(PRIVATE_FILE_MODE))?;
+        if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+            File::open(parent)?.sync_all()?;
+        }
+    }
+
+    Ok(())
+}
+
+fn create_private_temp(path: &Path) -> io::Result<(PathBuf, File)> {
+    let file_name = path.file_name().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "private file path has no file name")
+    })?;
+
+    for _ in 0..TEMP_CREATE_ATTEMPTS {
+        let mut random = [0u8; 16];
+        OsRng
+            .try_fill_bytes(&mut random)
+            .map_err(|_| io::Error::other("OS randomness unavailable"))?;
+        let tmp_name = format!(".{}.tmp-{}", file_name.to_string_lossy(), hex::encode(random));
+        let tmp_path = path.with_file_name(tmp_name);
+        match open_private_new(&tmp_path) {
+            Ok(file) => return Ok((tmp_path, file)),
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(err) => return Err(err),
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not create a unique private temporary file",
+    ))
+}
+
+fn open_private_new(path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(PRIVATE_FILE_MODE);
+    }
+
+    options.open(path)
+}
+
+struct TempCleanup {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempCleanup {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempCleanup {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{atomic_write_private, ensure_private_directory};
+
+    #[test]
+    fn private_file_roundtrip_and_replace() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("private").join("secret");
+
+        atomic_write_private(&path, b"first").expect("first write");
+        atomic_write_private(&path, b"second").expect("replacement write");
+
+        assert_eq!(std::fs::read(path).expect("read private file"), b"second");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_storage_enforces_unix_modes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let directory = temp.path().join("private");
+        std::fs::create_dir(&directory).expect("create permissive directory");
+        std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o755))
+            .expect("set permissive directory mode");
+        ensure_private_directory(&directory).expect("secure directory");
+        let path = directory.join("secret");
+        atomic_write_private(&path, b"secret").expect("write private file");
+
+        let directory_mode =
+            std::fs::metadata(&directory).expect("directory metadata").permissions().mode() & 0o777;
+        let file_mode =
+            std::fs::metadata(&path).expect("file metadata").permissions().mode() & 0o777;
+        assert_eq!(directory_mode, 0o700);
+        assert_eq!(file_mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_write_ignores_preexisting_legacy_temp_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("secret.key");
+        let legacy_tmp = path.with_extension("tmp");
+        let victim = temp.path().join("victim");
+        std::fs::write(&victim, b"unchanged").expect("write victim");
+        symlink(&victim, &legacy_tmp).expect("create legacy temp symlink");
+
+        atomic_write_private(&path, b"private").expect("write private file");
+
+        assert_eq!(std::fs::read(&victim).expect("read victim"), b"unchanged");
+        assert!(legacy_tmp.is_symlink());
+        assert_eq!(std::fs::read(path).expect("read private file"), b"private");
+    }
+}

--- a/crates/libs/rns-core/tests/key_manager_security.rs
+++ b/crates/libs/rns-core/tests/key_manager_security.rs
@@ -1,0 +1,62 @@
+use rns_core::key_manager::{FileKeyManager, KeyManagerBackend, KeyPurpose, StoredKey};
+
+fn sample_key(key_id: &str) -> StoredKey {
+    StoredKey {
+        key_id: key_id.to_owned(),
+        purpose: KeyPurpose::IdentitySigning,
+        material: vec![1, 2, 3, 4],
+    }
+}
+
+#[test]
+fn stored_key_debug_redacts_material() {
+    let formatted = format!("{:?}", sample_key("debug-key"));
+    assert!(formatted.contains("debug-key"));
+    assert!(formatted.contains("[REDACTED]"));
+    assert!(!formatted.contains("[1, 2, 3, 4]"));
+}
+
+#[cfg(unix)]
+#[test]
+fn file_key_manager_uses_private_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("keys");
+    std::fs::create_dir(&root).expect("create permissive key directory");
+    std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o755))
+        .expect("set permissive directory mode");
+    let manager = FileKeyManager::new(&root).expect("file manager");
+
+    manager.put(sample_key("private-key")).expect("store private key");
+
+    let directory_mode =
+        std::fs::metadata(&root).expect("key directory metadata").permissions().mode() & 0o777;
+    let file_mode = std::fs::metadata(root.join("private-key.key"))
+        .expect("key file metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(directory_mode, 0o700);
+    assert_eq!(file_mode, 0o600);
+}
+
+#[cfg(unix)]
+#[test]
+fn file_key_manager_does_not_follow_legacy_temp_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let victim = temp.path().join("victim");
+    std::fs::write(&victim, b"unchanged").expect("write victim");
+    let root = temp.path().join("keys");
+    let manager = FileKeyManager::new(&root).expect("file manager");
+    let legacy_tmp = root.join("node-signing.tmp");
+    symlink(&victim, &legacy_tmp).expect("create legacy temp symlink");
+
+    manager.put(sample_key("node-signing")).expect("store key");
+
+    assert_eq!(std::fs::read(&victim).expect("read victim"), b"unchanged");
+    assert!(legacy_tmp.is_symlink());
+    assert!(manager.get("node-signing").expect("load key").is_some());
+}

--- a/crates/libs/rns-transport/src/destination/ratchet.rs
+++ b/crates/libs/rns-transport/src/destination/ratchet.rs
@@ -92,9 +92,6 @@ impl RatchetState {
     }
 
     fn persist(&self, identity: &PrivateIdentity, path: &Path) -> Result<(), RnsError> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|_| RnsError::PacketError)?;
-        }
         let packed = pack_ratchets(&self.ratchets)?;
         let signature = identity.sign(&packed).to_bytes();
         let persisted = PersistedRatchets {
@@ -102,13 +99,8 @@ impl RatchetState {
             ratchets: ByteBuf::from(packed),
         };
         let encoded = rmp_serde::to_vec(&persisted).map_err(|_| RnsError::PacketError)?;
-        let tmp_path = path.with_extension("tmp");
-        std::fs::write(&tmp_path, encoded).map_err(|_| RnsError::PacketError)?;
-        #[cfg(windows)]
-        if path.exists() {
-            std::fs::remove_file(path).map_err(|_| RnsError::PacketError)?;
-        }
-        std::fs::rename(&tmp_path, path).map_err(|_| RnsError::PacketError)?;
+        rns_core::secure_storage::atomic_write_private(path, &encoded)
+            .map_err(|_| RnsError::PacketError)?;
         Ok(())
     }
 
@@ -162,4 +154,72 @@ pub(crate) fn try_decrypt_with_ratchets(
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RatchetState;
+    use crate::identity::PrivateIdentity;
+    use rand_core::OsRng;
+
+    #[test]
+    fn persisted_ratchets_roundtrip() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("ratchets").join("destination.ratchets");
+        let identity = PrivateIdentity::new_from_rand(OsRng);
+        let expected = vec![[0x42; super::RATCHET_LENGTH]];
+        let state = RatchetState { ratchets: expected.clone(), ..RatchetState::default() };
+
+        state.persist(&identity, &path).expect("persist ratchets");
+        let mut loaded = RatchetState::default();
+        loaded.reload(&identity, &path).expect("reload ratchets");
+
+        assert_eq!(loaded.ratchets, expected);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persisted_ratchets_use_private_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let directory = temp.path().join("ratchets");
+        std::fs::create_dir(&directory).expect("create permissive ratchet directory");
+        std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o755))
+            .expect("set permissive directory mode");
+        let path = directory.join("destination.ratchets");
+        let identity = PrivateIdentity::new_from_rand(OsRng);
+
+        RatchetState::default().persist(&identity, &path).expect("persist ratchets");
+
+        let directory_mode =
+            std::fs::metadata(&directory).expect("ratchet directory metadata").permissions().mode()
+                & 0o777;
+        let file_mode =
+            std::fs::metadata(&path).expect("ratchet file metadata").permissions().mode() & 0o777;
+        assert_eq!(directory_mode, 0o700);
+        assert_eq!(file_mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persisted_ratchets_do_not_follow_legacy_temp_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let directory = temp.path().join("ratchets");
+        std::fs::create_dir(&directory).expect("create ratchet directory");
+        let path = directory.join("destination.ratchets");
+        let victim = temp.path().join("victim");
+        std::fs::write(&victim, b"unchanged").expect("write victim");
+        let legacy_tmp = path.with_extension("tmp");
+        symlink(&victim, &legacy_tmp).expect("create legacy temp symlink");
+        let identity = PrivateIdentity::new_from_rand(OsRng);
+
+        RatchetState::default().persist(&identity, &path).expect("persist ratchets");
+
+        assert_eq!(std::fs::read(&victim).expect("read victim"), b"unchanged");
+        assert!(legacy_tmp.is_symlink());
+        assert!(path.is_file());
+    }
 }


### PR DESCRIPTION
## Summary

I looked at how the project writes keys and ratchets to disk and found that several paths used std::fs::write() with predictable temporary file names.

That leaves file permissions dependent on the process umask. It also means an existing temporary-file symlink can be followed before the file is renamed. This is not a good default for files containing raw private key material.

This patch adds a small shared helper which creates randomized temporary files exclusively, writes and syncs the data, and then renames the file into place. On Unix, secret directories use mode 0700 and files use 0600.

I also replaced the derived Debug implementation for StoredKey, since the previous implementation printed the complete key material.

The patch includes permission, symlink, round-trip and redaction tests.

## Type
- [ ] breaking
- [ ] refactor
- [ ] reliability
- [x] security
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `make test`
- [x] `make test-all` (optional compatibility pass)
- [x] `make test-full-targets` (optional full-target parity check)
- [x] `cargo doc --workspace --no-deps`
- [x] `cargo deny check`
- [x] `cargo audit`

## Compatibility
- [x] Updated compatibility matrix / contract docs (if needed)
