### PR TITLE
Provide a real time source for no_std ratchet validation

### DIFF
--- a/crates/libs/rns-core/src/destination/ratchet.rs
+++ b/crates/libs/rns-core/src/destination/ratchet.rs
@@ -178,3 +178,67 @@ pub(crate) fn try_decrypt_with_ratchets(
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{RatchetState, DEFAULT_RATCHET_INTERVAL_SECS};
+    use crate::identity::PrivateIdentity;
+    use rand_core::OsRng;
+
+    // no_std-focused tests for issue #518: ratchet rotation is driven
+    // entirely by the injected `now`, so the embedded time contract can
+    // be validated deterministically. A frozen or zero clock must never
+    // silently rotate (or refuse to rotate) — rotation happens exactly
+    // when the injected time crosses the interval boundary.
+    #[test]
+    fn rotate_if_needed_rotates_exactly_on_injected_interval_boundary() {
+        let identity = PrivateIdentity::new_from_rand(OsRng);
+        let mut state = RatchetState { enabled: true, ..RatchetState::default() };
+
+        state.rotate_if_needed(&identity, 1_000.0).expect("first rotation");
+        assert_eq!(state.ratchets.len(), 1, "empty state rotates regardless of clock");
+        let first = state.ratchets.clone();
+
+        state
+            .rotate_if_needed(&identity, 1_000.0 + DEFAULT_RATCHET_INTERVAL_SECS as f64 - 1.0)
+            .expect("within interval");
+        assert_eq!(state.ratchets, first, "no rotation before the interval elapses");
+
+        state
+            .rotate_if_needed(&identity, 1_000.0 + DEFAULT_RATCHET_INTERVAL_SECS as f64 + 1.0)
+            .expect("past interval");
+        assert_eq!(state.ratchets.len(), 2);
+        assert_ne!(
+            state.ratchets[0], first[0],
+            "rotation past the interval installs a new ratchet"
+        );
+    }
+
+    #[test]
+    fn rotate_if_needed_with_zero_clock_does_not_falsely_rotate_or_expire() {
+        let identity = PrivateIdentity::new_from_rand(OsRng);
+        let mut state = RatchetState { enabled: true, ..RatchetState::default() };
+
+        // The issue-518 no_std failure mode: a silent 0.0 clock rotates
+        // once and then never again (0 > 0 + interval is false), freezing
+        // the replay window. With the injected-time contract the caller
+        // controls `now`, and a zero value must behave as "no time
+        // elapsed": rotate the empty state once, then hold steady.
+        state.rotate_if_needed(&identity, 0.0).expect("zero clock");
+        assert_eq!(state.ratchets.len(), 1);
+        let only = state.ratchets.clone();
+        for _ in 0..3 {
+            state.rotate_if_needed(&identity, 0.0).expect("zero clock again");
+        }
+        assert_eq!(state.ratchets, only, "a frozen clock must not silently rotate or expire");
+    }
+
+    #[test]
+    fn rotate_if_needed_noops_when_ratchets_disabled() {
+        let identity = PrivateIdentity::new_from_rand(OsRng);
+        let mut state = RatchetState::default();
+
+        state.rotate_if_needed(&identity, 1_000.0).expect("disabled state");
+        assert!(state.ratchets.is_empty());
+    }
+}

--- a/crates/libs/rns-core/src/destination/tests.rs
+++ b/crates/libs/rns-core/src/destination/tests.rs
@@ -239,9 +239,10 @@ fn announce_random_blob_matches_python_layout() {
         priv_identity,
         DestinationName::new("example_utilities", "announcesample.fruits"),
     );
-    let before = now_secs().floor() as u64;
+    let _guard = crate::ratchets::tests::time_test_lock().lock().expect("time test lock");
+    let before = now_secs().expect("std tests have a system clock").floor() as u64;
     let announce = destination.announce(FixedRng::new(0x11), None).expect("valid announce");
-    let after = now_secs().floor() as u64;
+    let after = now_secs().expect("std tests have a system clock").floor() as u64;
 
     let blob = decode_announce_random_blob(&announce);
     assert_eq!(&blob[..5], &[0x11, 0x12, 0x13, 0x14, 0x15]);
@@ -251,4 +252,31 @@ fn announce_random_blob_matches_python_layout() {
     let emitted = u64::from_be_bytes(ts_bytes);
     assert!(emitted >= before.saturating_sub(1));
     assert!(emitted <= after.saturating_add(1));
+}
+
+// no_std-focused test for issue #518: with the embedded time contract
+// installed, the announce timestamp comes from the override, not a
+// silently-zero clock. (In a real no_std build without an override,
+// `announce` fails with `RnsError::TimeSourceUnavailable`; that branch
+// only compiles without the `std` feature, so host tests exercise the
+// contract through the override.)
+#[test]
+fn announce_timestamp_uses_embedded_time_override() {
+    let _guard = crate::ratchets::tests::time_test_lock().lock().expect("time test lock");
+    let priv_identity = PrivateIdentity::new_from_rand(OsRng);
+    let mut destination = SingleInputDestination::new(
+        priv_identity,
+        DestinationName::new("example_utilities", "announcesample.fruits"),
+    );
+
+    crate::ratchets::set_time_override(1_700_000_000.9);
+    let announce = destination
+        .announce(FixedRng::new(0x11), None)
+        .expect("valid announce with embedded time source");
+    crate::ratchets::clear_time_override();
+
+    let blob = decode_announce_random_blob(&announce);
+    let mut ts_bytes = [0u8; 8];
+    ts_bytes[3..8].copy_from_slice(&blob[5..10]);
+    assert_eq!(u64::from_be_bytes(ts_bytes), 1_700_000_000);
 }

--- a/crates/libs/rns-core/src/destination_parts/module_core.rs
+++ b/crates/libs/rns-core/src/destination_parts/module_core.rs
@@ -312,12 +312,18 @@ impl Destination<PrivateIdentity, Input, Single> {
         // Python Reticulum encodes announce randomness as 5 random bytes
         // followed by a 5-byte big-endian unix timestamp. Matching this
         // layout keeps announce freshness/path ordering interoperable.
+        // In no_std builds this fails explicitly with
+        // `TimeSourceUnavailable` until the embedding application
+        // installs a clock via `ratchets::set_time_override` — a silent
+        // zero timestamp would corrupt announce freshness ordering and
+        // freeze ratchet rotation (issue #518).
+        let now = now_secs().ok_or(RnsError::TimeSourceUnavailable)?;
         let mut rand_hash = [0u8; RAND_HASH_LENGTH];
         let mut random_part = [0u8; RAND_HASH_LENGTH / 2];
         let mut rng_mut = rng;
         rng_mut.fill_bytes(&mut random_part);
         rand_hash[..RAND_HASH_LENGTH / 2].copy_from_slice(&random_part);
-        let emitted_secs = now_secs().floor() as u64;
+        let emitted_secs = now.floor() as u64;
         let emitted_be = emitted_secs.to_be_bytes();
         rand_hash[RAND_HASH_LENGTH / 2..].copy_from_slice(&emitted_be[3..8]);
 
@@ -325,7 +331,6 @@ impl Destination<PrivateIdentity, Input, Single> {
         let verifying_key = self.identity.as_identity().verifying_key_bytes();
 
         let ratchet = if self.ratchet_state.enabled {
-            let now = now_secs();
             self.ratchet_state.rotate_if_needed(&self.identity, now)?;
             self.ratchet_state.current_ratchet_public()
         } else {

--- a/crates/libs/rns-core/src/error.rs
+++ b/crates/libs/rns-core/src/error.rs
@@ -7,6 +7,11 @@ pub enum RnsError {
     CryptoError,
     PacketError,
     ConnectionError,
+    /// No wall-clock time source is available. Returned by
+    /// timestamp-dependent operations (announce timestamps, ratchet
+    /// rotation) in `no_std` builds before the embedding application has
+    /// installed one via `ratchets::set_time_override`.
+    TimeSourceUnavailable,
 }
 
 impl core::fmt::Display for RnsError {
@@ -19,6 +24,10 @@ impl core::fmt::Display for RnsError {
             Self::CryptoError => "cryptographic operation failed",
             Self::PacketError => "invalid packet",
             Self::ConnectionError => "connection failed",
+            Self::TimeSourceUnavailable => {
+                "no wall-clock time source available (install one via \
+                 ratchets::set_time_override in no_std builds)"
+            }
         })
     }
 }

--- a/crates/libs/rns-core/src/ratchets.rs
+++ b/crates/libs/rns-core/src/ratchets.rs
@@ -1,6 +1,8 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
 use rand_core::CryptoRngCore;
 use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
 
@@ -123,16 +125,110 @@ pub fn decrypt_with_identity_into<'a>(
     Ok(plain.as_bytes())
 }
 
-pub(crate) fn now_secs() -> f64 {
+pub(crate) fn now_secs() -> Option<f64> {
+    if TIME_OVERRIDE_SET.load(Ordering::Acquire) {
+        return Some(f64::from(TIME_OVERRIDE_SECS.load(Ordering::Acquire)));
+    }
     #[cfg(feature = "std")]
     {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs_f64()
+        Some(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs_f64(),
+        )
     }
     #[cfg(not(feature = "std"))]
     {
-        0.0
+        // Embedded time contract (issue #518): there is no system clock
+        // in no_std builds. Rather than silently returning zero — which
+        // would pin announce timestamps to the epoch and freeze ratchet
+        // rotation after the first key, silently defeating expiry and
+        // replay-window checks — report the absence of a time source so
+        // callers fail explicitly until `set_time_override` is called.
+        None
+    }
+}
+
+// Embedded time contract state. Whole-second resolution is sufficient:
+// announce random blobs encode whole seconds and ratchet intervals are
+// seconds-granular. `AtomicU32` keeps the contract usable on embedded
+// targets without 64-bit atomics (e.g. thumbv6m).
+static TIME_OVERRIDE_SECS: AtomicU32 = AtomicU32::new(0);
+static TIME_OVERRIDE_SET: AtomicBool = AtomicBool::new(false);
+
+/// Installs (or replaces) the wall-clock time used by announce
+/// timestamps and ratchet rotation, at whole-second resolution.
+///
+/// This is the embedded time contract for `no_std` builds (issue #518):
+/// the embedding application must call this with the current unix time
+/// (e.g. from an RTC) before using announce/ratchet flows, and call it
+/// again as time advances. Without it, timestamp-dependent operations
+/// fail with [`RnsError::TimeSourceUnavailable`] instead of silently
+/// using a zero timestamp.
+///
+/// In `std` builds the system clock is used by default and this serves
+/// as a deterministic override, primarily for tests.
+///
+/// Non-finite or pre-epoch values are clamped to `0`; values beyond
+/// `u32::MAX` seconds are clamped to `u32::MAX`.
+pub fn set_time_override(now_secs: f64) {
+    let secs = if now_secs.is_finite() && now_secs > 0.0 {
+        (now_secs as u64).min(u64::from(u32::MAX)) as u32
+    } else {
+        0
+    };
+    TIME_OVERRIDE_SECS.store(secs, Ordering::Release);
+    TIME_OVERRIDE_SET.store(true, Ordering::Release);
+}
+
+/// Removes a previously installed time override, restoring the default
+/// clock behavior (system time in `std` builds, "no time source" in
+/// `no_std` builds).
+pub fn clear_time_override() {
+    TIME_OVERRIDE_SET.store(false, Ordering::Release);
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::{clear_time_override, now_secs, set_time_override};
+
+    /// Serializes tests that install the global time override against
+    /// each other and against tests that rely on the real clock (e.g.
+    /// `destination::tests::announce_random_blob_matches_python_layout`).
+    pub(crate) fn time_test_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        &LOCK
+    }
+
+    #[test]
+    fn now_secs_uses_override_once_embedded_time_source_is_installed() {
+        let _guard = time_test_lock().lock().expect("time test lock");
+        set_time_override(1_700_000_000.7);
+        assert_eq!(
+            now_secs(),
+            Some(1_700_000_000.0),
+            "override applies at whole-second resolution"
+        );
+        set_time_override(1_700_000_123.0);
+        assert_eq!(
+            now_secs(),
+            Some(1_700_000_123.0),
+            "the source can be refreshed as time advances"
+        );
+        clear_time_override();
+        assert_ne!(now_secs(), Some(1_700_000_123.0), "std builds fall back to the system clock");
+    }
+
+    #[test]
+    fn time_override_clamps_out_of_range_values() {
+        let _guard = time_test_lock().lock().expect("time test lock");
+        set_time_override(f64::NAN);
+        assert_eq!(now_secs(), Some(0.0));
+        set_time_override(-42.0);
+        assert_eq!(now_secs(), Some(0.0));
+        set_time_override(f64::from(u32::MAX) + 1000.0);
+        assert_eq!(now_secs(), Some(f64::from(u32::MAX)));
+        clear_time_override();
     }
 }


### PR DESCRIPTION
## Summary

Fixes #518.

Under `no_std`, `now_secs()` in `crates/libs/rns-core/src/ratchets.rs` silently returned `0.0`. That pinned announce timestamps to the unix epoch and froze ratchet rotation after the first key (`0 > 0 + interval` is never true), silently defeating timestamp-dependent expiry and replay-window checks in embedded builds.

**Embedded time contract (new):**
- `ratchets::set_time_override(now_secs: f64)` / `clear_time_override()` — the embedding application installs wall-clock time (e.g. from an RTC) before using announce/ratchet flows, refreshing it as time advances. Whole-second resolution (announce random blobs and ratchet intervals are seconds-granular) stored in an `AtomicU32` so targets without 64-bit atomics (e.g. thumbv6m) work. Non-finite/pre-epoch/overflow values are clamped explicitly.
- `now_secs()` now returns `Option<f64>`: `None` in `no_std` builds without an installed source — no more silent zero. `std` builds default to the system clock; the override doubles as a deterministic test hook.
- `announce()` fails explicitly with the new `RnsError::TimeSourceUnavailable` when no time source exists, instead of emitting a corrupt epoch timestamp. A single `now` is reused for both the announce timestamp and ratchet rotation.

**no_std-focused tests:**
- Override install/refresh/clamp semantics for `now_secs`.
- Announce timestamp comes from the installed override.
- Ratchet rotation happens exactly on the injected interval boundary; a frozen/zero clock never silently rotates or expires; disabled state no-ops.
- A shared test lock serializes override-installing tests against real-clock tests.

## Type
- [ ] breaking
- [ ] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p reticulum-rs-core --all-targets --all-features --no-deps` (clean; also clippy with `--no-default-features --features alloc`)
- [x] `cargo test -p reticulum-rs-core` (36 passed, 0 failed — includes 6 new tests)
- [x] `cargo check -p reticulum-rs-core --no-default-features --features alloc` (no_std build)
- [x] `cargo check --workspace` and `cargo check -p rns-embedded-mininode` (embedded consumer still builds)
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)

## Compatibility
- `now_secs()` is `pub(crate)` — no external signature changes. Additive public API: `set_time_override`, `clear_time_override`, and the `RnsError::TimeSourceUnavailable` variant (`std` behavior is unchanged when no override is installed).
- Note: `lxmf-core` has a similar `now_secs_f64` silent-zero path under `no_std`; left out of scope here, but it can adopt this contract in a follow-up.