### PR TITLE
Add a public release performance dashboard

### DIFF
--- a/.github/workflows/performance-release.yml
+++ b/.github/workflows/performance-release.yml
@@ -7,12 +7,19 @@ on:
         description: Candidate SHA or ref
         required: true
         default: main
+      release_tag:
+        description: Release tag/label for the generated dataset and asset
+        required: true
+        default: v0.9.8
   push:
     tags:
-      - v0.9.8-rc.*
+      - v*
 
 permissions:
   contents: read
+
+env:
+  RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.release_tag }}
 
 jobs:
   same-runner-comparison:
@@ -86,11 +93,17 @@ jobs:
         working-directory: candidate
         run: |
           python3 tools/scripts/performance_docs.py \
-            --release v0.9.8 \
+            --release "$RELEASE_TAG" \
             --report target/criterion/python-impl-report/report.json \
             --sdk-transport-report target/performance/sdk-transport.json \
-            --e2e-report target/performance/e2e.json
-          cp docs/performance/v0.9.8.json target/performance/candidate.json
+            --e2e-report target/performance/e2e.json \
+            --dashboard-output target/performance/lxmf-rs-performance.html
+          cp "docs/performance/${RELEASE_TAG}.json" target/performance/candidate.json
+          cp "docs/performance/${RELEASE_TAG}.json" target/performance/lxmf-rs-performance.json
+          sha256sum \
+            target/performance/lxmf-rs-performance.html \
+            target/performance/lxmf-rs-performance.json \
+            > target/performance/SHA256SUMS
       - name: Apply release regression budgets
         working-directory: candidate
         run: |
@@ -98,12 +111,45 @@ jobs:
             --candidate target/performance/candidate.json \
             --baseline ../baseline/target/criterion/python-impl-report/report.json \
             --output target/performance/release-gate.json
+          python3 tools/scripts/performance_docs.py \
+            --release "$RELEASE_TAG" \
+            --dashboard-output target/performance/lxmf-rs-performance.html \
+            --check
       - uses: actions/upload-artifact@v4
         with:
-          name: v0.9.8-performance-${{ github.run_id }}
+          name: performance-release-${{ github.run_id }}
           path: |
             candidate/target/criterion/python-impl-report/**
             baseline/target/criterion/python-impl-report/**
             candidate/target/performance/**
             candidate/docs/performance.md
           if-no-files-found: error
+
+  publish-performance-assets:
+    needs: same-runner-comparison
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: performance-release-${{ github.run_id }}
+          path: dist
+      - name: Collect public performance assets
+        shell: bash
+        run: |
+          mkdir -p release-assets
+          find dist -type f -name 'lxmf-rs-performance.html' -exec cp {} release-assets/lxmf-rs-performance.html \;
+          find dist -type f -name 'lxmf-rs-performance.json' -exec cp {} release-assets/lxmf-rs-performance.json \;
+          find dist -type f -name 'SHA256SUMS' -exec cp {} release-assets/SHA256SUMS \;
+          test -s release-assets/lxmf-rs-performance.html
+          test -s release-assets/lxmf-rs-performance.json
+          test -s release-assets/SHA256SUMS
+      - name: Attach public performance assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: release-assets/*
+          fail_on_unmatched_files: true
+          generate_release_notes: false

--- a/.github/workflows/performance-release.yml
+++ b/.github/workflows/performance-release.yml
@@ -100,10 +100,10 @@ jobs:
             --dashboard-output target/performance/lxmf-rs-performance.html
           cp "docs/performance/${RELEASE_TAG}.json" target/performance/candidate.json
           cp "docs/performance/${RELEASE_TAG}.json" target/performance/lxmf-rs-performance.json
-          sha256sum \
-            target/performance/lxmf-rs-performance.html \
-            target/performance/lxmf-rs-performance.json \
-            > target/performance/SHA256SUMS
+          (
+            cd target/performance
+            sha256sum lxmf-rs-performance.html lxmf-rs-performance.json
+          ) > target/performance/SHA256SUMS
       - name: Apply release regression budgets
         working-directory: candidate
         run: |

--- a/.github/workflows/performance-smoke.yml
+++ b/.github/workflows/performance-smoke.yml
@@ -1,11 +1,18 @@
-name: Performance smoke
+name: Performance request run
 
 on:
-  pull_request:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release label for the generated dataset and artifact
+        required: true
+        default: v0.9.8
 
 permissions:
   contents: read
+
+env:
+  RELEASE_TAG: ${{ inputs.release_tag }}
 
 jobs:
   fixture-and-report-smoke:
@@ -49,11 +56,20 @@ jobs:
       - name: Generate and verify report schema
         run: |
           python3 tools/scripts/performance_docs.py \
-            --release v0.9.8 \
+            --release "$RELEASE_TAG" \
             --report target/criterion/python-impl-report/report.json \
             --sdk-transport-report target/performance/sdk-transport.json \
-            --e2e-report target/performance/e2e.json
-          python3 tools/scripts/performance_docs.py --release v0.9.8 --check
+            --e2e-report target/performance/e2e.json \
+            --dashboard-output target/performance/lxmf-rs-performance.html
+          cp "docs/performance/${RELEASE_TAG}.json" target/performance/lxmf-rs-performance.json
+          sha256sum \
+            target/performance/lxmf-rs-performance.html \
+            target/performance/lxmf-rs-performance.json \
+            > target/performance/SHA256SUMS
+          python3 tools/scripts/performance_docs.py \
+            --release "$RELEASE_TAG" \
+            --dashboard-output target/performance/lxmf-rs-performance.html \
+            --check
       - uses: actions/upload-artifact@v4
         with:
           name: performance-smoke-${{ github.run_id }}

--- a/.github/workflows/performance-smoke.yml
+++ b/.github/workflows/performance-smoke.yml
@@ -62,10 +62,10 @@ jobs:
             --e2e-report target/performance/e2e.json \
             --dashboard-output target/performance/lxmf-rs-performance.html
           cp "docs/performance/${RELEASE_TAG}.json" target/performance/lxmf-rs-performance.json
-          sha256sum \
-            target/performance/lxmf-rs-performance.html \
-            target/performance/lxmf-rs-performance.json \
-            > target/performance/SHA256SUMS
+          (
+            cd target/performance
+            sha256sum lxmf-rs-performance.html lxmf-rs-performance.json
+          ) > target/performance/SHA256SUMS
           python3 tools/scripts/performance_docs.py \
             --release "$RELEASE_TAG" \
             --dashboard-output target/performance/lxmf-rs-performance.html \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap fmt clippy test test-all test-full-targets doc deny audit udeps boundaries ci release-check package-daemon-bundle api-diff licenses migration-checks forbidden-deps python-impl-bench python-impl-bench-report python-lxmd-smoke check-bin run-bin sccache-show-stats sccache-zero-stats
+.PHONY: bootstrap fmt clippy test test-all test-full-targets doc deny audit udeps boundaries ci release-check package-daemon-bundle api-diff licenses migration-checks forbidden-deps python-impl-bench python-impl-bench-report public-benchmark test-performance-dashboard python-lxmd-smoke check-bin run-bin sccache-show-stats sccache-zero-stats
 
 bootstrap:
 	./tools/scripts/bootstrap-dev.sh
@@ -83,6 +83,12 @@ python-impl-bench:
 
 python-impl-bench-report:
 	cargo xtask python-impl-bench-report
+
+public-benchmark:
+	cargo xtask public-benchmark --release $${RELEASE_TAG:-local-request}
+
+test-performance-dashboard:
+	python tools/scripts/test_performance_dashboard.py
 
 python-lxmd-smoke:
 	./tools/scripts/python-lxmd-rust-lxmd-smoke.sh

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ cargo xtask api-diff
 cargo xtask python-impl-bench-compare
 cargo xtask python-impl-bench-compare --profile report
 cargo xtask python-impl-bench-report
+cargo xtask public-benchmark --release v0.9.8
 ```
 
 For fast local iteration on one binary, prefer narrow commands:
@@ -237,7 +238,7 @@ cargo run -p rns-tools --bin rnx -- e2e --timeout-secs 20
 - Extension registry: `docs/contracts/extension-registry.md`
 - RPC contract: `docs/contracts/rpc-contract.md`
 - Payload contract: `docs/contracts/payload-contract.md`
-- Historical performance comparison archive: `docs/PerformancesComparison.html`; current generated results: [`docs/performance.md`](docs/performance.md)
+- Historical performance comparison archive: `docs/PerformancesComparison.html`; current generated results: [`docs/performance.md`](docs/performance.md); public release dashboard: [latest GitHub Release asset](https://github.com/FreeTAKTeam/LXMF-rs/releases/latest/download/lxmf-rs-performance.html)
 - reticulumd operational deployment: `docs/runbooks/reticulumd-operational-deployment.md`
 - Logging and diagnostics: `docs/runbooks/logging-and-diagnostics.md`
 - crates.io publish plan: `docs/runbooks/crates-io-publish-plan.md`

--- a/crates/apps/lxmf-cli/tests/support/python_lxmf_endpoint.py
+++ b/crates/apps/lxmf-cli/tests/support/python_lxmf_endpoint.py
@@ -289,6 +289,26 @@ class EndpointState:
         self._attach_link(link)
         return self.wait_link_state("active", timeout)
 
+    def wait_path(self, destination_hex: str, timeout: float = 60.0) -> dict:
+        destination_hash = bytes.fromhex(destination_hex)
+        deadline = time.time() + timeout
+        requested = False
+        while time.time() < deadline:
+            if RNS.Transport.has_path(destination_hash):
+                recipient_identity = RNS.Identity.recall(destination_hash)
+                if recipient_identity is not None:
+                    return {
+                        "path_found": True,
+                        "destination": destination_hex,
+                        "identity_hash": recipient_identity.hash.hex(),
+                    }
+            if not requested:
+                RNS.Transport.request_path(destination_hash)
+                requested = True
+            time.sleep(0.1)
+
+        raise RuntimeError(f"timed out waiting for path/identity to {destination_hex}")
+
     def link_status(self) -> dict:
         return self._link_snapshot()
 
@@ -357,6 +377,11 @@ class ControlHandler(socketserver.StreamRequestHandler):
                 )
             elif method == "open_link":
                 result = self.server.state.open_link(
+                    params["destination"],
+                    float(params.get("timeout", 60.0)),
+                )
+            elif method == "wait_path":
+                result = self.server.state.wait_path(
                     params["destination"],
                     float(params.get("timeout", 60.0)),
                 )

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,8 +56,8 @@ are kept in Git history instead of the live documentation tree.
   integration guide
 - `docs/interfaces/rnode-spp.md`: RNode Bluetooth Classic/SPP transport
   contract and backend guidance
-- `docs/PerformancesComparison.html`: retained performance comparison snapshot;
-  use the benchmarking runbook for current measurements
+- `docs/PerformancesComparison.html`: retained historical performance snapshot;
+  use the benchmarking runbook and [the latest release dashboard](https://github.com/FreeTAKTeam/LXMF-rs/releases/latest/download/lxmf-rs-performance.html) for current measurements
 - `docs/runbooks/release-readiness.md`: release gate checklist
 - `docs/runbooks/logging-and-diagnostics.md`: operator logging knobs and
   contributor failure-visibility rules

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -3,6 +3,7 @@
 <!-- GENERATED: tools/scripts/performance_docs.py -->
 
 Dataset: [`docs/performance/v0.9.5.json`](performance/v0.9.5.json). All numbers below originate from release SHA `c4fd18761e41caf2f7d2c7307d49c37aa6dc43ca`.
+The standalone release dashboard is available at [the latest GitHub Release asset](https://github.com/FreeTAKTeam/LXMF-rs/releases/latest/download/lxmf-rs-performance.html); the release asset is the public source for the complete matrix.
 
 ## Methodology
 

--- a/docs/runbooks/python-impl-benchmarking.md
+++ b/docs/runbooks/python-impl-benchmarking.md
@@ -18,6 +18,11 @@ The current report publishes protocol-core and transport-hotpath comparisons:
 - Two-node loopback TCP cold discovery plus warm direct, opportunistic,
   propagated, and 16 KiB resource delivery
 
+The public dashboard has a fixed matrix for packet encoding, announce
+validation, path convergence, link setup, exact-size Resource transfers,
+resource CPU/RSS, and 1000 active links. A cell is `N/A` when the release did
+not produce an exact measurement; nearby workloads must not be substituted.
+
 SDK transport and same-topology end-to-end results are kept in separate dataset
 tiers. Do not infer daemon or whole-system performance from protocol/core rows.
 
@@ -53,6 +58,18 @@ Aggregated report for serious claims:
 cargo xtask python-impl-bench-report
 ```
 
+Public release artifact:
+
+```bash
+cargo xtask public-benchmark --release v0.9.8
+```
+
+This command runs the full report and writes the canonical JSON, standalone
+HTML dashboard, raw E2E evidence, and `SHA256SUMS` under
+`target/performance/`. It is intentionally not part of pull-request or normal
+push CI. Use the manually dispatched performance workflow for an on-demand
+run, or the release performance workflow for tagged releases.
+
 Shortcuts:
 
 ```bash
@@ -63,8 +80,9 @@ make python-impl-bench-report
 ## Outputs
 
 `docs/PerformancesComparison.html` is historical and non-current. The current
-generated page is `docs/performance.md`, sourced from
-`docs/performance/v0.9.5.json`.
+generated page is `docs/performance.md`, sourced from the versioned JSON
+dataset. Tagged releases additionally publish the standalone
+`lxmf-rs-performance.html` dashboard and matching JSON/checksums.
 
 Quick comparison writes:
 
@@ -110,6 +128,14 @@ Publish and verify generated documentation:
 python3 tools/scripts/performance_docs.py --release v0.9.5 \
   --report target/criterion/python-impl-report/report.json
 python3 tools/scripts/performance_docs.py --check
+```
+
+The performance workflows have no pull-request, ordinary-push, or scheduled
+trigger. Real measurements run only from `workflow_dispatch` or release tags;
+regular CI may run the measurement-free renderer tests:
+
+```bash
+python tools/scripts/test_performance_dashboard.py
 ```
 
 Release candidates are measured on the same runner as a checkout of `v0.9.1`.

--- a/tools/scripts/e2e_performance.py
+++ b/tools/scripts/e2e_performance.py
@@ -27,6 +27,12 @@ WORKLOADS = (
         "rns_path_request_python_to_rust",
         0,
     ),
+    (
+        "link_setup",
+        "link_setup_rust_to_python",
+        "link_setup_python_to_rust",
+        0,
+    ),
     ("direct", "direct_rust_to_python", "direct_python_to_rust", 256),
     ("opportunistic", "opportunistic_rust_to_python", "opportunistic_python_to_rust", 256),
     ("propagated", "propagated_rust_to_python", "propagated_python_to_rust", 256),
@@ -116,11 +122,10 @@ def run_sample(
         )
     data = json.loads(report.read_text(encoding="utf-8"))
     timing = data.get("performance")
-    expected_boundary = (
-        "cold_path_request_to_route_available"
-        if workload == "cold_discovery"
-        else "enqueue_to_receiver_evidence"
-    )
+    expected_boundary = {
+        "cold_discovery": "cold_path_request_to_route_available",
+        "link_setup": "link_request_to_active",
+    }.get(workload, "enqueue_to_receiver_evidence")
     if not timing or timing.get("boundary") != expected_boundary:
         raise RuntimeError(f"{report} did not contain the E2E performance boundary")
     if timing.get("startup_included") or timing.get("route_warmup_included"):
@@ -222,16 +227,19 @@ def main() -> int:
                     "label": (
                         "Loopback TCP cold destination discovery"
                         if is_discovery
-                        else f"Loopback TCP {workload} delivery"
+                        else (
+                            "Loopback TCP link setup"
+                            if workload == "link_setup"
+                            else f"Loopback TCP {workload} delivery"
+                        )
                     ),
                     "topology": "two-node loopback TCP, one Rust and one pinned-Python endpoint",
                     "route_state": "cold" if is_discovery else "warm",
                     "payload_size_bytes": payload_bytes,
-                    "timed_boundary": (
-                        "cold_path_request_to_route_available"
-                        if is_discovery
-                        else "enqueue_to_receiver_evidence"
-                    ),
+                    "timed_boundary": {
+                        "cold_discovery": "cold_path_request_to_route_available",
+                        "link_setup": "link_request_to_active",
+                    }.get(workload, "enqueue_to_receiver_evidence"),
                     "rust": rust,
                     "python": python,
                     "rust_p50_speedup_vs_python": python["p50_ns"] / rust["p50_ns"],

--- a/tools/scripts/performance_dashboard.py
+++ b/tools/scripts/performance_dashboard.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Render the public, self-contained performance dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+from typing import Any
+
+
+IMPLEMENTATIONS = (
+    ("python", "Python"),
+    ("lxmf_rs", "LXMF-rs"),
+    ("rns_rs", "rns-rs"),
+)
+
+PUBLIC_ROWS = (
+    ("packet_encode", "Packet encode/s", "ops/s"),
+    ("announce_validation", "Announce validation/s", "ops/s"),
+    ("path_convergence", "Path convergence", "s"),
+    ("link_setup", "Link setup p50/p99", "s"),
+    ("resource_1mb_mtu500", "1 MB Resource @ MTU 500", "MB/s"),
+    ("resource_50mb_mtu8192", "50 MB Resource @ MTU 8192", "MB/s"),
+    ("peak_ram", "Peak RAM", "MiB"),
+    ("cpu_per_mb", "CPU/MB", "ms/MB"),
+    ("active_links_1000", "1000 active links", "links"),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", type=Path, required=True)
+    parser.add_argument("--release", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def find_comparison(data: dict[str, Any], label: str) -> dict[str, Any] | None:
+    return next((row for row in data.get("comparisons", []) if row.get("label") == label), None)
+
+
+def find_e2e(data: dict[str, Any], label: str) -> dict[str, Any] | None:
+    return next((row for row in data.get("e2e_comparisons", []) if row.get("label") == label), None)
+
+
+def unavailable(reason: str) -> dict[str, Any]:
+    return {"status": "not_available", "reason": reason}
+
+
+def unavailable_reason(row_id: str, implementation: str) -> str:
+    if implementation == "rns_rs":
+        return "rns-rs adapter is not configured for this release"
+    return {
+        "resource_1mb_mtu500": "No exact 1 MB Resource @ MTU 500 measurement is present",
+        "resource_50mb_mtu8192": "No exact 50 MB Resource @ MTU 8192 measurement is present",
+        "link_setup": "No exact link setup measurement is present",
+        "peak_ram": "No exact peak RAM measurement is present",
+        "cpu_per_mb": "No exact CPU/MB measurement is present",
+        "active_links_1000": "No exact 1000-active-link measurement is present",
+    }.get(row_id, "No exact release measurement is present")
+
+
+def measured(value: float, *, p99: float | None = None, details: dict[str, Any] | None = None) -> dict[str, Any]:
+    result: dict[str, Any] = {"status": "measured", "value": value}
+    if p99 is not None:
+        result["p99"] = p99
+    if details:
+        result["details"] = details
+    return result
+
+
+def comparison_cell(row: dict[str, Any], implementation: str) -> dict[str, Any]:
+    source = row["rust"] if implementation == "lxmf_rs" else row["python"]
+    return measured(
+        float(source["throughput_ops_per_sec"]),
+        details={
+            "p50_ns": source.get("p50_ns"),
+            "p95_ns": source.get("p95_ns"),
+            "p99_ns": source.get("p99_ns"),
+        },
+    )
+
+
+def fallback_matrix(data: dict[str, Any]) -> list[dict[str, Any]]:
+    packet = find_comparison(data, "Reticulum packet pack")
+    announce = find_comparison(data, "Reticulum announce validate")
+    discovery = find_e2e(data, "Loopback TCP cold destination discovery")
+    link_setup = find_e2e(data, "Loopback TCP link setup")
+    rows: list[dict[str, Any]] = []
+
+    for row_id, label, unit in PUBLIC_ROWS:
+        cells = {
+            implementation: unavailable(unavailable_reason(row_id, implementation))
+            for implementation, _ in IMPLEMENTATIONS
+        }
+        if row_id == "packet_encode" and packet:
+            cells["python"] = comparison_cell(packet, "python")
+            cells["lxmf_rs"] = comparison_cell(packet, "lxmf_rs")
+        elif row_id == "announce_validation" and announce:
+            cells["python"] = comparison_cell(announce, "python")
+            cells["lxmf_rs"] = comparison_cell(announce, "lxmf_rs")
+        elif row_id == "path_convergence" and discovery:
+            for implementation, source_key in (("python", "python"), ("lxmf_rs", "rust")):
+                source = discovery[source_key]
+                cells[implementation] = measured(
+                    float(source["p50_ns"]) / 1_000_000_000.0,
+                    p99=float(source["p99_ns"]) / 1_000_000_000.0,
+                    details={"topology": discovery.get("topology"), "timed_boundary": discovery.get("timed_boundary")},
+                )
+        elif row_id == "link_setup" and link_setup:
+            for implementation, source_key in (("python", "python"), ("lxmf_rs", "rust")):
+                source = link_setup[source_key]
+                cells[implementation] = measured(
+                    float(source["p50_ns"]) / 1_000_000_000.0,
+                    p99=float(source["p99_ns"]) / 1_000_000_000.0,
+                    details={"topology": link_setup.get("topology"), "timed_boundary": link_setup.get("timed_boundary")},
+                )
+        rows.append({"id": row_id, "label": label, "unit": unit, "cells": cells})
+
+    return rows
+
+
+def public_rows(data: dict[str, Any]) -> list[dict[str, Any]]:
+    public = data.get("public_benchmark")
+    if isinstance(public, dict) and isinstance(public.get("rows"), list):
+        return public["rows"]
+    return fallback_matrix(data)
+
+
+def format_value(cell: dict[str, Any], unit: str) -> str:
+    if cell.get("status") != "measured":
+        return "N/A"
+    value = float(cell["value"])
+    if cell.get("p99") is not None:
+        return f"{value:.3f} / {float(cell['p99']):.3f}"
+    if unit == "ops/s":
+        return f"{value:,.0f}"
+    if unit in ("MB/s", "MiB/s", "MiB", "ms/MB", "ms/MiB"):
+        return f"{value:,.2f}"
+    if unit == "links":
+        return f"{value:,.0f}"
+    return f"{value:.3f}"
+
+
+def cell_title(cell: dict[str, Any]) -> str:
+    if cell.get("status") == "measured":
+        details = cell.get("details")
+        return json.dumps(details, sort_keys=True) if details else "Measured"
+    return str(cell.get("reason", "No measurement"))
+
+
+def render_dashboard(data: dict[str, Any], release: str) -> str:
+    environment = data.get("environment", {})
+    rows = public_rows(data)
+    rows_json = json.dumps(rows, sort_keys=True).replace("</", "<\\/")
+    source_commit = html.escape(str(environment.get("git_commit", "unknown")))
+    generated_at = html.escape(str(environment.get("timestamp_utc", "unknown")))
+    profile = html.escape(str(data.get("profile", data.get("e2e_profile", "unknown"))))
+
+    table_rows = []
+    for row in rows:
+        cells = []
+        for implementation, _ in IMPLEMENTATIONS:
+            cell = row["cells"].get(implementation, unavailable("Implementation did not report this workload"))
+            status = html.escape(str(cell.get("status", "unknown")))
+            title = html.escape(cell_title(cell), quote=True)
+            value = html.escape(format_value(cell, row["unit"]))
+            cells.append(f'<td class="{status}" title="{title}">{value}</td>')
+        table_rows.append(
+            f'<tr><th scope="row">{html.escape(row["label"])}</th>'
+            f'<td class="unit">{html.escape(row["unit"])}</td>{"".join(cells)}</tr>'
+        )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>LXMF-rs performance — {html.escape(release)}</title>
+<style>
+:root {{ color-scheme: dark; --bg:#0d1117; --panel:#161b22; --line:#30363d; --text:#e6edf3; --muted:#8b949e; --good:#3fb950; --warn:#d29922; }}
+* {{ box-sizing:border-box; }} body {{ margin:0; background:var(--bg); color:var(--text); font:15px/1.5 system-ui,sans-serif; }}
+main {{ max-width:1180px; margin:0 auto; padding:32px 20px 56px; }} h1 {{ margin:0 0 6px; font-size:32px; }} h2 {{ margin-top:30px; }}
+.muted {{ color:var(--muted); }} .panel {{ background:var(--panel); border:1px solid var(--line); border-radius:10px; padding:18px; margin-top:18px; }}
+table {{ width:100%; border-collapse:collapse; }} th,td {{ border-bottom:1px solid var(--line); padding:12px 10px; text-align:right; white-space:nowrap; }} th:first-child, td:first-child {{ text-align:left; }} thead th {{ color:var(--muted); font-weight:600; }} td.unit {{ color:var(--muted); font-size:13px; }} td.measured {{ color:var(--good); font-variant-numeric:tabular-nums; }} td.not_available,td.not_supported,td.failed {{ color:var(--warn); }}
+.meta {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:10px; }} .meta div {{ color:var(--muted); }} code {{ color:var(--text); }} a {{ color:#58a6ff; }} .note {{ color:var(--muted); font-size:13px; }}
+@media (max-width:760px) {{ main {{ padding:22px 10px; }} .panel {{ overflow-x:auto; }} table {{ min-width:760px; }} }}
+</style>
+</head>
+<body>
+<main>
+<h1>LXMF-rs performance dashboard</h1>
+<div class="muted">Release {html.escape(release)} · matched local workloads · generated from canonical JSON</div>
+<section class="panel">
+<table>
+<thead><tr><th>Test</th><th>Unit</th><th>Python</th><th>LXMF-rs</th><th>rns-rs</th></tr></thead>
+<tbody>{"".join(table_rows)}</tbody>
+</table>
+</section>
+<section class="panel meta">
+<div>Release SHA<br><code>{source_commit}</code></div>
+<div>Generated<br><code>{generated_at}</code></div>
+<div>Profile<br><code>{profile}</code></div>
+<div>Raw data<br><code>{html.escape(release)}.json</code></div>
+</section>
+<h2>Methodology</h2>
+<p class="note">Values are comparable only within the recorded fixture, runner, toolchain, topology, and timing boundary. N/A means that this release did not produce an exact measurement for the requested workload; it is not a zero and must not be inferred from a nearby workload.</p>
+<p class="note">The dashboard is generated locally or by an explicitly requested/release benchmark workflow. Ordinary pushes and pull requests do not run performance measurements.</p>
+<script type="application/json" id="benchmark-data">{rows_json}</script>
+</main>
+</body>
+</html>
+"""
+
+
+def main() -> int:
+    args = parse_args()
+    data = load(args.dataset)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(render_dashboard(data, args.release), encoding="utf-8")
+    print(f"performance_dashboard: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/scripts/performance_docs.py
+++ b/tools/scripts/performance_docs.py
@@ -11,6 +11,8 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
+from performance_dashboard import public_rows, render_dashboard
+
 
 ROOT = Path(__file__).resolve().parents[2]
 README = ROOT / "README.md"
@@ -28,11 +30,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--report", type=Path)
     parser.add_argument("--sdk-transport-report", type=Path)
     parser.add_argument("--e2e-report", type=Path)
+    parser.add_argument("--dashboard-output", type=Path)
     parser.add_argument("--check", action="store_true")
     return parser.parse_args()
 
 
 def dataset_path(release: str) -> Path:
+    if not release or release in {".", ".."} or any(char in release for char in "/\\"):
+        raise ValueError("release must be a non-empty tag-like name without path separators")
     return ROOT / "docs/performance" / f"{release}.json"
 
 
@@ -209,6 +214,7 @@ def performance_page(data: dict[str, Any], release: str, scale_data: dict[str, A
         "<!-- GENERATED: tools/scripts/performance_docs.py -->",
         "",
         f"Dataset: [`docs/performance/{release}.json`](performance/{release}.json). All numbers below originate from release SHA `{env['git_commit']}`.",
+        "The standalone release dashboard is available at [the latest GitHub Release asset](https://github.com/FreeTAKTeam/LXMF-rs/releases/latest/download/lxmf-rs-performance.html); the release asset is the public source for the complete matrix.",
         "",
         "## Methodology",
         "",
@@ -328,8 +334,8 @@ def replace_marked(source: str, replacement: str) -> str:
 
 def main() -> int:
     args = parse_args()
-    target = dataset_path(args.release)
     try:
+        target = dataset_path(args.release)
         references = current_python_references()
         verify_workflow_refs(references)
         if args.report:
@@ -345,20 +351,39 @@ def main() -> int:
                 if e2e["python_lxmf_revision"] != data["environment"]["python_lxmf_revision"]:
                     raise ValueError("E2E LXMF revision differs from core report")
                 data.update(e2e)
+            data["public_benchmark"] = {
+                "schema": "lxmf-rs-public-benchmark-v1",
+                "implementations": ["python", "lxmf_rs", "rns_rs"],
+                "rows": public_rows(data),
+            }
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         data = load(target)
         scale_data = load(SCALE_DATASET)
         expected_page = performance_page(data, args.release, scale_data)
         expected_readme = replace_marked(README.read_text(encoding="utf-8"), summary_section(data, args.release))
+        expected_dashboard = (
+            render_dashboard(data, args.release) if args.dashboard_output is not None else None
+        )
         if args.check:
             if not PAGE.is_file() or PAGE.read_text(encoding="utf-8") != expected_page:
                 raise ValueError("docs/performance.md drift")
             if README.read_text(encoding="utf-8") != expected_readme:
                 raise ValueError("README performance section drift")
+            if (
+                args.dashboard_output is not None
+                and (
+                    not args.dashboard_output.is_file()
+                    or args.dashboard_output.read_text(encoding="utf-8") != expected_dashboard
+                )
+            ):
+                raise ValueError(f"{args.dashboard_output} drift")
         else:
             PAGE.write_text(expected_page, encoding="utf-8")
             README.write_text(expected_readme, encoding="utf-8")
+            if args.dashboard_output is not None and expected_dashboard is not None:
+                args.dashboard_output.parent.mkdir(parents=True, exist_ok=True)
+                args.dashboard_output.write_text(expected_dashboard, encoding="utf-8")
     except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
         print(f"performance_docs: {error}", file=sys.stderr)
         return 1

--- a/tools/scripts/python-lxmd-rust-lxmd-smoke.sh
+++ b/tools/scripts/python-lxmd-rust-lxmd-smoke.sh
@@ -1134,6 +1134,10 @@ EOF
     link_liveness_python_to_rust|link_teardown_python_to_rust|link_setup_python_to_rust)
       rpc_call "${RUST_RPC_ADDR}" "announce_now" "null" >/dev/null
       if [[ "${COMPAT_CASE}" == "link_setup_python_to_rust" ]]; then
+        python_control_call "${PY_ENDPOINT_CONTROL_PORT}" "wait_path" "$(cat <<EOF
+{"destination":"${RUST_DELIVERY_HASH}","timeout":${TIMEOUT_SECS}}
+EOF
+)" >/dev/null
         PERFORMANCE_START_NS="$(date +%s%N)"
       fi
       active_snapshot="$(python_control_call "${PY_ENDPOINT_CONTROL_PORT}" "open_link" "$(cat <<EOF

--- a/tools/scripts/python-lxmd-rust-lxmd-smoke.sh
+++ b/tools/scripts/python-lxmd-rust-lxmd-smoke.sh
@@ -1103,35 +1103,47 @@ PY
   )"
 
   case "${COMPAT_CASE}" in
-    link_liveness_rust_to_python|link_teardown_rust_to_python)
+    link_liveness_rust_to_python|link_teardown_rust_to_python|link_setup_rust_to_python)
       python_control_call "${PY_ENDPOINT_CONTROL_PORT}" "announce" "{}" >/dev/null
       rpc_call "${RUST_RPC_ADDR}" "announce_now" "null" >/dev/null
       if ! wait_for_rust_peer "${py_delivery_hash}"; then
         echo "Rust did not learn Python endpoint announce for ${COMPAT_CASE}" >&2
         exit 1
       fi
+      if [[ "${COMPAT_CASE}" == "link_setup_rust_to_python" ]]; then
+        PERFORMANCE_START_NS="$(date +%s%N)"
+      fi
       rust_message_id="rust-link-${COMPAT_CASE}-$(date +%s)"
       rpc_call "${RUST_RPC_ADDR}" "send_message_v2" "$(cat <<EOF
 {"id":"${rust_message_id}","source":"${RUST_DELIVERY_HASH}","destination":"${py_delivery_hash}","title":"","content":"${smoke_message_content}","method":"direct"}
 EOF
 )" >"${PY_SEND_LOG}"
-      message_json="$(python_control_call "${PY_ENDPOINT_CONTROL_PORT}" "wait_message" "$(cat <<EOF
-{"content":"${smoke_message_content}","timeout":${TIMEOUT_SECS}}
-EOF
-)")"
       active_snapshot="$(python_control_call "${PY_ENDPOINT_CONTROL_PORT}" "wait_link_state" "$(cat <<EOF
 {"state":"active","timeout":${TIMEOUT_SECS}}
 EOF
 )")"
       echo "active_snapshot=${active_snapshot}" >>"${PY_LOG}"
+      if [[ "${COMPAT_CASE}" == "link_setup_rust_to_python" ]]; then
+        PERFORMANCE_END_NS="$(date +%s%N)"
+      fi
+      message_json="$(python_control_call "${PY_ENDPOINT_CONTROL_PORT}" "wait_message" "$(cat <<EOF
+{"content":"${smoke_message_content}","timeout":${TIMEOUT_SECS}}
+EOF
+)")"
       ;;
-    link_liveness_python_to_rust|link_teardown_python_to_rust)
+    link_liveness_python_to_rust|link_teardown_python_to_rust|link_setup_python_to_rust)
       rpc_call "${RUST_RPC_ADDR}" "announce_now" "null" >/dev/null
+      if [[ "${COMPAT_CASE}" == "link_setup_python_to_rust" ]]; then
+        PERFORMANCE_START_NS="$(date +%s%N)"
+      fi
       active_snapshot="$(python_control_call "${PY_ENDPOINT_CONTROL_PORT}" "open_link" "$(cat <<EOF
 {"destination":"${RUST_DELIVERY_HASH}","timeout":${TIMEOUT_SECS}}
 EOF
 )")"
       echo "active_snapshot=${active_snapshot}" >>"${PY_LOG}"
+      if [[ "${COMPAT_CASE}" == "link_setup_python_to_rust" ]]; then
+        PERFORMANCE_END_NS="$(date +%s%N)"
+      fi
       ;;
     *)
       echo "unsupported link lifecycle case: ${COMPAT_CASE}" >&2
@@ -1140,6 +1152,8 @@ EOF
   esac
 
   case "${COMPAT_CASE}" in
+    link_setup_rust_to_python|link_setup_python_to_rust)
+      ;;
     link_liveness_rust_to_python|link_liveness_python_to_rust)
       keepalive_wait="$("${PYTHON_BIN}" - <<'PY' "${active_snapshot}"
 import json
@@ -1253,7 +1267,9 @@ PY
     "${active_snapshot}" \
     "${steady_snapshot}" \
     "${closed_snapshot}" \
-    "${message_json}"
+    "${message_json}" \
+    "${PERFORMANCE_START_NS}" \
+    "${PERFORMANCE_END_NS}"
 import json
 import sys
 
@@ -1272,7 +1288,9 @@ import sys
     steady_snapshot,
     closed_snapshot,
     message_json,
-) = sys.argv[1:15]
+    performance_start_ns,
+    performance_end_ns,
+) = sys.argv[1:17]
 
 def decode(value):
     return json.loads(value) if value else None
@@ -1299,6 +1317,19 @@ report = {
         "rust_remote_status": rust_remote_status_log,
     },
 }
+
+if performance_start_ns and performance_end_ns:
+    start_ns = int(performance_start_ns)
+    end_ns = int(performance_end_ns)
+    if end_ns <= start_ns:
+        raise SystemExit("invalid link setup timing boundary")
+    report["performance"] = {
+        "boundary": "link_request_to_active",
+        "enqueue_to_delivery_ns": end_ns - start_ns,
+        "payload_size_bytes": 0,
+        "startup_included": False,
+        "route_warmup_included": False,
+    }
 
 with open(report_path, "w", encoding="utf-8") as handle:
     json.dump(report, handle, indent=2)

--- a/tools/scripts/test_performance_dashboard.py
+++ b/tools/scripts/test_performance_dashboard.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Unit tests for the measurement-free public dashboard renderer."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from performance_dashboard import PUBLIC_ROWS, fallback_matrix, render_dashboard
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class PerformanceDashboardTests(unittest.TestCase):
+    def test_fallback_keeps_requested_matrix_and_marks_exact_gaps(self) -> None:
+        data = {
+            "environment": {"git_commit": "abc123", "timestamp_utc": "now"},
+            "profile": "report",
+            "comparisons": [
+                {
+                    "label": "Reticulum packet pack",
+                    "rust": {"throughput_ops_per_sec": 20.0, "p50_ns": 50.0},
+                    "python": {"throughput_ops_per_sec": 10.0, "p50_ns": 100.0},
+                },
+                {
+                    "label": "Reticulum announce validate",
+                    "rust": {"throughput_ops_per_sec": 4.0, "p50_ns": 250.0},
+                    "python": {"throughput_ops_per_sec": 2.0, "p50_ns": 500.0},
+                },
+            ],
+            "e2e_comparisons": [
+                {
+                    "label": "Loopback TCP cold destination discovery",
+                    "topology": "fixed",
+                    "timed_boundary": "cold_path_request_to_route_available",
+                    "rust": {"p50_ns": 1_000_000.0, "p99_ns": 2_000_000.0},
+                    "python": {"p50_ns": 2_000_000.0, "p99_ns": 3_000_000.0},
+                }
+            ],
+        }
+        rows = fallback_matrix(data)
+
+        self.assertEqual([row["id"] for row in rows], [row[0] for row in PUBLIC_ROWS])
+        self.assertEqual(rows[0]["cells"]["lxmf_rs"]["value"], 20.0)
+        self.assertEqual(rows[2]["cells"]["python"]["p99"], 0.003)
+        self.assertEqual(rows[4]["cells"]["python"]["status"], "not_available")
+        self.assertIn("1 MB Resource", rows[4]["cells"]["python"]["reason"])
+        self.assertIn("rns-rs adapter", rows[0]["cells"]["rns_rs"]["reason"])
+        self.assertEqual(rows[8]["cells"]["rns_rs"]["status"], "not_available")
+
+    def test_render_is_standalone_and_escapes_metadata(self) -> None:
+        data = {
+            "environment": {"git_commit": "<commit>", "timestamp_utc": "now"},
+            "profile": "report",
+            "public_benchmark": {
+                "rows": [
+                    {
+                        "id": "packet_encode",
+                        "label": "Packet <encode>",
+                        "unit": "ops/s",
+                        "cells": {
+                            "python": {"status": "measured", "value": 1.0},
+                            "lxmf_rs": {"status": "not_available", "reason": "missing"},
+                            "rns_rs": {"status": "not_available", "reason": "missing"},
+                        },
+                    }
+                ]
+            },
+        }
+        rendered = render_dashboard(data, "v<test>")
+
+        self.assertIn("Packet &lt;encode&gt;", rendered)
+        self.assertIn("&lt;commit&gt;", rendered)
+        self.assertNotIn("https://", rendered)
+        self.assertIn('id="benchmark-data"', rendered)
+
+    def test_performance_workflows_are_opt_in(self) -> None:
+        release = (ROOT / ".github/workflows/performance-release.yml").read_text(encoding="utf-8")
+        request = (ROOT / ".github/workflows/performance-smoke.yml").read_text(encoding="utf-8")
+
+        for workflow in (release, request):
+            self.assertNotIn("pull_request:", workflow)
+            self.assertNotIn("schedule:", workflow)
+        self.assertIn("workflow_dispatch:", release)
+        self.assertIn("workflow_dispatch:", request)
+        self.assertIn("tags:", release)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -18,6 +18,8 @@ include!("main_parts/run_key_management_check.rs");
 
 include!("main_parts/run_python_impl_bench_report.rs");
 
+include!("main_parts/run_public_benchmark.rs");
+
 include!("main_parts/write_python_impl_compare_report.rs");
 
 include!("main_parts/rust_python_benchmark_fixtures.rs");

--- a/xtask/src/main_parts/run_public_benchmark.rs
+++ b/xtask/src/main_parts/run_public_benchmark.rs
@@ -1,0 +1,64 @@
+fn run_public_benchmark(release: &str, profile: PythonImplBenchProfile) -> Result<()> {
+    if release.is_empty() || release.chars().any(|character| matches!(character, '/' | '\\')) {
+        bail!("public benchmark release must be a non-empty tag-like name");
+    }
+
+    run_python_impl_bench_report(profile, None, None, None, None)?;
+
+    let python = if cfg!(windows) { "python" } else { "python3" };
+    let e2e_profile = match profile {
+        PythonImplBenchProfile::Fast => "smoke",
+        PythonImplBenchProfile::Report => "report",
+    };
+    run(
+        python,
+        &[
+            "tools/scripts/e2e_performance.py",
+            "--profile",
+            e2e_profile,
+            "--output",
+            "target/performance/e2e.json",
+        ],
+    )?;
+
+    let dashboard_path = Path::new("target/performance/lxmf-rs-performance.html");
+    run(
+        python,
+        &[
+            "tools/scripts/performance_docs.py",
+            "--release",
+            release,
+            "--report",
+            PYTHON_IMPL_REPORT_JSON_PATH,
+            "--e2e-report",
+            "target/performance/e2e.json",
+            "--dashboard-output",
+            dashboard_path
+                .to_str()
+                .context("dashboard output path must be UTF-8")?,
+        ],
+    )?;
+
+    let dataset_path = format!("docs/performance/{release}.json");
+    let target_dataset = Path::new("target/performance/lxmf-rs-performance.json");
+    fs::copy(&dataset_path, target_dataset)
+        .with_context(|| format!("copy {dataset_path} to {}", target_dataset.display()))?;
+
+    let checksum_paths = [target_dataset, dashboard_path];
+    let mut checksums = String::new();
+    for path in checksum_paths {
+        let bytes = fs::read(path).with_context(|| format!("read {}", path.display()))?;
+        let digest = Sha256::digest(bytes);
+        let file_name = path
+            .file_name()
+            .context("benchmark artifact must have a file name")?
+            .to_string_lossy();
+        checksums.push_str(&format!("{}  {file_name}\n", hex::encode(digest)));
+    }
+    fs::write("target/performance/SHA256SUMS", checksums)
+        .context("write target/performance/SHA256SUMS")?;
+    log::info!(
+        "public performance artifacts written under target/performance for {release}"
+    );
+    Ok(())
+}

--- a/xtask/src/main_parts/run_python_impl_bench_report.rs
+++ b/xtask/src/main_parts/run_python_impl_bench_report.rs
@@ -121,6 +121,7 @@ fn run_python_impl_bench_compare_with_paths(
     let warm_up_time = profile_config.criterion.warm_up_time_seconds.to_string();
     let measurement_time = profile_config.criterion.measurement_time_seconds.to_string();
     let python_iterations = python_iterations.to_string();
+    let python = if cfg!(windows) { "python" } else { "python3" };
 
     let run_rust = || -> Result<()> {
         run(
@@ -180,21 +181,21 @@ fn run_python_impl_bench_compare_with_paths(
     };
     let run_python = || -> Result<()> {
         run(
-        "python3",
-        &[
-            "tools/scripts/python_impl_benchmarks.py",
-            "--iterations",
-            &python_iterations,
-            "--output",
-            paths
-                .python_report_path
-                .to_str()
-                .context("python benchmark output path must be utf-8")?,
-            "--expected-rns-ref",
-            &config.references.reticulum,
-            "--expected-lxmf-ref",
-            &config.references.lxmf,
-        ],
+            python,
+            &[
+                "tools/scripts/python_impl_benchmarks.py",
+                "--iterations",
+                &python_iterations,
+                "--output",
+                paths
+                    .python_report_path
+                    .to_str()
+                    .context("python benchmark output path must be utf-8")?,
+                "--expected-rns-ref",
+                &config.references.reticulum,
+                "--expected-lxmf-ref",
+                &config.references.lxmf,
+            ],
         )
     };
     if rust_first {

--- a/xtask/src/main_parts/xtaskcommand.rs
+++ b/xtask/src/main_parts/xtaskcommand.rs
@@ -125,6 +125,12 @@ enum XtaskCommand {
         #[arg(long)]
         resource_iterations: Option<usize>,
     },
+    PublicBenchmark {
+        #[arg(long)]
+        release: String,
+        #[arg(long, value_enum, default_value_t = PythonImplBenchProfile::Report)]
+        profile: PythonImplBenchProfile,
+    },
     #[command(hide = true)]
     PythonImplBenchWorkload {
         #[arg(long, value_enum)]
@@ -373,6 +379,9 @@ fn main() -> Result<()> {
             resource_runs,
             resource_iterations,
         ),
+        XtaskCommand::PublicBenchmark { release, profile } => {
+            run_public_benchmark(&release, profile)
+        }
         XtaskCommand::PythonImplBenchWorkload { implementation, benchmark, iterations, output } => {
             run_python_impl_bench_workload(implementation, &benchmark, iterations, &output)
         }


### PR DESCRIPTION
## Summary

- Turn the existing Python/LXMF-rs benchmark report into a versioned canonical dataset and self-contained HTML dashboard.
- Add `cargo xtask public-benchmark --release <tag>` with JSON, HTML, raw E2E evidence, and SHA256 checksums under `target/performance/`.
- Add link-setup p50/p99 evidence to the matched E2E workload report.
- Publish the dashboard assets on tagged releases and provide an explicitly dispatched request workflow.

## Publication behavior

Real performance measurements run only through `workflow_dispatch`, the explicit local command, or a `v*` release tag. Pull requests, ordinary pushes, and schedules do not run the performance workflows.

The dashboard keeps rns-rs and exact scenarios without release evidence as explicit `N/A`; existing nearby measurements are not relabeled as the requested 1 MB/50 MB Resource or 1000-link workloads.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p xtask`
- `cargo test -p xtask`
- `cargo clippy -p xtask --all-targets --all-features --no-deps -- -D warnings`
- Dashboard unit tests and Python syntax checks
- Generated docs/dashboard drift check
- Workflow YAML parsing and shell syntax check
- `git diff --check`