### PR TITLE
Fix bearer-neutral RNode startup compatibility

### DIFF
--- a/crates/libs/rns-transport/src/iface/lora_parts/lorainterface.rs
+++ b/crates/libs/rns-transport/src/iface/lora_parts/lorainterface.rs
@@ -73,6 +73,7 @@ pub struct LoraInterface {
     hardware_errors: Vec<RNodeHardwareError>,
     last_command_error: Option<String>,
     online: bool,
+    radio_state_response_seen: bool,
     flow_control: bool,
     id_beacon: Option<KissIdBeaconConfig>,
     reconnect_backoff: Duration,
@@ -95,6 +96,7 @@ impl LoraInterface {
             hardware_errors: Vec::new(),
             last_command_error: None,
             online: false,
+            radio_state_response_seen: false,
             flow_control: false,
             id_beacon: None,
             reconnect_backoff: Duration::from_millis(500),
@@ -117,6 +119,7 @@ impl LoraInterface {
             hardware_errors: Vec::new(),
             last_command_error: None,
             online: false,
+            radio_state_response_seen: false,
             flow_control: false,
             id_beacon: None,
             reconnect_backoff: Duration::from_millis(500),
@@ -218,9 +221,13 @@ impl LoraInterface {
         self.hardware_errors.clear();
         self.last_command_error = None;
         self.online = false;
+        self.radio_state_response_seen = false;
     }
 
     pub fn record_command_response(&mut self, command: u8, payload: &[u8]) -> Result<bool, String> {
+        if command == CMD_RADIO_STATE {
+            self.radio_state_response_seen = true;
+        }
         if self.probe_status.accept_command(command, payload)? {
             return Ok(true);
         }
@@ -282,7 +289,7 @@ impl LoraInterface {
     /// requirement, hardware error, and explicit radio-state mismatch. It is
     /// only usable when the radio-state response is absent.
     pub fn accept_missing_radio_state_compatibility(&mut self) -> Result<bool, String> {
-        if self.radio_status.radio_state.is_some() {
+        if self.radio_status.radio_state.is_some() || self.radio_state_response_seen {
             return Ok(false);
         }
         if let Some(err) = self.last_command_error() {

--- a/crates/libs/rns-transport/src/iface/lora_parts/lorainterface.rs
+++ b/crates/libs/rns-transport/src/iface/lora_parts/lorainterface.rs
@@ -275,6 +275,27 @@ impl LoraInterface {
         self.validate_radio_status()
     }
 
+    /// Accept older RNode firmware that applies the requested radio state but
+    /// does not echo `CMD_RADIO_STATE` during startup.
+    ///
+    /// This remains fail-closed for every reported radio parameter, probe
+    /// requirement, hardware error, and explicit radio-state mismatch. It is
+    /// only usable when the radio-state response is absent.
+    pub fn accept_missing_radio_state_compatibility(&mut self) -> Result<bool, String> {
+        if self.radio_status.radio_state.is_some() {
+            return Ok(false);
+        }
+        if let Some(err) = self.last_command_error() {
+            return Err(err.to_string());
+        }
+        self.validate_probe_status()?;
+        let mut compatible_status = self.radio_status.clone();
+        compatible_status.radio_state = Some(RADIO_STATE_ON);
+        compatible_status.validate_config(self.config, RADIO_STATE_ON)?;
+        self.online = true;
+        Ok(true)
+    }
+
     pub fn reported_bitrate_bps(&self) -> Option<f64> {
         self.radio_status.reported_bitrate_bps()
     }

--- a/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
@@ -13,7 +13,8 @@ use super::rnode_bearer::{
     RnodeBearerBackend, RnodeBearerInfo, RnodeBearerKind, RnodeBearerKissRuntime,
 };
 use super::rnode_ble::{
-    rnode_ble_initial_runtime_status_json, RnodeBleCommandMonitor, RnodeBleKissConfig,
+    rnode_ble_initial_runtime_status_json, rnode_ble_payload_writes_enabled,
+    RnodeBleCommandMonitor, RnodeBleKissConfig,
 };
 
 const IO_POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -150,7 +151,7 @@ impl<B> RnodeBearerKissInterface<B> {
                 }
             }
 
-            if radio_config_sent {
+            if rnode_ble_payload_writes_enabled(radio_config_sent, Some(&monitor)) {
                 while let Ok(message) = tx_channel.try_recv() {
                     let raw = match message.packet.to_bytes() {
                         Ok(raw) => raw,
@@ -292,6 +293,7 @@ impl<B> RnodeBearerKissInterface<B> {
                 }
             }
             if let Err(error) = monitor.validate_startup_deadline() {
+                log::warn!("RNode startup response validation failed iface={label} error={error}");
                 set_error_status(&status, &error);
                 break;
             }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
@@ -647,5 +647,6 @@ pub struct RnodeBleCommandMonitor {
     lora: LoraInterface,
     startup_deadline: Option<Instant>,
     startup_validated: bool,
+    startup_payload_writes_enabled: bool,
     startup_compatibility_warning: Option<String>,
 }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
@@ -646,5 +646,6 @@ impl Interface for NativeRnodeBleKissInterface {
 pub struct RnodeBleCommandMonitor {
     lora: LoraInterface,
     startup_deadline: Option<Instant>,
+    startup_validated: bool,
     startup_compatibility_warning: Option<String>,
 }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
@@ -41,7 +41,12 @@ where
             .map_err(|message| RnodeBleKissError::Backend { operation: "connect", message })?;
         if let Some(mtu) = self.backend.negotiated_mtu() {
             let att_payload = (mtu as usize).saturating_sub(3);
-            self.session.config.max_write_len = att_payload.min(self.session.config.mtu);
+            self.session.config.max_write_len = self
+                .session
+                .config
+                .max_write_len
+                .min(att_payload)
+                .min(self.session.config.mtu);
         }
         self.backend.subscribe_notifications().await.map_err(|message| {
             RnodeBleKissError::Backend { operation: "subscribe_notifications", message }
@@ -413,7 +418,7 @@ impl NativeRnodeBleKissInterface {
                     break;
                 }
 
-                if radio_config_sent {
+                if rnode_ble_payload_writes_enabled(radio_config_sent, command_monitor.as_ref()) {
                     while let Ok(message) = tx_channel.try_recv() {
                         let raw = match message.packet.to_bytes() {
                             Ok(raw) => raw,
@@ -641,4 +646,5 @@ impl Interface for NativeRnodeBleKissInterface {
 pub struct RnodeBleCommandMonitor {
     lora: LoraInterface,
     startup_deadline: Option<Instant>,
+    startup_compatibility_warning: Option<String>,
 }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
@@ -6,6 +6,7 @@ impl RnodeBleCommandMonitor {
         Self {
             lora,
             startup_deadline: Some(Instant::now() + startup_response_timeout),
+            startup_validated: false,
             startup_compatibility_warning: None,
         }
     }
@@ -72,6 +73,11 @@ impl RnodeBleCommandMonitor {
     }
 
     #[must_use]
+    pub fn startup_validated(&self) -> bool {
+        self.startup_validated
+    }
+
+    #[must_use]
     pub fn online(&self) -> bool {
         self.lora.online()
     }
@@ -110,7 +116,7 @@ impl RnodeBleCommandMonitor {
             return Ok(());
         }
         self.startup_deadline = None;
-        match self.lora.validate_startup_responses() {
+        let validation = match self.lora.validate_startup_responses() {
             Ok(()) => Ok(()),
             Err(error) => match self.lora.accept_missing_radio_state_compatibility() {
                 Ok(true) => {
@@ -121,7 +127,11 @@ impl RnodeBleCommandMonitor {
                 }
                 Ok(false) | Err(_) => Err(error),
             },
+        };
+        if validation.is_ok() {
+            self.startup_validated = true;
         }
+        validation
     }
 }
 
@@ -129,7 +139,7 @@ pub(crate) fn rnode_ble_payload_writes_enabled(
     radio_config_sent: bool,
     command_monitor: Option<&RnodeBleCommandMonitor>,
 ) -> bool {
-    radio_config_sent && command_monitor.is_none_or(RnodeBleCommandMonitor::online)
+    radio_config_sent && command_monitor.is_none_or(RnodeBleCommandMonitor::startup_validated)
 }
 
 #[must_use]

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
@@ -3,7 +3,11 @@ impl RnodeBleCommandMonitor {
     pub fn new(config: LoraConfig, startup_response_timeout: Duration) -> Self {
         let mut lora = LoraInterface::new_tcp("ble://rnode", config);
         lora.begin_startup_response_collection();
-        Self { lora, startup_deadline: Some(Instant::now() + startup_response_timeout) }
+        Self {
+            lora,
+            startup_deadline: Some(Instant::now() + startup_response_timeout),
+            startup_compatibility_warning: None,
+        }
     }
 
     pub fn accept_notification(
@@ -84,7 +88,18 @@ impl RnodeBleCommandMonitor {
 
     #[must_use]
     pub fn runtime_status_json(&self, endpoint: &str) -> serde_json::Value {
-        rnode_ble_runtime_status_json(&self.lora, endpoint)
+        let mut value = rnode_ble_runtime_status_json(&self.lora, endpoint);
+        if let Some(object) = value.as_object_mut() {
+            object.insert(
+                "startup_compatibility_warning".to_string(),
+                self.startup_compatibility_warning
+                    .as_ref()
+                    .map_or(serde_json::Value::Null, |warning| {
+                        serde_json::Value::String(warning.clone())
+                    }),
+            );
+        }
+        value
     }
 
     pub fn validate_startup_deadline(&mut self) -> Result<(), String> {
@@ -95,8 +110,26 @@ impl RnodeBleCommandMonitor {
             return Ok(());
         }
         self.startup_deadline = None;
-        self.lora.validate_startup_responses()
+        match self.lora.validate_startup_responses() {
+            Ok(()) => Ok(()),
+            Err(error) => match self.lora.accept_missing_radio_state_compatibility() {
+                Ok(true) => {
+                    let warning = "RNode omitted the startup radio-state response; accepted after all other probe and radio parameters validated".to_string();
+                    log::warn!("{warning}");
+                    self.startup_compatibility_warning = Some(warning);
+                    Ok(())
+                }
+                Ok(false) | Err(_) => Err(error),
+            },
+        }
     }
+}
+
+pub(crate) fn rnode_ble_payload_writes_enabled(
+    radio_config_sent: bool,
+    command_monitor: Option<&RnodeBleCommandMonitor>,
+) -> bool {
+    radio_config_sent && command_monitor.is_none_or(RnodeBleCommandMonitor::online)
 }
 
 #[must_use]
@@ -119,6 +152,10 @@ pub fn rnode_ble_runtime_status_json(
         object.insert("endpoint".to_string(), serde_json::Value::String(endpoint.to_string()));
         object.insert("bearer".to_string(), serde_json::Value::String("ble".to_string()));
         object.insert("baud_rate".to_string(), serde_json::Value::Null);
+        object.insert(
+            "startup_compatibility_warning".to_string(),
+            serde_json::Value::Null,
+        );
     }
     value
 }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
@@ -7,6 +7,7 @@ impl RnodeBleCommandMonitor {
             lora,
             startup_deadline: Some(Instant::now() + startup_response_timeout),
             startup_validated: false,
+            startup_payload_writes_enabled: false,
             startup_compatibility_warning: None,
         }
     }
@@ -70,11 +71,17 @@ impl RnodeBleCommandMonitor {
 
     pub fn accept_degraded_startup(&mut self) {
         self.startup_deadline = None;
+        self.startup_payload_writes_enabled = true;
     }
 
     #[must_use]
     pub fn startup_validated(&self) -> bool {
         self.startup_validated
+    }
+
+    #[must_use]
+    fn startup_payload_writes_enabled(&self) -> bool {
+        self.startup_payload_writes_enabled
     }
 
     #[must_use]
@@ -130,6 +137,7 @@ impl RnodeBleCommandMonitor {
         };
         if validation.is_ok() {
             self.startup_validated = true;
+            self.startup_payload_writes_enabled = true;
         }
         validation
     }
@@ -139,7 +147,8 @@ pub(crate) fn rnode_ble_payload_writes_enabled(
     radio_config_sent: bool,
     command_monitor: Option<&RnodeBleCommandMonitor>,
 ) -> bool {
-    radio_config_sent && command_monitor.is_none_or(RnodeBleCommandMonitor::startup_validated)
+    radio_config_sent
+        && command_monitor.is_none_or(RnodeBleCommandMonitor::startup_payload_writes_enabled)
 }
 
 #[must_use]

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
@@ -124,6 +124,18 @@ fn payload_writes_wait_for_validated_radio_startup() {
 }
 
 #[test]
+fn degraded_startup_enables_payload_writes_after_fallback() {
+    let config = LoraConfig::us915_default();
+    let mut monitor = RnodeBleCommandMonitor::new(config, Duration::from_secs(5));
+
+    monitor.accept_degraded_startup();
+
+    assert!(!monitor.startup_validated());
+    assert!(rnode_ble_payload_writes_enabled(true, Some(&monitor)));
+    assert!(!rnode_ble_payload_writes_enabled(false, Some(&monitor)));
+}
+
+#[test]
 fn payload_writes_wait_when_radio_state_arrives_before_startup_validation() {
     let config = LoraConfig::us915_default();
     let mut monitor = RnodeBleCommandMonitor::new(config, Duration::ZERO);

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
@@ -1,7 +1,7 @@
 use crate::iface::lora::{
     CMD_BANDWIDTH, CMD_BLINK, CMD_CR, CMD_DETECT, CMD_FB_EXT, CMD_FREQUENCY, CMD_FW_VERSION,
     CMD_LEAVE, CMD_MCU, CMD_PLATFORM, CMD_RADIO_STATE, CMD_SF, CMD_TXPOWER, DETECT_RESP,
-    PLATFORM_ESP32, RADIO_STATE_ASK, RADIO_STATE_OFF,
+    PLATFORM_ESP32, RADIO_STATE_ASK, RADIO_STATE_OFF, RADIO_STATE_ON,
 };
 use crate::kiss::decode_frames;
 
@@ -109,6 +109,7 @@ fn payload_writes_wait_for_validated_radio_startup() {
     let mut monitor = RnodeBleCommandMonitor::new(config, Duration::ZERO);
 
     assert!(!rnode_ble_payload_writes_enabled(true, Some(&monitor)));
+    assert!(!monitor.startup_validated());
     monitor
         .accept_notification(&startup_notification_without_radio_state(config))
         .expect("accept startup responses");
@@ -116,9 +117,60 @@ fn payload_writes_wait_for_validated_radio_startup() {
         .validate_startup_deadline()
         .expect("compatible startup should validate");
 
+    assert!(monitor.startup_validated());
     assert!(rnode_ble_payload_writes_enabled(true, Some(&monitor)));
     assert!(rnode_ble_payload_writes_enabled(true, None));
     assert!(!rnode_ble_payload_writes_enabled(false, None));
+}
+
+#[test]
+fn payload_writes_wait_when_radio_state_arrives_before_startup_validation() {
+    let config = LoraConfig::us915_default();
+    let mut monitor = RnodeBleCommandMonitor::new(config, Duration::ZERO);
+    monitor
+        .accept_notification(&RnodeBleNotification {
+            commands: vec![(CMD_RADIO_STATE, vec![RADIO_STATE_ON])],
+            packets: Vec::new(),
+        })
+        .expect("accept radio-state response");
+
+    assert!(monitor.online());
+    assert!(!monitor.startup_validated());
+    assert!(!rnode_ble_payload_writes_enabled(true, Some(&monitor)));
+
+    let mut mismatched = startup_notification_without_radio_state(config);
+    let (_, bandwidth) = mismatched
+        .commands
+        .iter_mut()
+        .find(|(command, _)| *command == CMD_BANDWIDTH)
+        .expect("bandwidth response");
+    *bandwidth = (config.bandwidth_hz + 1).to_be_bytes().to_vec();
+    monitor.accept_notification(&mismatched).expect("accept startup responses");
+
+    let error = monitor
+        .validate_startup_deadline()
+        .expect_err("mismatched startup response must remain fatal");
+    assert!(error.contains("rnode bandwidth mismatch"));
+    assert!(!monitor.startup_validated());
+    assert!(!rnode_ble_payload_writes_enabled(true, Some(&monitor)));
+}
+
+#[test]
+fn startup_compatibility_rejects_malformed_radio_state_response() {
+    let config = LoraConfig::us915_default();
+    let mut monitor = RnodeBleCommandMonitor::new(config, Duration::ZERO);
+    let mut notification = startup_notification_without_radio_state(config);
+    notification.commands.push((CMD_RADIO_STATE, Vec::new()));
+    monitor
+        .accept_notification(&notification)
+        .expect("malformed radio-state response should not abort notification handling");
+
+    let error = monitor
+        .validate_startup_deadline()
+        .expect_err("malformed radio-state response must not use compatibility mode");
+    assert!(error.contains("rnode radio state response is missing"));
+    assert!(!monitor.startup_validated());
+    assert!(!rnode_ble_payload_writes_enabled(true, Some(&monitor)));
 }
 
 #[tokio::test]

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
@@ -1,6 +1,7 @@
 use crate::iface::lora::{
-    CMD_BLINK, CMD_DETECT, CMD_FB_EXT, CMD_FW_VERSION, CMD_LEAVE, CMD_MCU, CMD_PLATFORM,
-    CMD_RADIO_STATE, DETECT_RESP, PLATFORM_ESP32, RADIO_STATE_ASK, RADIO_STATE_OFF,
+    CMD_BANDWIDTH, CMD_BLINK, CMD_CR, CMD_DETECT, CMD_FB_EXT, CMD_FREQUENCY, CMD_FW_VERSION,
+    CMD_LEAVE, CMD_MCU, CMD_PLATFORM, CMD_RADIO_STATE, CMD_SF, CMD_TXPOWER, DETECT_RESP,
+    PLATFORM_ESP32, RADIO_STATE_ASK, RADIO_STATE_OFF,
 };
 use crate::kiss::decode_frames;
 
@@ -34,6 +35,92 @@ impl RnodeBleBackend for TestBackend {
     }
 }
 
+fn startup_notification_without_radio_state(config: LoraConfig) -> RnodeBleNotification {
+    RnodeBleNotification {
+        commands: vec![
+            (CMD_DETECT, vec![DETECT_RESP]),
+            (CMD_FW_VERSION, vec![1, 83]),
+            (CMD_PLATFORM, vec![PLATFORM_ESP32]),
+            (CMD_MCU, vec![1]),
+            (
+                CMD_FREQUENCY,
+                u32::try_from(config.frequency_hz)
+                    .expect("test frequency fits RNode response")
+                    .to_be_bytes()
+                    .to_vec(),
+            ),
+            (CMD_BANDWIDTH, config.bandwidth_hz.to_be_bytes().to_vec()),
+            (CMD_TXPOWER, config.tx_power_dbm.to_be_bytes().to_vec()),
+            (CMD_SF, vec![config.spreading_factor]),
+            (CMD_CR, vec![config.coding_rate]),
+        ],
+        packets: Vec::new(),
+    }
+}
+
+#[test]
+fn startup_accepts_only_missing_radio_state_for_compatible_firmware() {
+    let config = LoraConfig::us915_default();
+    let mut monitor = RnodeBleCommandMonitor::new(config, Duration::ZERO);
+    monitor
+        .accept_notification(&startup_notification_without_radio_state(config))
+        .expect("accept startup responses");
+
+    monitor
+        .validate_startup_deadline()
+        .expect("missing radio-state echo should use compatibility mode");
+
+    assert!(monitor.online());
+    let status = monitor.runtime_status_json("ble://legacy-rnode");
+    assert_eq!(status["last_command_error"], serde_json::Value::Null);
+    assert!(status["startup_compatibility_warning"]
+        .as_str()
+        .is_some_and(|warning| warning.contains("omitted the startup radio-state response")));
+}
+
+#[test]
+fn startup_compatibility_rejects_other_radio_mismatches() {
+    let config = LoraConfig::us915_default();
+    let mut notification = startup_notification_without_radio_state(config);
+    let (_, bandwidth) = notification
+        .commands
+        .iter_mut()
+        .find(|(command, _)| *command == CMD_BANDWIDTH)
+        .expect("bandwidth response");
+    *bandwidth = (config.bandwidth_hz + 1).to_be_bytes().to_vec();
+    let mut monitor = RnodeBleCommandMonitor::new(config, Duration::ZERO);
+    monitor.accept_notification(&notification).expect("accept startup responses");
+
+    let error = monitor
+        .validate_startup_deadline()
+        .expect_err("bandwidth mismatch must remain fatal");
+
+    assert!(error.contains("rnode bandwidth mismatch"));
+    assert!(!monitor.online());
+    assert_eq!(
+        monitor.runtime_status_json("ble://wrong-rnode")["startup_compatibility_warning"],
+        serde_json::Value::Null
+    );
+}
+
+#[test]
+fn payload_writes_wait_for_validated_radio_startup() {
+    let config = LoraConfig::us915_default();
+    let mut monitor = RnodeBleCommandMonitor::new(config, Duration::ZERO);
+
+    assert!(!rnode_ble_payload_writes_enabled(true, Some(&monitor)));
+    monitor
+        .accept_notification(&startup_notification_without_radio_state(config))
+        .expect("accept startup responses");
+    monitor
+        .validate_startup_deadline()
+        .expect("compatible startup should validate");
+
+    assert!(rnode_ble_payload_writes_enabled(true, Some(&monitor)));
+    assert!(rnode_ble_payload_writes_enabled(true, None));
+    assert!(!rnode_ble_payload_writes_enabled(false, None));
+}
+
 #[tokio::test]
 async fn startup_caps_max_write_len_to_negotiated_att_payload() {
     let backend =
@@ -51,6 +138,28 @@ async fn startup_caps_max_write_len_to_negotiated_att_payload() {
         runtime.session.config.max_write_len,
         20,
         "startup should clamp writes to the negotiated ATT payload length"
+    );
+}
+
+#[tokio::test]
+async fn startup_preserves_a_conservative_configured_write_cap() {
+    let backend = TestBackend {
+        negotiated_mtu: Some(517),
+        notifications: VecDeque::new(),
+        writes: Vec::new(),
+    };
+    let config = RnodeBleKissConfig {
+        mtu: 508,
+        max_write_len: 20,
+        ..RnodeBleKissConfig::default()
+    };
+    let mut runtime = RnodeBleKissRuntime::new(backend, config);
+
+    runtime.startup().await.expect("startup should succeed");
+
+    assert_eq!(
+        runtime.session.config.max_write_len, 20,
+        "a large negotiated ATT payload must not override the configured firmware-safe write cap"
     );
 }
 

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -533,9 +533,14 @@ Scoped release evidence is split as follows:
   `RnodeBearerKissInterface` now let mobile platform owners provide ordered BLE
   or Bluetooth Classic byte streams while this crate retains shared KISS
   framing, RNode probe/configuration, MTU and flow-control enforcement, runtime
-  status, and teardown. Focused no-default-feature tests cover shared BLE/SPP
+  status, and teardown. Platform backends can retain a conservative write cap
+  after ATT MTU negotiation, payload writes wait until radio startup is
+  validated, and older firmware that omits only the radio-state echo can enter
+  an explicit compatibility mode after every other probe and radio parameter
+  matches. Focused no-default-feature tests cover shared BLE/SPP
   framing, notification preservation, empty-read backoff, cancellation-safe and
-  idempotent close, and close-failure reporting during aborted startup. Native
+  idempotent close, close-failure reporting during aborted startup, the
+  firmware compatibility boundary, and conservative BLE chunking. Native
   Android callback/resource lifecycle validation, physical RNode BLE/SPP
   lifecycle cycling, and long-running hardware soak evidence remain external
   mobile/HIL gaps and are not claimed by this software increment.

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -558,7 +558,11 @@ bearer, firmware, platform, MCU identity, and capture provenance fields.
 Display-capable BLE RNode shutdown now disables the external framebuffer before
 radio-off/leave frames. Android configured RNode BLE reconnect now excludes
 the failed configured peripheral from fallback scan matching, with shared alias
-matching helpers and stable service-UUID fallback log context. Serial/TCP RNode
+matching helpers and stable service-UUID fallback log context. Bearer-neutral
+RNode startup preserves platform write caps after ATT MTU negotiation, blocks
+payload writes until radio validation completes, and accepts older firmware
+that omits only the radio-state echo after all other probe and radio parameters
+match; focused regressions keep mismatches fail-closed. Serial/TCP RNode
 streams now expose a transport-local management dispatch handle that writes
 pre-encoded KISS command frames through the live KISS runtime; feature-gated
 BLE RNode streams expose the same management dispatch through the Nordic UART


### PR DESCRIPTION
## What

- keep BLE payload writes behind successful RNode radio validation
- tolerate older firmware that omits only the radio-state echo after all other startup probes and configured radio parameters succeed
- preserve the configured conservative BLE write cap even when Android reports a larger ATT MTU
- add focused runtime tests and update the parity/roadmap documentation

## Why

Some RNode firmware accepts and applies the full radio configuration but does not echo the final radio-state command. The previous fail-closed behavior left these otherwise usable radios permanently offline, while negotiated BLE MTUs could also cause writes larger than the configured safe limit.

The compatibility path remains narrow: missing or invalid firmware/platform/MCU probes, parameter mismatches, and explicit command errors still fail startup.

## Impact

This improves Android BLE RNode startup compatibility without allowing application payloads before the transport has validated the device. It also avoids oversized BLE writes on stacks that advertise a large ATT MTU.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p reticulum-rs-transport --all-features` (653 unit tests plus all transport integration suites passed)
- `cargo clippy -p reticulum-rs-transport --all-targets --all-features --no-deps -- -D warnings`

## Hardware evidence

With the corresponding REM 1.3 build, two Android phones progressed beyond the earlier startup failure: the POCO received the Pixel's full 251-byte announce and the Pixel received the POCO's 67-byte link request. Full end-to-end LXMF message delivery was not yet proven because the link proof did not complete and the Pixel RNode BLE session later disconnected.
