### PR TITLE
Centralize the direct-hop path invariant on PathEntry (#515)

### DIFF
--- a/crates/libs/rns-transport/src/transport/path.rs
+++ b/crates/libs/rns-transport/src/transport/path.rs
@@ -20,14 +20,10 @@ pub(super) fn route_inbound_packet(
         return RouteDecision { packet: original_packet.clone(), next_iface: None };
     };
 
-    // Now that inbound packets are correctly incremented on receipt (see
-    // `transport/jobs.rs`'s `apply_receive_hop_increment`), a genuinely
-    // direct (zero real hops away) destination is `entry.hops == 0` —
-    // matching reference Reticulum's own `for_local_client` criterion
-    // (`Transport.py`, `Transport.path_table[dest][IDX_PT_HOPS] == 0`),
-    // confirmed by direct reading. `received_from` doesn't factor into it at
-    // all in the reference implementation.
-    let is_direct_hop = entry.hops == 0;
+    // Centralized direct-hop criterion (issue #515): see
+    // `PathEntry::is_direct` for the full invariant and its dependency on
+    // `apply_receive_hop_increment` in transport/jobs.rs.
+    let is_direct_hop = entry.is_direct();
     let packet = if is_direct_hop {
         Packet {
             header: Header {
@@ -90,28 +86,10 @@ pub(super) fn route_outbound_packet(
         return RouteDecision { packet: original_packet.clone(), next_iface: None };
     };
 
-    // Matches reference Reticulum's own `Transport.outbound()` exactly
-    // (confirmed by direct reading):
-    //
-    //   if hops > 1: Type2
-    //   elif hops == 1 and connected_to_shared_instance: Type2
-    //   else: Type1
-    //
-    // No `received_from` check anywhere in the reference rule — that
-    // condition (previously required here) happened to work for
-    // destinations whose path was learned via a direct announce but broke
-    // anything learned via a relayed/PathResponse announce instead, which is
-    // the overwhelmingly common case for anything reached through a
-    // Transport hub. This only became provably correct once inbound packets
-    // were fixed to increment hops on receipt (see `transport/jobs.rs`) —
-    // reference Reticulum's own `for_local_client`/outbound rules assume
-    // hops faithfully reflects real distance, which this crate's own hops
-    // previously didn't.
-    let type1_eligible = match entry.hops {
-        0 => true,
-        1 => !connected_to_shared_instance,
-        _ => false,
-    };
+    // Centralized `Transport.outbound()` header rule (issue #515): see
+    // `PathEntry::type1_eligible` for the full reference-parity rule and
+    // why `received_from` deliberately doesn't factor into it.
+    let type1_eligible = entry.type1_eligible(connected_to_shared_instance);
 
     if type1_eligible {
         return RouteDecision { packet: original_packet.clone(), next_iface: Some(entry.iface) };

--- a/crates/libs/rns-transport/src/transport/path_table.rs
+++ b/crates/libs/rns-transport/src/transport/path_table.rs
@@ -22,11 +22,46 @@ pub(super) type RandomBlob = [u8; RAND_HASH_LENGTH];
 pub struct PathEntry {
     pub timestamp: Instant,
     pub received_from: AddressHash,
+    /// Real network distance to the destination. This value is only
+    /// meaningful because `apply_receive_hop_increment` (transport/jobs.rs)
+    /// runs on every inbound packet before any path-table bookkeeping —
+    /// see [`PathEntry::is_direct`] (issue #515).
     pub hops: u8,
     pub iface: AddressHash,
     pub packet_hash: Hash,
     random_blobs: Vec<RandomBlob>,
     state: PathState,
+}
+
+impl PathEntry {
+    /// Direct-hop invariant (issue #515): a genuinely direct destination
+    /// is `hops == 0`, matching reference Reticulum's `for_local_client`
+    /// criterion (`Transport.path_table[dest][IDX_PT_HOPS] == 0`). The
+    /// invariant holds only because inbound packets get their hop count
+    /// incremented on receipt (`apply_receive_hop_increment` in
+    /// transport/jobs.rs) before any routing/path decision is made —
+    /// centralizing the checks here means a future refactor of that
+    /// ordering has exactly one place to break, loudly, in tests.
+    pub fn is_direct(&self) -> bool {
+        self.hops == 0
+    }
+
+    /// Reference Reticulum `Transport.outbound()` header rule (confirmed
+    /// by direct reading):
+    ///
+    ///   hops > 1 → Type2
+    ///   hops == 1 and connected_to_shared_instance → Type2
+    ///   else → Type1
+    ///
+    /// Like [`PathEntry::is_direct`], this assumes `hops` reflects real
+    /// distance (see its doc comment).
+    pub fn type1_eligible(&self, connected_to_shared_instance: bool) -> bool {
+        match self.hops {
+            0 => true,
+            1 => !connected_to_shared_instance,
+            _ => false,
+        }
+    }
 }
 
 pub struct PathTable {

--- a/crates/libs/rns-transport/src/transport/path_table_tests.rs
+++ b/crates/libs/rns-transport/src/transport/path_table_tests.rs
@@ -45,6 +45,45 @@ fn announce(destination: AddressHash, hops: u8, prefix: &[u8; 5], emitted: u64) 
     }
 }
 
+fn entry_with_hops(hops: u8) -> PathEntry {
+    PathEntry {
+        timestamp: test_now(),
+        received_from: addr(b"from"),
+        hops,
+        iface: addr(b"iface"),
+        packet_hash: hash(b"packet"),
+        random_blobs: Vec::new(),
+        state: PathState::Unknown,
+    }
+}
+
+/// Issue #515: the direct-hop invariant is centralized in `PathEntry`
+/// helpers so every routing decision agrees on what "direct" means. These
+/// tests pin the full matrix, including the inconsistent intermediate
+/// states a broken `apply_receive_hop_increment` ordering could produce.
+#[test]
+fn direct_hop_invariant_hops_zero_is_direct() {
+    assert!(entry_with_hops(0).is_direct());
+    for hops in [1u8, 2, 3, u8::MAX] {
+        assert!(!entry_with_hops(hops).is_direct(), "hops={hops} must not be direct");
+    }
+}
+
+#[test]
+fn type1_eligibility_matches_reference_outbound_rule() {
+    // Reference Transport.outbound(): hops > 1 -> Type2; hops == 1 and
+    // shared instance -> Type2; else Type1.
+    for shared in [false, true] {
+        assert!(entry_with_hops(0).type1_eligible(shared));
+    }
+    assert!(entry_with_hops(1).type1_eligible(false));
+    assert!(!entry_with_hops(1).type1_eligible(true));
+    for hops in [2u8, 3, 64, u8::MAX] {
+        assert!(!entry_with_hops(hops).type1_eligible(false), "hops={hops} must be Type2");
+        assert!(!entry_with_hops(hops).type1_eligible(true), "hops={hops} must be Type2");
+    }
+}
+
 #[test]
 fn remove_stale_and_expire_path_match_expected_lifetimes() {
     let now = test_now();


### PR DESCRIPTION
## Summary

Closes #515.

Both route decisions in `transport/path.rs` re-implemented the direct-hop criterion inline:

- `route_inbound_packet`: `entry.hops == 0` ? Type1/Broadcast;
- `route_outbound_packet`: `match entry.hops { 0 => true, 1 => !connected_to_shared_instance, _ => false }`.

These are only correct because `apply_receive_hop_increment` (`transport/jobs.rs`) runs on every inbound packet *before* any path-table bookkeeping, so `PathEntry::hops` faithfully reflects real network distance. That coupling was undocumented and duplicated across call sites.

This PR centralizes the invariant in two `PathEntry` helpers with the full reference-parity rationale:

- `is_direct()` � `hops == 0`, matching reference Reticulum `for_local_client` (`Transport.path_table[dest][IDX_PT_HOPS] == 0`);
- `type1_eligible(connected_to_shared_instance)` � the exact reference `Transport.outbound()` header rule (hops > 1 ? Type2; hops == 1 + shared instance ? Type2; else Type1), including why `received_from` deliberately doesn't factor in.

A future refactor of the hop-increment ordering now has exactly one place to break, loudly, in tests. Regression tests pin the full matrix, including the inconsistent intermediate states a broken ordering could produce (`hops=0` must always route Type1; `hops=2` must never be Type1-eligible).

## Type
- [ ] breaking
- [x] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p reticulum-rs-transport --lib --no-deps -- -D warnings`
- [x] `cargo test -p reticulum-rs-transport --lib path` (92/92, incl. new invariant matrix tests)
- [ ] `make test`
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [ ] `cargo doc --workspace --no-deps`
- [ ] `cargo deny check`
- [ ] `cargo audit`

## Compatibility
- Routing behavior unchanged � same decisions, now made through shared helpers pinned to reference `Transport.outbound()` semantics.
