### PR TITLE
Report split-resource assemblies that are abandoned mid-transfer

### DIFF
--- a/crates/libs/rns-transport/src/resource/manager_segments.rs
+++ b/crates/libs/rns-transport/src/resource/manager_segments.rs
@@ -12,6 +12,32 @@ struct InboundSegmentAssembly {
 }
 
 impl ResourceManager {
+    /// Abandon a partially assembled split resource and tell the caller why.
+    ///
+    /// Every path that drops an assembly has to come through here. Returning
+    /// quietly instead leaves whoever is awaiting the resource blocked until
+    /// its own timeout expires, with nothing on either side saying the transfer
+    /// is already dead (issue #369).
+    fn fail_inbound_segments(&mut self, original_hash: Hash, reason: &str) {
+        let Some(assembly) = self.incoming_segments.remove(&original_hash) else {
+            return;
+        };
+        log::warn!("split resource assembly failed hash={original_hash} reason={reason}");
+        self.events.push(ResourceEvent {
+            hash: original_hash,
+            link_id: assembly.link_id,
+            kind: ResourceEventKind::InboundFailed(ResourceFailure {
+                reason: reason.to_string(),
+                progress: ResourceProgress {
+                    received_bytes: assembly.data.len() as u64,
+                    total_bytes: assembly.total_data_size,
+                    received_parts: assembly.next_segment.saturating_sub(1) as usize,
+                    total_parts: assembly.total_segments as usize,
+                },
+            }),
+        });
+    }
+
     pub fn confirm_outbound_dispatch(&mut self, resource_hash: Hash, sent: bool) {
         let Some(mut sender) = self.pending_outgoing.remove(&resource_hash) else {
             return;
@@ -66,6 +92,9 @@ impl ResourceManager {
                 is_request: payload.is_request,
                 is_response: payload.is_response,
             });
+        // Deliberately a drop rather than a failure: issue #520 established that
+        // an out-of-order segment must leave the assembly intact so the transfer
+        // resumes when the expected segment arrives.
         if assembly.link_id != link_id
             || assembly.total_segments != segment.total_segments
             || assembly.total_data_size != segment.total_data_size
@@ -91,13 +120,7 @@ impl ResourceManager {
             .saturating_add(metadata_size)
             > assembly.total_data_size as usize
         {
-            log::warn!(
-                "discarding oversized split resource segment original_hash={} segment={}/{}",
-                segment.original_hash,
-                segment.segment_index,
-                segment.total_segments
-            );
-            self.incoming_segments.remove(&segment.original_hash);
+            self.fail_inbound_segments(segment.original_hash, "oversized_segment");
             return;
         }
         assembly.data.extend_from_slice(&payload.data);
@@ -109,19 +132,17 @@ impl ResourceManager {
         });
 
         if segment.segment_index == segment.total_segments {
+            let Some(assembly) = self.incoming_segments.get(&segment.original_hash) else {
+                return;
+            };
+            let assembled_size = assembly.data.len().saturating_add(
+                assembly.metadata.as_ref().map(|metadata| metadata.len() + 3).unwrap_or(0),
+            ) as u64;
+            if assembled_size != assembly.total_data_size {
+                self.fail_inbound_segments(segment.original_hash, "assembled_size_mismatch");
+                return;
+            }
             if let Some(assembly) = self.incoming_segments.remove(&segment.original_hash) {
-                let assembled_size = assembly.data.len().saturating_add(
-                    assembly.metadata.as_ref().map(|metadata| metadata.len() + 3).unwrap_or(0),
-                ) as u64;
-                if assembled_size != assembly.total_data_size {
-                    log::warn!(
-                        "discarding split resource with inconsistent size original_hash={} expected={} assembled={}",
-                        segment.original_hash,
-                        assembly.total_data_size,
-                        assembled_size
-                    );
-                    return;
-                }
                 self.events.push(ResourceEvent {
                     hash: segment.original_hash,
                     link_id,

--- a/crates/libs/rns-transport/src/resource/tests.rs
+++ b/crates/libs/rns-transport/src/resource/tests.rs
@@ -1053,6 +1053,7 @@ mod tests {
     include!("tests_retry_failures.rs");
     include!("tests_hashmap_gate.rs");
     include!("tests_window_rounds.rs");
+    include!("tests_split_assembly.rs");
     include!("tests_timeouts.rs");
     include!("tests_timeouts_lifecycle.rs");
 

--- a/crates/libs/rns-transport/src/resource/tests_split_assembly.rs
+++ b/crates/libs/rns-transport/src/resource/tests_split_assembly.rs
@@ -1,0 +1,57 @@
+/// Every path that abandons a split-resource assembly has to say so. Returning
+/// quietly leaves the caller blocked on a transfer the manager already knows is
+/// dead, until an unrelated timeout expires (issue #369).
+#[test]
+fn resource_manager_reports_a_split_resource_that_assembles_to_the_wrong_size() {
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination = DestinationDesc {
+        identity,
+        address_hash: identity.address_hash,
+        name: DestinationName::new("lxmf", "resource"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(1);
+    let mut link = Link::new(destination, tx);
+    link.request();
+    let mut manager = ResourceManager::new_with_config(Duration::from_secs(1), 2);
+
+    let first_data = b"first-segment";
+    let second_data = b"second-segment";
+    // One byte more than the segments actually deliver, so the final size check
+    // rejects the assembly.
+    let total_data_size = (first_data.len() + second_data.len() + 1) as u64;
+
+    let (first_adv, first_part) = split_test_segment(first_data, None, 1, 2, total_data_size);
+    let original_hash = first_adv.hash;
+    let (second_adv, second_part) =
+        split_test_segment(second_data, Some(original_hash), 2, 2, total_data_size);
+
+    for (adv, part) in [(first_adv, first_part), (second_adv, second_part)] {
+        let adv_packet = resource_packet(
+            PacketContext::ResourceAdvrtisement,
+            &adv.pack().expect("pack advertisement"),
+            *link.id(),
+        );
+        assert_eq!(manager.handle_packet(&adv_packet, &mut link).len(), 1);
+        let part_packet = resource_packet(PacketContext::Resource, &part, *link.id());
+        assert_eq!(manager.handle_packet(&part_packet, &mut link).len(), 1);
+    }
+
+    assert!(!manager.incoming_segments.contains_key(&original_hash));
+    let events = manager.drain_events();
+    assert!(
+        !events.iter().any(|event| matches!(event.kind, ResourceEventKind::Complete(_))),
+        "a short assembly must not complete"
+    );
+    let failure = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            ResourceEventKind::InboundFailed(failure) if event.hash == original_hash => {
+                Some(failure)
+            }
+            _ => None,
+        })
+        .expect("inbound failure for the abandoned assembly");
+    assert_eq!(failure.reason, "assembled_size_mismatch");
+    assert_eq!(failure.progress.total_parts, 2);
+}


### PR DESCRIPTION
Closes #554.

### Problem

Two paths in `finish_inbound_payload` discard a partially assembled split resource and return with no event: an oversized segment, and a final assembly whose size disagrees with the advertised total. The assembly is gone and nothing can complete it, but the caller is never told — it stays blocked until an unrelated timeout expires.

### Change

Both paths route through `fail_inbound_segments`, which removes the assembly, logs, and emits `InboundFailed` with the segment progress reached.

The out-of-order path is deliberately left as a silent drop. #520 established that an inconsistent segment must leave the assembly intact so the transfer resumes when the expected segment arrives, and this PR does not revisit that — only the two paths that actually destroy the assembly gain an event.

The final size check is restructured to `get` before `remove`, so the failure helper still finds the assembly it needs to report progress from.

### Evidence

Found chasing a 46 MB fetch that transferred every byte — 45 of 45 segments, all fragments, all proofs — and then never returned. The transfer was genuinely broken (#553), but establishing that took a packet capture, because the only trace was a `log::warn!` and the caller saw nothing but a stalled future.

### Test

`tests_split_assembly.rs` drives a two-segment resource whose advertised total exceeds what the segments deliver, and asserts `InboundFailed` with reason `assembled_size_mismatch`, no `Complete` event, and the assembly removed. **It fails on unmodified `main`** — no event of any kind is emitted.
