### PR TITLE
Prepare stable v0.9.9 release

### DIFF
--- a/docs/contracts/baselines/interop-artifacts-manifest.json
+++ b/docs/contracts/baselines/interop-artifacts-manifest.json
@@ -28,8 +28,8 @@
     },
     {
       "path": "docs/contracts/compatibility-contract.md",
-      "bytes": 3008,
-      "sha256": "f0bd1210ec3b08d9a3309e0f29d25aa159c2c089f02cfa8ea8d8a46d9151e007"
+      "bytes": 3764,
+      "sha256": "f50e1c172f391fbad2b9cdc691c455b03c67c7819319ad4fa83f2ebba19e08b3"
     },
     {
       "path": "docs/contracts/compatibility-matrix.md",

--- a/docs/release-notes-v0.9.9.md
+++ b/docs/release-notes-v0.9.9.md
@@ -1,0 +1,48 @@
+# LXMF-rs v0.9.9
+
+v0.9.9 promotes the RNS 1.4.2 software-parity release candidate to the stable
+release channel. It includes the reviewed work merged after v0.9.8 and keeps
+hardware, public-network, and third-party-client validation as separate
+evidence tracks rather than folding them into the software-parity result.
+
+## Highlights
+
+- Completes the generated Python Reticulum 1.4.2 software inventory: 1,810
+  applicable entries are complete, zero are partial or unmapped, and the absent
+  `CRNS` package is the single provenance-backed not-applicable entry.
+- Adds the repository-native HIL controller and pinned Python Reticulum/LXMF
+  verification for virtual transport, channels, paper messages, compatibility
+  matrices, and LXMD relay scenarios.
+- Expands routing, resource, lifecycle, interface-policy, blocked-IP reporting,
+  and `rngit` repository-service compatibility, including document ACL and
+  work-item behavior.
+- Publishes independent rns-rs and Reticulum-Go interoperability evidence as a
+  separate release axis, including multi-hop, restart, large-resource, routing,
+  and deterministic-chaos scenarios.
+- Adds a five-sample release performance gate and standalone JSON, HTML, and raw
+  evidence artifacts with explicit warning and hard-regression budgets.
+- Extends the release pipeline with static multi-platform bundles, Debian/RPM
+  packages, Windows MSI output, SBOMs, checksums, provenance attestations, OCI
+  images, and stable-channel publication hooks.
+
+## Compatibility boundary
+
+The release targets Python Reticulum 1.4.2 at
+`b48b96e61676504e0a4e527b33b9a0b4495c6872` and Python LXMF at
+`727830cefda83d9c6e3982b48675425f3f988f9c`. The seven tracked LXMF software
+rows and the generated RNS callable inventory are complete for their named
+software scenarios.
+
+Physical RNode/RNodeMulti, Weave, VR-N76, BLE, and serial-radio validation;
+public I2P and public Reticulum soak; and Sideband, MeshChatX, Columba, and
+other third-party-client validation remain explicitly separate. Their absence
+does not imply evidence that those environments were tested by this release.
+
+## Validation and publication
+
+Stable publication is performed from the immutable `v0.9.9` tag. The
+tag-triggered workflows build and attest release bundles, run the exact-tag
+independent interoperability and performance gates, publish the GitHub release
+and OCI image, and publish the public Rust crates in dependency order. Public
+assets include checksums and standalone interoperability and performance
+evidence so each claim can be verified against the release commit.

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -57,10 +57,25 @@ Resource measurements, all SDK transport surfaces, and the explicit bounded
 Final release attachment remains tag-triggered and must use the eventual tag's
 exact commit; this evidence is not attached retroactively to `v0.9.9-rc.6`.
 
-## v0.9.9-rc.6 Release Candidate
+## v0.9.9 Stable Release Preparation
 
-The current candidate is `v0.9.9-rc.6`, with workspace and publishable crate
-version `0.9.9`. It is the RNS 1.4.2 software-parity prerelease: the pinned
+The reviewed RNS 1.4.2 parity and independent-evidence work is merged on
+`main`, and the workspace and publishable crate version is `0.9.9`. Stable
+release notes are in [`docs/release-notes-v0.9.9.md`](../release-notes-v0.9.9.md).
+The immutable `v0.9.9` tag is the final truth owner for bundle, OCI, crates.io,
+independent-interoperability, and performance publication; those outcomes must
+be verified from the tag workflows before the stable release is declared
+complete.
+
+The software-parity boundary remains 1,811 generated entries: 1,810 applicable
+and complete, zero partial, zero unmapped, and one provenance-backed
+not-applicable entry. Physical interfaces, public networks, and third-party
+clients remain separate evidence axes described above.
+
+## v0.9.9-rc.6 Historical Release Candidate
+
+The final candidate was `v0.9.9-rc.6`, with workspace and publishable crate
+version `0.9.9`. It was the RNS 1.4.2 software-parity prerelease: the pinned
 Reticulum reference is `b48b96e61676504e0a4e527b33b9a0b4495c6872`, the pinned
 LXMF reference is `727830cefda83d9c6e3982b48675425f3f988f9c`, and the generated
 strict inventory target is 1,811 total, 1,810 complete, zero partial, and one
@@ -74,7 +89,7 @@ Weave, VR-N76, BLE, serial-radio, public-I2P/public-Reticulum, and
 third-party-client evidence remains separately tracked and does not become a
 hidden implementation partial.
 
-Candidate notes are in `docs/release-notes-v0.9.9-rc.6.md`; the exact gate,
+Historical candidate notes are in `docs/release-notes-v0.9.9-rc.6.md`; the exact gate,
 artifact, signing, OCI, and performance record is in
 `docs/status/v0.9.9-release-candidate.md`.
 


### PR DESCRIPTION
## Summary

- regenerate the interop artifact manifest after the compatibility contract update
- add stable v0.9.9 release notes
- promote the roadmap from the rc.6 candidate posture to stable release preparation

## Validation

- `cargo run -p xtask -- interop-artifacts`
- `python3 tools/scripts/python_surface_inventory.py --check`
- `cargo fmt --all -- --check`

This is a metadata-only release-preparation slice; source behavior remains identical to the merged parity and evidence tree.