### PR TITLE
Document and pin out-of-order resource segment handling (#520)

### DIFF
--- a/crates/libs/rns-transport/src/resource/manager.rs
+++ b/crates/libs/rns-transport/src/resource/manager.rs
@@ -210,6 +210,20 @@ impl ResourceManager {
                 .map(|assembly| assembly.next_segment)
                 .unwrap_or(1);
             if advertisement.segment_index != expected_segment {
+                // Out-of-order split-resource segment (issue #520): we
+                // deliberately log-and-drop rather than accept or reject.
+                // Reference Reticulum has NO segment-ordering check and
+                // blindly accepts segments in any order, so silently
+                // accepting would mask a real receiver-side assembly
+                // divergence here (our receiver assembles strictly in
+                // order). Sending a ResourceReceiverCancel (RCL, context
+                // 0x07) is the interoperable reject signal, but it would
+                // tear down the sender's entire resource — much harsher
+                // than the reference behavior for what is usually a
+                // reordered/in-flight segment that the sender will
+                // retransmit on the next request window. Dropping keeps
+                // the transfer alive: the sender re-offers the missing
+                // segment and normal flow resumes.
                 log::warn!(
                     "rejecting out-of-order resource segment original_hash={} expected={} received={}",
                     advertisement.original_hash,

--- a/crates/libs/rns-transport/src/resource/tests.rs
+++ b/crates/libs/rns-transport/src/resource/tests.rs
@@ -280,6 +280,87 @@ mod tests {
         assert_eq!(complete.1.data, [first_data.as_slice(), second_data.as_slice()].concat());
     }
 
+    /// Issue #520: out-of-order split segments are logged and dropped (not
+    /// accepted, not RCL-cancelled), and the transfer recovers once the
+    /// expected segment arrives.
+    #[test]
+    fn resource_receiver_drops_out_of_order_split_segments_until_sequence_resumes() {
+        let signer = PrivateIdentity::new_from_rand(OsRng);
+        let identity = *signer.as_identity();
+        let destination = DestinationDesc {
+            identity,
+            address_hash: identity.address_hash,
+            name: DestinationName::new("lxmf", "resource"),
+        };
+        let (tx, _) = tokio::sync::broadcast::channel(1);
+        let mut link = Link::new(destination, tx);
+        link.request();
+        let mut manager = ResourceManager::new_with_config(Duration::from_secs(1), 2);
+        let first_data = b"first-segment";
+        let second_data = b"second-segment";
+
+        let total_data_size = (first_data.len() + second_data.len()) as u64;
+        let (first_adv, first_part) =
+            split_test_segment(first_data, None, 1, 2, total_data_size);
+        let original_hash = first_adv.hash;
+        let (second_adv, second_part) =
+            split_test_segment(second_data, Some(original_hash), 2, 2, total_data_size);
+
+        // Segment 2 advertisement arrives before segment 1: dropped, with
+        // no request issued and no receiver state created.
+        let early_second = resource_packet(
+            PacketContext::ResourceAdvrtisement,
+            &second_adv.pack().expect("second advertisement"),
+            *link.id(),
+        );
+        assert!(manager.handle_packet(&early_second, &mut link).is_empty());
+        assert!(manager.incoming.is_empty(), "out-of-order segment must not create a receiver");
+
+        // Segment 1 arrives and is accepted normally.
+        let first_packet = resource_packet(
+            PacketContext::ResourceAdvrtisement,
+            &first_adv.pack().expect("first advertisement"),
+            *link.id(),
+        );
+        assert_eq!(manager.handle_packet(&first_packet, &mut link).len(), 1);
+        assert_eq!(
+            manager
+                .handle_packet(
+                    &resource_packet(PacketContext::Resource, &first_part, *link.id()),
+                    &mut link,
+                )
+                .len(),
+            1
+        );
+
+        // A stale replay of segment 1 (expected segment is now 2) is also
+        // dropped without tearing anything down.
+        assert!(manager.handle_packet(&first_packet, &mut link).is_empty());
+
+        // Segment 2, now in order, is accepted and assembly completes.
+        let second_packet = resource_packet(
+            PacketContext::ResourceAdvrtisement,
+            &second_adv.pack().expect("second advertisement"),
+            *link.id(),
+        );
+        assert_eq!(manager.handle_packet(&second_packet, &mut link).len(), 1);
+        manager.handle_packet(
+            &resource_packet(PacketContext::Resource, &second_part, *link.id()),
+            &mut link,
+        );
+
+        let complete = manager
+            .drain_events()
+            .into_iter()
+            .find_map(|event| match event.kind {
+                ResourceEventKind::Complete(complete) => Some((event.hash, complete)),
+                _ => None,
+            })
+            .expect("split resource should assemble once order resumes");
+        assert_eq!(complete.0, original_hash);
+        assert_eq!(complete.1.data, [first_data.as_slice(), second_data.as_slice()].concat());
+    }
+
     #[test]
     fn resource_manager_ignores_duplicate_active_advertisement() {
         let signer = PrivateIdentity::new_from_rand(OsRng);


### PR DESCRIPTION
## Summary

Closes #520.

The resource receiver drops split-resource advertisements whose `segment_index` does not match the expected next segment, emitting only a warning. This PR documents the protocol rationale at the drop site and pins the behavior with an integration regression test:

- **Why not silently accept (reference behavior):** reference Reticulum has NO segment-ordering check and blindly accepts segments in any order. Our receiver assembles strictly in order, so silently accepting would mask a real assembly divergence.
- **Why not send ResourceReceiverCancel (RCL, context 0x07):** RCL is the interoperable reject signal, but it tears down the sender's entire resource � far harsher than the reference for what is usually an in-flight reordering that the sender will retransmit on the next request window.
- **Why log-and-drop is right:** the transfer stays alive; the sender re-offers the missing segment and normal flow resumes.

Regression test (`resource_receiver_drops_out_of_order_split_segments_until_sequence_resumes`):

1. segment 2 arriving before segment 1 is dropped � no request issued, no receiver state created;
2. segment 1 is then accepted normally;
3. a stale replay of segment 1 is also dropped without tearing anything down;
4. segment 2, now in order, completes assembly with the concatenated payload intact.

## Type
- [ ] breaking
- [ ] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p reticulum-rs-transport --lib --no-deps -- -D warnings`
- [x] `cargo test -p reticulum-rs-transport --lib resource` (43/43, incl. new ordering regression test)
- [ ] `make test`
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [ ] `cargo doc --workspace --no-deps`
- [ ] `cargo deny check`
- [ ] `cargo audit`

## Compatibility
- Behavior unchanged; rationale documented against reference Reticulum (which accepts out-of-order segments) and the harsher RCL alternative.
