### PR TITLE
chore(license): elect GPL-2.0-or-later as EPL-2.0 Secondary License (Exhibit A)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ default-members = [
 [workspace.package]
 edition = "2021"
 rust-version = "1.85"
-license = "EPL-2.0"
+license = "EPL-2.0 OR GPL-2.0-or-later"
 repository = "https://github.com/FreeTAKTeam/LXMF-rs"
 
 [workspace.metadata.boundaries]

--- a/LICENSE
+++ b/LICENSE
@@ -275,3 +275,12 @@ version(s), and exceptions or additional permissions here}."
   look for such a notice.
 
   You may add additional accurate notices of copyright ownership.
+
+--------------------------------------------------------------------------------
+Exhibit A - Secondary Licenses Notice:
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+or any later version.
+--------------------------------------------------------------------------------

--- a/tools/e2e-runner/Cargo.toml
+++ b/tools/e2e-runner/Cargo.toml
@@ -3,7 +3,7 @@ name = "lxmf-e2e-runner"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.88"
-license = "EPL-2.0"
+license = "EPL-2.0 OR GPL-2.0-or-later"
 publish = false
 
 [workspace]


### PR DESCRIPTION
## Summary

Adds the Eclipse Public License v2.0 **Exhibit A Secondary Licenses Notice** electing `GPL-2.0-or-later` and updates crate metadata across the workspace.

- **No change to the primary license:** The repository and all crates remain primarily licensed under **EPL-2.0**.
- Enables downstream projects under GPLv3 and AGPLv3 to statically link workspace crates via the EPL-2.0 Section 3.2 Secondary License mechanism.
- Appended the standard Exhibit A Secondary Licenses Notice to the root `LICENSE`.
- Updated SPDX `license` expressions across all published and workspace crates to `EPL-2.0 OR GPL-2.0-or-later`.

Closes #571.

## Type
- [ ] breaking
- [ ] refactor
- [ ] reliability
- [x] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] Verified valid SPDX license expressions across root and workspace manifests.

## Compatibility
- [x] No change to primary license (remains EPL-2.0).
- [x] Fully backward-compatible for all existing consumers and downstream licenses.