### PR TITLE
Add bearer-neutral RNode transport backend

### DIFF
--- a/crates/libs/rns-transport/src/iface.rs
+++ b/crates/libs/rns-transport/src/iface.rs
@@ -21,6 +21,10 @@ pub mod rnode_multi;
 
 pub mod rnode_ble;
 
+pub mod rnode_bearer;
+
+mod rnode_bearer_interface;
+
 pub mod rnode_spp;
 
 pub mod serial;

--- a/crates/libs/rns-transport/src/iface/rnode_bearer.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer.rs
@@ -32,6 +32,10 @@ pub struct RnodeBearerInfo {
 pub trait RnodeBearerBackend {
     async fn open(&mut self) -> Result<RnodeBearerInfo, String>;
 
+    /// Read the next available chunk.
+    ///
+    /// `Ok(None)` means no bytes are currently available. A closed or failed
+    /// transport must return `Err` so the single-attempt interface can stop.
     async fn read(&mut self) -> Result<Option<Vec<u8>>, String>;
 
     async fn write(&mut self, payload: Vec<u8>) -> Result<(), String>;
@@ -121,8 +125,8 @@ where
         self.inner.send_management_frame(frame).await
     }
 
-    pub async fn poll(&mut self) -> Result<RnodeBleNotification, RnodeBleKissError> {
-        self.inner.poll_notification_events().await
+    pub async fn poll(&mut self) -> Result<Option<RnodeBleNotification>, RnodeBleKissError> {
+        self.inner.poll_optional_notification_events().await
     }
 
     pub async fn shutdown(&mut self) -> Result<(), RnodeBleKissError> {
@@ -171,7 +175,6 @@ mod tests {
     struct TestBackend {
         opens: usize,
         closes: usize,
-        startup_drain_completed: bool,
         reads: VecDeque<Vec<u8>>,
         writes: Vec<Vec<u8>>,
     }
@@ -186,10 +189,6 @@ mod tests {
         }
 
         async fn read(&mut self) -> Result<Option<Vec<u8>>, String> {
-            if !self.startup_drain_completed {
-                self.startup_drain_completed = true;
-                return Ok(None);
-            }
             Ok(self.reads.pop_front())
         }
 
@@ -213,7 +212,7 @@ mod tests {
         let info = runtime.startup().await.expect("startup");
         assert_eq!(info.kind, RnodeBearerKind::BluetoothClassic);
         assert_eq!(runtime.negotiated_mtu(), Some(64));
-        let notification = runtime.poll().await.expect("poll");
+        let notification = runtime.poll().await.expect("poll").expect("notification");
         assert_eq!(notification.packets, vec![b"hello".to_vec()]);
         runtime.send_packet(b"world").await.expect("send packet");
         runtime.shutdown().await.expect("shutdown");
@@ -263,6 +262,16 @@ mod tests {
         let error = runtime.shutdown().await.expect_err("shutdown write should fail");
         assert!(matches!(error, RnodeBleKissError::Backend { operation: "shutdown_write", .. }));
         assert_eq!(runtime.into_backend().closes, 1);
+    }
+
+    #[tokio::test]
+    async fn empty_bearer_reads_remain_distinct_from_empty_notifications() {
+        let backend = TestBackend::default();
+        let mut runtime = RnodeBearerKissRuntime::new(backend, RnodeBleKissConfig::default());
+
+        runtime.startup().await.expect("startup");
+
+        assert_eq!(runtime.poll().await.expect("empty poll"), None);
     }
 
     #[derive(Clone, Copy)]

--- a/crates/libs/rns-transport/src/iface/rnode_bearer.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer.rs
@@ -1,0 +1,375 @@
+//! Bearer-neutral RNode transport contract.
+//!
+//! Platform owners implement raw, ordered byte I/O here. RNode probing,
+//! configuration, KISS framing, MTU validation, and flow control remain in
+//! this crate's shared protocol runtime.
+
+use super::rnode_ble::{
+    RnodeBleBackend, RnodeBleKissConfig, RnodeBleKissError, RnodeBleKissRuntime,
+    RnodeBleKissStatus, RnodeBleNotification, RnodeBleWrite,
+};
+
+pub use super::rnode_bearer_interface::{RnodeBearerKissInterface, RnodeBearerRuntimeStatusHandle};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RnodeBearerKind {
+    Ble,
+    BluetoothClassic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RnodeBearerInfo {
+    pub kind: RnodeBearerKind,
+    pub negotiated_mtu: Option<u16>,
+}
+
+/// Cancellation-safe, single-attempt raw RNode bearer.
+///
+/// Dropping an in-flight operation must not prevent a subsequent `close` from
+/// releasing the native resource. `close` must be idempotent and must unblock
+/// any pending read or write. Retry and backoff belong to the caller.
+#[allow(async_fn_in_trait)]
+pub trait RnodeBearerBackend {
+    async fn open(&mut self) -> Result<RnodeBearerInfo, String>;
+
+    async fn read(&mut self) -> Result<Option<Vec<u8>>, String>;
+
+    async fn write(&mut self, payload: Vec<u8>) -> Result<(), String>;
+
+    async fn close(&mut self) -> Result<(), String>;
+}
+
+struct RnodeBearerAdapter<B> {
+    backend: B,
+    info: Option<RnodeBearerInfo>,
+}
+
+impl<B> RnodeBearerAdapter<B> {
+    fn new(backend: B) -> Self {
+        Self { backend, info: None }
+    }
+}
+
+impl<B> RnodeBleBackend for RnodeBearerAdapter<B>
+where
+    B: RnodeBearerBackend,
+{
+    async fn connect(&mut self) -> Result<(), String> {
+        self.info = Some(self.backend.open().await?);
+        Ok(())
+    }
+
+    async fn subscribe_notifications(&mut self) -> Result<(), String> {
+        // The platform backend returns from open only after its byte stream is ready.
+        Ok(())
+    }
+
+    async fn write(&mut self, write: RnodeBleWrite) -> Result<(), String> {
+        self.backend.write(write.payload).await
+    }
+
+    async fn next_notification(&mut self) -> Result<Option<Vec<u8>>, String> {
+        self.backend.read().await
+    }
+
+    async fn close(&mut self) -> Result<(), String> {
+        let result = self.backend.close().await;
+        self.info = None;
+        result
+    }
+
+    fn negotiated_mtu(&self) -> Option<u16> {
+        self.info.and_then(|info| info.negotiated_mtu)
+    }
+}
+
+/// Shared KISS/RNode runtime for BLE and Bluetooth Classic bearers.
+pub struct RnodeBearerKissRuntime<B> {
+    inner: RnodeBleKissRuntime<RnodeBearerAdapter<B>>,
+}
+
+impl<B> RnodeBearerKissRuntime<B>
+where
+    B: RnodeBearerBackend,
+{
+    #[must_use]
+    pub fn new(backend: B, config: RnodeBleKissConfig) -> Self {
+        Self { inner: RnodeBleKissRuntime::new(RnodeBearerAdapter::new(backend), config) }
+    }
+
+    pub async fn startup(&mut self) -> Result<RnodeBearerInfo, RnodeBleKissError> {
+        self.inner.startup().await?;
+        self.inner.backend().info.ok_or_else(|| RnodeBleKissError::Backend {
+            operation: "open",
+            message: "bearer opened without connection information".to_string(),
+        })
+    }
+
+    pub async fn send_packet(&mut self, payload: &[u8]) -> Result<(), RnodeBleKissError> {
+        self.inner.send_packet(payload).await
+    }
+
+    pub async fn send_deferred_frames(&mut self) -> Result<(), RnodeBleKissError> {
+        self.inner.send_deferred_frames().await
+    }
+
+    pub async fn send_id_beacon(&mut self) -> Result<(), RnodeBleKissError> {
+        self.inner.send_id_beacon().await
+    }
+
+    pub async fn send_management_frame(&mut self, frame: Vec<u8>) -> Result<(), RnodeBleKissError> {
+        self.inner.send_management_frame(frame).await
+    }
+
+    pub async fn poll(&mut self) -> Result<RnodeBleNotification, RnodeBleKissError> {
+        self.inner.poll_notification_events().await
+    }
+
+    pub async fn shutdown(&mut self) -> Result<(), RnodeBleKissError> {
+        self.inner.shutdown().await
+    }
+
+    pub async fn shutdown_with_prefix_frames(
+        &mut self,
+        prefix_frames: Vec<Vec<u8>>,
+    ) -> Result<(), RnodeBleKissError> {
+        self.inner.shutdown_with_prefix_frames(prefix_frames).await
+    }
+
+    pub async fn close(&mut self) -> Result<(), RnodeBleKissError> {
+        self.inner.close().await
+    }
+
+    #[must_use]
+    pub fn status(&self) -> RnodeBleKissStatus {
+        self.inner.status()
+    }
+
+    #[must_use]
+    pub fn negotiated_mtu(&self) -> Option<u16> {
+        self.inner.negotiated_mtu()
+    }
+
+    #[must_use]
+    pub fn into_backend(self) -> B {
+        self.inner.into_backend().backend
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::future::pending;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::kiss::{encode_data_frame, KissFrame};
+
+    #[derive(Default)]
+    struct TestBackend {
+        opens: usize,
+        closes: usize,
+        startup_drain_completed: bool,
+        reads: VecDeque<Vec<u8>>,
+        writes: Vec<Vec<u8>>,
+    }
+
+    impl RnodeBearerBackend for TestBackend {
+        async fn open(&mut self) -> Result<RnodeBearerInfo, String> {
+            self.opens += 1;
+            Ok(RnodeBearerInfo {
+                kind: RnodeBearerKind::BluetoothClassic,
+                negotiated_mtu: Some(64),
+            })
+        }
+
+        async fn read(&mut self) -> Result<Option<Vec<u8>>, String> {
+            if !self.startup_drain_completed {
+                self.startup_drain_completed = true;
+                return Ok(None);
+            }
+            Ok(self.reads.pop_front())
+        }
+
+        async fn write(&mut self, payload: Vec<u8>) -> Result<(), String> {
+            self.writes.push(payload);
+            Ok(())
+        }
+
+        async fn close(&mut self) -> Result<(), String> {
+            self.closes += 1;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn both_bearers_use_shared_kiss_runtime_and_close() {
+        let mut backend = TestBackend::default();
+        backend.reads.push_back(encode_data_frame(b"hello"));
+        let mut runtime = RnodeBearerKissRuntime::new(backend, RnodeBleKissConfig::default());
+
+        let info = runtime.startup().await.expect("startup");
+        assert_eq!(info.kind, RnodeBearerKind::BluetoothClassic);
+        assert_eq!(runtime.negotiated_mtu(), Some(64));
+        let notification = runtime.poll().await.expect("poll");
+        assert_eq!(notification.packets, vec![b"hello".to_vec()]);
+        runtime.send_packet(b"world").await.expect("send packet");
+        runtime.shutdown().await.expect("shutdown");
+
+        let backend = runtime.into_backend();
+        assert_eq!(backend.opens, 1);
+        assert_eq!(backend.closes, 1);
+        assert!(!backend.writes.is_empty());
+        let decoded = crate::kiss::decode_frames(
+            &backend.writes.into_iter().flatten().collect::<Vec<_>>(),
+            508,
+        )
+        .expect("decode writes");
+        assert!(decoded.contains(&KissFrame::Data(b"world".to_vec())));
+    }
+
+    #[tokio::test]
+    async fn close_is_attempted_when_shutdown_write_fails() {
+        struct FailingBackend {
+            closes: usize,
+        }
+
+        impl RnodeBearerBackend for FailingBackend {
+            async fn open(&mut self) -> Result<RnodeBearerInfo, String> {
+                Ok(RnodeBearerInfo { kind: RnodeBearerKind::Ble, negotiated_mtu: None })
+            }
+
+            async fn read(&mut self) -> Result<Option<Vec<u8>>, String> {
+                Ok(None)
+            }
+
+            async fn write(&mut self, _payload: Vec<u8>) -> Result<(), String> {
+                Err("write failed".to_string())
+            }
+
+            async fn close(&mut self) -> Result<(), String> {
+                self.closes += 1;
+                Ok(())
+            }
+        }
+
+        let config = RnodeBleKissConfig {
+            shutdown_frames: vec![vec![0xc0, 0xff, 0xc0]],
+            ..RnodeBleKissConfig::default()
+        };
+        let mut runtime = RnodeBearerKissRuntime::new(FailingBackend { closes: 0 }, config);
+        let error = runtime.shutdown().await.expect_err("shutdown write should fail");
+        assert!(matches!(error, RnodeBleKissError::Backend { operation: "shutdown_write", .. }));
+        assert_eq!(runtime.into_backend().closes, 1);
+    }
+
+    #[derive(Clone, Copy)]
+    enum BlockOperation {
+        Open,
+        Read,
+        Write,
+    }
+
+    struct BlockingBackend {
+        operation: BlockOperation,
+        closed: Arc<AtomicBool>,
+        block_write: Arc<AtomicBool>,
+    }
+
+    impl RnodeBearerBackend for BlockingBackend {
+        async fn open(&mut self) -> Result<RnodeBearerInfo, String> {
+            if matches!(self.operation, BlockOperation::Open) {
+                pending::<()>().await;
+            }
+            Ok(RnodeBearerInfo { kind: RnodeBearerKind::Ble, negotiated_mtu: Some(185) })
+        }
+
+        async fn read(&mut self) -> Result<Option<Vec<u8>>, String> {
+            if matches!(self.operation, BlockOperation::Read) {
+                pending::<()>().await;
+            }
+            Ok(None)
+        }
+
+        async fn write(&mut self, _payload: Vec<u8>) -> Result<(), String> {
+            if matches!(self.operation, BlockOperation::Write)
+                && self.block_write.load(Ordering::Acquire)
+            {
+                pending::<()>().await;
+            }
+            Ok(())
+        }
+
+        async fn close(&mut self) -> Result<(), String> {
+            self.closed.store(true, Ordering::Release);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_during_open_still_allows_idempotent_close() {
+        let closed = Arc::new(AtomicBool::new(false));
+        let backend = BlockingBackend {
+            operation: BlockOperation::Open,
+            closed: closed.clone(),
+            block_write: Arc::new(AtomicBool::new(false)),
+        };
+        let mut runtime = RnodeBearerKissRuntime::new(backend, RnodeBleKissConfig::default());
+
+        let completed = tokio::select! {
+            _ = runtime.startup() => true,
+            () = tokio::time::sleep(Duration::from_millis(5)) => false,
+        };
+        assert!(!completed, "open unexpectedly completed");
+        runtime.close().await.expect("close after cancelled open");
+        runtime.close().await.expect("second close is safe");
+
+        assert!(closed.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn cancellation_during_read_still_allows_close() {
+        let closed = Arc::new(AtomicBool::new(false));
+        let backend = BlockingBackend {
+            operation: BlockOperation::Read,
+            closed: closed.clone(),
+            block_write: Arc::new(AtomicBool::new(false)),
+        };
+        let mut runtime = RnodeBearerKissRuntime::new(backend, RnodeBleKissConfig::default());
+        runtime.startup().await.expect("startup");
+
+        let completed = tokio::select! {
+            _ = runtime.poll() => true,
+            () = tokio::time::sleep(Duration::from_millis(5)) => false,
+        };
+        assert!(!completed, "read unexpectedly completed");
+        runtime.close().await.expect("close after cancelled read");
+
+        assert!(closed.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn cancellation_during_write_still_allows_close() {
+        let closed = Arc::new(AtomicBool::new(false));
+        let block_write = Arc::new(AtomicBool::new(false));
+        let backend = BlockingBackend {
+            operation: BlockOperation::Write,
+            closed: closed.clone(),
+            block_write: block_write.clone(),
+        };
+        let mut runtime = RnodeBearerKissRuntime::new(backend, RnodeBleKissConfig::default());
+        runtime.startup().await.expect("startup");
+        block_write.store(true, Ordering::Release);
+
+        let completed = tokio::select! {
+            _ = runtime.send_packet(b"blocked") => true,
+            () = tokio::time::sleep(Duration::from_millis(5)) => false,
+        };
+        assert!(!completed, "write unexpectedly completed");
+        runtime.close().await.expect("close after cancelled write");
+
+        assert!(closed.load(Ordering::Acquire));
+    }
+}

--- a/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
@@ -1,0 +1,339 @@
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::time::{timeout, Instant};
+
+use crate::buffer::InputBuffer;
+use crate::iface::{IfaceSource, Interface, InterfaceContext, RxMessage};
+use crate::packet::Packet;
+
+use super::lora::LoraConfig;
+use super::rnode_bearer::{
+    RnodeBearerBackend, RnodeBearerInfo, RnodeBearerKind, RnodeBearerKissRuntime,
+};
+use super::rnode_ble::{
+    rnode_ble_initial_runtime_status_json, RnodeBleCommandMonitor, RnodeBleKissConfig,
+};
+
+const IO_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const STARTUP_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+const DETECTION_FALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+pub struct RnodeBearerRuntimeStatusHandle {
+    inner: Arc<Mutex<serde_json::Value>>,
+}
+
+impl RnodeBearerRuntimeStatusHandle {
+    #[must_use]
+    pub fn to_json(&self) -> serde_json::Value {
+        self.inner.lock().unwrap_or_else(|poisoned| poisoned.into_inner()).clone()
+    }
+}
+
+/// A single RNode bearer attempt integrated with the Reticulum interface manager.
+///
+/// It intentionally does not reconnect. The platform owner creates a fresh backend
+/// and interface after this task returns.
+pub struct RnodeBearerKissInterface<B> {
+    label: String,
+    endpoint: String,
+    backend: Option<B>,
+    config: RnodeBleKissConfig,
+    lora: LoraConfig,
+    status: Arc<Mutex<serde_json::Value>>,
+}
+
+impl<B> RnodeBearerKissInterface<B> {
+    #[must_use]
+    pub fn new(
+        label: impl Into<String>,
+        endpoint: impl Into<String>,
+        backend: B,
+        config: RnodeBleKissConfig,
+        lora: LoraConfig,
+    ) -> Self {
+        let endpoint = endpoint.into();
+        let status = Arc::new(Mutex::new(rnode_ble_initial_runtime_status_json(lora, &endpoint)));
+        Self { label: label.into(), endpoint, backend: Some(backend), config, lora, status }
+    }
+
+    #[must_use]
+    pub fn runtime_status_handle(&self) -> RnodeBearerRuntimeStatusHandle {
+        RnodeBearerRuntimeStatusHandle { inner: self.status.clone() }
+    }
+
+    pub async fn spawn(context: InterfaceContext<Self>)
+    where
+        B: RnodeBearerBackend + Send + 'static,
+    {
+        let iface_stop = context.channel.stop.clone();
+        let iface_address = context.channel.address;
+        let (rx_channel, mut tx_channel) = context.channel.split();
+        let (label, endpoint, backend, config, lora, status) = {
+            let mut guard = context.inner.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            (
+                guard.label.clone(),
+                guard.endpoint.clone(),
+                guard.backend.take(),
+                guard.config.clone(),
+                guard.lora,
+                guard.status.clone(),
+            )
+        };
+        let Some(backend) = backend else {
+            set_error_status(&status, "RNode bearer backend was already consumed");
+            iface_stop.cancel();
+            return;
+        };
+        let packet_mtu = config.mtu;
+        let id_beacon = config.kiss.id_beacon.clone();
+        let mut runtime = RnodeBearerKissRuntime::new(backend, config);
+        let info = tokio::select! {
+            result = runtime.startup() => match result {
+                Ok(info) => info,
+                Err(error) => {
+                    set_error_status(&status, &format!("RNode bearer startup failed: {error:?}"));
+                    let _ = runtime.close().await;
+                    iface_stop.cancel();
+                    return;
+                }
+            },
+            () = context.cancel.cancelled() => {
+                let _ = runtime.close().await;
+                iface_stop.cancel();
+                return;
+            }
+        };
+
+        let bearer = bearer_label(info);
+        let mut monitor = RnodeBleCommandMonitor::new(lora, STARTUP_RESPONSE_TIMEOUT);
+        publish_monitor_status(&status, &monitor, &endpoint, bearer);
+        let mut radio_config_sent = false;
+        let detection_deadline = Instant::now() + DETECTION_FALLBACK_TIMEOUT;
+        let mut first_tx_at: Option<Instant> = None;
+        let mut attempt_failed = false;
+        let mut cancelled = false;
+
+        while !context.cancel.is_cancelled() && !iface_stop.is_cancelled() {
+            if !radio_config_sent && Instant::now() >= detection_deadline {
+                radio_config_sent = true;
+                let Some(result) =
+                    run_or_cancel(runtime.send_deferred_frames(), &context.cancel, &iface_stop)
+                        .await
+                else {
+                    cancelled = true;
+                    break;
+                };
+                match result {
+                    Ok(()) => monitor.accept_degraded_startup(),
+                    Err(error) => {
+                        set_error_status(
+                            &status,
+                            &format!("RNode radio configuration failed: {error:?}"),
+                        );
+                        break;
+                    }
+                }
+            }
+
+            if radio_config_sent {
+                while let Ok(message) = tx_channel.try_recv() {
+                    let raw = match message.packet.to_bytes() {
+                        Ok(raw) => raw,
+                        Err(error) => {
+                            log::warn!(
+                                "RNode packet serialization failed iface={label} error={error:?}"
+                            );
+                            continue;
+                        }
+                    };
+                    if raw.len() > packet_mtu {
+                        log::warn!(
+                            "RNode packet exceeds configured MTU iface={} actual={} mtu={}",
+                            label,
+                            raw.len(),
+                            packet_mtu
+                        );
+                        continue;
+                    }
+                    let Some(result) =
+                        run_or_cancel(runtime.send_packet(&raw), &context.cancel, &iface_stop)
+                            .await
+                    else {
+                        cancelled = true;
+                        attempt_failed = true;
+                        break;
+                    };
+                    if let Err(error) = result {
+                        set_error_status(&status, &format!("RNode packet write failed: {error:?}"));
+                        attempt_failed = true;
+                        break;
+                    }
+                    first_tx_at.get_or_insert_with(Instant::now);
+                }
+            }
+            if attempt_failed {
+                break;
+            }
+
+            if let (Some(beacon), Some(first_tx)) = (id_beacon.as_ref(), first_tx_at) {
+                if first_tx.elapsed() >= beacon.interval {
+                    let Some(result) =
+                        run_or_cancel(runtime.send_id_beacon(), &context.cancel, &iface_stop).await
+                    else {
+                        cancelled = true;
+                        break;
+                    };
+                    if let Err(error) = result {
+                        set_error_status(
+                            &status,
+                            &format!("RNode station ID write failed: {error:?}"),
+                        );
+                        break;
+                    }
+                    first_tx_at = None;
+                }
+            }
+
+            let polled = tokio::select! {
+                result = timeout(IO_POLL_INTERVAL, runtime.poll()) => result,
+                () = context.cancel.cancelled() => {
+                    cancelled = true;
+                    break;
+                },
+                () = iface_stop.cancelled() => {
+                    cancelled = true;
+                    break;
+                },
+            };
+            match polled {
+                Err(_) => {}
+                Ok(Err(error)) => {
+                    set_error_status(&status, &format!("RNode bearer read failed: {error:?}"));
+                    break;
+                }
+                Ok(Ok(notification)) => {
+                    if let Err(error) = monitor.accept_notification(&notification) {
+                        set_error_status(&status, &error);
+                        break;
+                    }
+                    if !radio_config_sent && monitor.is_detected() {
+                        radio_config_sent = true;
+                        let Some(result) = run_or_cancel(
+                            runtime.send_deferred_frames(),
+                            &context.cancel,
+                            &iface_stop,
+                        )
+                        .await
+                        else {
+                            cancelled = true;
+                            break;
+                        };
+                        if let Err(error) = result {
+                            set_error_status(
+                                &status,
+                                &format!("RNode radio configuration failed: {error:?}"),
+                            );
+                            break;
+                        }
+                        monitor.reset_startup_deadline(STARTUP_RESPONSE_TIMEOUT);
+                    }
+                    publish_monitor_status(&status, &monitor, &endpoint, bearer);
+                    for payload in notification.packets {
+                        match Packet::deserialize(&mut InputBuffer::new(&payload)) {
+                            Ok(packet) => {
+                                if rx_channel
+                                    .send(RxMessage {
+                                        address: iface_address,
+                                        packet,
+                                        source: IfaceSource::None,
+                                    })
+                                    .await
+                                    .is_err()
+                                {
+                                    iface_stop.cancel();
+                                    break;
+                                }
+                            }
+                            Err(error) => log::warn!(
+                                "RNode packet deserialize failed iface={} len={} error={error:?}",
+                                label,
+                                payload.len()
+                            ),
+                        }
+                    }
+                }
+            }
+            if let Err(error) = monitor.validate_startup_deadline() {
+                set_error_status(&status, &error);
+                break;
+            }
+            publish_monitor_status(&status, &monitor, &endpoint, bearer);
+        }
+
+        if cancelled || context.cancel.is_cancelled() || iface_stop.is_cancelled() {
+            if let Err(error) = runtime.close().await {
+                log::warn!("RNode bearer close failed iface={label} error={error:?}");
+            }
+        } else {
+            let shutdown_prefix = monitor.external_framebuffer_frame(false).into_iter().collect();
+            if let Err(error) = runtime.shutdown_with_prefix_frames(shutdown_prefix).await {
+                log::warn!("RNode bearer shutdown failed iface={label} error={error:?}");
+            }
+        }
+        iface_stop.cancel();
+    }
+}
+
+async fn run_or_cancel<T>(
+    future: impl Future<Output = T>,
+    cancel: &tokio_util::sync::CancellationToken,
+    stop: &tokio_util::sync::CancellationToken,
+) -> Option<T> {
+    tokio::select! {
+        result = future => Some(result),
+        () = cancel.cancelled() => None,
+        () = stop.cancelled() => None,
+    }
+}
+
+impl<B> Interface for RnodeBearerKissInterface<B> {
+    fn mtu() -> usize {
+        508
+    }
+
+    fn configured_mtu(&self) -> usize {
+        self.config.mtu
+    }
+}
+
+fn bearer_label(info: RnodeBearerInfo) -> &'static str {
+    match info.kind {
+        RnodeBearerKind::Ble => "ble",
+        RnodeBearerKind::BluetoothClassic => "bluetooth_classic",
+    }
+}
+
+fn publish_monitor_status(
+    status: &Arc<Mutex<serde_json::Value>>,
+    monitor: &RnodeBleCommandMonitor,
+    endpoint: &str,
+    bearer: &str,
+) {
+    let mut value = monitor.runtime_status_json(endpoint);
+    if let Some(object) = value.as_object_mut() {
+        object.insert("bearer".to_string(), serde_json::Value::String(bearer.to_string()));
+    }
+    *status.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = value;
+}
+
+fn set_error_status(status: &Arc<Mutex<serde_json::Value>>, error: &str) {
+    let mut guard = status.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(object) = guard.as_object_mut() else {
+        return;
+    };
+    object.insert("online".to_string(), serde_json::Value::Bool(false));
+    object.insert("last_command_error".to_string(), serde_json::Value::String(error.to_string()));
+}

--- a/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use tokio::time::{timeout, Instant};
+use tokio::time::{sleep, timeout, Instant};
 
 use crate::buffer::InputBuffer;
 use crate::iface::{IfaceSource, Interface, InterfaceContext, RxMessage};
@@ -214,7 +214,20 @@ impl<B> RnodeBearerKissInterface<B> {
                     set_error_status(&status, &format!("RNode bearer read failed: {error:?}"));
                     break;
                 }
-                Ok(Ok(notification)) => {
+                Ok(Ok(None)) => {
+                    tokio::select! {
+                        () = sleep(IO_POLL_INTERVAL) => {}
+                        () = context.cancel.cancelled() => {
+                            cancelled = true;
+                            break;
+                        }
+                        () = iface_stop.cancelled() => {
+                            cancelled = true;
+                            break;
+                        }
+                    }
+                }
+                Ok(Ok(Some(notification))) => {
                     if let Err(error) = monitor.accept_notification(&notification) {
                         set_error_status(&status, &error);
                         break;

--- a/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
@@ -95,13 +95,25 @@ impl<B> RnodeBearerKissInterface<B> {
                 Ok(info) => info,
                 Err(error) => {
                     set_error_status(&status, &format!("RNode bearer startup failed: {error:?}"));
-                    let _ = runtime.close().await;
+                    close_after_aborted_startup(
+                        &mut runtime,
+                        &status,
+                        &label,
+                        "startup_failure",
+                    )
+                    .await;
                     iface_stop.cancel();
                     return;
                 }
             },
             () = context.cancel.cancelled() => {
-                let _ = runtime.close().await;
+                close_after_aborted_startup(
+                    &mut runtime,
+                    &status,
+                    &label,
+                    "startup_cancellation",
+                )
+                .await;
                 iface_stop.cancel();
                 return;
             }
@@ -350,3 +362,38 @@ fn set_error_status(status: &Arc<Mutex<serde_json::Value>>, error: &str) {
     object.insert("online".to_string(), serde_json::Value::Bool(false));
     object.insert("last_command_error".to_string(), serde_json::Value::String(error.to_string()));
 }
+
+async fn close_after_aborted_startup<B>(
+    runtime: &mut RnodeBearerKissRuntime<B>,
+    status: &Arc<Mutex<serde_json::Value>>,
+    label: &str,
+    phase: &str,
+) where
+    B: RnodeBearerBackend,
+{
+    if let Err(error) = runtime.close().await {
+        let message =
+            format!("RNode bearer close failed iface={label} phase={phase} error={error:?}");
+        log::warn!("{message}");
+        append_error_status(status, &message);
+    }
+}
+
+fn append_error_status(status: &Arc<Mutex<serde_json::Value>>, error: &str) {
+    let mut guard = status.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let previous = guard
+        .get("last_command_error")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+    let Some(object) = guard.as_object_mut() else {
+        return;
+    };
+    let combined = previous.map_or_else(|| error.to_string(), |value| format!("{value}; {error}"));
+    object.insert("online".to_string(), serde_json::Value::Bool(false));
+    object.insert("last_command_error".to_string(), serde_json::Value::String(combined));
+}
+
+#[cfg(test)]
+#[path = "rnode_bearer_interface_tests.rs"]
+mod tests;

--- a/crates/libs/rns-transport/src/iface/rnode_bearer_interface_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer_interface_tests.rs
@@ -1,0 +1,86 @@
+use std::future::pending;
+use std::time::Duration;
+
+use crate::iface::InterfaceManager;
+
+use super::*;
+
+enum OpenBehavior {
+    Fail,
+    Block,
+}
+
+struct FailingCloseBackend {
+    open_behavior: OpenBehavior,
+}
+
+impl RnodeBearerBackend for FailingCloseBackend {
+    async fn open(&mut self) -> Result<RnodeBearerInfo, String> {
+        match self.open_behavior {
+            OpenBehavior::Fail => Err("open failed".to_string()),
+            OpenBehavior::Block => pending().await,
+        }
+    }
+
+    async fn read(&mut self) -> Result<Option<Vec<u8>>, String> {
+        Ok(None)
+    }
+
+    async fn write(&mut self, _payload: Vec<u8>) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<(), String> {
+        Err("close failed".to_string())
+    }
+}
+
+fn test_interface(
+    open_behavior: OpenBehavior,
+) -> (InterfaceContext<RnodeBearerKissInterface<FailingCloseBackend>>, RnodeBearerRuntimeStatusHandle)
+{
+    let interface = RnodeBearerKissInterface::new(
+        "test-rnode",
+        "test-endpoint",
+        FailingCloseBackend { open_behavior },
+        RnodeBleKissConfig::default(),
+        LoraConfig::us915_default(),
+    );
+    let status = interface.runtime_status_handle();
+    let mut manager = InterfaceManager::new(4);
+    (manager.new_context(interface), status)
+}
+
+#[tokio::test]
+async fn failed_startup_records_close_failure_without_losing_open_error() {
+    let (context, status) = test_interface(OpenBehavior::Fail);
+
+    RnodeBearerKissInterface::spawn(context).await;
+
+    let snapshot = status.to_json();
+    let error = snapshot["last_command_error"].as_str().expect("startup failure status");
+    assert!(error.contains("open failed"));
+    assert!(error.contains("iface=test-rnode"));
+    assert!(error.contains("phase=startup_failure"));
+    assert!(error.contains("close failed"));
+}
+
+#[tokio::test]
+async fn cancelled_startup_records_close_failure() {
+    let (context, status) = test_interface(OpenBehavior::Block);
+    let cancel = context.cancel.clone();
+    let task = tokio::spawn(RnodeBearerKissInterface::spawn(context));
+    tokio::task::yield_now().await;
+
+    cancel.cancel();
+    timeout(Duration::from_secs(1), task)
+        .await
+        .expect("cancelled startup timeout")
+        .expect("cancelled startup task");
+
+    let snapshot = status.to_json();
+    let error = snapshot["last_command_error"].as_str().expect("cancelled startup failure status");
+    assert!(error.contains("iface=test-rnode"));
+    assert!(error.contains("phase=startup_cancellation"));
+    assert!(error.contains("close failed"));
+}

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
@@ -33,8 +33,10 @@ use btleplug::platform::PeripheralId;
 #[cfg(feature = "rnode-ble")]
 use futures::{stream::Stream, StreamExt};
 
+use tokio::time::{timeout, Instant as TokioInstant};
+
 #[cfg(feature = "rnode-ble")]
-use tokio::time::{sleep, timeout, Instant as TokioInstant};
+use tokio::time::sleep;
 
 #[cfg(feature = "rnode-ble")]
 use uuid::Uuid;
@@ -61,10 +63,8 @@ pub const RNODE_BLE_READ_FRAME_TIMEOUT: Duration = Duration::from_millis(1_250);
 
 const DEFAULT_ATT_NOTIFICATION_PAYLOAD_BYTES: usize = 20;
 
-#[cfg(feature = "rnode-ble")]
 const RNODE_BLE_STARTUP_STABILIZATION_TIMEOUT: Duration = Duration::from_secs(2);
 
-#[cfg(feature = "rnode-ble")]
 const RNODE_BLE_STARTUP_NOTIFICATION_QUIET_TIMEOUT: Duration = Duration::from_millis(100);
 
 #[cfg(feature = "rnode-ble")]
@@ -161,6 +161,13 @@ pub trait RnodeBleBackend {
     async fn write(&mut self, write: RnodeBleWrite) -> Result<(), String>;
 
     async fn next_notification(&mut self) -> Result<Option<Vec<u8>>, String>;
+
+    /// Close the current connection and release native resources.
+    ///
+    /// Compatibility backends may rely on this no-op default for one release.
+    async fn close(&mut self) -> Result<(), String> {
+        Ok(())
+    }
 
     fn negotiated_mtu(&self) -> Option<u16> {
         None
@@ -616,6 +623,10 @@ impl RnodeBleBackend for NativeRnodeBleBackend {
             ));
         }
         Ok(Some(notification.value))
+    }
+
+    async fn close(&mut self) -> Result<(), String> {
+        self.cleanup().await
     }
 }
 

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
@@ -162,6 +162,15 @@ pub trait RnodeBleBackend {
 
     async fn next_notification(&mut self) -> Result<Option<Vec<u8>>, String>;
 
+    /// Whether startup should discard notifications queued before the probe frames.
+    ///
+    /// Compatibility and platform-owned backends default to preserving all bytes.
+    /// Native BLE enables this to discard stale notifications left by an earlier
+    /// GATT subscription.
+    fn drains_stale_startup_notifications(&self) -> bool {
+        false
+    }
+
     /// Close the current connection and release native resources.
     ///
     /// Compatibility backends may rely on this no-op default for one release.
@@ -623,6 +632,10 @@ impl RnodeBleBackend for NativeRnodeBleBackend {
             ));
         }
         Ok(Some(notification.value))
+    }
+
+    fn drains_stale_startup_notifications(&self) -> bool {
+        true
     }
 
     async fn close(&mut self) -> Result<(), String> {

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
@@ -46,7 +46,6 @@ where
         self.backend.subscribe_notifications().await.map_err(|message| {
             RnodeBleKissError::Backend { operation: "subscribe_notifications", message }
         })?;
-        #[cfg(feature = "rnode-ble")]
         self.drain_startup_notifications().await?;
         let writes = self.session.startup_frames();
         self.write_all(writes, "startup_write").await?;
@@ -54,7 +53,6 @@ where
         Ok(())
     }
 
-    #[cfg(feature = "rnode-ble")]
     pub async fn send_deferred_frames(&mut self) -> Result<(), RnodeBleKissError> {
         let writes = self.session.deferred_frames();
         self.write_all(writes, "deferred_frames_write").await
@@ -93,7 +91,22 @@ where
         prefix_frames: Vec<Vec<u8>>,
     ) -> Result<(), RnodeBleKissError> {
         let writes = self.session.shutdown_frames_with_prefix(prefix_frames);
-        self.write_all(writes, "shutdown_write").await
+        let write_result = self.write_all(writes, "shutdown_write").await;
+        let close_result = self.backend.close().await.map_err(|message| RnodeBleKissError::Backend {
+            operation: "close",
+            message,
+        });
+        self.connected = false;
+        write_result.and(close_result)
+    }
+
+    pub async fn close(&mut self) -> Result<(), RnodeBleKissError> {
+        let result = self.backend.close().await.map_err(|message| RnodeBleKissError::Backend {
+            operation: "close",
+            message,
+        });
+        self.connected = false;
+        result
     }
 
     pub async fn poll_notification(&mut self) -> Result<Vec<Vec<u8>>, RnodeBleKissError> {

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
@@ -46,7 +46,9 @@ where
         self.backend.subscribe_notifications().await.map_err(|message| {
             RnodeBleKissError::Backend { operation: "subscribe_notifications", message }
         })?;
-        self.drain_startup_notifications().await?;
+        if self.backend.drains_stale_startup_notifications() {
+            self.drain_startup_notifications().await?;
+        }
         let writes = self.session.startup_frames();
         self.write_all(writes, "startup_write").await?;
         self.connected = true;
@@ -116,12 +118,18 @@ where
     pub async fn poll_notification_events(
         &mut self,
     ) -> Result<RnodeBleNotification, RnodeBleKissError> {
+        Ok(self.poll_optional_notification_events().await?.unwrap_or_default())
+    }
+
+    pub(crate) async fn poll_optional_notification_events(
+        &mut self,
+    ) -> Result<Option<RnodeBleNotification>, RnodeBleKissError> {
         let Some(payload) = self.backend.next_notification().await.map_err(|message| {
             self.connected = false;
             RnodeBleKissError::Backend { operation: "next_notification", message }
         })?
         else {
-            return Ok(RnodeBleNotification::default());
+            return Ok(None);
         };
         {
             let hex: String = payload
@@ -134,7 +142,7 @@ where
         let notification = self.session.accept_notification_events(&payload)?;
         let writes = self.session.take_pending_writes();
         self.write_all(writes, "write_pending").await?;
-        Ok(notification)
+        Ok(Some(notification))
     }
 
     async fn write_all(

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_startup_notification_drain.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_startup_notification_drain.rs
@@ -2,7 +2,6 @@ impl<B> RnodeBleKissRuntime<B>
 where
     B: RnodeBleBackend,
 {
-    #[cfg(feature = "rnode-ble")]
     async fn drain_startup_notifications(&mut self) -> Result<(), RnodeBleKissError> {
         let deadline = TokioInstant::now() + RNODE_BLE_STARTUP_STABILIZATION_TIMEOUT;
         let mut drained = 0_usize;

--- a/crates/libs/rns-transport/src/iface/rnode_spp.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_spp.rs
@@ -67,6 +67,11 @@ pub trait RnodeSppBackend {
     async fn write(&mut self, payload: Vec<u8>) -> Result<(), String>;
 
     async fn read(&mut self) -> Result<Option<Vec<u8>>, String>;
+
+    /// Close the current RFCOMM stream. The default preserves existing backends for one release.
+    async fn close(&mut self) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -276,7 +281,14 @@ where
     }
 
     pub async fn shutdown(&mut self) -> Result<(), RnodeSppKissError> {
-        self.write_all(self.session.shutdown_frames(), "shutdown_write").await
+        let write_result = self.write_all(self.session.shutdown_frames(), "shutdown_write").await;
+        let close_result = self
+            .backend
+            .close()
+            .await
+            .map_err(|message| RnodeSppKissError::Backend { operation: "close", message });
+        self.connected = false;
+        write_result.and(close_result)
     }
 
     pub async fn poll_read(&mut self) -> Result<Vec<Vec<u8>>, RnodeSppKissError> {

--- a/crates/libs/rns-transport/tests/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/tests/rnode_ble_parts/module_prelude.rs
@@ -348,6 +348,7 @@ struct TestRnodeBleBackend {
     events: Vec<&'static str>,
     writes: Vec<RnodeBleWrite>,
     notifications: std::collections::VecDeque<Option<Vec<u8>>>,
+    drain_stale_startup_notifications: bool,
 }
 
 impl TestRnodeBleBackend {
@@ -357,6 +358,14 @@ impl TestRnodeBleBackend {
 
     fn with_notification_sequence(notifications: Vec<Option<Vec<u8>>>) -> Self {
         Self { notifications: notifications.into(), ..Default::default() }
+    }
+
+    fn with_stale_notifications(notifications: Vec<Option<Vec<u8>>>) -> Self {
+        Self {
+            notifications: notifications.into(),
+            drain_stale_startup_notifications: true,
+            ..Default::default()
+        }
     }
 }
 
@@ -381,6 +390,10 @@ impl RnodeBleBackend for TestRnodeBleBackend {
         self.events.push("next_notification");
         Ok(self.notifications.pop_front().flatten())
     }
+
+    fn drains_stale_startup_notifications(&self) -> bool {
+        self.drain_stale_startup_notifications
+    }
 }
 
 #[tokio::test]
@@ -397,21 +410,6 @@ async fn rnode_ble_runtime_connects_subscribes_and_writes_startup_frames() {
     assert_eq!(runtime.status().pending_payloads, 0);
     assert_eq!(runtime.status().pending_writes, 0);
     let backend = runtime.backend();
-    #[cfg(feature = "rnode-ble")]
-    assert_eq!(
-        backend.events,
-        vec![
-            "connect",
-            "subscribe_notifications",
-            "next_notification",
-            "write",
-            "write",
-            "write",
-            "write",
-            "write",
-        ]
-    );
-    #[cfg(not(feature = "rnode-ble"))]
     assert_eq!(
         backend.events,
         vec!["connect", "subscribe_notifications", "write", "write", "write", "write", "write",]
@@ -426,12 +424,6 @@ async fn rnode_ble_runtime_connects_subscribes_and_writes_startup_frames() {
 
 #[tokio::test]
 async fn rnode_ble_runtime_writes_packets_and_polls_notifications() {
-    #[cfg(feature = "rnode-ble")]
-    let backend = TestRnodeBleBackend::with_notification_sequence(vec![
-        None,
-        Some(encode_data_frame(&[0xAA, 0xBB])),
-    ]);
-    #[cfg(not(feature = "rnode-ble"))]
     let backend =
         TestRnodeBleBackend::with_notification_sequence(vec![Some(encode_data_frame(&[
             0xAA, 0xBB,
@@ -453,10 +445,9 @@ async fn rnode_ble_runtime_writes_packets_and_polls_notifications() {
     );
 }
 
-#[cfg(feature = "rnode-ble")]
 #[tokio::test]
 async fn rnode_ble_runtime_drains_stale_notifications_before_startup_writes() {
-    let backend = TestRnodeBleBackend::with_notification_sequence(vec![
+    let backend = TestRnodeBleBackend::with_stale_notifications(vec![
         Some(encode_command_frame(CMD_DETECT, &[DETECT_RESP])),
         Some(encode_data_frame(&[0xAA, 0xBB])),
         None,

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -529,6 +529,16 @@ Scoped release evidence is split as follows:
   display/NeoPixel controls, interference-avoidance control, Wi-Fi settings,
   config save/delete, firmware-update metadata, and ROM/EEPROM read/write/wipe
   requests.
+- A bearer-neutral `RnodeBearerBackend` and single-attempt
+  `RnodeBearerKissInterface` now let mobile platform owners provide ordered BLE
+  or Bluetooth Classic byte streams while this crate retains shared KISS
+  framing, RNode probe/configuration, MTU and flow-control enforcement, runtime
+  status, and teardown. Focused no-default-feature tests cover shared BLE/SPP
+  framing, notification preservation, empty-read backoff, cancellation-safe and
+  idempotent close, and close-failure reporting during aborted startup. Native
+  Android callback/resource lifecycle validation, physical RNode BLE/SPP
+  lifecycle cycling, and long-running hardware soak evidence remain external
+  mobile/HIL gaps and are not claimed by this software increment.
 - WeaveInterface has a transport-side WDCL/HDLC slice: a shared serial parent
   can answer discovery, learn endpoint events, register virtual endpoint
   children, receive endpoint packets, write direct endpoint commands, and expose

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -265,6 +265,14 @@ placeholders:
   requests, and live daemon/RPC `rnode_status` refresh plus compact
   `rnstatus-rs` human summaries for probe and radio state, with an opt-in
   prepared-host smoke harness for serial, TCP/Wi-Fi, or BLE RNode devices.
+  The bearer-neutral `RnodeBearerBackend` and single-attempt
+  `RnodeBearerKissInterface` reuse that KISS/probe/configuration runtime for
+  platform-owned BLE and Bluetooth Classic streams. Focused
+  no-default-feature tests cover shared framing, notification preservation,
+  empty-read backoff, cancellation-safe and idempotent close, and contextual
+  close-failure status during aborted startup. Native Android callback/resource
+  behavior, physical RNode BLE/SPP lifecycle cycling, and long-running hardware
+  soak evidence remain `hardware-unverified` external mobile/HIL work.
 - Meshtastic tunnel support includes the reference `RETICULUM_TUNNEL_APP`
   framing/reassembly layer, modem-preset pacing, missing-chunk requests,
   node/destination route learning, an injectable bearer handle, daemon config


### PR DESCRIPTION
## Summary

- add a cancellation-safe `RnodeBearerBackend` contract for platform-owned BLE and Bluetooth Classic byte transports
- extract a shared RNode KISS runtime and Reticulum interface used by both bearer kinds
- preserve native `RnodeBleBackend`, `RnodeSppBackend`, and feature-gated btleplug APIs as compatibility wrappers
- close BLE/SPP backends deterministically during cancellation and shutdown

## Why

REM must own Android permissions, GATT/RFCOMM resources, and operation deadlines without duplicating RNode probing, KISS framing, MTU validation, flow control, or radio-state handling. This contract lets mobile platforms provide ordered bytes while LXMF-rs remains the protocol owner.

## Compatibility

- daemon-native BLE remains behind the existing `rnode-ble` feature
- existing BLE/SPP APIs remain available for the compatibility release
- retry and backoff remain caller-owned; each backend instance represents one connection attempt

## Validation

- `cargo check -p reticulum-rs-transport --no-default-features`
- `cargo check -p reticulum-rs-transport --no-default-features --features rnode-ble`
- `cargo clippy -p reticulum-rs-transport --no-default-features -- -D warnings`
- 30 focused RNode tests, including shared framing, backend errors, cancellation during open/read/write, idempotent close, and existing probe/MTU/runtime coverage
