### PR TITLE
Reduce per-connection TCP buffer memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ LXMF-rs is a Rust implementation of the
 provides reusable libraries, a typed SDK, host daemons and command-line tools,
 plus embedded and FFI surfaces.
 
-
 <!-- performance-summary:start -->
 ## Measured performance
 
@@ -25,7 +24,7 @@ Release dataset: `v0.9.9` at `7199c4038a3ba786abb4dfbc95cbd6cd16ed9116`; Python 
 | LXMF large message decode | 455 ns | 8.31 ms | 18252.45x |
 | LXMF large message encode | 762 ns | 2.19 ms | 2869.52x |
 
-These are matched-workload comparisons. See [methodology, complete results, variability, and limitations](docs/performance.md).
+These are matched-workload comparisons, not a claim of whole-system superiority. See [methodology, complete results, variability, and limitations](docs/performance.md).
 <!-- performance-summary:end -->
 
 

--- a/crates/libs/rns-transport/examples/tcp_connection_memory.rs
+++ b/crates/libs/rns-transport/examples/tcp_connection_memory.rs
@@ -1,0 +1,367 @@
+use std::env;
+#[cfg(target_os = "linux")]
+use std::fs;
+use std::io;
+use std::net::{Ipv4Addr, SocketAddrV4, TcpListener as StdTcpListener};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use rns_transport::buffer::OutputBuffer;
+use rns_transport::iface::hdlc::Hdlc;
+use rns_transport::iface::tcp_client::TcpClient;
+use rns_transport::iface::tcp_server::TcpServer;
+use rns_transport::iface::{InterfaceManager, TxMessage, TxMessageType};
+use rns_transport::packet::{Packet, PacketDataBuffer};
+use serde_json::{json, Value};
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+
+#[derive(Clone, Copy)]
+enum Activity {
+    Idle,
+    Small,
+    Maximum,
+}
+
+impl Activity {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "idle" => Ok(Self::Idle),
+            "small" => Ok(Self::Small),
+            "maximum" => Ok(Self::Maximum),
+            _ => Err(format!("unknown activity '{value}'; expected idle, small, or maximum")),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Small => "small",
+            Self::Maximum => "maximum",
+        }
+    }
+}
+
+struct Args {
+    connections: usize,
+    activity: Activity,
+    mtu: usize,
+    settle: Duration,
+    broadcasts: usize,
+}
+
+impl Args {
+    fn parse() -> Result<Self, String> {
+        let mut args = env::args().skip(1);
+        let mut parsed = Self {
+            connections: 100,
+            activity: Activity::Idle,
+            mtu: TcpClient::DEFAULT_MTU,
+            settle: Duration::from_millis(500),
+            broadcasts: 0,
+        };
+        while let Some(flag) = args.next() {
+            let value = args.next().ok_or_else(|| format!("missing value for {flag}"))?;
+            match flag.as_str() {
+                "--connections" => {
+                    parsed.connections = value.parse().map_err(|_| "invalid connection count")?;
+                }
+                "--activity" => parsed.activity = Activity::parse(&value)?,
+                "--mtu" => parsed.mtu = value.parse().map_err(|_| "invalid MTU")?,
+                "--settle-ms" => {
+                    let millis = value.parse().map_err(|_| "invalid settle time")?;
+                    parsed.settle = Duration::from_millis(millis);
+                }
+                "--broadcasts" => {
+                    parsed.broadcasts = value.parse().map_err(|_| "invalid broadcast count")?;
+                }
+                _ => return Err(format!("unknown option {flag}")),
+            }
+        }
+        if parsed.connections == 0 {
+            return Err("connections must be greater than zero".to_string());
+        }
+        if parsed.mtu < 256 {
+            return Err("MTU must be at least 256".to_string());
+        }
+        Ok(parsed)
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct ProcessMemory {
+    rss_kib: Option<u64>,
+    peak_rss_kib: Option<u64>,
+    virtual_kib: Option<u64>,
+}
+
+impl ProcessMemory {
+    fn sample() -> Self {
+        #[cfg(target_os = "linux")]
+        {
+            let Ok(status) = fs::read_to_string("/proc/self/status") else {
+                return Self::default();
+            };
+            Self {
+                rss_kib: status_kib(&status, "VmRSS:"),
+                peak_rss_kib: status_kib(&status, "VmHWM:"),
+                virtual_kib: status_kib(&status, "VmSize:"),
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        Self::default()
+    }
+
+    fn json(self) -> Value {
+        json!({
+            "rss_kib": self.rss_kib,
+            "peak_rss_kib": self.peak_rss_kib,
+            "virtual_kib": self.virtual_kib,
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn status_kib(status: &str, key: &str) -> Option<u64> {
+    status
+        .lines()
+        .find_map(|line| line.strip_prefix(key)?.split_whitespace().next()?.parse::<u64>().ok())
+}
+
+#[derive(Clone, Copy, Default)]
+struct CpuTicks {
+    user: u64,
+    system: u64,
+}
+
+impl CpuTicks {
+    fn sample() -> Self {
+        #[cfg(target_os = "linux")]
+        {
+            let Ok(stat) = fs::read_to_string("/proc/self/stat") else {
+                return Self::default();
+            };
+            let Some(after_name) = stat.rsplit_once(") ").map(|(_, fields)| fields) else {
+                return Self::default();
+            };
+            let fields = after_name.split_whitespace().collect::<Vec<_>>();
+            Self {
+                user: fields.get(11).and_then(|value| value.parse().ok()).unwrap_or(0),
+                system: fields.get(12).and_then(|value| value.parse().ok()).unwrap_or(0),
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        Self::default()
+    }
+
+    fn elapsed(self, start: Self) -> u64 {
+        self.user
+            .saturating_sub(start.user)
+            .saturating_add(self.system.saturating_sub(start.system))
+    }
+}
+
+fn reserve_loopback_addr() -> io::Result<SocketAddrV4> {
+    let listener = StdTcpListener::bind((Ipv4Addr::LOCALHOST, 0))?;
+    let addr = match listener.local_addr()? {
+        std::net::SocketAddr::V4(addr) => addr,
+        std::net::SocketAddr::V6(_) => unreachable!("IPv4 loopback bind returned IPv6"),
+    };
+    drop(listener);
+    Ok(addr)
+}
+
+fn packet_frame(payload_len: usize, mtu: usize) -> Result<Vec<u8>, String> {
+    let packet = Packet {
+        data: PacketDataBuffer::new_from_slice(&vec![0x55; payload_len]),
+        ..Default::default()
+    };
+    let raw = packet.to_bytes().map_err(|err| format!("packet serialization failed: {err:?}"))?;
+    if raw.len() > mtu {
+        return Err(format!("serialized packet {} exceeds MTU {mtu}", raw.len()));
+    }
+    let mut wire = vec![0_u8; raw.len().saturating_mul(2).saturating_add(2)];
+    let mut output = OutputBuffer::new(&mut wire);
+    let used =
+        Hdlc::encode(&raw, &mut output).map_err(|err| format!("HDLC encode failed: {err:?}"))?;
+    wire.truncate(used);
+    Ok(wire)
+}
+
+async fn wait_for_count<F>(mut observed: F, expected: usize, label: &str) -> Result<(), String>
+where
+    F: FnMut() -> usize,
+{
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while observed() < expected {
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "timed out waiting for {label}: expected {expected}, got {}",
+                observed()
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    Ok(())
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse().map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    let addr = reserve_loopback_addr()?;
+    let manager = Arc::new(tokio::sync::Mutex::new(InterfaceManager::new(4096)));
+    let receiver = manager.lock().await.receiver();
+    let received_packets = Arc::new(AtomicUsize::new(0));
+    let receive_task = {
+        let received_packets = received_packets.clone();
+        tokio::spawn(async move {
+            loop {
+                let message = receiver.lock().await.recv().await;
+                if message.is_none() {
+                    break;
+                }
+                received_packets.fetch_add(1, Ordering::Relaxed);
+            }
+        })
+    };
+
+    let server = TcpServer::new(addr.to_string(), manager.clone()).with_client_mtu(args.mtu);
+    let server_status = server.runtime_status_handle();
+    let server_iface = manager.lock().await.spawn(server, TcpServer::spawn);
+    wait_for_count(
+        || usize::from(server_status.to_json()["listener_state"].as_str() == Some("listening")),
+        1,
+        "TCP listener startup",
+    )
+    .await
+    .map_err(io::Error::other)?;
+    let baseline_memory = ProcessMemory::sample();
+    let baseline_tasks = tokio::runtime::Handle::current().metrics().num_alive_tasks();
+
+    let mut clients = Vec::with_capacity(args.connections);
+    for _ in 0..args.connections {
+        clients.push(TcpStream::connect(addr).await?);
+    }
+    wait_for_count(
+        || {
+            server_status.to_json()["accepted_connections"]
+                .as_u64()
+                .and_then(|value| usize::try_from(value).ok())
+                .unwrap_or(0)
+        },
+        args.connections,
+        "accepted connections",
+    )
+    .await
+    .map_err(io::Error::other)?;
+    tokio::time::sleep(args.settle).await;
+    let connected_memory = ProcessMemory::sample();
+    let connected_tasks = tokio::runtime::Handle::current().metrics().num_alive_tasks();
+
+    let cpu_start = CpuTicks::sample();
+    let activity_started = Instant::now();
+    let mut application_bytes = 0_usize;
+    match args.activity {
+        Activity::Idle => {}
+        Activity::Small => {
+            let frame = packet_frame(64, args.mtu).map_err(io::Error::other)?;
+            application_bytes = frame.len().saturating_mul(clients.len());
+            for client in &mut clients {
+                client.write_all(&frame).await?;
+            }
+            wait_for_count(
+                || received_packets.load(Ordering::Relaxed),
+                clients.len(),
+                "small inbound packets",
+            )
+            .await
+            .map_err(io::Error::other)?;
+        }
+        Activity::Maximum => {
+            let base_len = Packet::default().to_bytes()?.len();
+            let payload_len = args.mtu.saturating_sub(base_len);
+            let frame = packet_frame(payload_len, args.mtu).map_err(io::Error::other)?;
+            application_bytes = frame.len().saturating_mul(clients.len());
+            for client in &mut clients {
+                client.write_all(&frame).await?;
+            }
+            wait_for_count(
+                || received_packets.load(Ordering::Relaxed),
+                clients.len(),
+                "maximum inbound packets",
+            )
+            .await
+            .map_err(io::Error::other)?;
+        }
+    }
+
+    let mut broadcast_matched = 0_usize;
+    let mut broadcast_sent = 0_usize;
+    let mut broadcast_failed = 0_usize;
+    for _ in 0..args.broadcasts {
+        let packet =
+            Packet { data: PacketDataBuffer::new_from_slice(&[0x42; 64]), ..Default::default() };
+        let trace = manager
+            .lock()
+            .await
+            .send(TxMessage { tx_type: TxMessageType::Broadcast(None), packet })
+            .await;
+        broadcast_matched = broadcast_matched.saturating_add(trace.matched_ifaces);
+        broadcast_sent = broadcast_sent.saturating_add(trace.sent_ifaces);
+        broadcast_failed = broadcast_failed.saturating_add(trace.failed_ifaces);
+    }
+
+    let activity_elapsed = activity_started.elapsed();
+    let cpu_ticks = CpuTicks::sample().elapsed(cpu_start);
+    tokio::time::sleep(args.settle).await;
+    let activity_memory = ProcessMemory::sample();
+    let activity_tasks = tokio::runtime::Handle::current().metrics().num_alive_tasks();
+    let elapsed_seconds = activity_elapsed.as_secs_f64();
+    let packet_rate = if elapsed_seconds > 0.0 {
+        received_packets.load(Ordering::Relaxed) as f64 / elapsed_seconds
+    } else {
+        0.0
+    };
+    let byte_rate =
+        if elapsed_seconds > 0.0 { application_bytes as f64 / elapsed_seconds } else { 0.0 };
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "activity": args.activity.as_str(),
+            "connections": args.connections,
+            "mtu": args.mtu,
+            "server_iface": server_iface.to_string(),
+            "baseline": {
+                "memory": baseline_memory.json(),
+                "tokio_tasks": baseline_tasks,
+            },
+            "connected": {
+                "memory": connected_memory.json(),
+                "tokio_tasks": connected_tasks,
+            },
+            "after_activity": {
+                "memory": activity_memory.json(),
+                "tokio_tasks": activity_tasks,
+                "received_packets": received_packets.load(Ordering::Relaxed),
+                "wire_bytes": application_bytes,
+                "elapsed_ms": activity_elapsed.as_millis(),
+                "cpu_ticks": cpu_ticks,
+                "packets_per_second": packet_rate,
+                "wire_bytes_per_second": byte_rate,
+            },
+            "broadcasts": {
+                "attempts": args.broadcasts,
+                "matched_ifaces": broadcast_matched,
+                "sent_ifaces": broadcast_sent,
+                "failed_ifaces": broadcast_failed,
+            },
+        }))?
+    );
+
+    manager.lock().await.stop_interface(server_iface);
+    drop(clients);
+    receive_task.abort();
+    Ok(())
+}

--- a/crates/libs/rns-transport/src/iface/tcp_client.rs
+++ b/crates/libs/rns-transport/src/iface/tcp_client.rs
@@ -36,6 +36,9 @@ const HDLC_KEEPALIVE_FRAME: &[u8] = &[0x7e, 0x7e];
 // iterations rather than many.
 const MIN_STABLE_CONNECTION: Duration = Duration::from_secs(2);
 pub(crate) const HDLC_STREAM_EVENT_CHANNEL_CAPACITY: usize = 128;
+const TCP_READ_BUFFER_SIZE: usize = 32 * 1024;
+const MIN_TCP_READ_BUFFER_SIZE: usize = 1024;
+const INITIAL_HDLC_FRAME_BUFFER_CAPACITY: usize = 4 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct TcpSocketTuning {
@@ -359,7 +362,7 @@ async fn track_tcp_stream_events(
 
 fn tcp_wire_buffer_capacity(mtu: usize) -> usize {
     // Worst-case HDLC expansion doubles bytes (all escaped) plus frame delimiters.
-    mtu.saturating_mul(2).saturating_add(16)
+    mtu.saturating_mul(2).saturating_add(2)
 }
 
 /// Maximum number of bytes the HDLC frame reassembly buffer may hold
@@ -373,6 +376,64 @@ fn tcp_wire_buffer_capacity(mtu: usize) -> usize {
 /// this caps it at ~1 MiB instead.
 fn max_hdlc_frame_buffer_len(mtu: usize) -> usize {
     tcp_wire_buffer_capacity(mtu).saturating_mul(2)
+}
+
+fn tcp_read_buffer_len(mtu: usize) -> usize {
+    TCP_READ_BUFFER_SIZE.min(tcp_wire_buffer_capacity(mtu).max(MIN_TCP_READ_BUFFER_SIZE))
+}
+
+fn initial_hdlc_frame_buffer_capacity(mtu: usize) -> usize {
+    INITIAL_HDLC_FRAME_BUFFER_CAPACITY.min(max_hdlc_frame_buffer_len(mtu))
+}
+
+struct TcpRxBuffers {
+    decoded: Vec<u8>,
+    frame: Vec<u8>,
+    tcp: Vec<u8>,
+}
+
+impl TcpRxBuffers {
+    fn new(mtu: usize) -> Self {
+        Self {
+            decoded: Vec::new(),
+            frame: Vec::with_capacity(initial_hdlc_frame_buffer_capacity(mtu)),
+            tcp: vec![0_u8; tcp_read_buffer_len(mtu)],
+        }
+    }
+}
+
+#[derive(Default)]
+struct TcpTxBuffers {
+    raw: Vec<u8>,
+    wire: Vec<u8>,
+}
+
+impl TcpTxBuffers {
+    fn encode_packet<'a>(
+        &'a mut self,
+        packet: &Packet,
+        mtu: usize,
+    ) -> Result<(usize, &'a [u8]), RnsError> {
+        let raw_capacity = packet.serialized_len()?;
+        if raw_capacity > mtu {
+            return Err(RnsError::OutOfMemory);
+        }
+
+        self.raw.resize(raw_capacity, 0);
+        let raw_len = {
+            let mut output = OutputBuffer::new(self.raw.as_mut_slice());
+            packet.serialize(&mut output)?;
+            output.offset()
+        };
+
+        self.wire.resize(tcp_wire_buffer_capacity(raw_len), 0);
+        let wire_len = {
+            let mut output = OutputBuffer::new(self.wire.as_mut_slice());
+            Hdlc::encode(&self.raw[..raw_len], &mut output)?;
+            output.offset()
+        };
+        Ok((raw_len, &self.wire[..wire_len]))
+    }
 }
 
 /// Drops malformed backlog from the HDLC frame reassembly buffer once it
@@ -480,9 +541,7 @@ pub(crate) async fn run_hdlc_stream_with_runtime<R, W>(
         let events = events.clone();
 
         tokio::spawn(async move {
-            let mut hdlc_rx_buffer = vec![0u8; mtu];
-            let mut frame_buffer: Vec<u8> = Vec::with_capacity(mtu.saturating_mul(4));
-            let mut tcp_buffer = vec![0u8; mtu.saturating_mul(16)];
+            let mut buffers = TcpRxBuffers::new(mtu);
 
             loop {
                 tokio::select! {
@@ -496,7 +555,7 @@ pub(crate) async fn run_hdlc_stream_with_runtime<R, W>(
                     _ = stop.cancelled() => {
                             break;
                     }
-                    result = stream.read(&mut tcp_buffer[..]) => {
+                    result = stream.read(buffers.tcp.as_mut_slice()) => {
                             match result {
                                 Ok(0) => {
                                     log::warn!("connection closed");
@@ -511,11 +570,16 @@ pub(crate) async fn run_hdlc_stream_with_runtime<R, W>(
                                         Instant::now();
                                     send_hdlc_stream_event(&events, HdlcStreamEvent::Read { bytes: n });
                                     // TCP and Unix streams can deliver partial or multiple HDLC frames.
-                                    frame_buffer.extend_from_slice(&tcp_buffer[..n]);
+                                    buffers.frame.extend_from_slice(&buffers.tcp[..n]);
 
-                                    while let Some((start, end)) = Hdlc::find(&frame_buffer) {
-                                        let frame = &frame_buffer[start..=end];
-                                        let mut output = OutputBuffer::new(&mut hdlc_rx_buffer[..]);
+                                    while let Some((start, end)) = Hdlc::find(&buffers.frame) {
+                                        // Removing the two HDLC flags is an upper bound for
+                                        // decoded data; escaped frames decode to less. The MTU
+                                        // remains the hard ceiling.
+                                        let decoded_len = (end - start + 1).saturating_sub(2).min(mtu);
+                                        buffers.decoded.resize(decoded_len, 0);
+                                        let frame = &buffers.frame[start..=end];
+                                        let mut output = OutputBuffer::new(buffers.decoded.as_mut_slice());
                                         if Hdlc::decode(frame, &mut output).is_ok() {
                                             if let Ok(packet) =
                                                 Packet::deserialize(&mut InputBuffer::new(output.as_slice()))
@@ -558,13 +622,13 @@ pub(crate) async fn run_hdlc_stream_with_runtime<R, W>(
 
                                         // Drop all bytes up to and including the closing
                                         // flag of the frame we just handled.
-                                        frame_buffer.drain(..=end);
+                                        buffers.frame.drain(..=end);
                                     }
 
                                     let frame_buffer_limit = max_hdlc_frame_buffer_len(mtu);
-                                    let buffered = frame_buffer.len();
+                                    let buffered = buffers.frame.len();
                                     if trim_malformed_hdlc_backlog(
-                                        &mut frame_buffer,
+                                        &mut buffers.frame,
                                         frame_buffer_limit,
                                         mtu,
                                     ) {
@@ -578,7 +642,7 @@ pub(crate) async fn run_hdlc_stream_with_runtime<R, W>(
                                             label,
                                             iface_address,
                                             buffered,
-                                            frame_buffer.len(),
+                                            buffers.frame.len(),
                                             frame_buffer_limit
                                         );
                                     }
@@ -623,15 +687,13 @@ pub(crate) async fn run_hdlc_stream_with_runtime<R, W>(
         tokio::spawn(async move {
             let mut last_write_at = Instant::now();
             let mut stale = false;
+            let mut buffers = TcpTxBuffers::default();
             let mut watchdog_tick = tokio::time::interval(Duration::from_secs(1));
             watchdog_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
                 if stop.is_cancelled() {
                     break;
                 }
-
-                let mut hdlc_tx_buffer = vec![0u8; tcp_wire_buffer_capacity(mtu)];
-                let mut tx_buffer = vec![0u8; mtu];
 
                 let mut tx_channel = tx_channel.lock().await;
 
@@ -709,10 +771,10 @@ pub(crate) async fn run_hdlc_stream_with_runtime<R, W>(
                             log::trace!("tx >> ({}) {}", iface_address, packet);
                         }
                         log::debug!("[tp-diag] {} tx_dequeue iface={} {}", label, iface_address, packet);
-                        let mut output = OutputBuffer::new(&mut tx_buffer);
-                        if packet.serialize(&mut output).is_ok() {
+                        match buffers.encode_packet(&packet, mtu) {
+                            Ok((raw_len, wire)) => {
                             if let Some(bitrate_bps) = forced_bitrate_bps {
-                                if let Some(delay) = forced_bitrate_delay(output.as_slice().len(), bitrate_bps) {
+                                if let Some(delay) = forced_bitrate_delay(raw_len, bitrate_bps) {
                                     tokio::select! {
                                         _ = cancel.cancelled() => break,
                                         _ = iface_stop_tx.cancelled() => {
@@ -724,9 +786,7 @@ pub(crate) async fn run_hdlc_stream_with_runtime<R, W>(
                                     }
                                 }
                             }
-                            let mut hdlc_output = OutputBuffer::new(&mut hdlc_tx_buffer[..]);
-                            if Hdlc::encode(output.as_slice(), &mut hdlc_output).is_ok() {
-                                if let Err(err) = stream.write_all(hdlc_output.as_slice()).await {
+                                if let Err(err) = stream.write_all(wire).await {
                                     log::warn!("[tp-diag] write_all failed iface={} err={}", iface_address, err);
                                     send_hdlc_stream_event(
                                         &events,
@@ -747,28 +807,24 @@ pub(crate) async fn run_hdlc_stream_with_runtime<R, W>(
                                 last_write_at = Instant::now();
                                 send_hdlc_stream_event(
                                     &events,
-                                    HdlcStreamEvent::Write { bytes: hdlc_output.as_slice().len() },
+                                    HdlcStreamEvent::Write { bytes: wire.len() },
                                 );
                                 log::debug!(
                                     "[tp-diag] {} tx_write_ok iface={} wire_len={} raw_len={}",
                                     label,
                                     iface_address,
-                                    hdlc_output.as_slice().len(),
-                                    output.as_slice().len()
-                                );
-                            } else {
-                                log::warn!(
-                                    "[tp-diag] hdlc_encode failed iface={} raw_len={}",
-                                    iface_address,
-                                    output.as_slice().len()
+                                    wire.len(),
+                                    raw_len
                                 );
                             }
-                        } else {
+                            Err(err) => {
                             log::warn!(
-                                "[tp-diag] serialize failed iface={} buffer_cap={}",
+                                "[tp-diag] serialize or HDLC encode failed iface={} mtu={} err={:?}",
                                 iface_address,
-                                tx_buffer.len()
+                                mtu,
+                                err
                             );
+                            }
                         }
                     }
                 };
@@ -2111,3 +2167,7 @@ mod tests {
         assert!(saw_error_event, "expected an Error event from the simulated reset");
     }
 }
+
+#[cfg(test)]
+#[path = "tcp_client_memory_tests.rs"]
+mod memory_tests;

--- a/crates/libs/rns-transport/src/iface/tcp_client_memory_tests.rs
+++ b/crates/libs/rns-transport/src/iface/tcp_client_memory_tests.rs
@@ -1,0 +1,320 @@
+use std::collections::VecDeque;
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    run_hdlc_stream_with_runtime, tcp_read_buffer_len, tcp_wire_buffer_capacity, HdlcStreamEvent,
+    HdlcStreamRuntime, HdlcStreamWatchdog, TcpClient, TcpRxBuffers, TcpTxBuffers,
+    HDLC_STREAM_EVENT_CHANNEL_CAPACITY,
+};
+use crate::buffer::{InputBuffer, OutputBuffer};
+use crate::hash::AddressHash;
+use crate::iface::hdlc::Hdlc;
+use crate::iface::{RxMessage, TxMessage, TxMessageType};
+use crate::packet::{Packet, PacketDataBuffer};
+
+struct ChunkedReader {
+    chunks: VecDeque<Vec<u8>>,
+}
+
+impl ChunkedReader {
+    fn new(chunks: impl IntoIterator<Item = Vec<u8>>) -> Self {
+        Self { chunks: chunks.into_iter().collect() }
+    }
+}
+
+impl AsyncRead for ChunkedReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if let Some(chunk) = self.chunks.pop_front() {
+            buffer.put_slice(&chunk);
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+struct PendingReader;
+
+impl AsyncRead for PendingReader {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Poll::Pending
+    }
+}
+
+struct BrokenWriter;
+
+impl AsyncWrite for BrokenWriter {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _buffer: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(Err(io::Error::new(io::ErrorKind::BrokenPipe, "simulated disconnect")))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+fn frame_for_packet(packet: &Packet) -> Vec<u8> {
+    let raw = packet.to_bytes().expect("serialize packet");
+    let mut wire = vec![0_u8; tcp_wire_buffer_capacity(raw.len())];
+    let used = {
+        let mut output = OutputBuffer::new(wire.as_mut_slice());
+        Hdlc::encode(&raw, &mut output).expect("encode packet");
+        output.offset()
+    };
+    wire.truncate(used);
+    wire
+}
+
+async fn decode_chunks(chunks: impl IntoIterator<Item = Vec<u8>>, mtu: usize) -> Vec<RxMessage> {
+    let cancel = CancellationToken::new();
+    let iface_stop = CancellationToken::new();
+    let (rx_sender, mut rx_receiver) = tokio::sync::mpsc::channel(8);
+    let (_tx_sender, tx_receiver) = tokio::sync::mpsc::channel(1);
+    run_hdlc_stream_with_runtime(
+        "memory-test".to_string(),
+        AddressHash::new([0x51; 16]),
+        mtu,
+        cancel,
+        iface_stop,
+        rx_sender,
+        Arc::new(tokio::sync::Mutex::new(tx_receiver)),
+        ChunkedReader::new(chunks),
+        tokio::io::sink(),
+        HdlcStreamRuntime::new(),
+    )
+    .await;
+
+    let mut messages = Vec::new();
+    while let Ok(message) = rx_receiver.try_recv() {
+        messages.push(message);
+    }
+    messages
+}
+
+#[test]
+fn idle_stream_buffers_are_small_and_tx_is_lazy() {
+    let mtu = TcpClient::DEFAULT_MTU;
+    let rx = TcpRxBuffers::new(mtu);
+    let tx = TcpTxBuffers::default();
+
+    assert_eq!(tcp_read_buffer_len(mtu), 32 * 1024);
+    assert_eq!(rx.tcp.len(), 32 * 1024);
+    assert!(rx.frame.capacity() <= 4 * 1024);
+    assert_eq!(rx.decoded.capacity(), 0);
+    assert_eq!(tx.raw.capacity(), 0);
+    assert_eq!(tx.wire.capacity(), 0);
+    assert!(
+        rx.tcp.capacity() + rx.frame.capacity() < 64 * 1024,
+        "idle connection must not reserve memory proportional to mtu * 16"
+    );
+}
+
+#[test]
+fn tx_buffers_are_reused_and_stale_bytes_are_not_exposed() {
+    let mtu = 4096;
+    let mut buffers = TcpTxBuffers::default();
+    let first =
+        Packet { data: PacketDataBuffer::new_from_slice(&vec![0x7e; 512]), ..Default::default() };
+
+    let (first_raw_len, first_wire_len, raw_ptr, wire_ptr, raw_capacity, wire_capacity) = {
+        let (raw_len, wire) = buffers.encode_packet(&first, mtu).expect("encode first packet");
+        (
+            raw_len,
+            wire.len(),
+            buffers.raw.as_ptr(),
+            buffers.wire.as_ptr(),
+            buffers.raw.capacity(),
+            buffers.wire.capacity(),
+        )
+    };
+    assert!(first_wire_len > first_raw_len);
+
+    let second =
+        Packet { data: PacketDataBuffer::new_from_slice(&vec![0x42; 512]), ..Default::default() };
+    let second_wire = {
+        let (_, wire) = buffers.encode_packet(&second, mtu).expect("encode second packet");
+        wire.to_vec()
+    };
+    assert_eq!(buffers.raw.as_ptr(), raw_ptr);
+    assert_eq!(buffers.wire.as_ptr(), wire_ptr);
+    assert_eq!(buffers.raw.capacity(), raw_capacity);
+    assert_eq!(buffers.wire.capacity(), wire_capacity);
+
+    let mut decoded = vec![0_u8; mtu];
+    let decoded_len = {
+        let mut output = OutputBuffer::new(decoded.as_mut_slice());
+        Hdlc::decode(&second_wire, &mut output).expect("decode second packet");
+        output.offset()
+    };
+    let expected = second.to_bytes().expect("serialize second packet");
+    assert_eq!(&decoded[..decoded_len], expected.as_slice());
+}
+
+#[tokio::test]
+async fn valid_frame_split_across_single_byte_reads_is_reassembled() {
+    let packet = Packet {
+        data: PacketDataBuffer::new_from_slice(b"split-across-many-reads"),
+        ..Default::default()
+    };
+    let frame = frame_for_packet(&packet);
+    let messages = decode_chunks(frame.into_iter().map(|byte| vec![byte]), 4096).await;
+
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].packet, packet);
+}
+
+#[tokio::test]
+async fn multiple_frames_in_one_read_are_all_delivered() {
+    let first = Packet { data: PacketDataBuffer::new_from_slice(b"first"), ..Default::default() };
+    let second = Packet { data: PacketDataBuffer::new_from_slice(b"second"), ..Default::default() };
+    let mut combined = frame_for_packet(&first);
+    combined.extend_from_slice(&frame_for_packet(&second));
+
+    let messages = decode_chunks([combined], 4096).await;
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].packet, first);
+    assert_eq!(messages[1].packet, second);
+}
+
+#[tokio::test]
+async fn maximum_mtu_frame_is_delivered_across_fixed_size_reads() {
+    let mtu = TcpClient::DEFAULT_MTU;
+    let base_len = Packet::default().serialized_len().expect("default packet length");
+    let packet = Packet {
+        data: PacketDataBuffer::new_from_slice(&vec![0x55; mtu - base_len]),
+        ..Default::default()
+    };
+    assert_eq!(packet.serialized_len().expect("maximum packet length"), mtu);
+    let frame = frame_for_packet(&packet);
+    let chunks = frame.chunks(997).map(<[u8]>::to_vec).collect::<Vec<_>>();
+
+    let messages = decode_chunks(chunks, mtu).await;
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].packet.data.len(), mtu - base_len);
+    assert_eq!(messages[0].packet, packet);
+}
+
+#[tokio::test]
+async fn maximum_escaping_frame_is_delivered() {
+    let mtu = 4096;
+    let base_len = Packet::default().serialized_len().expect("default packet length");
+    let payload = (0..mtu - base_len)
+        .map(|index| if index % 2 == 0 { 0x7e } else { 0x7d })
+        .collect::<Vec<_>>();
+    let packet = Packet { data: PacketDataBuffer::new_from_slice(&payload), ..Default::default() };
+    let frame = frame_for_packet(&packet);
+    assert!(frame.len() > mtu * 2 - 64, "test must exercise near-maximum expansion");
+
+    let messages = decode_chunks(frame.chunks(31).map(<[u8]>::to_vec), mtu).await;
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].packet, packet);
+}
+
+#[tokio::test]
+async fn tx_disconnect_stops_both_stream_tasks() {
+    let cancel = CancellationToken::new();
+    let iface_stop = CancellationToken::new();
+    let (rx_sender, _rx_receiver) = tokio::sync::mpsc::channel(1);
+    let (tx_sender, tx_receiver) = tokio::sync::mpsc::channel(1);
+    let (event_sender, mut event_receiver) =
+        tokio::sync::mpsc::channel(HDLC_STREAM_EVENT_CHANNEL_CAPACITY);
+    tx_sender
+        .send(TxMessage { tx_type: TxMessageType::Broadcast(None), packet: Packet::default() })
+        .await
+        .expect("queue packet");
+
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        run_hdlc_stream_with_runtime(
+            "broken-writer".to_string(),
+            AddressHash::new([0x52; 16]),
+            4096,
+            cancel,
+            iface_stop,
+            rx_sender,
+            Arc::new(tokio::sync::Mutex::new(tx_receiver)),
+            PendingReader,
+            BrokenWriter,
+            HdlcStreamRuntime::new().with_events(event_sender),
+        ),
+    )
+    .await
+    .expect("stream must stop after TX disconnect");
+
+    assert!(
+        std::iter::from_fn(|| event_receiver.try_recv().ok())
+            .any(|event| matches!(event, HdlcStreamEvent::Error { .. })),
+        "TX disconnect must emit an error event"
+    );
+}
+
+#[tokio::test]
+async fn watchdog_stream_cancels_promptly_while_tx_is_idle() {
+    let cancel = CancellationToken::new();
+    let iface_stop = CancellationToken::new();
+    let (rx_sender, _rx_receiver) = tokio::sync::mpsc::channel(1);
+    let (_tx_sender, tx_receiver) = tokio::sync::mpsc::channel(1);
+    let task = tokio::spawn(run_hdlc_stream_with_runtime(
+        "idle-watchdog".to_string(),
+        AddressHash::new([0x53; 16]),
+        TcpClient::DEFAULT_MTU,
+        cancel.clone(),
+        iface_stop,
+        rx_sender,
+        Arc::new(tokio::sync::Mutex::new(tx_receiver)),
+        PendingReader,
+        tokio::io::sink(),
+        HdlcStreamRuntime::new().with_watchdog(HdlcStreamWatchdog {
+            keepalive_after: Duration::from_secs(60),
+            stale_after: Duration::from_secs(120),
+            read_timeout: Duration::from_secs(180),
+        }),
+    ));
+
+    tokio::task::yield_now().await;
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_secs(1), task)
+        .await
+        .expect("idle watchdog stream must observe cancellation")
+        .expect("stream task must not panic");
+}
+
+#[test]
+fn second_tx_frame_decodes_without_bytes_from_the_first() {
+    let mut buffers = TcpTxBuffers::default();
+    let large =
+        Packet { data: PacketDataBuffer::new_from_slice(&vec![0x7e; 2048]), ..Default::default() };
+    let _ = buffers.encode_packet(&large, 4096).expect("encode large frame");
+
+    let small = Packet { data: PacketDataBuffer::new_from_slice(b"small"), ..Default::default() };
+    let (_, wire) = buffers.encode_packet(&small, 4096).expect("encode small frame");
+    let mut raw = vec![0_u8; 4096];
+    let raw_len = {
+        let mut output = OutputBuffer::new(raw.as_mut_slice());
+        Hdlc::decode(wire, &mut output).expect("decode reused frame");
+        output.offset()
+    };
+    let decoded = Packet::deserialize(&mut InputBuffer::new(&raw[..raw_len])).expect("packet");
+    assert_eq!(decoded, small);
+}

--- a/crates/libs/rns-transport/src/iface_parts/interfacemanager_send.rs
+++ b/crates/libs/rns-transport/src/iface_parts/interfacemanager_send.rs
@@ -261,8 +261,8 @@ enum TxIfaceSendResult {
 }
 
 fn packet_wire_len_for_dispatch(message: &TxMessage) -> Option<usize> {
-    match message.packet.to_bytes() {
-        Ok(raw) => Some(raw.len()),
+    match message.packet.serialized_len() {
+        Ok(wire_len) => Some(wire_len),
         Err(err) => {
             log::warn!(
                 "tx packet serialize failed before interface enqueue tx_type={:?} \

--- a/crates/libs/rns-transport/src/packet.rs
+++ b/crates/libs/rns-transport/src/packet.rs
@@ -233,7 +233,7 @@ impl Packet {
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, RnsError> {
-        let mut out = Vec::with_capacity(2 + ADDRESS_HASH_SIZE + 1 + self.data.len());
+        let mut out = Vec::with_capacity(self.serialized_len()?);
 
         out.push(self.header.to_meta());
         out.push(self.header.hops);
@@ -248,6 +248,20 @@ impl Packet {
         out.extend_from_slice(self.data.as_slice());
 
         Ok(out)
+    }
+
+    /// Exact number of bytes produced by the Reticulum packet serializer.
+    ///
+    /// This excludes HDLC framing and validates the same type-2 transport
+    /// address requirement as [`Self::to_bytes`].
+    pub fn serialized_len(&self) -> Result<usize, RnsError> {
+        let transport_len = if self.header.header_type == HeaderType::Type2 {
+            self.transport.ok_or(RnsError::InvalidArgument)?;
+            ADDRESS_HASH_SIZE
+        } else {
+            0
+        };
+        Ok(2 + transport_len + ADDRESS_HASH_SIZE + 1 + self.data.len())
     }
 
     /// Packet hash used for deduplication, cache keys, and proofs.
@@ -416,5 +430,31 @@ mod tests {
             different_packet_type.hash(),
             "packet_type is inside the mask and must affect the hash"
         );
+    }
+
+    #[test]
+    fn serialized_len_matches_type1_and_type2_wire_output() {
+        let type1 = base_packet();
+        assert_eq!(
+            type1.serialized_len().expect("type-1 length"),
+            type1.to_bytes().expect("type-1 bytes").len()
+        );
+
+        let mut type2 = base_packet();
+        type2.header.header_type = HeaderType::Type2;
+        type2.transport = Some(AddressHash::new([0x24; 16]));
+        assert_eq!(
+            type2.serialized_len().expect("type-2 length"),
+            type2.to_bytes().expect("type-2 bytes").len()
+        );
+    }
+
+    #[test]
+    fn serialized_len_rejects_type2_packet_without_transport_address() {
+        let mut packet = base_packet();
+        packet.header.header_type = HeaderType::Type2;
+
+        assert!(packet.serialized_len().is_err());
+        assert!(packet.to_bytes().is_err());
     }
 }

--- a/crates/libs/rns-transport/tests/tcp_connection_memory.rs
+++ b/crates/libs/rns-transport/tests/tcp_connection_memory.rs
@@ -1,0 +1,90 @@
+use std::net::{Ipv4Addr, SocketAddrV4, TcpListener as StdTcpListener};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use rns_transport::buffer::OutputBuffer;
+use rns_transport::iface::hdlc::Hdlc;
+use rns_transport::iface::tcp_client::TcpClient;
+use rns_transport::iface::tcp_server::TcpServer;
+use rns_transport::iface::InterfaceManager;
+use rns_transport::packet::{Packet, PacketDataBuffer};
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+
+fn reserve_loopback_addr() -> SocketAddrV4 {
+    let listener = StdTcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve loopback port");
+    let addr = match listener.local_addr().expect("reserved address") {
+        std::net::SocketAddr::V4(addr) => addr,
+        std::net::SocketAddr::V6(_) => unreachable!("IPv4 bind returned IPv6"),
+    };
+    drop(listener);
+    addr
+}
+
+async fn wait_for(mut condition: impl FnMut() -> bool, label: &str) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !condition() {
+        assert!(Instant::now() < deadline, "timed out waiting for {label}");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn tcp_server_handles_many_idle_then_active_small_connections() {
+    const CONNECTIONS: usize = 128;
+    let addr = reserve_loopback_addr();
+    let manager = Arc::new(tokio::sync::Mutex::new(InterfaceManager::new(512)));
+    let receiver = manager.lock().await.receiver();
+    let server = TcpServer::new(addr.to_string(), manager.clone());
+    let status = server.runtime_status_handle();
+    let server_iface = manager.lock().await.spawn(server, TcpServer::spawn);
+
+    wait_for(
+        || status.to_json()["listener_state"].as_str() == Some("listening"),
+        "TCP listener startup",
+    )
+    .await;
+
+    let mut clients = Vec::with_capacity(CONNECTIONS);
+    for _ in 0..CONNECTIONS {
+        clients.push(TcpStream::connect(addr).await.expect("connect idle client"));
+    }
+    wait_for(
+        || status.to_json()["accepted_connections"].as_u64() == Some(CONNECTIONS as u64),
+        "idle connections",
+    )
+    .await;
+
+    let packet = Packet {
+        data: PacketDataBuffer::new_from_slice(b"small-active-packet"),
+        ..Default::default()
+    };
+    let raw = packet.to_bytes().expect("serialize packet");
+    let mut frame = vec![0_u8; raw.len() * 2 + 2];
+    let frame_len = {
+        let mut output = OutputBuffer::new(frame.as_mut_slice());
+        Hdlc::encode(&raw, &mut output).expect("encode frame");
+        output.offset()
+    };
+    for client in &mut clients {
+        client.write_all(&frame[..frame_len]).await.expect("send small packet");
+    }
+
+    let mut received = 0_usize;
+    while received < CONNECTIONS {
+        let message = tokio::time::timeout(Duration::from_secs(10), receiver.lock().await.recv())
+            .await
+            .expect("receive deadline")
+            .expect("received packet");
+        assert_eq!(message.packet.data.as_slice(), b"small-active-packet");
+        received += 1;
+    }
+
+    drop(clients);
+    assert!(manager.lock().await.stop_interface(server_iface));
+}
+
+#[test]
+fn default_tcp_mtu_remains_reticulum_compatible() {
+    assert_eq!(TcpClient::DEFAULT_MTU, 262_144);
+}

--- a/docs/performance/tcp-connection-memory.md
+++ b/docs/performance/tcp-connection-memory.md
@@ -1,0 +1,203 @@
+# TCP connection memory
+
+This report isolates the user-space memory retained by accepted
+`TcpServer`/`TcpClient` streams. It does not treat Tokio tasks as operating-system
+threads and does not include kernel TCP buffer memory in process RSS.
+
+## Baseline allocation audit
+
+At the default TCP MTU of 262,144 bytes, the stream implementation at revision
+`93ec0eac4065fe2f7953cbe5fee67cace73eb4b4` requests the following buffers for
+each accepted connection:
+
+| Buffer | Requested bytes | Lifetime and commitment |
+| --- | ---: | --- |
+| decoded HDLC receive buffer | 262,144 | Allocated when the RX task starts; pages are touched as decoded output is written. |
+| HDLC reassembly capacity | 1,048,576 | Reserved when the RX task starts by `Vec::with_capacity`; logical length and committed pages grow with received data. |
+| TCP read buffer | 4,194,304 | Allocated when the RX task starts; the kernel writes into pages covered by each read. |
+| encoded HDLC transmit buffer | 524,304 | Allocated before the TX task waits for work and reallocated on every TX-loop iteration. |
+| raw packet transmit buffer | 262,144 | Allocated with the encoded buffer and reallocated on every TX-loop iteration. |
+| **total requested buffer storage** | **6,291,472 (6.00 MiB)** | Excludes allocator metadata, tasks, channels, packet queues and socket state. |
+
+The malformed-input limit is 1,048,608 bytes: twice the worst-case encoded
+wire length for one MTU-sized frame. The `mtu * 16` TCP read buffer is not used
+as a protocol limit. HDLC reassembly already spans reads, and no test or
+protocol rule requires a single read to contain sixteen MTUs.
+
+Each live accepted stream also owns an interface task, RX task, TX task and
+status task. It has a 128-entry bounded TX channel and shares the transport's
+128-entry RX channel. Empty Tokio channels do not contain packet payloads, but
+queued `TxMessage` values do: `PacketDataBuffer` is a `Vec<u8>`, so broadcast
+`message.clone()` currently copies packet payload data once per selected
+interface. This fan-out issue is separate from the fixed per-connection stream
+buffers.
+
+Kernel send/receive buffers, TCP control structures and file-descriptor tables
+are charged by the operating system and are not visible in process RSS. Their
+sizes depend on platform defaults, autotuning and traffic history.
+
+## Repeatable measurement
+
+Build and run the release-profile scenarios with:
+
+```sh
+python3 tools/scripts/tcp_connection_memory_benchmark.py \
+  --counts 100,500,1000 \
+  --activities idle,small \
+  --json-out artifacts/tcp-connection-memory.json
+```
+
+The runner starts a fresh process for every count/activity pair. On Linux it
+records `VmRSS`, `VmHWM` and `VmSize` from `/proc/self/status`; on every platform
+it records Tokio live-task counts, transferred packets/bytes, elapsed time, CPU
+ticks where available, and broadcast dispatch failures. Client sockets live in
+the same process, so their small and consistent overhead is included in both
+baseline and optimized measurements.
+
+Measurements below use the release profile on the same host for both builds:
+Linux 7.0.0-28-generic x86_64, rustc 1.96.0. The client sockets are in the
+benchmark process, so slopes include the client-side Tokio socket objects as
+well as the accepted server interfaces.
+
+## Results
+
+The idle figures are sampled after a 300 ms settle period. A slope is
+`(connected - pre-connect baseline) / connections`.
+
+| Idle connections | Baseline RSS slope | Optimized RSS slope | Baseline `VmSize` slope | Optimized `VmSize` slope | Tokio tasks |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 100 | 35.84 KiB/conn | 28.76 KiB/conn | 6,165.56 KiB/conn | 1.56 KiB/conn | 403 |
+| 500 | 33.46 KiB/conn | 25.82 KiB/conn | 6,164.98 KiB/conn | 0.98 KiB/conn | 2,003 |
+| 1,000 | 33.09 KiB/conn | 25.34 KiB/conn | 6,164.97 KiB/conn | 0.96 KiB/conn | 4,003 |
+
+At 1,000 idle connections, RSS falls from 37,268 KiB to 29,520 KiB. More
+importantly, the connection-driven `VmSize` increase falls from 6,164,968 KiB
+to 960 KiB. RSS was already much lower than the requested buffer total because
+zero-filled and capacity-only allocations do not commit every page
+immediately. `VmSize` exposes the address-space reservation that RSS alone
+misses.
+
+After one 85-byte wire frame is received from every connection, the 1,000
+connection RSS slope is 33.09 KiB before and 25.56 KiB after. Lazy buffer growth
+therefore does not recreate the old fixed reservation for normal packets.
+
+Maximum-frame measurements use one 262,146-byte HDLC frame per connection:
+
+| 100 maximum frames | Baseline | Optimized |
+| --- | ---: | ---: |
+| Peak RSS slope | 715.56 KiB/conn | 713.24 KiB/conn |
+| Post-transfer `VmSize` slope | 6,168.12 KiB/conn | 416.76 KiB/conn |
+| Throughput | 5,118 packets/s | 5,373 packets/s |
+| Aggregate process CPU ticks | 11 | 19 |
+
+The maximum-frame RSS peak is intentionally not eliminated: receiving a real
+maximum frame must commit reassembly and decode storage. The optimized build
+stops retaining unrelated maximum-size TCP and TX buffers. CPU ticks are Linux
+process ticks and are coarse for this short, parallel workload; maximum-frame
+growth performs allocation work that the baseline paid at connection startup.
+
+For normal 64-byte payloads at 1,000 connections, the same zero-settle run
+reported 60,849 packets/s before and 58,509 packets/s after, with one aggregate
+CPU tick in both runs. The 3.8% difference is within the scheduling resolution
+of this short loopback test; longer application benchmarks should be used for
+capacity planning.
+
+A single 64-byte broadcast with 100 accepted clients matched and enqueued to
+all 101 selected interfaces with zero enqueue failures. Use `--broadcasts N`
+to exercise queue saturation; the JSON reports matched, sent and failed
+interface counts.
+
+## Allocation changes
+
+An idle accepted connection now requests 32 KiB for TCP reads and an initial
+4 KiB HDLC reassembly capacity. The decoded RX buffer and both TX buffers start
+empty, reducing direct idle buffer requests from 6.00 MiB to about 36 KiB.
+
+- The TCP read buffer is independent of MTU. TCP streaming and HDLC reassembly
+  preserve frames split across reads and multiple frames in one read.
+- HDLC reassembly starts at 4 KiB and grows as encoded bytes arrive. Its
+  malformed-stream limit remains derived from the MTU and worst-case HDLC
+  escaping. A partial frame after the last flag is retained only while it can
+  still be valid.
+- The decoded buffer grows only when a complete frame is found and remains
+  capped by the configured MTU.
+- TX raw and HDLC buffers are allocated on the first outgoing packet, sized
+  from that packet, and retained for reuse. Only the newly encoded logical
+  slice is written, so cancellation, failed writes and smaller later packets
+  cannot expose stale bytes.
+- Dispatch length checks use `Packet::serialized_len()` instead of allocating
+  a serialized packet solely to measure it.
+
+`Vec` growth can temporarily hold the old and new allocation while a large
+reassembly buffer is moved. That temporary peak occurs only after receiving a
+large partial frame; normal packets remain within the initial capacity. The
+logical malformed backlog is bounded and is trimmed after each 32 KiB read.
+
+## Remaining limits
+
+- Accepted streams still use four Tokio tasks each. This is not an OS
+  thread-per-connection model, but task state and scheduling remain linear in
+  the client count.
+- Each client retains a 128-entry TX channel. Queued packets consume memory,
+  and slow readers can fill queues and kernel send buffers.
+- `PacketDataBuffer` is a `Vec<u8>`. `InterfaceManager` broadcast
+  `message.clone()` therefore copies payload storage once per target interface.
+  Converting packet ownership to shared immutable storage is a separate,
+  routing-wide change and was not mixed into this buffer patch.
+- `InterfaceManager` locking and sequential fan-out work grow with the number
+  of interfaces even when payload copies are small.
+- Kernel socket buffers and TCP control blocks are outside process RSS and are
+  controlled by each operating system. File-descriptor limits remain an
+  independent ceiling on Linux and macOS; Windows has its own handle and socket
+  resource limits.
+- No client limit was added. Current behavior remains unlimited, and runtime
+  status exposes cumulative accepted connections rather than active/rejected
+  counts. Admission control can be added separately as optional protection; it
+  is not a substitute for the allocation reduction.
+
+## Validation performed
+
+The following commands passed on the measured Linux host:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy -p reticulum-rs-transport --all-targets --all-features \
+  --no-deps -- -D warnings
+cargo test -p reticulum-rs-transport --no-default-features
+cargo test -p reticulumd --test code_quality_issue_369
+cargo test -p reticulumd \
+  --test backbone_python_channel_interop_contract \
+  --test backbone_selector_backpressure_probe_contract
+tools/scripts/check-boundaries.sh
+tools/scripts/check-module-size.sh
+```
+
+The transport suite passed 636 library tests plus all package integration
+tests. Live TCP and Backbone channel round trips passed in both directions
+against the local Python Reticulum 1.3.8 checkout:
+
+```sh
+RETICULUM_PY_REPO=../Reticulum \
+  cargo test -p reticulumd --test python_channel_interop \
+  backbone_channel_roundtrip -- --ignored --nocapture
+RETICULUM_PY_REPO=../Reticulum \
+  cargo test -p reticulumd --test python_channel_interop \
+  _to_rust_channel_roundtrip -- --ignored --nocapture
+RETICULUM_PY_REPO=../Reticulum \
+  cargo test -p reticulumd --test python_channel_interop \
+  rust_to_python_channel_roundtrip -- --ignored --exact --nocapture
+```
+
+Cross-target checks passed without platform-specific event APIs. Zig was used
+only to compile bundled C dependencies while checking from Linux:
+
+```sh
+env CC_x86_64_pc_windows_gnu='zig cc -target x86_64-windows-gnu' \
+  AR_x86_64_pc_windows_gnu='zig ar' CRATE_CC_NO_DEFAULTS=1 \
+  cargo check -p reticulum-rs-transport --lib --no-default-features \
+  --target x86_64-pc-windows-gnu
+env CC_x86_64_apple_darwin='zig cc -target x86_64-macos' \
+  AR_x86_64_apple_darwin='zig ar' CRATE_CC_NO_DEFAULTS=1 \
+  cargo check -p reticulum-rs-transport --lib --no-default-features \
+  --target x86_64-apple-darwin
+```

--- a/tools/scripts/tcp_connection_memory_benchmark.py
+++ b/tools/scripts/tcp_connection_memory_benchmark.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Run repeatable TCP connection RSS/virtual-memory scenarios.
+
+The benchmark keeps client sockets in the same process as the Rust TCP server.
+That adds a small, consistent client-side cost, while isolating the comparison
+from external process timing. Linux reports RSS, peak RSS and virtual memory
+from /proc; other platforms still exercise the workload and report task and
+throughput counters with memory fields set to null.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PACKAGE = "reticulum-rs-transport"
+EXAMPLE = "tcp_connection_memory"
+
+
+def run(command: list[str], *, capture: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--counts", default="100,500,1000")
+    parser.add_argument("--activities", default="idle,small")
+    parser.add_argument("--mtu", type=int, default=262_144)
+    parser.add_argument("--settle-ms", type=int, default=500)
+    parser.add_argument("--broadcasts", type=int, default=0)
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--skip-build", action="store_true")
+    args = parser.parse_args()
+
+    counts = [int(value) for value in args.counts.split(",") if value]
+    activities = [value for value in args.activities.split(",") if value]
+    if not args.skip_build:
+        run(["cargo", "build", "--release", "-p", PACKAGE, "--example", EXAMPLE])
+
+    executable = ROOT / "target" / "release" / "examples" / EXAMPLE
+    if sys.platform == "win32":
+        executable = executable.with_suffix(".exe")
+
+    results: list[dict[str, Any]] = []
+    for activity in activities:
+        for count in counts:
+            completed = run(
+                [
+                    str(executable),
+                    "--connections",
+                    str(count),
+                    "--activity",
+                    activity,
+                    "--mtu",
+                    str(args.mtu),
+                    "--settle-ms",
+                    str(args.settle_ms),
+                    "--broadcasts",
+                    str(args.broadcasts),
+                ],
+                capture=True,
+            )
+            results.append(json.loads(completed.stdout))
+
+    output = {
+        "schema": "lxmf-rs-tcp-connection-memory-v1",
+        "git_revision": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+        ).strip(),
+        "results": results,
+    }
+    text = json.dumps(output, indent=2, sort_keys=True) + "\n"
+    if args.json_out:
+        destination = args.json_out if args.json_out.is_absolute() else ROOT / args.json_out
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(text, encoding="utf-8")
+    sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- replace the per-connection `mtu * 16` TCP read buffer with a 32 KiB streaming buffer
- grow HDLC reassembly and decode storage on demand while retaining the MTU-derived malformed-input bound
- allocate TX buffers lazily, reuse them across packets, and expose only the newly encoded slice
- avoid serializing a packet solely to determine its dispatch length
- add focused framing/lifecycle tests, a many-connection integration test, a repeatable benchmark, and a baseline/after report

## Root cause and impact

The accepted TCP path already uses Tokio tasks rather than one OS thread per connection. The scalability issue was fixed buffer reservation: at the default 262,144-byte MTU, RX and TX requested 6,291,472 bytes per accepted connection even while idle.

The optimized idle path requests about 36 KiB directly: a 32 KiB TCP read buffer plus 4 KiB initial HDLC reassembly capacity. Decode and TX storage remain empty until traffic requires them.

On the same Linux release build at 1,000 idle connections:

| Metric | Before | After |
| --- | ---: | ---: |
| RSS | 37,268 KiB | 29,520 KiB |
| connection-driven VmSize | 6,164,968 KiB | 960 KiB |
| RSS slope | 33.09 KiB/connection | 25.34 KiB/connection |

Maximum-size frames remain accepted and retain the configured MTU. Their peak RSS is intentionally similar because that storage is genuinely needed during transfer.

## Compatibility

- no Reticulum wire or HDLC encoding changes
- no default MTU reduction
- no direct epoll dependency; all socket work remains on Tokio
- TCP and Backbone channel round trips pass in both directions against Python Reticulum 1.3.8
- Windows GNU and macOS cross-target checks pass
- no hard-coded connection limit was added

Broadcast payload cloning, per-interface queues, InterfaceManager locking, kernel socket buffers, and descriptor/handle limits remain documented follow-up scalability boundaries.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p reticulum-rs-transport --all-targets --all-features --no-deps -- -D warnings`
- `cargo test -p reticulum-rs-transport --no-default-features` — 636 library tests plus all package integration tests passed
- `cargo test -p reticulumd --test code_quality_issue_369`
- Backbone interoperability and selector/backpressure contract tests
- live Python TCP and Backbone channel round trips in both directions
- `tools/scripts/check-boundaries.sh`
- `tools/scripts/check-module-size.sh`
- Windows and macOS cross-target checks for the library and benchmark example

The full allocation audit, commands, raw methodology, and before/after tables are in `docs/performance/tcp-connection-memory.md`.