### PR TITLE
feat(transport): feature-gate rusqlite storage behind default-on feature

### DIFF
--- a/crates/libs/rns-transport/Cargo.toml
+++ b/crates/libs/rns-transport/Cargo.toml
@@ -27,7 +27,7 @@ rmp-serde.workspace = true
 rmpv.workspace = true
 rmp = "0.8.14"
 rand_core = { workspace = true, features = ["getrandom"] }
-rusqlite = { workspace = true }
+rusqlite = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }
 serde_json.workspace = true
@@ -48,7 +48,8 @@ x25519-dalek = { workspace = true, features = ["static_secrets"] }
 rns-core.workspace = true
 
 [features]
-default = []
+default = ["storage"]
+storage = ["dep:rusqlite"]
 fernet-aes128 = []
 rnode-ble = ["dep:btleplug", "btleplug/serde", "dep:futures", "dep:uuid"]
 vrn76-kiss-ble = ["rnode-ble"]

--- a/crates/libs/rns-transport/src/lib.rs
+++ b/crates/libs/rns-transport/src/lib.rs
@@ -24,6 +24,7 @@ pub mod ratchets;
 pub mod receipt;
 pub mod resource;
 pub mod serde;
+#[cfg(feature = "storage")]
 pub mod storage;
 pub mod time;
 pub mod transport;

--- a/crates/libs/rns-transport/src/transport/mod.rs
+++ b/crates/libs/rns-transport/src/transport/mod.rs
@@ -79,6 +79,7 @@ pub use reticulum_path_store::{
     ReticulumPathTableRestoreSkipped,
 };
 
+#[cfg(feature = "storage")]
 pub mod test_bridge {
     use std::cell::RefCell;
     use std::collections::HashMap;

--- a/crates/libs/rns-transport/tests/storage_migrations.rs
+++ b/crates/libs/rns-transport/tests/storage_migrations.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "storage")]
 use rns_transport::storage::messages::MessagesStore;
 use rusqlite::Connection;
 


### PR DESCRIPTION
## Summary

Feature-gates `rusqlite` storage in `reticulum-rs-transport` behind a default-on `storage` feature flag.

- Marked `rusqlite` as optional in `crates/libs/rns-transport/Cargo.toml`.
- Added `storage = ["dep:rusqlite"]` and included `"storage"` in `default`.
- Feature-gated `storage` modules, `test_bridge`, and `tests/storage_migrations.rs`.

**Why:** Allows embedded, memory-constrained, or headless transport environments that do not require local SQLite message persistence to build `reticulum-rs-transport` without `rusqlite` (using `default-features = false`), while maintaining 100% backward compatibility for all existing consumers.

## Type
- [ ] breaking
- [x] refactor
- [ ] reliability
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo check -p reticulum-rs-transport`
- [x] `cargo check -p reticulum-rs-transport --no-default-features`
- [x] `cargo test -p reticulum-rs-transport`
- [x] `cargo check --workspace`

## Compatibility
- [x] Fully backward-compatible: default feature set is retained, ensuring existing builds remain byte-identical.