### PR TITLE
Pin roaming same-iface path-response suppression to reference (#516)

### DIFF
--- a/crates/libs/rns-transport/src/transport/path.rs
+++ b/crates/libs/rns-transport/src/transport/path.rs
@@ -239,6 +239,18 @@ pub(super) async fn handle_path_request<'a>(
                 }
 
                 let incoming_iface_mode = handler.iface_manager.lock().await.mode(&iface);
+                // Reference parity (issue #516): Python Reticulum
+                // `Transport.py` (~line 3044) suppresses a known-path
+                // response when the request arrived on a MODE_ROAMING
+                // interface and the known next hop is attached to that
+                // same interface (`attached_interface == received_from`),
+                // because roaming peers are expected to move and answering
+                // would pin a stale route. Behavior here matches the
+                // reference exactly; regression coverage lives in
+                // `tests_parts/module_prelude.rs`
+                // (`roaming_iface_suppresses_known_path_response_when_next_hop_is_same_iface`,
+                // `roaming_iface_delays_known_path_response_when_next_hop_differs`,
+                // `roaming_suppression_only_applies_to_roaming_mode`).
                 if incoming_iface_mode == Some(InterfaceMode::Roaming) && learned_iface == iface {
                     log::trace!(
                         "tp({}): suppressing roaming same-iface path response for {}",

--- a/crates/libs/rns-transport/src/transport/tests.rs
+++ b/crates/libs/rns-transport/src/transport/tests.rs
@@ -12,6 +12,8 @@ include!("tests_parts/tunnel_restore_freshness.rs");
 
 include!("tests_parts/held_udp_announce_preserves_peer_sou.rs");
 
+include!("tests_parts/roaming_path_response_suppression.rs");
+
 include!("tests_parts/announce_broadcast_policy.rs");
 
 include!("tests_parts/encrypted_resource_control_packet.rs");

--- a/crates/libs/rns-transport/src/transport/tests_parts/roaming_path_response_suppression.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/roaming_path_response_suppression.rs
@@ -1,0 +1,52 @@
+// Issue #516: the same-iface known-path suppression is specific to
+// InterfaceMode::Roaming (reference Transport.py ~line 3044). Other
+// interface modes must still answer when the known next hop is attached
+// to the requesting interface.
+
+#[tokio::test]
+async fn roaming_suppression_only_applies_to_roaming_mode() {
+    let local_identity = PrivateIdentity::new_from_rand(OsRng);
+    let mut config = TransportConfig::new("test", &local_identity, true);
+    config.set_retransmit(true);
+    let transport = Transport::new(config);
+    let handler = transport.get_handler();
+
+    let iface = {
+        let manager = transport.iface_manager();
+        let mut manager = manager.lock().await;
+        *manager
+            .new_channel_with_role_and_mode(
+                16,
+                crate::iface::IfaceRole::Unicast,
+                crate::iface::InterfaceMode::AccessPoint,
+            )
+            .address()
+    };
+
+    let remote_identity = PrivateIdentity::new_from_rand(OsRng);
+    let mut remote_destination =
+        SingleInputDestination::new(remote_identity, DestinationName::new("lxmf", "delivery"));
+    let mut announce = remote_destination.announce(OsRng, None).expect("valid announce packet");
+    announce.header.hops = 2;
+    let destination = announce.destination;
+
+    handle_announce(&announce, handler.lock().await, iface, crate::iface::IfaceSource::None).await;
+
+    let path_request = {
+        let mut guard = handler.lock().await;
+        guard.path_requests.generate(&destination, Some(vec![0x67; crate::hash::ADDRESS_HASH_SIZE]))
+    };
+
+    {
+        let mut guard = handler.lock().await;
+        handle_path_request(&path_request, &mut guard, iface).await;
+    }
+
+    let guard = handler.lock().await;
+    let response = guard
+        .announce_table
+        .pending_response_for_destination(&destination)
+        .expect("access-point iface must answer a known-path request even on the learned iface");
+    assert_eq!(response.response_to_iface, Some(iface));
+    assert_eq!(response.packet.context, PacketContext::PathResponse);
+}


### PR DESCRIPTION
## Summary

Closes #516.

The transport suppresses known-path responses when a path request arrives on a `Roaming` interface and the known next hop was learned on that same interface. Verified against the reference: Python Reticulum `Transport.py` (~line 3044) has the identical rule (`MODE_ROAMING and attached_interface == received_from` ? don't answer), because roaming peers are expected to move and answering would pin a stale route. Behavior already matches the reference exactly.

This PR:

- adds the reference-parity citation at the suppression site so the rule isn't "fixed" away later;
- adds a regression test proving the suppression is **roaming-specific**: an `AccessPoint`-mode iface still answers a known-path request arriving on the learned iface (the existing `roaming_iface_suppresses_known_path_response_when_next_hop_is_same_iface` and `roaming_iface_delays_known_path_response_when_next_hop_differs` tests cover the suppress/delay branches).

## Type
- [ ] breaking
- [ ] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p reticulum-rs-transport --lib --no-deps -- -D warnings`
- [x] `cargo test -p reticulum-rs-transport --lib roaming` (7/7, incl. new mode-specificity test)
- [ ] `make test`
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [ ] `cargo doc --workspace --no-deps`
- [ ] `cargo deny check`
- [ ] `cargo audit`

## Compatibility
- Behavior unchanged and now explicitly pinned to reference `Transport.py` roaming semantics.
