### PR TITLE
Prepare resource sends before taking the handler lock

### DIFF
--- a/crates/libs/rns-transport/src/resource/manager_segments.rs
+++ b/crates/libs/rns-transport/src/resource/manager_segments.rs
@@ -1,3 +1,16 @@
+/// A send that has been fully built but not yet handed to the manager.
+///
+/// Exists so the expensive half of starting a resource send can happen without
+/// the transport handler lock: `ResourceManager::prepare_send` produces one of
+/// these from a `&Link` alone, and `track_prepared` files it away. The
+/// advertisement packet is already built and encrypted by this point, so
+/// filing it needs no link at all.
+#[derive(Debug)]
+pub struct PreparedSend {
+    first: ResourceSender,
+    pending: Option<PendingSegments>,
+}
+
 /// The not-yet-built tail of an outbound split resource.
 ///
 /// This used to be a `VecDeque<ResourceSender>` filled by `start_send`, which

--- a/crates/libs/rns-transport/src/resource/manager_start.rs
+++ b/crates/libs/rns-transport/src/resource/manager_start.rs
@@ -92,6 +92,28 @@ impl ResourceManager {
         is_response: bool,
         interface_mtu: usize,
     ) -> Result<(Hash, Packet), RnsError> {
+        let prepared =
+            Self::prepare_send(link, data, metadata, request_id, is_response, interface_mtu)?;
+        Ok(self.track_prepared(prepared))
+    }
+
+    /// Everything a send needs done *before* the manager is touched.
+    ///
+    /// Deliberately an associated function: it takes no `&self` and no
+    /// `&mut self`, which is what lets a caller run it without holding the
+    /// transport handler lock. All of the expensive work lives here —
+    /// compression, encryption, chunking, hashing — while [`track_prepared`]
+    /// is a pair of map inserts.
+    ///
+    /// [`track_prepared`]: ResourceManager::track_prepared
+    pub fn prepare_send(
+        link: &Link,
+        data: Vec<u8>,
+        metadata: Option<Vec<u8>>,
+        request_id: Option<Vec<u8>>,
+        is_response: bool,
+        interface_mtu: usize,
+    ) -> Result<PreparedSend, RnsError> {
         let metadata_size = metadata
             .as_ref()
             .map(|value| value.len().saturating_add(3))
@@ -106,7 +128,7 @@ impl ResourceManager {
                 is_response,
                 interface_mtu,
             )?;
-            return self.track_sender(sender);
+            return Ok(PreparedSend { first: sender, pending: None });
         }
         if metadata_size >= MAX_EFFICIENT_SIZE || total_size > AUTO_COMPRESS_MAX_SIZE {
             return Err(RnsError::InvalidArgument);
@@ -129,9 +151,8 @@ impl ResourceManager {
         let original_hash = first.original_hash;
         // Only segment 1 is built here. The rest are built as each preceding
         // segment's proof arrives — see `PendingSegments`.
-        self.outgoing_segment_chains.insert(
-            original_hash,
-            PendingSegments {
+        Ok(PreparedSend {
+            pending: Some(PendingSegments {
                 link_id: first.link_id,
                 data,
                 offset: first_data_len,
@@ -142,15 +163,27 @@ impl ResourceManager {
                 is_response,
                 interface_mtu,
                 original_hash,
-            },
-        );
-        self.track_sender(first)
+            }),
+            first,
+        })
     }
 
-    fn track_sender(&mut self, sender: ResourceSender) -> Result<(Hash, Packet), RnsError> {
-        let resource_hash = sender.resource_hash;
-        let packet = sender.advertisement_packet();
-        self.pending_outgoing.insert(resource_hash, sender);
-        Ok((resource_hash, packet))
+    /// Takes ownership of a [`prepare_send`] result and returns the
+    /// advertisement to dispatch.
+    ///
+    /// Cheap by construction — two map inserts and a clone of an
+    /// already-built packet — so it is safe to call with the handler lock
+    /// held.
+    ///
+    /// [`prepare_send`]: ResourceManager::prepare_send
+    pub fn track_prepared(&mut self, prepared: PreparedSend) -> (Hash, Packet) {
+        let PreparedSend { first, pending } = prepared;
+        if let Some(pending) = pending {
+            self.outgoing_segment_chains.insert(pending.original_hash, pending);
+        }
+        let resource_hash = first.resource_hash;
+        let packet = first.advertisement_packet();
+        self.pending_outgoing.insert(resource_hash, first);
+        (resource_hash, packet)
     }
 }

--- a/crates/libs/rns-transport/src/transport/links_parts/transport_sections/close_channel.rs
+++ b/crates/libs/rns-transport/src/transport/links_parts/transport_sections/close_channel.rs
@@ -30,17 +30,16 @@ impl Transport {
     ) -> Result<Hash, RnsError> {
         let link = self.find_in_link(link_id).await.ok_or(RnsError::InvalidArgument)?;
         let interface_mtu = self.resource_mtu_for_iface(Some(iface)).await;
-        let (resource_hash, packet) = {
-            let mut handler = self.handler.lock().await;
+        // See `reset_out_link.rs::send_resource_observed`: the build is done
+        // before the handler lock is taken, so a large payload does not hold
+        // every other link and announce on this node behind it.
+        let prepared = {
             let link_guard = link.lock().await;
             let interface_mtu = interface_mtu.min(link_guard.link_mtu());
-            handler.resource_manager.start_send_with_mtu(
-                &link_guard,
-                data,
-                metadata,
-                interface_mtu,
-            )?
+            ResourceManager::prepare_send(&link_guard, data, metadata, None, false, interface_mtu)?
         };
+        let (resource_hash, packet) =
+            self.handler.lock().await.resource_manager.track_prepared(prepared);
         let dispatch = self
             .handler
             .lock()

--- a/crates/libs/rns-transport/src/transport/links_parts/transport_sections/reset_out_link.rs
+++ b/crates/libs/rns-transport/src/transport/links_parts/transport_sections/reset_out_link.rs
@@ -136,19 +136,20 @@ impl Transport {
             link_guard.ingress_iface()
         };
         let interface_mtu = self.resource_mtu_for_iface(iface).await;
+        // Prepared before the handler lock is taken, not under it. Building the
+        // advertisement compresses, encrypts and chunks the payload, which on a
+        // large send is a long time to hold a mutex every other link, announce
+        // and packet on this node also needs.
+        let prepared = {
+            let link_guard = link.lock().await;
+            // See `resource_wire.rs`: the negotiated link MTU, not the local
+            // interface alone, is what a fragment has to fit through.
+            let interface_mtu = interface_mtu.min(link_guard.link_mtu());
+            ResourceManager::prepare_send(&link_guard, data, metadata, None, false, interface_mtu)?
+        };
         let mut handler = self.handler.lock().await;
-        let link_guard = link.lock().await;
-        // See `resource_wire.rs`: the negotiated link MTU, not the local
-        // interface alone, is what a fragment has to fit through.
-        let interface_mtu = interface_mtu.min(link_guard.link_mtu());
-        let (resource_hash, packet) = handler.resource_manager.start_send_with_mtu(
-            &link_guard,
-            data,
-            metadata,
-            interface_mtu,
-        )?;
+        let (resource_hash, packet) = handler.resource_manager.track_prepared(prepared);
         observe_resource(resource_hash);
-        drop(link_guard);
         drop(handler);
         let outcome = self.send_link_packet_on_bound_iface(&link, packet).await;
         let mut handler = self.handler.lock().await;
@@ -177,20 +178,23 @@ impl Transport {
             link_guard.ingress_iface()
         };
         let interface_mtu = self.resource_mtu_for_iface(iface).await;
+        // See `send_resource_observed`: prepared off the handler lock.
+        let prepared = {
+            let link_guard = link.lock().await;
+            // See `resource_wire.rs`: the negotiated link MTU, not the local
+            // interface alone, is what a fragment has to fit through.
+            let interface_mtu = interface_mtu.min(link_guard.link_mtu());
+            ResourceManager::prepare_send(
+                &link_guard,
+                data,
+                metadata,
+                Some(request_id),
+                true,
+                interface_mtu,
+            )?
+        };
         let mut handler = self.handler.lock().await;
-        let link_guard = link.lock().await;
-        // See `resource_wire.rs`: the negotiated link MTU, not the local
-        // interface alone, is what a fragment has to fit through.
-        let interface_mtu = interface_mtu.min(link_guard.link_mtu());
-        let (resource_hash, packet) = handler.resource_manager.start_send_with_options_mtu(
-            &link_guard,
-            data,
-            metadata,
-            Some(request_id),
-            true,
-            interface_mtu,
-        )?;
-        drop(link_guard);
+        let (resource_hash, packet) = handler.resource_manager.track_prepared(prepared);
         drop(handler);
         let outcome = self.send_link_packet_on_bound_iface(&link, packet).await;
         let mut handler = self.handler.lock().await;
@@ -219,20 +223,23 @@ impl Transport {
             link_guard.ingress_iface()
         };
         let interface_mtu = self.resource_mtu_for_iface(iface).await;
+        // See `send_resource_observed`: prepared off the handler lock.
+        let prepared = {
+            let link_guard = link.lock().await;
+            // See `resource_wire.rs`: the negotiated link MTU, not the local
+            // interface alone, is what a fragment has to fit through.
+            let interface_mtu = interface_mtu.min(link_guard.link_mtu());
+            ResourceManager::prepare_send(
+                &link_guard,
+                data,
+                metadata,
+                Some(request_id),
+                false,
+                interface_mtu,
+            )?
+        };
         let mut handler = self.handler.lock().await;
-        let link_guard = link.lock().await;
-        // See `resource_wire.rs`: the negotiated link MTU, not the local
-        // interface alone, is what a fragment has to fit through.
-        let interface_mtu = interface_mtu.min(link_guard.link_mtu());
-        let (resource_hash, packet) = handler.resource_manager.start_send_with_options_mtu(
-            &link_guard,
-            data,
-            metadata,
-            Some(request_id),
-            false,
-            interface_mtu,
-        )?;
-        drop(link_guard);
+        let (resource_hash, packet) = handler.resource_manager.track_prepared(prepared);
         drop(handler);
         let outcome = self.send_link_packet_on_bound_iface(&link, packet).await;
         let mut handler = self.handler.lock().await;


### PR DESCRIPTION
> **Rebased onto `main` after #560 merged** (squash `d7c04b0d`). The duplicated commit is dropped — this branch is now a single commit touching four files, none of them #560's.

`start_send*` is called with the global transport handler mutex **already held**, at all four call sites (`reset_out_link.rs` ×3, `close_channel.rs` ×1). Everything it does — compression, encryption, chunking, hashing — is pure CPU over the caller's payload and needs only the link, but none of it can overlap with any other link, announce or packet on the node.

This splits it in two:

- **`ResourceManager::prepare_send`** — an associated function. No `&self`, no `&mut self`, so it *cannot* touch manager state and a caller can run it without the handler lock. All the expensive work lives here.
- **`track_prepared`** — takes the result and files it. Two map inserts and a clone of an already-built packet.

Call sites become prepare-then-lock:

```rust
let prepared = {
    let link_guard = link.lock().await;
    let interface_mtu = interface_mtu.min(link_guard.link_mtu());
    ResourceManager::prepare_send(&link_guard, data, metadata, None, false, interface_mtu)?
};
let mut handler = self.handler.lock().await;
let (resource_hash, packet) = handler.resource_manager.track_prepared(prepared);
```

## Measured

46 MB payload, default MTU, three runs, medians, on top of #545 and #560:

| | |
|---|---|
| `prepare_send` (no lock held) | 0.090 s |
| **`track_prepared` (under the lock)** | **0.000001 s** |

The same send held the handler lock for **2.686 s** before either change.

**What that 1 microsecond does and does not cover.** It is the *startup* hold —
this PR's whole subject. It is not the total lock time of a send, and I should
have said so plainly the first time. Once #560 makes preparation lazy, segments
2..N are built inside `handle_proof_into`, and `transport/resource_wire.rs:22-32`
takes `handler.lock().await` before calling into the manager, so those builds
are under the lock too. Measured on the same 46 MB payload, timing every
sender-side proof that produces the next advertisement:

| | main | main + #545 | + #560 | + #560 + this | + #545 + both |
|---|---|---|---|---|---|
| hold at startup | 1.073 s | 2.648 s | 0.031 s | 0.000001 s | 0.000001 s |
| 44 later holds, median | 0.0000 s | 0.0000 s | 0.0232 s | 0.0232 s | 0.0546 s |
| 44 later holds, max | 0.0001 s | 0.0000 s | 0.0237 s | 0.0237 s | 0.1516 s |
| summed lock time over the transfer | 1.074 s | 2.649 s | 1.044 s | 1.013 s | 2.552 s |
| **longest single hold** | **1.073 s** | **2.648 s** | **0.031 s** | **0.024 s** | **0.152 s** |

So the aggregate CPU under the lock barely moves: 2.649 s to 2.552 s. The work
is not cheaper, it is rescheduled. What actually changes is worth stating in the
terms that survive scrutiny:

- **Longest single hold: 2.648 s to 0.152 s**, a 17x cut. Nothing else on the
  node stalls for more than one segment's worth of work at a time.
- **The hold stops scaling with payload size.** On main it is O(payload) — a
  460 MB send would hold the lock around 10 s. After #560 each hold is bounded
  by `MAX_EFFICIENT_SIZE` (1 MiB) whatever the payload. That invariant is the
  part I would defend hardest.
- **On main the whole hold lands before the first byte moves**, so it is pure
  added latency. Afterwards it lands where the transfer is already idle waiting
  to advertise the next segment.

## Two questions this usually raises

**Lock ordering.** This *removes* a `handler → link` nested acquisition rather than adding one. `send_resource_observed` already did `link.lock()` → drop → `handler.lock()` to read `ingress_iface()` (`reset_out_link.rs:133-138`), so link-before-handler is the order this file already used — there is simply less nesting now.

**Staleness between prepare and track.** No new failure mode. The same window already exists between tracking a sender and dispatching its advertisement, which happens *after* the handler lock is dropped. If the link died in between, the dispatch fails and `confirm_outbound_dispatch(hash, false)` removes the state and emits `OutboundFailed` — unchanged.

## Compatibility

`start_send`, `start_send_with_mtu`, `start_send_with_options` and `start_send_with_options_mtu` keep their signatures and now call prepare-then-track internally, so nothing outside the transport layer changes. `prepare_send`/`track_prepared` are additive.

601 lib tests, fmt, `clippy -D warnings`, module-size and boundary checks all green locally; full workspace builds.

## Context

This is the second half of the answer to Codex's P2 on #545 ("move outbound compression out of the transport lock"). #560 makes the work incremental; this one takes the startup half off the lock entirely. Together, on the full stack: **a 2.686 s contiguous global-lock hold before the first byte moves becomes 1 microsecond at startup plus bounded sub-second holds thereafter, none of them growing with the payload.**


