### PR TITLE
Report inbound resource cancellation failures

### DIFF
--- a/crates/libs/rns-transport/src/resource/manager.rs
+++ b/crates/libs/rns-transport/src/resource/manager.rs
@@ -442,7 +442,14 @@ impl ResourceManager {
             return;
         };
         let hash = Hash::new(hash_bytes);
-        self.incoming.remove(&hash);
+        if let Some(receiver) = self.incoming.remove(&hash) {
+            // A split receiver keeps the already-completed segments in a
+            // separate assembly keyed by the original resource hash. A
+            // remote cancel names the segment currently in flight, so remove
+            // that assembly as well and report the abandoned payload instead
+            // of leaving the caller waiting for a timeout.
+            self.fail_inbound_segments(receiver.original_hash, "remote_cancelled");
+        }
         // Removed from both, as before: a hash lives in exactly one of these,
         // but which one depends on whether dispatch has been confirmed yet.
         let cancelled = self.pending_outgoing.remove(&hash);

--- a/crates/libs/rns-transport/src/resource/tests_split_assembly.rs
+++ b/crates/libs/rns-transport/src/resource/tests_split_assembly.rs
@@ -55,3 +55,67 @@ fn resource_manager_reports_a_split_resource_that_assembles_to_the_wrong_size() 
     assert_eq!(failure.reason, "assembled_size_mismatch");
     assert_eq!(failure.progress.total_parts, 2);
 }
+
+#[test]
+fn remote_cancel_clears_the_partial_split_assembly_and_reports_failure() {
+    let signer = PrivateIdentity::new_from_rand(OsRng);
+    let identity = *signer.as_identity();
+    let destination = DestinationDesc {
+        identity,
+        address_hash: identity.address_hash,
+        name: DestinationName::new("lxmf", "resource"),
+    };
+    let (tx, _) = tokio::sync::broadcast::channel(1);
+    let mut link = Link::new(destination, tx);
+    link.request();
+    let mut manager = ResourceManager::new_with_config(Duration::from_secs(1), 2);
+
+    let first_data = b"first-segment";
+    let second_data = b"second-segment";
+    let total_data_size = (first_data.len() + second_data.len()) as u64;
+    let (first_adv, first_part) = split_test_segment(first_data, None, 1, 2, total_data_size);
+    let original_hash = first_adv.hash;
+    let (second_adv, _) =
+        split_test_segment(second_data, Some(original_hash), 2, 2, total_data_size);
+
+    let first_adv_packet = resource_packet(
+        PacketContext::ResourceAdvrtisement,
+        &first_adv.pack().expect("pack first advertisement"),
+        *link.id(),
+    );
+    assert_eq!(manager.handle_packet(&first_adv_packet, &mut link).len(), 1);
+    let first_part_packet = resource_packet(PacketContext::Resource, &first_part, *link.id());
+    assert_eq!(manager.handle_packet(&first_part_packet, &mut link).len(), 1);
+
+    let second_adv_packet = resource_packet(
+        PacketContext::ResourceAdvrtisement,
+        &second_adv.pack().expect("pack second advertisement"),
+        *link.id(),
+    );
+    assert_eq!(manager.handle_packet(&second_adv_packet, &mut link).len(), 1);
+    assert!(manager.incoming_segments.contains_key(&original_hash));
+    assert!(manager.incoming.contains_key(&second_adv.hash));
+
+    let cancel_packet = resource_packet(
+        PacketContext::ResourceReceiverCancel,
+        second_adv.hash.as_slice(),
+        *link.id(),
+    );
+    assert!(manager.handle_packet(&cancel_packet, &mut link).is_empty());
+    assert!(!manager.incoming.contains_key(&second_adv.hash));
+    assert!(!manager.incoming_segments.contains_key(&original_hash));
+
+    let events = manager.drain_events();
+    let failure = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            ResourceEventKind::InboundFailed(failure) if event.hash == original_hash => {
+                Some(failure)
+            }
+            _ => None,
+        })
+        .expect("remote cancellation should report an inbound failure");
+    assert_eq!(failure.reason, "remote_cancelled");
+    assert_eq!(failure.progress.received_parts, 1);
+    assert_eq!(failure.progress.total_parts, 2);
+}


### PR DESCRIPTION
## Summary

Follow-up to the inbound cancellation leak identified during the #545/#560 review.

When a remote peer cancels a split Resource, the cancel packet names the segment currently in flight. `ResourceManager::cancel_into` removed that segment's `ResourceReceiver` from `incoming`, but left the already-completed data in `incoming_segments`, keyed by the split resource's `original_hash`. The partial payload could therefore remain retained until link teardown, and the caller received no failure event.

This change:

- derives the split resource hash from the cancelled receiver;
- routes the abandoned assembly through `fail_inbound_segments`;
- emits `InboundFailed` with `remote_cancelled` and the accumulated progress;
- adds a regression test covering first-segment assembly, second-segment cancellation, state cleanup, and failure reporting.

Related discussion: #545

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p reticulum-rs-transport remote_cancel_clears_the_partial_split_assembly_and_reports_failure -- --nocapture`
- `cargo test -p reticulum-rs-transport` (599 tests passed)
- `cargo test -p reticulumd --test code_quality_issue_369`
- `cargo clippy -p reticulum-rs-transport --all-targets --all-features --no-deps -- -D warnings`
- `cargo run -p xtask -- architecture-checks`
