### PR TITLE
Supervise transport worker tasks (#525)

### DIFF
--- a/crates/libs/rns-transport/src/transport/jobs.rs
+++ b/crates/libs/rns-transport/src/transport/jobs.rs
@@ -293,13 +293,21 @@ pub(super) async fn manage_transport(
     let cancel = handler_arc.lock().await.cancel.clone();
     let transport_enabled = handler_arc.lock().await.config.transport_enabled;
 
-    let _packet_task = {
+    // Worker supervision (issue #525): every worker handle is retained in
+    // this set. The loop at the end of this function fails loudly and
+    // cancels the remaining workers if any worker exits before shutdown,
+    // so a panicked or silently returned worker can no longer degrade the
+    // transport invisibly. Each worker returns its name on exit for
+    // actionable logging.
+    let mut workers = tokio::task::JoinSet::new();
+
+    {
         let handler_arc = handler_arc.clone();
         let cancel = cancel.clone();
 
         log::trace!("tp({}): start packet task", handler_arc.lock().await.config.name);
 
-        tokio::spawn(async move {
+        workers.spawn(async move {
             loop {
                 let mut rx_receiver = rx_receiver.lock().await;
 
@@ -394,14 +402,16 @@ pub(super) async fn manage_transport(
                     }
                 };
             }
-        })
-    };
+
+            "packet"
+        });
+    }
 
     {
         let handler = handler_arc.clone();
         let cancel = cancel.clone();
 
-        tokio::spawn(async move {
+        workers.spawn(async move {
             loop {
                 if cancel.is_cancelled() {
                     break;
@@ -417,6 +427,8 @@ pub(super) async fn manage_transport(
                     }
                 }
             }
+
+            "link-check"
         });
     }
 
@@ -424,7 +436,7 @@ pub(super) async fn manage_transport(
         let handler = handler_arc.clone();
         let cancel = cancel.clone();
 
-        tokio::spawn(async move {
+        workers.spawn(async move {
             loop {
                 if cancel.is_cancelled() {
                     break;
@@ -439,6 +451,8 @@ pub(super) async fn manage_transport(
                     }
                 }
             }
+
+            "iface-cleanup"
         });
     }
 
@@ -446,7 +460,7 @@ pub(super) async fn manage_transport(
         let handler = handler_arc.clone();
         let cancel = cancel.clone();
 
-        tokio::spawn(async move {
+        workers.spawn(async move {
             loop {
                 if cancel.is_cancelled() {
                     break;
@@ -469,6 +483,8 @@ pub(super) async fn manage_transport(
                     },
                 }
             }
+
+            "packet-cache-cleanup"
         });
     }
 
@@ -476,7 +492,7 @@ pub(super) async fn manage_transport(
         let handler = handler_arc.clone();
         let cancel = cancel.clone();
 
-        tokio::spawn(async move {
+        workers.spawn(async move {
             loop {
                 if cancel.is_cancelled() {
                     break;
@@ -500,6 +516,8 @@ pub(super) async fn manage_transport(
                     }
                 }
             }
+
+            "announce-retransmit"
         });
     }
 
@@ -510,7 +528,7 @@ pub(super) async fn manage_transport(
             handler_arc.lock().await.config.resource_retry_interval_secs.max(1),
         );
 
-        tokio::spawn(async move {
+        workers.spawn(async move {
             loop {
                 if cancel.is_cancelled() {
                     break;
@@ -546,7 +564,38 @@ pub(super) async fn manage_transport(
                     }
                 }
             }
+
+            "resource-retry"
         });
+    }
+
+    // Supervision loop (issue #525) — extracted so the failure semantics
+    // are directly testable: normal shutdown cancels every worker and
+    // drains this set quietly; any worker that exits while the transport
+    // is still running cancels the rest and is logged with its name and
+    // failure.
+    supervise_workers(&mut workers, &cancel).await;
+}
+
+async fn supervise_workers(
+    workers: &mut tokio::task::JoinSet<&'static str>,
+    cancel: &tokio_util::sync::CancellationToken,
+) {
+    while let Some(result) = workers.join_next().await {
+        match result {
+            Ok(name) => {
+                if !cancel.is_cancelled() {
+                    log::error!(
+                        "tp: transport worker '{name}' exited before shutdown; cancelling remaining workers"
+                    );
+                    cancel.cancel();
+                }
+            }
+            Err(err) => {
+                log::error!("tp: transport worker failed ({err}); cancelling remaining workers");
+                cancel.cancel();
+            }
+        }
     }
 }
 

--- a/crates/libs/rns-transport/src/transport/jobs.rs
+++ b/crates/libs/rns-transport/src/transport/jobs.rs
@@ -297,9 +297,11 @@ pub(super) async fn manage_transport(
     // this set. The loop at the end of this function fails loudly and
     // cancels the remaining workers if any worker exits before shutdown,
     // so a panicked or silently returned worker can no longer degrade the
-    // transport invisibly. Each worker returns its name on exit for
-    // actionable logging.
-    let mut workers = tokio::task::JoinSet::new();
+    // transport invisibly. Each worker returns its name on exit, and the
+    // id-to-name map keeps failures attributable even when a panic means
+    // no value comes back (review follow-up on #539).
+    let mut workers = WorkerSet::new();
+    let mut worker_names = WorkerNames::new();
 
     {
         let handler_arc = handler_arc.clone();
@@ -307,7 +309,7 @@ pub(super) async fn manage_transport(
 
         log::trace!("tp({}): start packet task", handler_arc.lock().await.config.name);
 
-        workers.spawn(async move {
+        spawn_named_worker(&mut workers, &mut worker_names, "packet", async move {
             loop {
                 let mut rx_receiver = rx_receiver.lock().await;
 
@@ -402,8 +404,6 @@ pub(super) async fn manage_transport(
                     }
                 };
             }
-
-            "packet"
         });
     }
 
@@ -411,7 +411,7 @@ pub(super) async fn manage_transport(
         let handler = handler_arc.clone();
         let cancel = cancel.clone();
 
-        workers.spawn(async move {
+        spawn_named_worker(&mut workers, &mut worker_names, "link-check", async move {
             loop {
                 if cancel.is_cancelled() {
                     break;
@@ -427,8 +427,6 @@ pub(super) async fn manage_transport(
                     }
                 }
             }
-
-            "link-check"
         });
     }
 
@@ -436,7 +434,7 @@ pub(super) async fn manage_transport(
         let handler = handler_arc.clone();
         let cancel = cancel.clone();
 
-        workers.spawn(async move {
+        spawn_named_worker(&mut workers, &mut worker_names, "iface-cleanup", async move {
             loop {
                 if cancel.is_cancelled() {
                     break;
@@ -451,8 +449,6 @@ pub(super) async fn manage_transport(
                     }
                 }
             }
-
-            "iface-cleanup"
         });
     }
 
@@ -460,7 +456,7 @@ pub(super) async fn manage_transport(
         let handler = handler_arc.clone();
         let cancel = cancel.clone();
 
-        workers.spawn(async move {
+        spawn_named_worker(&mut workers, &mut worker_names, "packet-cache-cleanup", async move {
             loop {
                 if cancel.is_cancelled() {
                     break;
@@ -483,8 +479,6 @@ pub(super) async fn manage_transport(
                     },
                 }
             }
-
-            "packet-cache-cleanup"
         });
     }
 
@@ -492,7 +486,7 @@ pub(super) async fn manage_transport(
         let handler = handler_arc.clone();
         let cancel = cancel.clone();
 
-        workers.spawn(async move {
+        spawn_named_worker(&mut workers, &mut worker_names, "announce-retransmit", async move {
             loop {
                 if cancel.is_cancelled() {
                     break;
@@ -516,8 +510,6 @@ pub(super) async fn manage_transport(
                     }
                 }
             }
-
-            "announce-retransmit"
         });
     }
 
@@ -528,7 +520,7 @@ pub(super) async fn manage_transport(
             handler_arc.lock().await.config.resource_retry_interval_secs.max(1),
         );
 
-        workers.spawn(async move {
+        spawn_named_worker(&mut workers, &mut worker_names, "resource-retry", async move {
             loop {
                 if cancel.is_cancelled() {
                     break;
@@ -564,8 +556,6 @@ pub(super) async fn manage_transport(
                     }
                 }
             }
-
-            "resource-retry"
         });
     }
 
@@ -574,17 +564,36 @@ pub(super) async fn manage_transport(
     // drains this set quietly; any worker that exits while the transport
     // is still running cancels the rest and is logged with its name and
     // failure.
-    supervise_workers(&mut workers, &cancel).await;
+    supervise_workers(&mut workers, &worker_names, &cancel).await;
+}
+
+type WorkerSet = tokio::task::JoinSet<()>;
+type WorkerNames = std::collections::HashMap<tokio::task::Id, &'static str>;
+
+/// Spawns a named transport worker, recording the task id so failures
+/// (including panics, which return no value) stay attributable to the
+/// worker that caused them.
+fn spawn_named_worker<F>(
+    workers: &mut WorkerSet,
+    worker_names: &mut WorkerNames,
+    name: &'static str,
+    future: F,
+) where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    worker_names.insert(workers.spawn(future).id(), name);
 }
 
 async fn supervise_workers(
-    workers: &mut tokio::task::JoinSet<&'static str>,
+    workers: &mut WorkerSet,
+    worker_names: &WorkerNames,
     cancel: &tokio_util::sync::CancellationToken,
 ) {
-    while let Some(result) = workers.join_next().await {
+    while let Some(result) = workers.join_next_with_id().await {
         match result {
-            Ok(name) => {
+            Ok((id, ())) => {
                 if !cancel.is_cancelled() {
+                    let name = worker_names.get(&id).copied().unwrap_or("<unnamed>");
                     log::error!(
                         "tp: transport worker '{name}' exited before shutdown; cancelling remaining workers"
                     );
@@ -592,7 +601,13 @@ async fn supervise_workers(
                 }
             }
             Err(err) => {
-                log::error!("tp: transport worker failed ({err}); cancelling remaining workers");
+                // JoinError carries no return value, but it does carry
+                // the failed task id — look the worker name up so panics
+                // stay attributable (review follow-up on #539).
+                let name = worker_names.get(&err.id()).copied().unwrap_or("<unnamed>");
+                log::error!(
+                    "tp: transport worker '{name}' failed ({err}); cancelling remaining workers"
+                );
                 cancel.cancel();
             }
         }

--- a/crates/libs/rns-transport/src/transport/jobs_parts/tests.rs
+++ b/crates/libs/rns-transport/src/transport/jobs_parts/tests.rs
@@ -23,4 +23,79 @@ mod tests {
 
         assert_eq!(link_check_delay_from_deadline(now, None), INTERVAL_LINKS_CHECK);
     }
+
+    /// Issue #525: a worker that silently returns before shutdown must
+    /// cancel the remaining workers instead of degrading invisibly.
+    #[tokio::test]
+    async fn supervision_cancels_remaining_workers_when_one_exits_early() {
+        use tokio_util::sync::CancellationToken;
+
+        let cancel = CancellationToken::new();
+        let mut workers = tokio::task::JoinSet::new();
+
+        workers.spawn(async { "faulty" });
+        {
+            let cancel = cancel.clone();
+            workers.spawn(async move {
+                cancel.cancelled().await;
+                "long-lived"
+            });
+        }
+
+        tokio::time::timeout(Duration::from_secs(2), supervise_workers(&mut workers, &cancel))
+            .await
+            .expect("supervision should drain all workers after early exit");
+
+        assert!(cancel.is_cancelled(), "early worker exit must cancel the transport");
+        assert!(workers.is_empty());
+    }
+
+    /// Issue #525: a panicking worker must surface as a failure and cancel
+    /// the remaining workers.
+    #[tokio::test]
+    async fn supervision_cancels_remaining_workers_when_one_panics() {
+        use tokio_util::sync::CancellationToken;
+
+        let cancel = CancellationToken::new();
+        let mut workers = tokio::task::JoinSet::<&'static str>::new();
+
+        workers.spawn(async { panic!("boom") });
+        {
+            let cancel = cancel.clone();
+            workers.spawn(async move {
+                cancel.cancelled().await;
+                "long-lived"
+            });
+        }
+
+        tokio::time::timeout(Duration::from_secs(2), supervise_workers(&mut workers, &cancel))
+            .await
+            .expect("supervision should drain all workers after a panic");
+
+        assert!(cancel.is_cancelled(), "worker panic must cancel the transport");
+        assert!(workers.is_empty());
+    }
+
+    /// Issue #525: on normal shutdown all workers exit after cancellation
+    /// and supervision drains quietly without re-cancelling or hanging.
+    #[tokio::test]
+    async fn supervision_drains_quietly_on_normal_shutdown() {
+        use tokio_util::sync::CancellationToken;
+
+        let cancel = CancellationToken::new();
+        let mut workers = tokio::task::JoinSet::new();
+        for _ in 0..3 {
+            let cancel = cancel.clone();
+            workers.spawn(async move {
+                cancel.cancelled().await;
+                "worker"
+            });
+        }
+
+        cancel.cancel();
+        tokio::time::timeout(Duration::from_secs(2), supervise_workers(&mut workers, &cancel))
+            .await
+            .expect("supervision should drain cleanly on normal shutdown");
+        assert!(workers.is_empty());
+    }
 }

--- a/crates/libs/rns-transport/src/transport/jobs_parts/tests.rs
+++ b/crates/libs/rns-transport/src/transport/jobs_parts/tests.rs
@@ -31,20 +31,23 @@ mod tests {
         use tokio_util::sync::CancellationToken;
 
         let cancel = CancellationToken::new();
-        let mut workers = tokio::task::JoinSet::new();
+        let mut workers = WorkerSet::new();
+        let mut worker_names = WorkerNames::new();
 
-        workers.spawn(async { "faulty" });
+        spawn_named_worker(&mut workers, &mut worker_names, "faulty", async {});
         {
             let cancel = cancel.clone();
-            workers.spawn(async move {
+            spawn_named_worker(&mut workers, &mut worker_names, "long-lived", async move {
                 cancel.cancelled().await;
-                "long-lived"
             });
         }
 
-        tokio::time::timeout(Duration::from_secs(2), supervise_workers(&mut workers, &cancel))
-            .await
-            .expect("supervision should drain all workers after early exit");
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            supervise_workers(&mut workers, &worker_names, &cancel),
+        )
+        .await
+        .expect("supervision should drain all workers after early exit");
 
         assert!(cancel.is_cancelled(), "early worker exit must cancel the transport");
         assert!(workers.is_empty());
@@ -57,23 +60,51 @@ mod tests {
         use tokio_util::sync::CancellationToken;
 
         let cancel = CancellationToken::new();
-        let mut workers = tokio::task::JoinSet::<&'static str>::new();
+        let mut workers = WorkerSet::new();
+        let mut worker_names = WorkerNames::new();
 
-        workers.spawn(async { panic!("boom") });
+        spawn_named_worker(&mut workers, &mut worker_names, "panicky", async {
+            panic!("boom")
+        });
         {
             let cancel = cancel.clone();
-            workers.spawn(async move {
+            spawn_named_worker(&mut workers, &mut worker_names, "long-lived", async move {
                 cancel.cancelled().await;
-                "long-lived"
             });
         }
 
-        tokio::time::timeout(Duration::from_secs(2), supervise_workers(&mut workers, &cancel))
-            .await
-            .expect("supervision should drain all workers after a panic");
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            supervise_workers(&mut workers, &worker_names, &cancel),
+        )
+        .await
+        .expect("supervision should drain all workers after a panic");
 
         assert!(cancel.is_cancelled(), "worker panic must cancel the transport");
         assert!(workers.is_empty());
+    }
+
+    /// Issue #539 review follow-up: worker names are tracked by task id,
+    /// so the failure log can attribute a panic (which returns no value)
+    /// to the worker that caused it.
+    #[tokio::test]
+    async fn worker_names_attribute_failures_by_task_id() {
+        let mut workers = WorkerSet::new();
+        let mut worker_names = WorkerNames::new();
+
+        spawn_named_worker(&mut workers, &mut worker_names, "first", async {});
+        spawn_named_worker(&mut workers, &mut worker_names, "second", async {});
+
+        let (id, result) = workers
+            .join_next_with_id()
+            .await
+            .expect("a completed worker")
+            .expect("worker finished without panicking");
+        assert_eq!(result, ());
+        assert!(
+            matches!(worker_names.get(&id).copied(), Some("first" | "second")),
+            "completed task id must map back to its worker name"
+        );
     }
 
     /// Issue #525: on normal shutdown all workers exit after cancellation
@@ -83,19 +114,27 @@ mod tests {
         use tokio_util::sync::CancellationToken;
 
         let cancel = CancellationToken::new();
-        let mut workers = tokio::task::JoinSet::new();
-        for _ in 0..3 {
+        let mut workers = WorkerSet::new();
+        let mut worker_names = WorkerNames::new();
+        for idx in 0..3 {
             let cancel = cancel.clone();
-            workers.spawn(async move {
+            let name = match idx {
+                0 => "worker-a",
+                1 => "worker-b",
+                _ => "worker-c",
+            };
+            spawn_named_worker(&mut workers, &mut worker_names, name, async move {
                 cancel.cancelled().await;
-                "worker"
             });
         }
 
         cancel.cancel();
-        tokio::time::timeout(Duration::from_secs(2), supervise_workers(&mut workers, &cancel))
-            .await
-            .expect("supervision should drain cleanly on normal shutdown");
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            supervise_workers(&mut workers, &worker_names, &cancel),
+        )
+        .await
+        .expect("supervision should drain cleanly on normal shutdown");
         assert!(workers.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Closes #525.

`manage_transport` spawned six worker tasks (packet intake, link check, iface cleanup, packet-cache cleanup, announce retransmit, resource retry) and **dropped every JoinHandle**. A panicked or silently returned worker degraded the transport invisibly � stale paths, no announce retransmits, dead packet intake � with no log and no recovery.

Workers are now spawned into a `JoinSet` (each returning its name on exit) and supervised by an extracted `supervise_workers()`:

- any worker that exits **before shutdown** � panic or silent return � is logged with its name and failure, and the remaining workers are cancelled via the shared `CancellationToken`, so the failure is visible instead of a silent partial outage;
- **normal shutdown** cancels all workers and drains the set quietly without re-cancelling or hanging.

The supervision loop is extracted as `supervise_workers(workers, cancel)` so the failure semantics are directly testable. Regression tests cover: early silent worker exit cancels the rest, a panicking worker cancels the rest, and normal shutdown drains cleanly.

## Type
- [ ] breaking
- [ ] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p reticulum-rs-transport --lib --no-deps -- -D warnings`
- [x] `cargo test -p reticulum-rs-transport --lib jobs` (10/10, incl. 3 new supervision tests)
- [ ] `make test`
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [ ] `cargo doc --workspace --no-deps`
- [ ] `cargo deny check`
- [ ] `cargo audit`

## Compatibility
- Worker behavior unchanged while healthy; `manage_transport` now runs as a long-lived supervisor (its only call site spawns it and does not await, so startup semantics are unchanged). On worker failure the transport now shuts down its workers loudly instead of silently degrading.
