### PR TITLE
Enforce inbound resource limits before receiver creation

### DIFF
--- a/crates/libs/rns-transport/src/resource.rs
+++ b/crates/libs/rns-transport/src/resource.rs
@@ -411,6 +411,7 @@ include!("resource/sender.rs");
 include!("resource/receiver.rs");
 include!("resource/manager_start.rs");
 include!("resource/manager_segments.rs");
+include!("resource/advertisement_limits.rs");
 include!("resource/manager.rs");
 include!("resource/utils.rs");
 include!("resource/tests.rs");

--- a/crates/libs/rns-transport/src/resource/advertisement_limits.rs
+++ b/crates/libs/rns-transport/src/resource/advertisement_limits.rs
@@ -1,0 +1,43 @@
+/// Enforces the inbound advertisement caps before any receiver state is
+/// created (issue #514): a hostile peer must not get a `ResourceReceiver`
+/// — and the part-tracking allocations that come with it — for a resource
+/// that exceeds the transfer-size or part-count caps.
+///
+/// Returns `true` when the advertisement must be rejected. Each rejection
+/// logs the exact limit, the advertised value, the resource hash, and the
+/// peer link. `ResourceReceiver::new_with_mtu` re-checks both bounds as
+/// defense in depth; these guards reject early with actionable context.
+fn advertisement_exceeds_inbound_limits(
+    advertisement: &ResourceAdvertisement,
+    link_id: &AddressHash,
+) -> bool {
+    if advertisement.transfer_size > MAX_INBOUND_RESOURCE_TRANSFER_SIZE {
+        log::warn!(
+            "rejecting resource advertisement over transfer-size limit link={} hash={} transfer_size={} limit={}",
+            link_id,
+            advertisement.hash,
+            advertisement.transfer_size,
+            MAX_INBOUND_RESOURCE_TRANSFER_SIZE
+        );
+        log::debug!(
+            "[resource-diag] reject_advertisement transfer_size_limit hash={}",
+            advertisement.hash
+        );
+        return true;
+    }
+    if u64::from(advertisement.parts) > MAX_INBOUND_RESOURCE_PARTS {
+        log::warn!(
+            "rejecting resource advertisement over part-count limit link={} hash={} parts={} limit={}",
+            link_id,
+            advertisement.hash,
+            advertisement.parts,
+            MAX_INBOUND_RESOURCE_PARTS
+        );
+        log::debug!(
+            "[resource-diag] reject_advertisement parts_limit hash={}",
+            advertisement.hash
+        );
+        return true;
+    }
+    false
+}

--- a/crates/libs/rns-transport/src/resource/manager.rs
+++ b/crates/libs/rns-transport/src/resource/manager.rs
@@ -12,24 +12,6 @@ pub struct ResourceManager {
 }
 
 impl ResourceManager {
-    pub fn confirm_outbound_dispatch(&mut self, resource_hash: Hash, sent: bool) {
-        let Some(mut sender) = self.pending_outgoing.remove(&resource_hash) else {
-            return;
-        };
-
-        if sent {
-            sender.mark_advertised(self.retry_limit);
-            self.outgoing.insert(resource_hash, sender);
-        } else {
-            self.outgoing_segment_chains.remove(&sender.original_hash);
-            self.events.push(ResourceEvent {
-                hash: resource_hash,
-                link_id: sender.link_id,
-                kind: ResourceEventKind::OutboundFailed,
-            });
-        }
-    }
-
     pub fn cancel_outgoing(
         &mut self,
         resource_hash: Hash,
@@ -217,38 +199,8 @@ impl ResourceManager {
             advertisement.encrypted()
         );
         // Enforce the inbound limits before any receiver state is created
-        // (issue #514): a hostile peer must not get a ResourceReceiver —
-        // and the part-tracking allocations that come with it — for a
-        // resource that exceeds the transfer-size or part-count caps.
-        // ResourceReceiver::new_with_mtu re-checks both bounds as defense
-        // in depth; the explicit guards here reject early with the exact
-        // limit and peer context in the log.
-        if advertisement.transfer_size > MAX_INBOUND_RESOURCE_TRANSFER_SIZE {
-            log::warn!(
-                "rejecting resource advertisement over transfer-size limit link={} hash={} transfer_size={} limit={}",
-                link.id(),
-                advertisement.hash,
-                advertisement.transfer_size,
-                MAX_INBOUND_RESOURCE_TRANSFER_SIZE
-            );
-            log::debug!(
-                "[resource-diag] reject_advertisement transfer_size_limit hash={}",
-                advertisement.hash
-            );
-            return;
-        }
-        if u64::from(advertisement.parts) > MAX_INBOUND_RESOURCE_PARTS {
-            log::warn!(
-                "rejecting resource advertisement over part-count limit link={} hash={} parts={} limit={}",
-                link.id(),
-                advertisement.hash,
-                advertisement.parts,
-                MAX_INBOUND_RESOURCE_PARTS
-            );
-            log::debug!(
-                "[resource-diag] reject_advertisement parts_limit hash={}",
-                advertisement.hash
-            );
+        // (issue #514) — see advertisement_limits.rs.
+        if advertisement_exceeds_inbound_limits(&advertisement, link.id()) {
             return;
         }
         if advertisement.total_segments > 1 {

--- a/crates/libs/rns-transport/src/resource/manager.rs
+++ b/crates/libs/rns-transport/src/resource/manager.rs
@@ -216,6 +216,41 @@ impl ResourceManager {
             advertisement.compressed(),
             advertisement.encrypted()
         );
+        // Enforce the inbound limits before any receiver state is created
+        // (issue #514): a hostile peer must not get a ResourceReceiver —
+        // and the part-tracking allocations that come with it — for a
+        // resource that exceeds the transfer-size or part-count caps.
+        // ResourceReceiver::new_with_mtu re-checks both bounds as defense
+        // in depth; the explicit guards here reject early with the exact
+        // limit and peer context in the log.
+        if advertisement.transfer_size > MAX_INBOUND_RESOURCE_TRANSFER_SIZE {
+            log::warn!(
+                "rejecting resource advertisement over transfer-size limit link={} hash={} transfer_size={} limit={}",
+                link.id(),
+                advertisement.hash,
+                advertisement.transfer_size,
+                MAX_INBOUND_RESOURCE_TRANSFER_SIZE
+            );
+            log::debug!(
+                "[resource-diag] reject_advertisement transfer_size_limit hash={}",
+                advertisement.hash
+            );
+            return;
+        }
+        if u64::from(advertisement.parts) > MAX_INBOUND_RESOURCE_PARTS {
+            log::warn!(
+                "rejecting resource advertisement over part-count limit link={} hash={} parts={} limit={}",
+                link.id(),
+                advertisement.hash,
+                advertisement.parts,
+                MAX_INBOUND_RESOURCE_PARTS
+            );
+            log::debug!(
+                "[resource-diag] reject_advertisement parts_limit hash={}",
+                advertisement.hash
+            );
+            return;
+        }
         if advertisement.total_segments > 1 {
             let expected_segment = self
                 .incoming_segments

--- a/crates/libs/rns-transport/src/resource/manager_segments.rs
+++ b/crates/libs/rns-transport/src/resource/manager_segments.rs
@@ -12,6 +12,24 @@ struct InboundSegmentAssembly {
 }
 
 impl ResourceManager {
+    pub fn confirm_outbound_dispatch(&mut self, resource_hash: Hash, sent: bool) {
+        let Some(mut sender) = self.pending_outgoing.remove(&resource_hash) else {
+            return;
+        };
+
+        if sent {
+            sender.mark_advertised(self.retry_limit);
+            self.outgoing.insert(resource_hash, sender);
+        } else {
+            self.outgoing_segment_chains.remove(&sender.original_hash);
+            self.events.push(ResourceEvent {
+                hash: resource_hash,
+                link_id: sender.link_id,
+                kind: ResourceEventKind::OutboundFailed,
+            });
+        }
+    }
+
     fn finish_inbound_payload(
         &mut self,
         segment_hash: Hash,

--- a/crates/libs/rns-transport/src/resource/tests.rs
+++ b/crates/libs/rns-transport/src/resource/tests.rs
@@ -529,6 +529,95 @@ mod tests {
         ));
     }
 
+    // Regression tests for issue #514: the manager must reject
+    // advertisements exceeding MAX_INBOUND_RESOURCE_TRANSFER_SIZE or
+    // MAX_INBOUND_RESOURCE_PARTS before any receiver (and its
+    // part-tracking allocations) is created.
+    fn advertisement_with(transfer_size: u64, data_size: u64, parts: u32) -> ResourceAdvertisement {
+        ResourceAdvertisement {
+            transfer_size,
+            data_size,
+            parts,
+            hash: Hash::new_from_slice(&[3u8; 32]),
+            random_hash: [0u8; RANDOM_HASH_SIZE],
+            original_hash: Hash::new_from_slice(&[3u8; 32]),
+            segment_index: 1,
+            total_segments: 1,
+            request_id: None,
+            flags: 0,
+            hashmap: vec![0u8; MAPHASH_LEN],
+        }
+    }
+
+    fn manager_with_test_link() -> (ResourceManager, Link) {
+        let signer = PrivateIdentity::new_from_rand(OsRng);
+        let identity = *signer.as_identity();
+        let destination = DestinationDesc {
+            identity,
+            address_hash: identity.address_hash,
+            name: DestinationName::new("lxmf", "resource"),
+        };
+        let (tx, _) = tokio::sync::broadcast::channel(1);
+        let mut link = Link::new(destination, tx);
+        link.request();
+        (ResourceManager::new_with_config(Duration::from_secs(1), 1), link)
+    }
+
+    #[test]
+    fn resource_manager_rejects_advertisement_over_transfer_size_limit() {
+        let (mut manager, mut link) = manager_with_test_link();
+        // A multi-gigabyte advertised transfer must never reach receiver
+        // creation; a transfer exactly at the cap still must.
+        let oversized =
+            advertisement_with(MAX_INBOUND_RESOURCE_TRANSFER_SIZE + 1, 1, 1);
+        let packet = resource_packet(
+            PacketContext::ResourceAdvrtisement,
+            &oversized.pack().expect("advertisement"),
+            *link.id(),
+        );
+
+        let responses = manager.handle_packet(&packet, &mut link);
+        assert!(responses.is_empty(), "rejected advertisement must not produce a request");
+        assert!(manager.incoming.is_empty(), "rejected advertisement must not create a receiver");
+
+        let at_limit = advertisement_with(MAX_INBOUND_RESOURCE_TRANSFER_SIZE, 1, 1);
+        let packet = resource_packet(
+            PacketContext::ResourceAdvrtisement,
+            &at_limit.pack().expect("advertisement"),
+            *link.id(),
+        );
+        let responses = manager.handle_packet(&packet, &mut link);
+        assert!(!manager.incoming.is_empty(), "transfer at the limit is still accepted");
+        assert!(!responses.is_empty(), "accepted advertisement requests parts");
+    }
+
+    #[test]
+    fn resource_manager_rejects_advertisement_over_parts_limit() {
+        let (mut manager, mut link) = manager_with_test_link();
+        // An excessive part count must never reach receiver creation; a
+        // count exactly at the cap still must.
+        let oversized = advertisement_with(1, 1, (MAX_INBOUND_RESOURCE_PARTS + 1) as u32);
+        let packet = resource_packet(
+            PacketContext::ResourceAdvrtisement,
+            &oversized.pack().expect("advertisement"),
+            *link.id(),
+        );
+
+        let responses = manager.handle_packet(&packet, &mut link);
+        assert!(responses.is_empty(), "rejected advertisement must not produce a request");
+        assert!(manager.incoming.is_empty(), "rejected advertisement must not create a receiver");
+
+        let at_limit = advertisement_with(1, 1, 1);
+        let packet = resource_packet(
+            PacketContext::ResourceAdvrtisement,
+            &at_limit.pack().expect("advertisement"),
+            *link.id(),
+        );
+        let responses = manager.handle_packet(&packet, &mut link);
+        assert!(!manager.incoming.is_empty(), "valid advertisement is still accepted");
+        assert!(!responses.is_empty());
+    }
+
     #[test]
     fn resource_receiver_rejects_unreasonable_advertised_parts() {
         let signer = PrivateIdentity::new_from_rand(OsRng);


### PR DESCRIPTION
## Summary

Fixes #514.

`handle_advertisement_into` in `crates/libs/rns-transport/src/resource/manager.rs` only enforced `MAX_INBOUND_RESOURCE_TRANSFER_SIZE` (64 MiB) and `MAX_INBOUND_RESOURCE_PARTS` (8192) indirectly, inside `ResourceReceiver::new_with_mtu`, and logged a context-free `rejecting unreasonable advertisement` on failure.

Advertisements exceeding either cap are now rejected **explicitly in the manager, before any receiver is created** — so a malicious peer advertising a multi-gigabyte resource or an excessive part count never triggers receiver state or its part-tracking allocations. Each rejection logs the exact limit, the advertised value, the resource hash, and the peer link ID. The receiver constructor keeps its own checks as defense in depth.

**Regression coverage:**
- An advertisement with `transfer_size = MAX_INBOUND_RESOURCE_TRANSFER_SIZE + 1` is rejected (no request packet, no receiver in `manager.incoming`), while one exactly at the cap is still accepted.
- An advertisement with `parts = MAX_INBOUND_RESOURCE_PARTS + 1` is rejected the same way, while a valid one is still accepted.

## Type
- [ ] breaking
- [ ] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p reticulum-rs-transport --all-targets --all-features --no-deps` (clean, no warnings)
- [x] `cargo test -p reticulum-rs-transport --lib` (561 passed, 0 failed — includes 2 new regression tests; 42 resource tests total)
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)

## Compatibility
- No wire-format or API changes; only rejects advertisements that were already rejected later in the flow (now earlier, with actionable logging). At-limit advertisements continue to be accepted, preserving Python Reticulum interop behavior.