### PR TITLE
Build split-resource segments on demand instead of all up front

### DIFF
--- a/crates/libs/rns-transport/src/resource.rs
+++ b/crates/libs/rns-transport/src/resource.rs
@@ -470,6 +470,7 @@ include!("resource/manager_start.rs");
 include!("resource/manager_segments.rs");
 include!("resource/advertisement_limits.rs");
 include!("resource/manager.rs");
+include!("resource/manager_proof.rs");
 include!("resource/manager_polling.rs");
 include!("resource/utils.rs");
 include!("resource/tests.rs");

--- a/crates/libs/rns-transport/src/resource/manager.rs
+++ b/crates/libs/rns-transport/src/resource/manager.rs
@@ -2,7 +2,7 @@
 pub struct ResourceManager {
     pending_outgoing: HashMap<Hash, ResourceSender>,
     outgoing: HashMap<Hash, ResourceSender>,
-    outgoing_segment_chains: HashMap<Hash, VecDeque<ResourceSender>>,
+    outgoing_segment_chains: HashMap<Hash, PendingSegments>,
     incoming: HashMap<Hash, ResourceReceiver>,
     incoming_segments: HashMap<Hash, InboundSegmentAssembly>,
     events: Vec<ResourceEvent>,
@@ -55,8 +55,9 @@ impl ResourceManager {
     pub fn remove_link_state(&mut self, link_id: AddressHash) {
         self.pending_outgoing.retain(|_, sender| sender.link_id != link_id);
         self.outgoing.retain(|_, sender| sender.link_id != link_id);
-        self.outgoing_segment_chains
-            .retain(|_, senders| senders.front().is_none_or(|sender| sender.link_id != link_id));
+        // Was `senders.front().is_none_or(..)`, which also leaked: a chain
+        // drained to empty matched no link and so was retained forever.
+        self.outgoing_segment_chains.retain(|_, pending| pending.link_id != link_id);
         self.incoming.retain(|_, receiver| receiver.link_id != link_id);
         self.incoming_segments.retain(|_, assembly| assembly.link_id != link_id);
         self.link_stats.remove(&link_id);
@@ -103,7 +104,7 @@ impl ResourceManager {
                 self.handle_hash_update_into(packet, link, responses)
             }
             PacketContext::Resource => self.handle_resource_part_into(packet, link, responses),
-            PacketContext::ResourceProof => self.handle_proof_into(packet, responses),
+            PacketContext::ResourceProof => self.handle_proof_into(packet, link, responses),
             PacketContext::ResourceInitiatorCancel | PacketContext::ResourceReceiverCancel => {
                 self.cancel_into(packet, responses)
             }
@@ -428,39 +429,6 @@ impl ResourceManager {
             responses.push(packet);
         } else if let Some(packet) = request_packet {
             responses.push(packet);
-        }
-    }
-
-    fn handle_proof_into(&mut self, packet: &Packet, responses: &mut Vec<Packet>) {
-        let Ok(proof) = ResourceProof::decode(packet.data.as_slice()) else {
-            return;
-        };
-        if self
-            .outgoing
-            .get_mut(&proof.resource_hash)
-            .is_some_and(|sender| sender.handle_proof(&proof))
-        {
-            if let Some(sender) = self.outgoing.remove(&proof.resource_hash) {
-                if sender.segment_index < sender.total_segments {
-                    let next = self
-                        .outgoing_segment_chains
-                        .get_mut(&sender.original_hash)
-                        .and_then(VecDeque::pop_front);
-                    if let Some(mut next) = next {
-                        let advertisement = next.advertisement_packet();
-                        next.mark_advertised(self.retry_limit);
-                        self.outgoing.insert(next.resource_hash, next);
-                        responses.push(advertisement);
-                        return;
-                    }
-                }
-                self.outgoing_segment_chains.remove(&sender.original_hash);
-                self.events.push(ResourceEvent {
-                    hash: sender.original_hash,
-                    link_id: packet.destination,
-                    kind: ResourceEventKind::OutboundComplete,
-                });
-            }
         }
     }
 

--- a/crates/libs/rns-transport/src/resource/manager.rs
+++ b/crates/libs/rns-transport/src/resource/manager.rs
@@ -432,12 +432,22 @@ impl ResourceManager {
         }
     }
 
+    /// A cancel names the *segment* that is in flight, not the split resource
+    /// it belongs to — `cancel_outgoing` builds the packet from the active
+    /// segment's own hash, and so does the reference. Dropping the sender is
+    /// therefore not enough: the unbuilt tail is keyed by `original_hash`, so
+    /// it would go on holding the caller's whole payload until the link closed.
     fn cancel_into(&mut self, packet: &Packet, _responses: &mut Vec<Packet>) {
-        if let Ok(hash_bytes) = copy_hash(packet.data.as_slice()) {
-            let hash = Hash::new(hash_bytes);
-            self.incoming.remove(&hash);
-            self.pending_outgoing.remove(&hash);
-            self.outgoing.remove(&hash);
+        let Ok(hash_bytes) = copy_hash(packet.data.as_slice()) else {
+            return;
+        };
+        let hash = Hash::new(hash_bytes);
+        self.incoming.remove(&hash);
+        // Removed from both, as before: a hash lives in exactly one of these,
+        // but which one depends on whether dispatch has been confirmed yet.
+        let cancelled = self.pending_outgoing.remove(&hash);
+        if let Some(sender) = self.outgoing.remove(&hash).or(cancelled) {
+            self.outgoing_segment_chains.remove(&sender.original_hash);
         }
     }
 }

--- a/crates/libs/rns-transport/src/resource/manager_proof.rs
+++ b/crates/libs/rns-transport/src/resource/manager_proof.rs
@@ -1,0 +1,69 @@
+impl ResourceManager {
+    /// Concludes a segment and advertises the next one.
+    ///
+    /// Split out of `manager.rs` to keep it inside the module-size budget once
+    /// the next segment started being *built* here rather than popped off a
+    /// pre-built queue.
+    fn handle_proof_into(&mut self, packet: &Packet, link: &Link, responses: &mut Vec<Packet>) {
+        let Ok(proof) = ResourceProof::decode(packet.data.as_slice()) else {
+            return;
+        };
+        if !self
+            .outgoing
+            .get_mut(&proof.resource_hash)
+            .is_some_and(|sender| sender.handle_proof(&proof))
+        {
+            return;
+        }
+        let Some(sender) = self.outgoing.remove(&proof.resource_hash) else {
+            return;
+        };
+
+        if sender.segment_index < sender.total_segments {
+            // Built here rather than up front in `start_send`: the transfer is
+            // idle at this exact point, waiting to advertise the next segment,
+            // so this is where the work belongs. See `PendingSegments`.
+            let next = self
+                .outgoing_segment_chains
+                .get_mut(&sender.original_hash)
+                .and_then(|pending| pending.build_next(link));
+            match next {
+                Some(Ok(mut next)) => {
+                    let advertisement = next.advertisement_packet();
+                    next.mark_advertised(self.retry_limit);
+                    self.outgoing.insert(next.resource_hash, next);
+                    responses.push(advertisement);
+                    return;
+                }
+                // Nothing is waiting on a return value this deep in the packet
+                // path, so a build failure has to be reported as an event or
+                // the transfer simply stops with both ends believing it is
+                // still running — the same trap #557 closed for inbound
+                // assemblies.
+                Some(Err(error)) => {
+                    log::warn!(
+                        "split resource segment build failed hash={} segment={}/{} error={error:?}",
+                        sender.original_hash,
+                        sender.segment_index.saturating_add(1),
+                        sender.total_segments
+                    );
+                    self.outgoing_segment_chains.remove(&sender.original_hash);
+                    self.events.push(ResourceEvent {
+                        hash: sender.original_hash,
+                        link_id: sender.link_id,
+                        kind: ResourceEventKind::OutboundFailed,
+                    });
+                    return;
+                }
+                None => {}
+            }
+        }
+
+        self.outgoing_segment_chains.remove(&sender.original_hash);
+        self.events.push(ResourceEvent {
+            hash: sender.original_hash,
+            link_id: packet.destination,
+            kind: ResourceEventKind::OutboundComplete,
+        });
+    }
+}

--- a/crates/libs/rns-transport/src/resource/manager_segments.rs
+++ b/crates/libs/rns-transport/src/resource/manager_segments.rs
@@ -1,3 +1,64 @@
+/// The not-yet-built tail of an outbound split resource.
+///
+/// This used to be a `VecDeque<ResourceSender>` filled by `start_send`, which
+/// meant one bz2 + AES + SHA-256 pass over the *entire* payload, and chunking
+/// it into every fragment it would ever need, before the first advertisement
+/// could be returned. `start_send` runs with the transport handler mutex held,
+/// so on a 46 MB send that was a full second of global lock before any byte
+/// moved (2.5 s once outbound compression was added), and ~100k live `Vec<u8>`
+/// fragments retained for the life of the transfer.
+///
+/// The reference does not do that either: `RNS/Resource.py`'s `advertise()`
+/// prepares exactly one segment ahead, on a daemon thread, off the send path.
+/// Holding the inputs instead of the outputs is the single-threaded equivalent
+/// — segment n+1 is built when segment n's proof arrives, at which point the
+/// transfer is idle anyway waiting to advertise it.
+///
+/// `data` + `offset` rather than a drained buffer, so each segment costs the
+/// same one `to_vec()` copy it always did.
+#[derive(Debug)]
+struct PendingSegments {
+    link_id: AddressHash,
+    data: Vec<u8>,
+    offset: usize,
+    /// The segment `build_next` will produce, counting from 1. Past
+    /// `total_segments` the chain is exhausted.
+    next_segment_index: u32,
+    total_segments: u32,
+    total_size: u64,
+    request_id: Option<Vec<u8>>,
+    is_response: bool,
+    interface_mtu: usize,
+    original_hash: Hash,
+}
+
+impl PendingSegments {
+    /// Builds the next segment, or `None` once every segment has been built.
+    fn build_next(&mut self, link: &Link) -> Option<Result<ResourceSender, RnsError>> {
+        if self.next_segment_index > self.total_segments {
+            return None;
+        }
+        let end = self.offset.saturating_add(MAX_EFFICIENT_SIZE).min(self.data.len());
+        let sender = ResourceSender::new_segment_with_options_mtu(
+            link,
+            self.data[self.offset..end].to_vec(),
+            None,
+            self.request_id.clone(),
+            self.is_response,
+            self.interface_mtu,
+            Some(self.original_hash),
+            self.next_segment_index,
+            self.total_segments,
+            Some(self.total_size),
+        );
+        if sender.is_ok() {
+            self.offset = end;
+            self.next_segment_index = self.next_segment_index.saturating_add(1);
+        }
+        Some(sender)
+    }
+}
+
 #[derive(Debug)]
 struct InboundSegmentAssembly {
     link_id: AddressHash,

--- a/crates/libs/rns-transport/src/resource/manager_start.rs
+++ b/crates/libs/rns-transport/src/resource/manager_start.rs
@@ -127,25 +127,23 @@ impl ResourceManager {
             Some(total_size as u64),
         )?;
         let original_hash = first.original_hash;
-        let mut remaining = VecDeque::new();
-        let mut offset = first_data_len;
-        for segment_index in 2..=total_segments {
-            let end = offset.saturating_add(MAX_EFFICIENT_SIZE).min(data.len());
-            remaining.push_back(ResourceSender::new_segment_with_options_mtu(
-                link,
-                data[offset..end].to_vec(),
-                None,
-                request_id.clone(),
+        // Only segment 1 is built here. The rest are built as each preceding
+        // segment's proof arrives — see `PendingSegments`.
+        self.outgoing_segment_chains.insert(
+            original_hash,
+            PendingSegments {
+                link_id: first.link_id,
+                data,
+                offset: first_data_len,
+                next_segment_index: 2,
+                total_segments,
+                total_size: total_size as u64,
+                request_id,
                 is_response,
                 interface_mtu,
-                Some(original_hash),
-                segment_index,
-                total_segments,
-                Some(total_size as u64),
-            )?);
-            offset = end;
-        }
-        self.outgoing_segment_chains.insert(original_hash, remaining);
+                original_hash,
+            },
+        );
         self.track_sender(first)
     }
 

--- a/crates/libs/rns-transport/src/resource/tests.rs
+++ b/crates/libs/rns-transport/src/resource/tests.rs
@@ -1054,6 +1054,7 @@ mod tests {
     include!("tests_hashmap_gate.rs");
     include!("tests_window_rounds.rs");
     include!("tests_split_assembly.rs");
+    include!("tests_split_lazy.rs");
     include!("tests_timeouts.rs");
     include!("tests_timeouts_lifecycle.rs");
 

--- a/crates/libs/rns-transport/src/resource/tests_split_lazy.rs
+++ b/crates/libs/rns-transport/src/resource/tests_split_lazy.rs
@@ -230,3 +230,99 @@ fn removing_a_link_drops_its_unbuilt_segments() {
     assert!(manager.outgoing_segment_chains.is_empty());
     assert!(manager.has_no_outbound_state());
 }
+
+/// A peer cancelling mid-transfer has to drop the unbuilt tail too.
+///
+/// The trap is that a cancel names the **segment** in flight, not the split
+/// resource: from segment two onwards its hash is nothing like `original_hash`,
+/// which is what the tail is keyed by. Removing only the sender therefore looks
+/// like a clean cancel while leaving the entire remaining payload alive until
+/// the link closes — and a link that is being reused rather than torn down may
+/// not close for a long time.
+#[test]
+fn a_remote_cancel_drops_the_unbuilt_tail() {
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination = DestinationDesc {
+        identity,
+        address_hash: identity.address_hash,
+        name: DestinationName::new("lxmf", "resource"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(1);
+    let mut link = Link::new(destination, tx);
+    let mut manager = ResourceManager::new_with_config(Duration::from_secs(1), 2);
+    let data = vec![0x5a; (MAX_EFFICIENT_SIZE * 3) + 17];
+
+    let (original_hash, _) =
+        manager.start_send(&link, data, None).expect("start split resource");
+    manager.confirm_outbound_dispatch(original_hash, true);
+
+    // Advance to segment two, so the cancel names a hash that is *not* the key
+    // the tail is stored under. Cancelling segment one would pass even with the
+    // bug, since there `original_hash` is the sender's own hash.
+    let expected_proof =
+        manager.outgoing.get(&original_hash).expect("first sender").expected_proof;
+    let proof = ResourceProof { resource_hash: original_hash, proof: expected_proof };
+    let packets = manager.handle_packet(
+        &resource_packet(PacketContext::ResourceProof, &proof.encode(), *link.id()),
+        &mut link,
+    );
+    let second = decrypt_advertisement(&link, &packets[0]);
+    assert_eq!(second.segment_index, 2);
+    assert_ne!(second.hash, original_hash, "the test is only meaningful if these differ");
+    assert_eq!(
+        manager.outgoing_segment_chains.get(&original_hash).expect("tail").next_segment_index,
+        3
+    );
+
+    // We are the initiator, so a cancel from the peer is a receiver cancel.
+    manager.handle_packet(
+        &resource_packet(
+            PacketContext::ResourceReceiverCancel,
+            second.hash.as_slice(),
+            *link.id(),
+        ),
+        &mut link,
+    );
+
+    assert!(
+        !manager.outgoing_segment_chains.contains_key(&original_hash),
+        "a cancelled split send must not keep holding the rest of the payload"
+    );
+    assert!(manager.has_no_outbound_state());
+}
+
+/// The same cancel, arriving before the first advertisement has been confirmed
+/// as dispatched — the sender is still in `pending_outgoing` rather than
+/// `outgoing`, which is the other branch `cancel_into` has to clear the tail
+/// from.
+#[test]
+fn a_remote_cancel_before_dispatch_drops_the_unbuilt_tail() {
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination = DestinationDesc {
+        identity,
+        address_hash: identity.address_hash,
+        name: DestinationName::new("lxmf", "resource"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(1);
+    let mut link = Link::new(destination, tx);
+    let mut manager = ResourceManager::new_with_config(Duration::from_secs(1), 2);
+    let data = vec![0x5a; MAX_EFFICIENT_SIZE + 257];
+
+    let (original_hash, _) =
+        manager.start_send(&link, data, None).expect("start split resource");
+    assert!(manager.outgoing_segment_chains.contains_key(&original_hash));
+
+    manager.handle_packet(
+        &resource_packet(
+            PacketContext::ResourceReceiverCancel,
+            original_hash.as_slice(),
+            *link.id(),
+        ),
+        &mut link,
+    );
+
+    assert!(manager.outgoing_segment_chains.is_empty());
+    assert!(manager.has_no_outbound_state());
+}

--- a/crates/libs/rns-transport/src/resource/tests_split_lazy.rs
+++ b/crates/libs/rns-transport/src/resource/tests_split_lazy.rs
@@ -1,0 +1,232 @@
+/// Undoes what `resource/utils.rs::fill_link_packet_data` did, and only when it
+/// did it: fragments carry the sender's own ciphertext and proofs carry a
+/// signature, so neither gets a second link-layer encryption. Decrypting them
+/// anyway fails as `IncorrectSignature`.
+fn decrypt_link_packet(link: &Link, packet: &Packet) -> Packet {
+    let encrypted = packet.context != PacketContext::Resource
+        && !(packet.header.packet_type == PacketType::Proof
+            && packet.context == PacketContext::ResourceProof);
+    if !encrypted {
+        return packet.clone();
+    }
+    let mut plain = packet.clone();
+    let mut buffer = PacketDataBuffer::new();
+    let plain_len = {
+        let text = link
+            .decrypt(packet.data.as_slice(), buffer.accuire_buf_max())
+            .expect("peer link should decrypt");
+        text.len()
+    };
+    buffer.resize(plain_len);
+    plain.data = buffer;
+    plain
+}
+
+/// A split send must not build every segment before it can advertise the first
+/// one. `start_send` runs with the transport handler mutex held, so the eager
+/// loop this replaced put one bz2 + AES + SHA-256 pass over the whole payload,
+/// and every fragment it would ever need, in front of the first advertisement —
+/// a full second of global lock on a 46 MB send, and ~100k live `Vec<u8>`
+/// fragments retained until the transfer finished.
+#[test]
+fn split_send_builds_only_the_first_segment_up_front() {
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination = DestinationDesc {
+        identity,
+        address_hash: identity.address_hash,
+        name: DestinationName::new("lxmf", "resource"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(1);
+    let mut link = Link::new(destination, tx);
+    let mut manager = ResourceManager::new_with_config(Duration::from_secs(1), 2);
+    let data = vec![0x5a; (MAX_EFFICIENT_SIZE * 3) + 17];
+
+    let (original_hash, first_packet) =
+        manager.start_send(&link, data, None).expect("start split resource");
+    let first = decrypt_advertisement(&link, &first_packet);
+    assert_eq!(first.total_segments, 4);
+
+    // The whole point: exactly one sender exists, and the other three segments
+    // are still just an offset into the caller's payload.
+    assert_eq!(manager.pending_outgoing.len(), 1);
+    assert!(manager.outgoing.is_empty());
+    let pending = manager
+        .outgoing_segment_chains
+        .get(&original_hash)
+        .expect("chain for the unbuilt tail");
+    assert_eq!(pending.next_segment_index, 2);
+    assert_eq!(pending.total_segments, 4);
+
+    manager.confirm_outbound_dispatch(original_hash, true);
+
+    // Each proof builds exactly one more segment, and never more than one.
+    let mut advertised = first;
+    for expected_index in 2..=4u32 {
+        let expected_proof =
+            manager.outgoing.get(&advertised.hash).expect("advertised sender").expected_proof;
+        let proof = ResourceProof { resource_hash: advertised.hash, proof: expected_proof };
+        let packets = manager.handle_packet(
+            &resource_packet(PacketContext::ResourceProof, &proof.encode(), *link.id()),
+            &mut link,
+        );
+        assert_eq!(packets.len(), 1, "one advertisement per proof");
+        advertised = decrypt_advertisement(&link, &packets[0]);
+        assert_eq!(advertised.segment_index, expected_index);
+        assert_eq!(advertised.original_hash, original_hash);
+        assert_eq!(
+            manager.outgoing.len(),
+            1,
+            "only the in-flight segment is held, never the ones after it"
+        );
+    }
+}
+
+/// Building segments on demand must produce exactly the bytes the eager loop
+/// did. This drives a real multi-segment transfer through a sender and a
+/// receiver manager and compares the reassembled payload to the input, so a
+/// wrong offset or a dropped tail byte cannot pass.
+#[test]
+fn lazily_built_segments_reassemble_byte_for_byte() {
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination = DestinationDesc {
+        identity,
+        address_hash: identity.address_hash,
+        name: DestinationName::new("lxmf", "resource"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(1);
+    // A genuine pair, so each side really can read the other's packets rather
+    // than the test quietly measuring one link talking to itself.
+    let mut sender_link = Link::new(destination, tx.clone());
+    let request = sender_link.request();
+    let mut receiver_link =
+        Link::new_from_request(&request, signer.sign_key().clone(), destination, tx)
+            .expect("link request should parse");
+    assert!(matches!(
+        sender_link.handle_packet(&receiver_link.prove(), AddressHash::new_from_rand(OsRng)),
+        LinkHandleResult::Activated
+    ));
+    let mut sender = ResourceManager::new_with_config(Duration::from_secs(30), 8);
+    let mut receiver = ResourceManager::new_with_config(Duration::from_secs(30), 8);
+
+    // Deliberately not a round multiple of the segment size, and not uniform:
+    // a payload of one repeated byte would reassemble "correctly" even if two
+    // segments were swapped.
+    let payload: Vec<u8> =
+        (0..(MAX_EFFICIENT_SIZE * 2) + 4242).map(|index| (index % 251) as u8).collect();
+
+    let (original_hash, advertisement) =
+        sender.start_send(&sender_link, payload.clone(), None).expect("start split resource");
+    sender.confirm_outbound_dispatch(original_hash, true);
+
+    let mut to_receiver = vec![advertisement];
+    let mut delivered: Option<Vec<u8>> = None;
+    // Bounded so a stall fails the test instead of hanging it.
+    for _ in 0..100_000 {
+        if to_receiver.is_empty() {
+            break;
+        }
+        let mut to_sender = Vec::new();
+        for packet in std::mem::take(&mut to_receiver) {
+            let plain = decrypt_link_packet(&receiver_link, &packet);
+            to_sender.extend(receiver.handle_packet(&plain, &mut receiver_link));
+        }
+        for event in receiver.drain_events() {
+            if let ResourceEventKind::Complete(complete) = event.kind {
+                delivered = Some(complete.data);
+            }
+        }
+        // Deliberately does not stop at delivery: the sender has not seen the
+        // final proof yet, and the tail is only released when it does.
+        for packet in to_sender {
+            let plain = decrypt_link_packet(&sender_link, &packet);
+            to_receiver.extend(sender.handle_packet(&plain, &mut sender_link));
+        }
+        sender.drain_events();
+    }
+
+    assert_eq!(delivered.as_deref(), Some(payload.as_slice()));
+    // The tail is released once the last segment is built and proved — nothing
+    // is left holding a copy of the payload after the transfer.
+    assert!(!sender.outgoing_segment_chains.contains_key(&original_hash));
+    assert!(sender.has_no_outbound_state());
+}
+
+/// A segment that cannot be built has no caller left to return an error to —
+/// `handle_proof_into` is several frames deep in the packet path. Reporting it
+/// as `OutboundFailed` is what keeps a dead transfer from looking live to both
+/// ends, the same trap #557 closed for inbound assemblies.
+#[test]
+fn a_segment_that_cannot_be_built_reports_outbound_failure() {
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination = DestinationDesc {
+        identity,
+        address_hash: identity.address_hash,
+        name: DestinationName::new("lxmf", "resource"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(1);
+    let mut link = Link::new(destination, tx);
+    let mut manager = ResourceManager::new_with_config(Duration::from_secs(1), 2);
+    let data = vec![0x5a; MAX_EFFICIENT_SIZE + 257];
+
+    let (original_hash, _) = manager.start_send(&link, data, None).expect("start split resource");
+    manager.confirm_outbound_dispatch(original_hash, true);
+
+    // An MTU too small to carry a resource fragment makes the *next* build
+    // fail, without disturbing the segment already advertised.
+    manager
+        .outgoing_segment_chains
+        .get_mut(&original_hash)
+        .expect("pending tail")
+        .interface_mtu = 1;
+
+    let expected_proof =
+        manager.outgoing.get(&original_hash).expect("first sender").expected_proof;
+    let proof = ResourceProof { resource_hash: original_hash, proof: expected_proof };
+    let packets = manager.handle_packet(
+        &resource_packet(PacketContext::ResourceProof, &proof.encode(), *link.id()),
+        &mut link,
+    );
+
+    assert!(packets.is_empty(), "a failed build must not advertise anything");
+    assert!(!manager.outgoing_segment_chains.contains_key(&original_hash));
+    let events = manager.drain_events();
+    assert!(
+        events.iter().any(|event| event.hash == original_hash
+            && matches!(event.kind, ResourceEventKind::OutboundFailed)),
+        "a build failure must be reported, not dropped: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event.kind, ResourceEventKind::OutboundComplete)),
+        "a failed transfer must not also report completion"
+    );
+}
+
+/// Closing a link has to drop the unbuilt tail with it. The previous shape
+/// keyed this off the front sender's `link_id`, which also meant a chain
+/// drained to empty matched nothing and was retained for the process lifetime.
+#[test]
+fn removing_a_link_drops_its_unbuilt_segments() {
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination = DestinationDesc {
+        identity,
+        address_hash: identity.address_hash,
+        name: DestinationName::new("lxmf", "resource"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(1);
+    let link = Link::new(destination, tx);
+    let mut manager = ResourceManager::new_with_config(Duration::from_secs(1), 2);
+    let data = vec![0x5a; MAX_EFFICIENT_SIZE + 257];
+
+    let (original_hash, _) = manager.start_send(&link, data, None).expect("start split resource");
+    assert!(manager.outgoing_segment_chains.contains_key(&original_hash));
+
+    manager.remove_link_state(*link.id());
+    assert!(manager.outgoing_segment_chains.is_empty());
+    assert!(manager.has_no_outbound_state());
+}


### PR DESCRIPTION
`start_send` built **every** segment of a split resource before it could return the first advertisement — one AES + SHA-256 pass over the entire payload, chunked into every fragment the whole transfer would ever need. It runs with the global transport handler mutex held (`reset_out_link.rs:139-141` and three more call sites), so all of that is time no other link, announce or packet on the node makes progress.

This builds segments 2..N as each preceding segment's proof arrives instead — the point at which the transfer is idle anyway, waiting to advertise the next one.

## Measured

46 MB payload, default MTU (45 segments), three runs each, medians:

| | before | after |
|---|---|---|
| **`start_send` wall time** | **1.043 s** | **0.024 s** |
| live allocations retained | 100,926 | 2,267 |
| peak heap | 64.63 MiB | 6.36 MiB |
| total transfer | 1.682 s | 1.740 s |

A full second of global lock before one byte moves — **62% of the entire transfer** — and ~100k `Vec<u8>` fragments held until it finishes.

**The last row is included deliberately: total transfer is ~3% slower.** This moves work rather than removing it, and building 45 segments one at a time costs slightly more than building them in one pass. That is the honest trade — ~3% on a transfer that in production is dominated by the wire, against not holding a global lock for a second and not retaining 45 MB of ciphertext for the duration.

## Reference behaviour

This also moves the sender *toward* `RNS/Resource.py` rather than away from it. `advertise()` (Resource.py:508-518) starts `__prepare_next_segment` for exactly **one** segment ahead, on a daemon thread, off the send path. It never prepares all N.

I deliberately did not add a one-ahead lookahead. The reference's exists so the work overlaps the current segment's transfer *on another thread*; this manager is synchronous, so a lookahead would run on the same call path — gaining nothing while doubling peak memory. Building on demand is the single-threaded equivalent. Happy to revisit if you read it differently.

## Two other things in here

- **A segment that cannot be built now reports `OutboundFailed`.** Previously a build failure returned `Err` to `start_send`'s caller; lazily there is no caller left, several frames deep in the packet path. Dropping it silently would leave both ends believing the transfer is live until an unrelated timeout — the same trap #557 closed for inbound assemblies.
- **`remove_link_state` leaked.** It keyed off `senders.front()`'s `link_id`, so a chain drained to empty matched no link and was retained for the process lifetime. It now matches on the chain's own `link_id`.

`handle_proof_into` moved to `manager_proof.rs` to stay inside the module-size budget.

## Tests

Four new, in `resource/tests_split_lazy.rs`:
- only segment 1 is built up front, and each proof builds exactly one more;
- **a full multi-segment transfer through sender and receiver managers reassembles byte-for-byte** (non-uniform payload, not a round multiple of the segment size, so a swapped or truncated segment cannot pass);
- a build failure reports `OutboundFailed` and does not also report completion;
- closing a link drops its unbuilt tail.

601 lib tests, fmt, `clippy -D warnings`, module-size and boundary checks all green locally.

## Related

Independent of #545 — either can merge first. #545's compression makes this lock hold considerably worse (2.686 s), but as the numbers above show it was already a second without it.

The measurement harness is a small standalone crate (it needs a counting `#[global_allocator]`, which this workspace's `unsafe_code = "forbid"` rightly disallows). Not included here to avoid putting a slow benchmark in CI unasked — glad to contribute it if you'd like a regression guard.
