### PR TITLE
Size link payloads and resource fragments from the negotiated MTU

### DIFF
--- a/crates/libs/rns-transport/src/destination/link/payload.rs
+++ b/crates/libs/rns-transport/src/destination/link/payload.rs
@@ -1,6 +1,19 @@
+/// A decrypted link payload.
+///
+/// The buffer is heap-allocated rather than a fixed `[u8; PACKET_MDU]`
+/// because a link's MTU is negotiated, not constant: once a peer signals a
+/// larger one, a single data packet can legitimately carry far more than
+/// 464 bytes. The fixed array silently `min()`-truncated anything larger —
+/// so a correctly-sized Response from a peer that had agreed a bigger MTU
+/// arrived as its first 464 bytes and failed to parse, with no error
+/// anywhere. That is the failure #498 hit when it advertised 8192.
+///
+/// It also removes a latent panic: `new_from_vec` set `len` from the input
+/// while copying only what fitted, so `as_slice()` on an oversized payload
+/// indexed past the end of the array.
 #[derive(Clone)]
 pub struct LinkPayload {
-    buffer: [u8; PACKET_MDU],
+    buffer: Vec<u8>,
     len: usize,
     context: PacketContext,
     request_id: Option<[u8; ADDRESS_HASH_SIZE]>,
@@ -8,7 +21,7 @@ pub struct LinkPayload {
 
 impl LinkPayload {
     pub fn new() -> Self {
-        Self { buffer: [0u8; PACKET_MDU], len: 0, context: PacketContext::None, request_id: None }
+        Self { buffer: Vec::new(), len: 0, context: PacketContext::None, request_id: None }
     }
 
     pub fn new_from_slice(data: &[u8]) -> Self {
@@ -16,11 +29,7 @@ impl LinkPayload {
     }
 
     pub fn new_from_slice_with_context(data: &[u8], context: PacketContext) -> Self {
-        let mut buffer = [0u8; PACKET_MDU];
-        let len = min(data.len(), buffer.len());
-        buffer[..len].copy_from_slice(&data[..len]);
-
-        Self { buffer, len, context, request_id: None }
+        Self { buffer: data.to_vec(), len: data.len(), context, request_id: None }
     }
 
     pub fn new_from_slice_with_context_and_request_id(
@@ -34,11 +43,7 @@ impl LinkPayload {
     }
 
     pub fn new_from_vec(data: &[u8]) -> Self {
-        let mut buffer = [0u8; PACKET_MDU];
-        let copy_len = min(buffer.len(), data.len());
-        buffer[..copy_len].copy_from_slice(&data[..copy_len]);
-
-        Self { buffer, len: data.len(), context: PacketContext::None, request_id: None }
+        Self { buffer: data.to_vec(), len: data.len(), context: PacketContext::None, request_id: None }
     }
 
     pub fn len(&self) -> usize {

--- a/crates/libs/rns-transport/src/destination/link_parts/clamp_link_signalling.rs
+++ b/crates/libs/rns-transport/src/destination/link_parts/clamp_link_signalling.rs
@@ -1,3 +1,26 @@
+/// The MTU a peer signalled, decoded back out of the stored suffix.
+///
+/// The signalling bytes are kept verbatim (already clamped on receipt) so
+/// that the negotiated value can be recovered here rather than being
+/// recomputed from whatever the local interface happens to be. Those are
+/// different numbers: the local interface bounds what *we* can carry, the
+/// negotiated value bounds what the *path* can carry, and it is the latter
+/// that must size anything put on the wire.
+///
+/// `None` means the peer sent no suffix at all — an older peer, or one that
+/// never signalled — in which case the legacy Reticulum MTU is the only
+/// safe assumption.
+pub(crate) fn link_signalled_mtu(signalling: Option<[u8; LINK_MTU_SIZE]>) -> usize {
+    let Some(bytes) = signalling else {
+        return LEGACY_RETICULUM_MTU;
+    };
+    let value = ((bytes[0] as u32) << 16) | ((bytes[1] as u32) << 8) | bytes[2] as u32;
+    let mtu = (value & LINK_MTU_MASK) as usize;
+    // A peer that signals something absurdly small would otherwise make
+    // every derived size underflow; the legacy MTU is the floor.
+    mtu.max(LEGACY_RETICULUM_MTU)
+}
+
 fn clamp_link_signalling(bytes: [u8; LINK_MTU_SIZE]) -> [u8; LINK_MTU_SIZE] {
     let value = ((bytes[0] as u32) << 16) | ((bytes[1] as u32) << 8) | bytes[2] as u32;
     let mode = value & LINK_MODE_MASK;

--- a/crates/libs/rns-transport/src/destination/link_parts/link.rs
+++ b/crates/libs/rns-transport/src/destination/link_parts/link.rs
@@ -2,4 +2,5 @@ include!("link_sections/new.rs");
 include!("link_sections/remove_channel_handler.rs");
 include!("link_sections/next_watchdog_deadline.rs");
 include!("link_sections/response_packet.rs");
+include!("link_sections/link_mtu.rs");
 include!("link_sections/identify_packet_tests.rs");

--- a/crates/libs/rns-transport/src/destination/link_parts/link.rs
+++ b/crates/libs/rns-transport/src/destination/link_parts/link.rs
@@ -1,4 +1,5 @@
 include!("link_sections/new.rs");
+include!("link_sections/handle_proof_packet.rs");
 include!("link_sections/remove_channel_handler.rs");
 include!("link_sections/next_watchdog_deadline.rs");
 include!("link_sections/response_packet.rs");

--- a/crates/libs/rns-transport/src/destination/link_parts/link_sections/handle_proof_packet.rs
+++ b/crates/libs/rns-transport/src/destination/link_parts/link_sections/handle_proof_packet.rs
@@ -1,0 +1,56 @@
+impl Link {
+    /// Handle an inbound `Proof` packet: either a per-packet delivery proof on
+    /// an active link, or the `LinkRequestProof` that activates a pending one.
+    fn handle_proof_packet(&mut self, packet: &Packet, iface: AddressHash) -> LinkHandleResult {
+        if self.status == LinkStatus::Active && packet.context == PacketContext::LinkProof {
+            if let Ok(hash) = self.validate_packet_proof(packet) {
+                self.note_inbound(packet.context);
+                if let Some(pending) = self.channel_pending.remove(&hash) {
+                    self.channel_states.insert(pending.sequence, ChannelMessageState::Delivered);
+                    self.note_channel_delivery();
+                }
+                return LinkHandleResult::None;
+            }
+        }
+        if self.status != LinkStatus::Pending || packet.context != PacketContext::LinkRequestProof {
+            return LinkHandleResult::None;
+        }
+        let Ok(identity) = validate_link_request_proof_packet(&self.destination, &self.id, packet)
+        else {
+            log::warn!("link({}): proof is not valid", self.id);
+            return LinkHandleResult::None;
+        };
+        log::debug!("link({}): has been proved", self.id);
+
+        // The proof carries the responder's own MTU signalling, and until now
+        // it was read only to verify the signature over it and then dropped —
+        // so an initiator never learned what the far end could actually carry,
+        // and every size it derived came from its own interface instead.
+        // Capture it (clamped on the way in, like an inbound request's) so
+        // `link_mtu()` reports the negotiated value.
+        const MTU_PROOF_LEN: usize = SIGNATURE_LENGTH + PUBLIC_KEY_LENGTH + LINK_MTU_SIZE;
+        if packet.data.len() >= MTU_PROOF_LEN {
+            let start = SIGNATURE_LENGTH + PUBLIC_KEY_LENGTH;
+            let mut bytes = [0u8; LINK_MTU_SIZE];
+            bytes.copy_from_slice(&packet.data.as_slice()[start..start + LINK_MTU_SIZE]);
+            self.signalling = Some(clamp_link_signalling(bytes));
+        }
+
+        self.handshake(identity);
+        self.ingress_iface.get_or_insert(iface);
+
+        self.status = LinkStatus::Active;
+        self.rtt = self.request_time.elapsed();
+        self.activated_at = Some(Instant::now());
+        self.last_proof = self.activated_at;
+        self.stale_since = None;
+        self.update_keepalive_timing();
+        self.refresh_channel_flow_control();
+
+        log::debug!("link({}): activated", self.id);
+
+        self.post_event(LinkEvent::Activated);
+
+        LinkHandleResult::Activated
+    }
+}

--- a/crates/libs/rns-transport/src/destination/link_parts/link_sections/link_mtu.rs
+++ b/crates/libs/rns-transport/src/destination/link_parts/link_sections/link_mtu.rs
@@ -1,0 +1,16 @@
+// The negotiated link MTU, split out of `new.rs` to stay inside the
+// repository's 500-line module budget. `include!`d into the same module.
+
+impl Link {
+    /// The MTU negotiated for this link — the smaller of what the two peers
+    /// signalled, or [`LEGACY_RETICULUM_MTU`] if the peer signalled nothing.
+    ///
+    /// **This, not the local interface MTU, is what may size anything put on
+    /// the wire.** The interface bounds what this node can physically carry;
+    /// the negotiated value bounds what the whole path can carry, and a
+    /// resource fragment sized from the former will be silently dropped by
+    /// any hop that cannot take it.
+    pub fn link_mtu(&self) -> usize {
+        link_signalled_mtu(self.signalling)
+    }
+}

--- a/crates/libs/rns-transport/src/destination/link_parts/link_sections/new.rs
+++ b/crates/libs/rns-transport/src/destination/link_parts/link_sections/new.rs
@@ -259,7 +259,12 @@ impl Link {
                     return LinkHandleResult::None;
                 }
 
-                let mut buffer = [0u8; PACKET_MDU];
+                // Sized from the ciphertext, not from a fixed 464-byte
+                // array: decrypted output is never larger than what came
+                // in, and once a link negotiates a bigger MTU a single
+                // data packet legitimately exceeds `PACKET_MDU`. The
+                // fixed buffer made those decrypts fail silently.
+                let mut buffer = vec![0u8; packet.data.as_slice().len().max(PACKET_MDU)];
                 if let Ok(plain_text) = self.decrypt(packet.data.as_slice(), &mut buffer[..]) {
                     self.note_inbound(packet.context);
                     log::trace!("link({}): data {}B", self.id, plain_text.len());
@@ -270,7 +275,12 @@ impl Link {
                 return LinkHandleResult::None;
             }
             PacketContext::LinkIdentify => {
-                let mut buffer = [0u8; PACKET_MDU];
+                // Sized from the ciphertext, not from a fixed 464-byte
+                // array: decrypted output is never larger than what came
+                // in, and once a link negotiates a bigger MTU a single
+                // data packet legitimately exceeds `PACKET_MDU`. The
+                // fixed buffer made those decrypts fail silently.
+                let mut buffer = vec![0u8; packet.data.as_slice().len().max(PACKET_MDU)];
                 if let Ok(plain_text) = self.decrypt(packet.data.as_slice(), &mut buffer[..]) {
                     if let Some(identity) = parse_link_identify_payload(plain_text, &self.id) {
                         self.note_inbound(packet.context);
@@ -283,7 +293,12 @@ impl Link {
                 }
             }
             PacketContext::None | PacketContext::Request | PacketContext::Response => {
-                let mut buffer = [0u8; PACKET_MDU];
+                // Sized from the ciphertext, not from a fixed 464-byte
+                // array: decrypted output is never larger than what came
+                // in, and once a link negotiates a bigger MTU a single
+                // data packet legitimately exceeds `PACKET_MDU`. The
+                // fixed buffer made those decrypts fail silently.
+                let mut buffer = vec![0u8; packet.data.as_slice().len().max(PACKET_MDU)];
                 if let Ok(plain_text) = self.decrypt(packet.data.as_slice(), &mut buffer[..]) {
                     self.note_inbound(packet.context);
                     log::trace!("link({}): data {}B", self.id, plain_text.len());
@@ -324,7 +339,12 @@ impl Link {
                 }
             }
             PacketContext::LinkClose => {
-                let mut buffer = [0u8; PACKET_MDU];
+                // Sized from the ciphertext, not from a fixed 464-byte
+                // array: decrypted output is never larger than what came
+                // in, and once a link negotiates a bigger MTU a single
+                // data packet legitimately exceeds `PACKET_MDU`. The
+                // fixed buffer made those decrypts fail silently.
+                let mut buffer = vec![0u8; packet.data.as_slice().len().max(PACKET_MDU)];
                 match self.decrypt(packet.data.as_slice(), &mut buffer[..]) {
                     Ok(plain_text) if plain_text == self.id.as_slice() => {
                         self.note_inbound(packet.context);
@@ -344,7 +364,12 @@ impl Link {
                 return LinkHandleResult::None;
             }
             PacketContext::LinkRTT => {
-                let mut buffer = [0u8; PACKET_MDU];
+                // Sized from the ciphertext, not from a fixed 464-byte
+                // array: decrypted output is never larger than what came
+                // in, and once a link negotiates a bigger MTU a single
+                // data packet legitimately exceeds `PACKET_MDU`. The
+                // fixed buffer made those decrypts fail silently.
+                let mut buffer = vec![0u8; packet.data.as_slice().len().max(PACKET_MDU)];
                 if let Ok(plain_text) = self.decrypt(packet.data.as_slice(), &mut buffer[..]) {
                     let mut cursor = std::io::Cursor::new(plain_text);
                     if let Ok(peer_rtt) = rmp::decode::read_f32(&mut cursor) {
@@ -418,6 +443,23 @@ impl Link {
                         validate_link_request_proof_packet(&self.destination, &self.id, packet)
                     {
                         log::debug!("link({}): has been proved", self.id);
+
+                        // The proof carries the responder's own MTU
+                        // signalling, and until now it was read only to
+                        // verify the signature over it and then dropped —
+                        // so an initiator never learned what the far end
+                        // could actually carry, and every size it derived
+                        // came from its own interface instead. Capture it
+                        // (clamped on the way in, like an inbound request's)
+                        // so `link_mtu()` reports the negotiated value.
+                        const MTU_PROOF_LEN: usize =
+                            SIGNATURE_LENGTH + PUBLIC_KEY_LENGTH + LINK_MTU_SIZE;
+                        if packet.data.len() >= MTU_PROOF_LEN {
+                            let start = SIGNATURE_LENGTH + PUBLIC_KEY_LENGTH;
+                            let mut bytes = [0u8; LINK_MTU_SIZE];
+                            bytes.copy_from_slice(&packet.data.as_slice()[start..start + LINK_MTU_SIZE]);
+                            self.signalling = Some(clamp_link_signalling(bytes));
+                        }
 
                         self.handshake(identity);
                         self.ingress_iface.get_or_insert(iface);

--- a/crates/libs/rns-transport/src/destination/link_parts/link_sections/new.rs
+++ b/crates/libs/rns-transport/src/destination/link_parts/link_sections/new.rs
@@ -424,64 +424,7 @@ impl Link {
 
         match packet.header.packet_type {
             PacketType::Data => return self.handle_data_packet(packet),
-            PacketType::Proof => {
-                if self.status == LinkStatus::Active && packet.context == PacketContext::LinkProof {
-                    if let Ok(hash) = self.validate_packet_proof(packet) {
-                        self.note_inbound(packet.context);
-                        if let Some(pending) = self.channel_pending.remove(&hash) {
-                            self.channel_states
-                                .insert(pending.sequence, ChannelMessageState::Delivered);
-                            self.note_channel_delivery();
-                        }
-                        return LinkHandleResult::None;
-                    }
-                }
-                if self.status == LinkStatus::Pending
-                    && packet.context == PacketContext::LinkRequestProof
-                {
-                    if let Ok(identity) =
-                        validate_link_request_proof_packet(&self.destination, &self.id, packet)
-                    {
-                        log::debug!("link({}): has been proved", self.id);
-
-                        // The proof carries the responder's own MTU
-                        // signalling, and until now it was read only to
-                        // verify the signature over it and then dropped —
-                        // so an initiator never learned what the far end
-                        // could actually carry, and every size it derived
-                        // came from its own interface instead. Capture it
-                        // (clamped on the way in, like an inbound request's)
-                        // so `link_mtu()` reports the negotiated value.
-                        const MTU_PROOF_LEN: usize =
-                            SIGNATURE_LENGTH + PUBLIC_KEY_LENGTH + LINK_MTU_SIZE;
-                        if packet.data.len() >= MTU_PROOF_LEN {
-                            let start = SIGNATURE_LENGTH + PUBLIC_KEY_LENGTH;
-                            let mut bytes = [0u8; LINK_MTU_SIZE];
-                            bytes.copy_from_slice(&packet.data.as_slice()[start..start + LINK_MTU_SIZE]);
-                            self.signalling = Some(clamp_link_signalling(bytes));
-                        }
-
-                        self.handshake(identity);
-                        self.ingress_iface.get_or_insert(iface);
-
-                        self.status = LinkStatus::Active;
-                        self.rtt = self.request_time.elapsed();
-                        self.activated_at = Some(Instant::now());
-                        self.last_proof = self.activated_at;
-                        self.stale_since = None;
-                        self.update_keepalive_timing();
-                        self.refresh_channel_flow_control();
-
-                        log::debug!("link({}): activated", self.id);
-
-                        self.post_event(LinkEvent::Activated);
-
-                        return LinkHandleResult::Activated;
-                    } else {
-                        log::warn!("link({}): proof is not valid", self.id);
-                    }
-                }
-            }
+            PacketType::Proof => return self.handle_proof_packet(packet, iface),
             _ => {}
         }
 

--- a/crates/libs/rns-transport/src/destination/link_parts/link_status_predicates_make_lifecycl_sections/core_tests.rs
+++ b/crates/libs/rns-transport/src/destination/link_parts/link_status_predicates_make_lifecycl_sections/core_tests.rs
@@ -57,13 +57,50 @@
         let mut inbound =
             Link::new_from_request(&request, signer.sign_key().clone(), destination, tx)
                 .expect("link request should parse");
-        assert_eq!(inbound.signalling, Some([0x20, 0x01, 0xF4]));
+        // 0x202000 -> mode bits 0x20, MTU 8192. Honoured, not clamped: this
+        // build can now carry it, and clamping it to 500 was what pinned
+        // every resource fragment to 464 bytes regardless of the link.
+        assert_eq!(inbound.signalling, Some([0x20, 0x20, 0x00]));
+        assert_eq!(inbound.link_mtu(), 8192, "the negotiated value has to be readable back out");
 
+        // The proof echoes the same value, so the initiator learns it too.
         let proof = inbound.prove();
         assert_eq!(
             &proof.data.as_slice()[SIGNATURE_LENGTH + PUBLIC_KEY_LENGTH..],
-            &[0x20, 0x01, 0xF4]
+            &[0x20, 0x20, 0x00]
         );
+    }
+
+    /// A peer may still not talk us above what this build can carry.
+    #[test]
+    fn inbound_link_request_still_clamps_an_mtu_above_our_ceiling() {
+        let requester = PrivateIdentity::new_from_rand(OsRng);
+        let signer = PrivateIdentity::new_from_rand(OsRng);
+        let identity = *signer.as_identity();
+        let destination = DestinationDesc {
+            identity,
+            address_hash: identity.address_hash,
+            name: DestinationName::new("lxmf", "delivery"),
+        };
+        let (tx, _) = tokio::sync::broadcast::channel(4);
+        let mut data = PacketDataBuffer::new();
+        data.safe_write(requester.as_identity().public_key.as_bytes());
+        data.safe_write(requester.as_identity().verifying_key.as_bytes());
+        // Mode bits 0x20 plus the largest MTU the 21-bit field can express.
+        data.safe_write(&[0x3F, 0xFF, 0xFF]);
+        let request = Packet {
+            header: Header { packet_type: PacketType::LinkRequest, ..Default::default() },
+            ifac: None,
+            destination: destination.address_hash,
+            transport: None,
+            context: PacketContext::None,
+            data,
+        };
+
+        let inbound = Link::new_from_request(&request, signer.sign_key().clone(), destination, tx)
+            .expect("link request should parse");
+
+        assert_eq!(inbound.link_mtu(), 262_144, "clamped to what this build will actually carry");
     }
 
     // Outbound-side counterpart to `inbound_link_request_clamps_peer_mtu_

--- a/crates/libs/rns-transport/src/destination/link_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/destination/link_parts/module_prelude.rs
@@ -1,5 +1,4 @@
 use std::{
-    cmp::min,
     collections::{HashMap, VecDeque},
     panic::{catch_unwind, AssertUnwindSafe},
     time::{Duration, Instant},
@@ -36,7 +35,28 @@ const LINK_MTU_MASK: u32 = 0x1F_FFFF;
 
 const LINK_MODE_MASK: u32 = 0xE0_0000;
 
-const RETICULUM_COMPAT_MTU: u32 = (PACKET_MDU + 2 + 1 + ADDRESS_HASH_SIZE * 2 + 1) as u32;
+/// What a peer that signalled nothing at all is assumed to support, and the
+/// floor for anything it did signal. This is Reticulum's original fixed MTU
+/// and is a property of the *protocol's history*, not of this build — it
+/// must not move when the ceiling below does.
+pub(crate) const LEGACY_RETICULUM_MTU: usize = PACKET_MDU + 2 + 1 + ADDRESS_HASH_SIZE * 2 + 1;
+
+/// The largest MTU this build will advertise, or accept from a peer.
+///
+/// An outgoing link request is additionally clamped to the next hop's own
+/// interface MTU before it goes out (`transport/path.rs`), so in practice
+/// the *interface* decides and this is only a backstop — matching the
+/// reference, which signals `next_hop_interface_hw_mtu`. The value matches
+/// `TCPInterface.HW_MTU` in the reference, and `TcpClient::DEFAULT_MTU`
+/// here.
+///
+/// Raising this was tried once before, in #498, and broke single-packet
+/// Request/Response against a real destination. The reason is now fixed
+/// rather than avoided: the decrypt buffers and `LinkPayload` were a fixed
+/// 464 bytes and silently truncated anything larger, so a peer that honoured
+/// the bigger MTU got its replies dropped. Both are sized from the actual
+/// payload now, and resource fragments derive from the negotiated MTU.
+const RETICULUM_COMPAT_MTU: u32 = 262_144;
 
 const KEEPALIVE_MAX_RTT: f32 = 1.75;
 

--- a/crates/libs/rns-transport/src/resource.rs
+++ b/crates/libs/rns-transport/src/resource.rs
@@ -48,14 +48,19 @@ pub const DEFAULT_RESOURCE_RETRY_INTERVAL_SECS: u64 = 2;
 pub const DEFAULT_RESOURCE_MAX_RETRIES: u8 = 16;
 const DEFAULT_RESOURCE_MAX_ADV_RETRIES: u8 = 4;
 
-pub(crate) fn resource_packet_mdu_for_mtu(interface_mtu: usize) -> Result<usize, RnsError> {
-    if interface_mtu >= DEFAULT_RESOURCE_INTERFACE_MTU {
-        return Ok(PACKET_MDU);
-    }
-    interface_mtu
+/// Fragment payload size for a link of `link_mtu`.
+///
+/// This used to return `PACKET_MDU` (464) for *any* MTU at or above the
+/// legacy 500, so a larger MTU could only ever make fragments smaller (for
+/// LoRa), never bigger — pinning every transfer to 464-byte fragments even
+/// on a gigabit TCP path. The reference derives it the same way this now
+/// does (`RNS/Resource.py`: `sdu = link.mtu - HEADER_MAXSIZE - IFAC_MIN_SIZE`),
+/// which is what lets it move ~8 KB fragments over a link that negotiated
+/// 8192 instead of ~17x as many 464-byte ones.
+pub(crate) fn resource_packet_mdu_for_mtu(link_mtu: usize) -> Result<usize, RnsError> {
+    link_mtu
         .checked_sub(HEADER_MAXSIZE + IFAC_MIN_SIZE)
         .filter(|mdu| *mdu > 0)
-        .map(|mdu| mdu.min(PACKET_MDU))
         .ok_or(RnsError::InvalidArgument)
 }
 

--- a/crates/libs/rns-transport/src/transport/links_parts/transport_sections/close_channel.rs
+++ b/crates/libs/rns-transport/src/transport/links_parts/transport_sections/close_channel.rs
@@ -33,6 +33,7 @@ impl Transport {
         let (resource_hash, packet) = {
             let mut handler = self.handler.lock().await;
             let link_guard = link.lock().await;
+            let interface_mtu = interface_mtu.min(link_guard.link_mtu());
             handler.resource_manager.start_send_with_mtu(
                 &link_guard,
                 data,

--- a/crates/libs/rns-transport/src/transport/links_parts/transport_sections/reset_out_link.rs
+++ b/crates/libs/rns-transport/src/transport/links_parts/transport_sections/reset_out_link.rs
@@ -138,6 +138,9 @@ impl Transport {
         let interface_mtu = self.resource_mtu_for_iface(iface).await;
         let mut handler = self.handler.lock().await;
         let link_guard = link.lock().await;
+        // See `resource_wire.rs`: the negotiated link MTU, not the local
+        // interface alone, is what a fragment has to fit through.
+        let interface_mtu = interface_mtu.min(link_guard.link_mtu());
         let (resource_hash, packet) = handler.resource_manager.start_send_with_mtu(
             &link_guard,
             data,
@@ -176,6 +179,9 @@ impl Transport {
         let interface_mtu = self.resource_mtu_for_iface(iface).await;
         let mut handler = self.handler.lock().await;
         let link_guard = link.lock().await;
+        // See `resource_wire.rs`: the negotiated link MTU, not the local
+        // interface alone, is what a fragment has to fit through.
+        let interface_mtu = interface_mtu.min(link_guard.link_mtu());
         let (resource_hash, packet) = handler.resource_manager.start_send_with_options_mtu(
             &link_guard,
             data,
@@ -215,6 +221,9 @@ impl Transport {
         let interface_mtu = self.resource_mtu_for_iface(iface).await;
         let mut handler = self.handler.lock().await;
         let link_guard = link.lock().await;
+        // See `resource_wire.rs`: the negotiated link MTU, not the local
+        // interface alone, is what a fragment has to fit through.
+        let interface_mtu = interface_mtu.min(link_guard.link_mtu());
         let (resource_hash, packet) = handler.resource_manager.start_send_with_options_mtu(
             &link_guard,
             data,

--- a/crates/libs/rns-transport/src/transport/resource_wire.rs
+++ b/crates/libs/rns-transport/src/transport/resource_wire.rs
@@ -84,12 +84,18 @@ pub(super) async fn handle_link_resource_packet<'a>(
         Err(_) => return true,
     };
     let response_iface = link.ingress_iface().unwrap_or(iface);
+    // The smaller of what this node's interface can carry and what the link
+    // actually negotiated. The interface alone is not enough: it describes
+    // the first hop, while a resource fragment has to survive the whole
+    // path, and the negotiated value is the only number that knows about
+    // the far end.
     let interface_mtu = handler
         .iface_manager
         .lock()
         .await
         .mtu(&response_iface)
-        .unwrap_or(crate::resource::DEFAULT_RESOURCE_INTERFACE_MTU);
+        .unwrap_or(crate::resource::DEFAULT_RESOURCE_INTERFACE_MTU)
+        .min(link.link_mtu());
     let mut responses = std::mem::take(&mut handler.resource_response_packets);
     handler.resource_manager.handle_packet_into_with_mtu(
         &packet_for_manager,


### PR DESCRIPTION
Closes #552.

### Problem

Every Resource fragment is 464 bytes on every link. Stock RNS 1.4.2 negotiates 8192 on the same hub and derives an 8156-byte fragment — 17.6× larger. Fragment size is the dominant term in transfer time, so this is most of the gap against the reference client.

The MTU signalling is already here. What is missing is that `clamp_link_signalling` caps both directions at `RETICULUM_COMPAT_MTU` (500), and an initiator reads the responder's MTU out of the `LinkRequestProof` only to verify the signature over it and then drops it — so `Link` never knows what was negotiated.

### Change

The negotiated MTU is stored on the `Link` and every payload and fragment size derives from it.

- `link_mtu()` (new `link_sections/link_mtu.rs`) reports the negotiated value via `link_signalled_mtu`, falling back to the legacy 500 when a peer signals nothing.
- The initiator captures the responder's signalling from the proof, clamped on the way in exactly like an inbound request's.
- `resource_packet_mdu_for_mtu` derives from the link MTU (`mtu − HEADER_MAXSIZE − IFAC_MIN_SIZE`, as `RNS/Resource.py` does) instead of capping at `PACKET_MDU`.
- `RETICULUM_COMPAT_MTU` becomes 262144, matching `TCPInterface.HW_MTU`; the old 500 stays as `LEGACY_RETICULUM_MTU` for peers that signal nothing.

**The whole chain has to move together**, which is the part worth reviewing:

- `LinkPayload.buffer` becomes a `Vec<u8>`. It was a fixed `[u8; PACKET_MDU]` that silently `min()`-truncated anything larger — and `new_from_vec` set `len` from the input while copying only what fitted, a latent panic.
- The five decrypt buffers in `new.rs` are sized from the actual packet rather than `PACKET_MDU`.
- `resource_wire.rs` and the transport link sections size against `link.link_mtu()`.

This is why #498 walked its 8192 back. That change advertised a larger MTU while `LinkPayload` and the decrypt buffers stayed at 464 and silently truncated, so the peer sized its replies to something we could not receive — "advertise without capability", which presents exactly as the single-packet Request/Response failure recorded in `new.rs`'s comment. Raising the advertised value alone would break live traffic again.

Note also the structural difference this fixes: fragment size derived from the *local interface* MTU, where the reference derives it from the *negotiated link* MTU. The local interface says nothing about what the path will carry.

### Evidence

Fetching a 46 MB `/file/` from a live NomadNet node over a public hub, release build, same node and hub throughout:

| | fragment size | fragments | wall clock | throughput |
| --- | --- | --- | --- | --- |
| v0.9.7 | 464 B | 100,373 | 203 s | 224 KB/s |
| stock RNS 1.4.2 | 8,156 B | 5,710 | 11.16 s | 3.98 MB/s |
| **this PR** | **8,156 B** | **5,710** | **8.7 s** | **5.3 MB/s** |

The fetched 46,572,842-byte APK passes `unzip -t` with every entry's CRC intact, so this is verified content and not just a byte count. A single Micron page fetch also goes from 88 ms to 40 ms.

(The 8.7 s figure includes #553 and #554, which had to be fixed before a transfer this large could finish at all. Fragment sizing is the term that moved the number.)

### Notes for review

- The second commit moves the `PacketType::Proof` arm of `handle_packet` into its own section file. Capturing the proof MTU pushed `new.rs` from 499 to 541 lines, past the 500-line module budget; the split mirrors the existing `handle_data_packet` dispatch. No behaviour change.
- `cargo fmt`, `clippy -D warnings`, `check-boundaries.sh`, the module-size check and the full test suite all pass.
