### PR TITLE
Bound ZeroMQ request sends by the SDK timeout

### DIFF
--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/transport.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/transport.rs
@@ -100,38 +100,43 @@ impl ZmqPipelineBackendClient {
             .as_mut()
             .ok_or_else(|| sdk_error(ErrorCategory::Internal, "missing zmq transport"))?;
 
-        transport
-            .command
-            .send(ZmqMessage::from(encoded))
-            .await
-            .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+        // Bound the command send and response wait by one deadline.  A PUSH
+        // socket can itself await indefinitely when the peer or its receive
+        // queue is wedged; starting the timeout only after `send` completed
+        // lets the actor retain stale work until the application queue fills.
+        let result = tokio::time::timeout(self.config.request_timeout, async {
+            transport
+                .command
+                .send(ZmqMessage::from(encoded))
+                .await
+                .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
 
-        let deadline = tokio::time::sleep(self.config.request_timeout);
-        tokio::pin!(deadline);
-        loop {
-            tokio::select! {
-                _ = &mut deadline => {
-                    return Err(SdkError::new(
-                        "SDK_TRANSPORT_ZMQ_TIMEOUT",
-                        ErrorCategory::Timeout,
-                        "zmq rpc request timed out waiting for correlated response",
-                    ));
-                }
-                message = transport.responses.recv() => {
-                    let bytes = Vec::<u8>::try_from(message.map_err(|err| {
-                        sdk_error(ErrorCategory::Transport, err.to_string())
-                    })?)
+            loop {
+                let message = transport
+                    .responses
+                    .recv()
+                    .await
                     .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
-                    let envelope = zmq::decode_envelope(&bytes)
-                        .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
-                    if envelope.kind == ZmqRpcEnvelopeKind::Response
-                        && envelope.session_id == self.session_id
-                        && envelope.request_id == request_id
-                    {
-                        return Ok(envelope);
-                    }
+                let bytes = Vec::<u8>::try_from(message)
+                    .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+                let envelope = zmq::decode_envelope(&bytes)
+                    .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+                if envelope.kind == ZmqRpcEnvelopeKind::Response
+                    && envelope.session_id == self.session_id
+                    && envelope.request_id == request_id
+                {
+                    return Ok(envelope);
                 }
             }
+        })
+        .await;
+        match result {
+            Ok(result) => result,
+            Err(_) => Err(SdkError::new(
+                "SDK_TRANSPORT_ZMQ_TIMEOUT",
+                ErrorCategory::Timeout,
+                "zmq rpc request timed out waiting for send or correlated response",
+            )),
         }
     }
 
@@ -147,31 +152,37 @@ impl ZmqPipelineBackendClient {
         if slot_guard.is_none() {
             *slot_guard = Some(ZmqDealerTransport::connect(&self.config).await?);
         }
-        let transport = slot_guard
-            .as_mut()
-            .ok_or_else(|| sdk_error(ErrorCategory::Internal, "missing zmq dealer transport"))?;
-        if let Err(error) = transport.socket.send(ZmqMessage::from(encoded)).await {
-            *slot_guard = None;
-            return Err(sdk_error(ErrorCategory::Transport, error.to_string()));
-        }
-        let receive = {
+        // Apply the same deadline to DEALER sends as to response receives. A
+        // blocked send must not hold this pool slot forever or leave a caller
+        // retrying while the original request is still in flight.
+        let result = tokio::time::timeout(self.config.request_timeout, async {
             let transport = slot_guard.as_mut().ok_or_else(|| {
                 sdk_error(ErrorCategory::Internal, "missing zmq dealer transport")
             })?;
-            tokio::time::timeout(self.config.request_timeout, transport.socket.recv()).await
-        };
-        let message = match receive {
+            transport
+                .socket
+                .send(ZmqMessage::from(encoded))
+                .await
+                .map_err(|error| sdk_error(ErrorCategory::Transport, error.to_string()))?;
+            transport
+                .socket
+                .recv()
+                .await
+                .map_err(|error| sdk_error(ErrorCategory::Transport, error.to_string()))
+        })
+        .await;
+        let message = match result {
             Err(_) => {
                 *slot_guard = None;
                 return Err(SdkError::new(
                     "SDK_TRANSPORT_ZMQ_TIMEOUT",
                     ErrorCategory::Timeout,
-                    "zmq rpc request timed out waiting for correlated response",
+                    "zmq rpc request timed out waiting for send or correlated response",
                 ));
             }
             Ok(Err(error)) => {
                 *slot_guard = None;
-                return Err(sdk_error(ErrorCategory::Transport, error.to_string()));
+                return Err(error);
             }
             Ok(Ok(message)) => message,
         };

--- a/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/transport.rs
+++ b/crates/libs/lxmf-sdk/src/backend/zmq_pipeline/transport.rs
@@ -100,23 +100,34 @@ impl ZmqPipelineBackendClient {
             .as_mut()
             .ok_or_else(|| sdk_error(ErrorCategory::Internal, "missing zmq transport"))?;
 
-        // Bound the command send and response wait by one deadline.  A PUSH
+        // Bound the command send and response wait by one deadline. A PUSH
         // socket can itself await indefinitely when the peer or its receive
         // queue is wedged; starting the timeout only after `send` completed
         // lets the actor retain stale work until the application queue fills.
-        let result = tokio::time::timeout(self.config.request_timeout, async {
-            transport
-                .command
-                .send(ZmqMessage::from(encoded))
-                .await
-                .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+        let deadline = tokio::time::Instant::now() + self.config.request_timeout;
+        let timeout_error = || {
+            SdkError::new(
+                "SDK_TRANSPORT_ZMQ_TIMEOUT",
+                ErrorCategory::Timeout,
+                "zmq rpc request timed out waiting for send or correlated response",
+            )
+        };
+        async {
+            let send_result = tokio::select! {
+                biased;
+                _ = tokio::time::sleep_until(deadline) => Err(timeout_error()),
+                result = transport.command.send(ZmqMessage::from(encoded)) => result
+                    .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string())),
+            };
+            send_result?;
 
             loop {
-                let message = transport
-                    .responses
-                    .recv()
-                    .await
-                    .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
+                let message = tokio::select! {
+                    biased;
+                    _ = tokio::time::sleep_until(deadline) => return Err(timeout_error()),
+                    result = transport.responses.recv() => result
+                        .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?,
+                };
                 let bytes = Vec::<u8>::try_from(message)
                     .map_err(|err| sdk_error(ErrorCategory::Transport, err.to_string()))?;
                 let envelope = zmq::decode_envelope(&bytes)
@@ -128,16 +139,8 @@ impl ZmqPipelineBackendClient {
                     return Ok(envelope);
                 }
             }
-        })
-        .await;
-        match result {
-            Ok(result) => result,
-            Err(_) => Err(SdkError::new(
-                "SDK_TRANSPORT_ZMQ_TIMEOUT",
-                ErrorCategory::Timeout,
-                "zmq rpc request timed out waiting for send or correlated response",
-            )),
         }
+        .await
     }
 
     async fn send_and_recv_single_endpoint(


### PR DESCRIPTION
## Summary

- Bound PUSH and DEALER sends together with correlated response waits under one SDK request deadline.
- Drop/reset timed-out transport slots so blocked sends cannot retain stale actor work.

## Root cause

The SDK started its timeout only after `send()` completed. A wedged ZeroMQ peer could therefore block the single actor indefinitely; RCH callers timed out and retried until the control queue filled.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p lxmf-sdk`
- `cargo clippy -p lxmf-sdk --all-targets -- -D warnings`
- `cargo test -p lxmf-sdk`