### PR TITLE
Document and test the announce identity-drift invariant (#517)

### DIFF
--- a/crates/libs/rns-transport/src/transport/announce.rs
+++ b/crates/libs/rns-transport/src/transport/announce.rs
@@ -1,6 +1,23 @@
 use super::announce_limits::AnnounceLimitAction;
 use super::*;
+use crate::identity::Identity;
 use crate::packet::{Header, HeaderType, PropagationType};
+
+/// Identity-drift invariant (issue #517), matching reference Reticulum's
+/// `Identity.validate_announce`: the ONLY cross-announce binding for a
+/// known destination is the public/verifying key pair.
+///
+/// The destination-hash ↔ name-hash binding is enforced separately by
+/// `DestinationAnnounce::validate` (it recomputes the address hash from
+/// the announced identity + name hash), so name_hash cannot drift
+/// independently of the destination hash. app_data must NOT be compared
+/// here — the reference implementation overwrites app_data on every
+/// accepted announce, so rejecting on app_data change would break
+/// legitimate announces (e.g. LXMF peers rotating stamp-cost metadata)
+/// and diverge from protocol behavior.
+fn identity_drifted(existing: &Identity, announced: &Identity) -> bool {
+    existing.public_key != announced.public_key || existing.verifying_key != announced.verifying_key
+}
 
 async fn process_announce<'a>(
     packet: &Packet,
@@ -15,9 +32,8 @@ async fn process_announce<'a>(
 
     if let Some(existing) = handler.single_out_destinations.get(&packet.destination).cloned() {
         let existing = existing.lock().await;
-        if existing.identity.public_key != announce.destination.identity.public_key
-            || existing.identity.verifying_key != announce.destination.identity.verifying_key
-        {
+        // Centralized drift invariant (issue #517): see `identity_drifted`.
+        if identity_drifted(&existing.identity, &announce.destination.identity) {
             log::warn!(
                 "tp({}): rejecting announce for {} due to identity drift",
                 handler.config.name,

--- a/crates/libs/rns-transport/src/transport/tests.rs
+++ b/crates/libs/rns-transport/src/transport/tests.rs
@@ -12,6 +12,8 @@ include!("tests_parts/tunnel_restore_freshness.rs");
 
 include!("tests_parts/held_udp_announce_preserves_peer_sou.rs");
 
+include!("tests_parts/announce_identity_drift.rs");
+
 include!("tests_parts/announce_broadcast_policy.rs");
 
 include!("tests_parts/encrypted_resource_control_packet.rs");

--- a/crates/libs/rns-transport/src/transport/tests_parts/announce_identity_drift.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/announce_identity_drift.rs
@@ -1,0 +1,95 @@
+// Issue #517: an announce for an already-known destination hash carrying a
+// different key pair than the one on record must be rejected as identity
+// drift (reference `Identity.validate_announce` parity), while a rotated
+// app_data payload from the SAME key pair must still be accepted.
+
+#[tokio::test]
+async fn announce_with_drifted_identity_is_rejected_without_overwrite() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let mut config = TransportConfig::new("test", &local_identity, true);
+    config.set_retransmit(true);
+    let transport = Transport::new(config);
+    let handler = transport.get_handler();
+    let mut announce_rx = transport.recv_announces().await;
+    let iface = *transport.iface_manager().lock().await.new_channel(16).address();
+
+    let remote_identity = PrivateIdentity::new_from_rand(OsRng);
+    let mut remote_destination =
+        SingleInputDestination::new(remote_identity, DestinationName::new("lxmf", "delivery"));
+    let announce = remote_destination.announce(OsRng, None).expect("valid announce packet");
+    let destination = announce.destination;
+
+    // Simulate a desynchronized/poisoned identity cache: an entry for the
+    // real destination hash carrying an unrelated key pair.
+    let impostor_identity = *PrivateIdentity::new_from_rand(OsRng).as_identity();
+    let impostor_destination = crate::destination::new_out(impostor_identity, "lxmf", "delivery");
+    {
+        let mut guard = handler.lock().await;
+        guard
+            .single_out_destinations
+            .insert(destination, Arc::new(Mutex::new(impostor_destination)));
+    }
+
+    handle_announce(&announce, handler.lock().await, iface, crate::iface::IfaceSource::None).await;
+
+    assert!(
+        matches!(
+            announce_rx.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ),
+        "drifted announce must not emit an announce event"
+    );
+
+    let guard = handler.lock().await;
+    let stored = guard.single_out_destinations.get(&destination).expect("entry").clone();
+    let stored = stored.lock().await;
+    assert_eq!(
+        stored.identity.public_key_bytes(),
+        impostor_identity.public_key_bytes(),
+        "drifted announce must not overwrite the stored identity"
+    );
+    drop(stored);
+    assert!(
+        guard.path_table.get(&destination).is_none(),
+        "drifted announce must not install a path entry"
+    );
+}
+
+#[tokio::test]
+async fn reannounce_with_rotated_app_data_is_accepted() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let config = TransportConfig::new("test", &local_identity, true);
+    let transport = Transport::new(config);
+    let handler = transport.get_handler();
+    let mut announce_rx = transport.recv_announces().await;
+    let iface = *transport.iface_manager().lock().await.new_channel(16).address();
+
+    let remote_identity = PrivateIdentity::new_from_rand(OsRng);
+    let mut remote_destination =
+        SingleInputDestination::new(remote_identity, DestinationName::new("lxmf", "delivery"));
+    let first = remote_destination
+        .announce(OsRng, Some(b"stamp-cost-16"))
+        .expect("first announce");
+
+    handle_announce(&first, handler.lock().await, iface, crate::iface::IfaceSource::None).await;
+    timeout(Duration::from_millis(200), announce_rx.recv())
+        .await
+        .expect("first announce should emit")
+        .expect("broadcast receive");
+
+    // Same key pair, different app_data (e.g. rotated LXMF stamp cost):
+    // reference Reticulum overwrites app_data per accepted announce, so
+    // this must NOT be treated as identity drift. Wait past the ingress
+    // hold window so the reannounce is processed, not rate-held.
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+    let second = remote_destination
+        .announce(OsRng, Some(b"stamp-cost-22"))
+        .expect("rotated app_data announce");
+    handle_announce(&second, handler.lock().await, iface, crate::iface::IfaceSource::None).await;
+
+    let received = timeout(Duration::from_millis(200), announce_rx.recv())
+        .await
+        .expect("app_data rotation from the same identity must still be accepted")
+        .expect("broadcast receive");
+    assert_eq!(received.app_data.as_slice(), b"stamp-cost-22");
+}


### PR DESCRIPTION
## Summary

Closes #517.

When an announce arrives for an already-known destination, the transport rejects it on identity drift. The drift invariant is now centralized in `identity_drifted()` and documented against the reference implementation (`Identity.validate_announce`):

- the ONLY cross-announce binding for a known destination is the **public/verifying key pair**;
- the destination-hash ? name-hash binding is enforced separately by `DestinationAnnounce::validate` (it recomputes the address hash from the announced identity + name hash), so name_hash cannot drift independently;
- **app_data must NOT be compared** � reference Reticulum overwrites app_data on every accepted announce, so rejecting on app_data change would break legitimate announces (e.g. LXMF peers rotating stamp-cost metadata) and diverge from protocol behavior.

New regression tests:

- an announce for a known destination hash carrying an unrelated key pair is rejected without overwriting the stored identity, emitting an event, or installing a path entry;
- a re-announce from the same key pair with rotated app_data is still accepted (app_data updates to the new value).

## Type
- [ ] breaking
- [ ] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p reticulum-rs-transport --lib --no-deps -- -D warnings`
- [x] `cargo test -p reticulum-rs-transport --lib drift` / `rotated_app_data` (both new tests pass)
- [ ] `make test`
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [ ] `cargo doc --workspace --no-deps`
- [ ] `cargo deny check`
- [ ] `cargo audit`

## Compatibility
- Behavior unchanged (drift check already compared the key pair); this PR centralizes the invariant, documents the reference-parity rationale, and pins it with tests.
