### PR TITLE
docs: prepare v0.10.0 stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ These are matched-workload comparisons, not a claim of whole-system superiority.
 
 ## Current status
 
-The latest stable release is
+The latest published stable release is
 [`v0.9.9`](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.9.9),
-published on 2026-08-12. The release-candidate workspace packages are version
-`0.10.0`; current development targets Python Reticulum 1.5.0 at
-`e32d4df754a7b87b1bf1bb0d08675d12ff505ae6` for the next release candidate.
+and the reviewed `0.10.0` release aligned with Python Reticulum 1.5.0 is
+prepared on `main` pending its immutable tag and tag-triggered publication.
+The workspace packages are version `0.10.0`. Current development targets Python Reticulum 1.5.0 at
+`e32d4df754a7b87b1bf1bb0d08675d12ff505ae6` for the next release candidate;
+the [release ledger](docs/status/v0.10.0-release.md) tracks stable publication.
 
 | Area | Current position |
 | --- | --- |
@@ -45,8 +47,9 @@ published on 2026-08-12. The release-candidate workspace packages are version
 | Hardware and external clients | Physical devices, public networks, and third-party clients remain separate evidence tracks and are not claimed by the software-parity result |
 
 Read the [current roadmap](docs/status/current-roadmap.md) for the authoritative
-project posture, the [v0.9.9 release notes](docs/release-notes-v0.9.9.md) for
-the stable release summary, and the
+project posture, the [v0.10.0 release notes](docs/release-notes-v0.10.0.md) and
+[release ledger](docs/status/v0.10.0-release.md) for the prepared stable
+release, and the
 [Reticulum](docs/status/reticulum-parity-matrix.md) and
 [LXMF](docs/status/lxmf-parity-matrix.md) parity matrices for row-level detail.
 
@@ -82,8 +85,8 @@ Library consumers can start with the umbrella crates:
 
 ```toml
 [dependencies]
-lxmf = "0.9.9"
-reticulum-rs = "0.9.9"
+lxmf = "0.10.0"
+reticulum-rs = "0.10.0"
 ```
 
 See [Getting started](docs/getting-started.md) for release downloads, checksum

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,9 +37,10 @@ Update these documents when their corresponding behavior changes:
 - [v0.9.9 release notes](release-notes-v0.9.9.md): current stable release
   summary. The historical rc.6 evidence remains in the
   [candidate ledger](status/v0.9.9-release-candidate.md).
-- [v0.10.0-rc.1 release notes](release-notes-v0.10.0-rc.1.md): RNS 1.5.0
-  alignment candidate, with exact-head readiness tracked in its
-  [candidate ledger](status/v0.10.0-release-candidate.md).
+- [v0.10.0 release notes](release-notes-v0.10.0.md): RNS 1.5.0 stable-release
+  preparation, with tag-boundary readiness tracked in its
+  [release ledger](status/v0.10.0-release.md). The superseded rc.1 record
+  remains in the [historical candidate ledger](status/v0.10.0-release-candidate.md).
 - [Contracts](contracts/): public compatibility, support, API, payload, RPC,
   and protocol guarantees.
 - [Interfaces](interfaces/): interface-specific configuration and integration
@@ -77,8 +78,9 @@ Update these documents when their corresponding behavior changes:
 
 - [Latest GitHub release](https://github.com/FreeTAKTeam/LXMF-rs/releases/latest)
 - [v0.9.9 release notes](release-notes-v0.9.9.md)
-- [v0.10.0-rc.1 release notes](release-notes-v0.10.0-rc.1.md)
-- [v0.10.0 candidate evidence](status/v0.10.0-release-candidate.md)
+- [v0.10.0 release notes](release-notes-v0.10.0.md)
+- [v0.10.0 release evidence](status/v0.10.0-release.md)
+- [v0.10.0 historical candidate evidence](status/v0.10.0-release-candidate.md)
 - [v0.10.0 RNS 1.5 migration guide](migrations/v0.10.0-rns-1.5.md)
 - [Release readiness](runbooks/release-readiness.md)
 - [Release process](RELEASING.md)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,12 +43,12 @@ prepare ─► build (matrix: linux-musl x3, windows, macos x2)
 
 1. Bump `VERSION` and the crate versions (`cargo xtask` release helpers already
    exist for crates.io publishing).
-2. For this candidate, tag the reviewed commit: `git tag -a v0.9.9-rc.6 -m "LXMF-rs v0.9.9-rc.6" && git push origin v0.9.9-rc.6`.
+2. For this release, tag the reviewed commit: `git tag -a v0.10.0 -m "LXMF-rs v0.10.0" && git push origin v0.10.0`.
 3. The workflow runs end to end. A manual dry run is available via
    **Actions → Release → Run workflow** (set `publish: false` to build and
    smoke-test everything without publishing).
-4. Promote only the same immutable commit to `v0.9.9` after the RC evidence
-   ledger recommends stable publication.
+4. Promote only the same immutable commit to the stable `v0.10.0` release after
+   the release evidence ledger recommends publication.
 
 Pre-release tags containing `-rc`, `-alpha`, `-beta`, or `preview` are
 published as GitHub pre-releases automatically.
@@ -80,13 +80,13 @@ cosign verify-blob \
   SHA256SUMS.txt
 
 # 3. Verify build provenance of any file:
-  gh attestation verify lxmf-rs_0.9.9-rc.6_linux-x86_64.tar.gz --owner FreeTAKTeam
+  gh attestation verify lxmf-rs_0.10.0_linux-x86_64.tar.gz --owner FreeTAKTeam
 
 # 4. Verify the container image:
-  cosign verify ghcr.io/freetakteam/lxmf-rs:0.9.9-rc.6 \
+  cosign verify ghcr.io/freetakteam/lxmf-rs:0.10.0 \
   --certificate-identity-regexp "https://github.com/FreeTAKTeam/LXMF-rs/.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
-  gh attestation verify oci://ghcr.io/freetakteam/lxmf-rs:0.9.9-rc.6 --owner FreeTAKTeam
+  gh attestation verify oci://ghcr.io/freetakteam/lxmf-rs:0.10.0 --owner FreeTAKTeam
 ```
 
 ## Consumer usage
@@ -102,10 +102,10 @@ docker run --rm -v $PWD/data:/data ghcr.io/freetakteam/lxmf-rs:latest
 brew tap freetakteam/tap && brew install lxmf-rs
 
 # Debian/Ubuntu/Raspberry Pi OS:
-sudo dpkg -i lxmf-rs_0.9.9_arm64.deb     # or amd64 / armhf
+sudo dpkg -i lxmf-rs_0.10.0_arm64.deb     # or amd64 / armhf
 
 # Fedora/RHEL/openSUSE:
-sudo rpm -i lxmf-rs-0.9.9-1.aarch64.rpm  # or x86_64
+sudo rpm -i lxmf-rs-0.10.0-1.aarch64.rpm  # or x86_64
 ```
 
 ## Design notes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,22 +6,23 @@ an application.
 
 ## Install a stable release
 
-The [`v0.9.9` release](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.9.9)
-provides Linux, macOS, and Windows archives, Debian and RPM packages, a Windows
-MSI, SBOMs, and checksum files. Choose the asset for your platform and verify
-it against `SHA256SUMS` before extracting or installing it.
+The [`v0.10.0` release](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.0)
+is the prepared RNS 1.5.0-aligned release train. Once its immutable tag is
+published, it provides Linux, macOS, and Windows archives, Debian and RPM
+packages, a Windows MSI, SBOMs, and checksum files. Choose the asset for your
+platform and verify it against `SHA256SUMS` before extracting or installing it.
 
 For example, after downloading the Linux x86-64 archive and `SHA256SUMS` into
 the same directory:
 
 ```bash
-grep 'lxmf-rs_0.9.9_linux-x86_64.tar.gz$' SHA256SUMS | sha256sum -c -
-tar -xzf lxmf-rs_0.9.9_linux-x86_64.tar.gz
+grep 'lxmf-rs_0.10.0_linux-x86_64.tar.gz$' SHA256SUMS | sha256sum -c -
+tar -xzf lxmf-rs_0.10.0_linux-x86_64.tar.gz
 ```
 
 The [latest release page](https://github.com/FreeTAKTeam/LXMF-rs/releases/latest)
 is the durable entry point for future versions. Release claims and evidence
-boundaries are described in the [release notes](release-notes-v0.9.9.md) and
+boundaries are described in the [release notes](release-notes-v0.10.0.md) and
 [current roadmap](status/current-roadmap.md).
 
 ## Build from source
@@ -84,19 +85,19 @@ The umbrella crates provide the simplest dependency surface:
 
 ```toml
 [dependencies]
-lxmf = "0.9.9"
-reticulum-rs = "0.9.9"
+lxmf = "0.10.0"
+reticulum-rs = "0.10.0"
 ```
 
 Applications that need narrower features can depend on component crates:
 
 ```toml
 [dependencies]
-lxmf-sdk = "0.9.9"
-lxmf-wire = "0.9.9"
-reticulum-rs-core = "0.9.9"
-reticulum-rs-transport = "0.9.9"
-reticulum-rs-rpc = "0.9.9"
+lxmf-sdk = "0.10.0"
+lxmf-wire = "0.10.0"
+reticulum-rs-core = "0.10.0"
+reticulum-rs-transport = "0.10.0"
+reticulum-rs-rpc = "0.10.0"
 ```
 
 Use the [SDK quickstart](sdk/quickstart.md) for a minimal client, the

--- a/docs/release-notes-v0.10.0.md
+++ b/docs/release-notes-v0.10.0.md
@@ -1,0 +1,58 @@
+# LXMF-rs v0.10.0
+
+v0.10.0 is the stable release train for the Reticulum 1.5.0 alignment. It
+promotes the reviewed implementation merged on `main` and keeps hardware,
+public-network, and third-party-client validation as separate evidence tracks.
+Stable artifacts and package publication are produced only from the immutable
+`v0.10.0` tag.
+
+## Reticulum 1.5.0 alignment
+
+The release is compared with these exact Python references:
+
+- Reticulum `1.5.0` at
+  `e32d4df754a7b87b1bf1bb0d08675d12ff505ae6`;
+- LXMF at `727830cefda83d9c6e3982b48675425f3f988f9c`.
+
+The strict generated inventory contains 1,839 entries: 1,838 applicable and
+complete, zero partial, zero unmapped, and one provenance-backed
+not-applicable `CRNS` package. The manual 41-row release audit is recorded in
+[`docs/status/rns-1.5-delta.md`](status/rns-1.5-delta.md).
+
+Highlights include:
+
+- bounded four-class priority ingress with early filtering, violation
+  accounting, queue pressure, drop, and flow telemetry;
+- destination-scoped path-request batching, adaptive expiry, blackhole-aware
+  announce admission, and Backbone child-limiter accounting;
+- negotiated full-link Channel and Buffer MDU use, including pinned-Python
+  transfer validation above the legacy packet MDU;
+- medium-bitrate timeout accessors and adaptive `rnpath`/`rngit` policy;
+- operator-address discovery announcements, TCP-client discovery publication,
+  and encryption bound to an explicitly configured shared network identity; and
+- expanded typed RPC, JSON, SDK/ZeroMQ, and human `rnstatus` visibility.
+
+## Compatibility boundaries
+
+The pre-1.0 minor release advances the workspace and publishable crates to
+`0.10.0`. SDK/RPC consumers should tolerate the additive telemetry fields and
+regenerate strongly typed clients from the release schemas when applicable.
+Source-level changes and configuration cutover steps are listed in the
+[`v0.10.0 migration guide`](migrations/v0.10.0-rns-1.5.md).
+
+Reticulum IFAC authentication is not implemented; IFAC configuration fails
+closed at daemon startup instead of creating an unauthenticated carrier.
+Physical RNode/RNodeMulti, BLE, Weave, VR-N76, serial/radio operation, public
+networks, and third-party clients remain separate evidence axes. Their absence
+does not imply that those environments were tested by this release.
+
+## Validation and publication
+
+The reviewed RNS 1.5.0 implementation passed the complete local release gate,
+the pinned-Python interoperability and HIL matrix, strict parity/inventory
+checks, independent review, and the hosted pull-request workflows. The
+tag-triggered Release, crates.io, performance, signing, provenance, OCI, and
+Homebrew workflows are the publication authority for the immutable `v0.10.0`
+tag. Their artifacts must be verified against that tag before stable
+publication is declared complete.
+

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1,6 +1,6 @@
 # Current Roadmap Status
 
-Last reassessed: 2026-08-23
+Last reassessed: 2026-08-24
 
 This file is the repository-level source of truth for parity posture, release
 confidence, and execution order. Detailed row-level status lives in:
@@ -27,9 +27,11 @@ addresses, queue/interface/link telemetry, and medium-bitrate timeout accessors.
 The exact upstream-to-Rust disposition is recorded in
 [`rns-1.5-delta.md`](rns-1.5-delta.md).
 
-This alignment is prepared on the `0.10.0` release train. The `-rc.1` suffix
-belongs to the eventual immutable Git tag; public package manifests and the
-root `VERSION` use `0.10.0`, consistent with the repository release policy.
+This alignment is merged on `main` at
+`e9111b2621afc31329fa403a61696b7a3d8987f1` and is prepared for stable
+`0.10.0` publication. Public package manifests and the root `VERSION` use
+`0.10.0`, consistent with the repository release policy. The immutable tag and
+tag-triggered artifact workflows remain the final publication authority.
 
 The project is best described by capability level:
 
@@ -80,16 +82,20 @@ not-applicable entry. The published v0.9.9 tag retains its historical 1.4.2
 inventory. Physical interfaces, public networks, and third-party clients remain
 separate evidence axes described above.
 
-## v0.10.0-rc.1 Release Candidate Preparation
+## v0.10.0 Stable Release Preparation
 
-The current candidate preparation aligns the complete software-controlled RNS
-surface with Python Reticulum 1.5.0. Its implementation ledger is
-[`rns-1.5-delta.md`](rns-1.5-delta.md), its candidate evidence ledger is
-[`v0.10.0-release-candidate.md`](v0.10.0-release-candidate.md), and its release
-notes are [`release-notes-v0.10.0-rc.1.md`](../release-notes-v0.10.0-rc.1.md).
-The candidate is not a published release until its exact reviewed commit is
-tagged and the tag-triggered artifact, signing, provenance, and performance
-workflows are verified.
+The reviewed implementation aligns the complete software-controlled RNS
+surface with Python Reticulum 1.5.0 and is merged on `main` at
+`e9111b2621afc31329fa403a61696b7a3d8987f1`. Its implementation ledger is
+[`rns-1.5-delta.md`](rns-1.5-delta.md), its stable release ledger is
+[`v0.10.0-release.md`](v0.10.0-release.md), and its release notes are
+[`release-notes-v0.10.0.md`](../release-notes-v0.10.0.md). The historical
+candidate record remains [`v0.10.0-release-candidate.md`](v0.10.0-release-candidate.md).
+
+The release is not published until the release-preparation commit is merged,
+`v0.10.0` is created on that immutable commit, and the tag-triggered artifact,
+signing, provenance, crates.io, OCI, Homebrew, and performance workflows are
+verified.
 
 ## v0.9.9-rc.6 Historical Release Candidate
 
@@ -1613,7 +1619,9 @@ Scoped release evidence is split as follows:
 Stable `v0.9.9` publication is complete. The exact tag workflows, 35 release
 assets, checksums, SBOMs, provenance, OCI publication, independent
 interoperability reports, performance reports, and crates.io packages were
-published for the immutable release commit.
+published for the immutable release commit. Stable `v0.10.0` preparation is
+complete on the software and hosted-PR axes; tag-triggered publication remains
+pending and is tracked in `docs/status/v0.10.0-release.md`.
 
 Physical RNode/RNodeMulti, Weave, VR-N76, BLE, serial-radio, public I2P,
 public Reticulum networks, and Sideband/MeshChatX/Columba or other
@@ -1629,8 +1637,8 @@ validated without their own evidence.
    performance evidence for release-facing changes.
 3. Treat physical hardware, public-network operation, and third-party clients
    as separate evidence programs for the v1.0 boundary.
-4. Use the maintained release-readiness and release runbooks for the next
-   version instead of reopening the historical rc.6 checklist.
+4. Merge the stable `v0.10.0` release-preparation slice, tag only that exact
+   commit, and verify all tag-triggered release evidence before publication.
 
 ## Verification Baseline
 

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -23,7 +23,7 @@ traits. Row-level transport classification is generated in
 `docs/status/sdk-zmq-parity.json`.
 
 The historical v0.9.8 record retains its release boundary. Current `main` and
-`v0.9.9-rc.6` keeps all seven tracked LXMF module rows `complete` for their
+the v0.10.0 release train keep all seven tracked LXMF module rows `complete` for their
 named software scenarios, with hardware, public-network, and third-party-client
 evidence tracked independently.
 

--- a/docs/status/v0.10.0-release-candidate.md
+++ b/docs/status/v0.10.0-release-candidate.md
@@ -1,10 +1,11 @@
-# v0.10.0-rc.1 Release Candidate Evidence Ledger
+# v0.10.0-rc.1 Historical Candidate Evidence Ledger
 
-Status: **LOCAL QUALIFICATION COMPLETE - HOSTED PR CHECKS PENDING**
+Status: **HISTORICAL CANDIDATE RECORD - HOSTED PR CHECKS PASSED AND MERGED**
 
-This ledger records the exact evidence required before the RNS 1.5.0 alignment
-commit can be tagged as `v0.10.0-rc.1`. Pending and unavailable checks remain
-explicit; they are never converted into passes.
+This ledger records the untagged rc.1 preparation that became PR #576. The
+reviewed implementation passed the hosted pull-request gates and was merged
+into `main`; the stable release boundary and tag-triggered evidence are now
+tracked in [`v0.10.0-release.md`](v0.10.0-release.md).
 
 ## Candidate identity
 
@@ -12,7 +13,7 @@ explicit; they are never converted into passes.
 |---|---|
 | Intended candidate tag | `v0.10.0-rc.1` |
 | Validated implementation head | `608dbd47763aa5afe7663f612dd7d570a12bd76f` |
-| Final PR head | pending this evidence-ledger commit and hosted checks |
+| Final PR head | `4e83fcf541e8a302f4e5c7ddbb408554f84c0192` |
 | Workspace/package version | `0.10.0` |
 | Base | `origin/main` at `249815e2eed8a3288ca05477b9dcc9f153fb02fd` |
 | Prior stable | `v0.9.9` |
@@ -42,7 +43,7 @@ behavior is classified in [`rns-1.5-delta.md`](rns-1.5-delta.md).
 | Full pinned-Python compatibility/conformance/HIL | PASS | PR-level Python-reference HIL: 11/11; conformance: 117 passed, 2 skipped, 1 deselected |
 | Loaded-daemon queue/status smoke | PASS | 50,000 valid UDP data packets; 2/4 data height, 20 bounded drops, clean drain, 1,200 bps adaptive timeout evidence |
 | Independent implementation review | PASS | architecture and release reviews found no unresolved implementation or release-blocking findings |
-| Hosted pull-request checks | pending PR | every required check must reference the exact pushed head |
+| Hosted pull-request checks | PASS | PR #576 CI, Verify/HIL, and Independent interoperability passed on the exact final PR head |
 
 ## Tag-triggered evidence boundary
 
@@ -55,6 +56,6 @@ stable release.
 
 ## Recommendation
 
-**LOCALLY READY; HOSTED VERIFICATION PENDING** - publish the final documentation
-head, require every hosted check to reference that exact SHA, and do not tag
-while any required hosted check remains pending or failed.
+**HISTORICAL RC PREPARATION COMPLETE** - the final PR head passed local and
+hosted qualification and was merged as `e9111b2621afc31329fa403a61696b7a3d8987f1`.
+Stable tag and artifact evidence are tracked in the v0.10.0 release ledger.

--- a/docs/status/v0.10.0-release.md
+++ b/docs/status/v0.10.0-release.md
@@ -1,0 +1,56 @@
+# v0.10.0 Stable Release Preparation
+
+Status: **STABLE RELEASE PREPARATION - TAG-TRIGGERED EVIDENCE PENDING**
+
+This ledger records the release boundary for the Reticulum 1.5.0 aligned
+workspace. It separates software qualification already completed on the merged
+implementation from evidence that can only exist after the immutable release
+tag is created.
+
+## Candidate identity
+
+| Field | Value |
+|---|---|
+| Release train | `v0.10.0` |
+| Reviewed merged implementation | `e9111b2621afc31329fa403a61696b7a3d8987f1` |
+| Workspace/package version | `0.10.0` |
+| Prior stable | `v0.9.9` |
+| RNS reference | `1.5.0` at `e32d4df754a7b87b1bf1bb0d08675d12ff505ae6` |
+| LXMF reference | `727830cefda83d9c6e3982b48675425f3f988f9c` |
+| Intended tag | `v0.10.0` |
+
+## Parity target
+
+| Total | Applicable | Complete | Partial | Unmapped | Not applicable |
+|---:|---:|---:|---:|---:|---:|
+| 1,839 | 1,838 | 1,838 | 0 | 0 | 1 |
+
+The generated source of truth is
+[`python-surface-parity.json`](python-surface-parity.json); manual release-note
+behavior is classified in [`rns-1.5-delta.md`](rns-1.5-delta.md).
+
+## Qualification record
+
+| Gate | Result | Evidence |
+|---|---|---|
+| Exact RNS/LXMF pins and strict inventory | PASS | RNS 1.5.0 and LXMF revisions above; 1,839 / 1,838 / 0 / 1 |
+| Focused RNS 1.5 regressions | PASS | ingress, batching, traffic, status, timeout, discovery, and negotiated-MDU tests |
+| Full local release gate | PASS | `cargo xtask release-check` on the reviewed implementation; Miri, policy/audit, parity, soak/chaos, reproducible builds, footprint, and artifact checks included |
+| Pinned-Python compatibility and HIL | PASS | 11/11 PR cases; conformance 117 passed, 2 skipped, 1 deselected |
+| Loaded-daemon telemetry smoke | PASS | 50,000 valid UDP data packets; bounded queue pressure/drops, clean drain, and adaptive timeout evidence |
+| Hosted PR qualification | PASS | PR #576: CI, Verify/HIL, and Independent interoperability all passed on the exact implementation head |
+| Merged-main CI and Verify | PASS | CI and Verify (`32731214377`, `32731214417`) passed on merged implementation `e9111b26` |
+| Tag-triggered release artifacts | PENDING | Release, performance, crates.io, signing, provenance, OCI, and Homebrew workflows require immutable `v0.10.0` |
+
+## Evidence boundaries
+
+Raw IFAC cryptographic authentication is not implemented; daemon configuration
+fails closed for unsupported IFAC authentication fields. Physical carriers,
+public networks, and third-party clients remain separate evidence programs and
+are not implied by software parity or hosted virtual/interoperability checks.
+
+## Recommendation
+
+**READY TO TAG AFTER THIS RELEASE-PREPARATION PR PASSES HOSTED CHECKS.** Create
+`v0.10.0` only on the merged release-preparation commit, then verify every
+tag-triggered artifact and publication channel against that exact tag.


### PR DESCRIPTION
## Summary

- prepare the stable `v0.10.0` release metadata for the Reticulum 1.5.0-aligned implementation already merged on `main` at `e9111b2621afc31329fa403a61696b7a3d8987f1`
- add stable release notes and a tag-boundary evidence ledger
- reconcile README, getting-started, releasing, roadmap, and parity-matrix guidance from the historical rc.1 record to the stable release train
- record merged-main CI and Verify success and keep immutable-tag publication explicitly pending

## Exact release inputs

- RNS 1.5.0: `e32d4df754a7b87b1bf1bb0d08675d12ff505ae6`
- Python LXMF reference: `727830cefda83d9c6e3982b48675425f3f988f9c`
- strict inventory: 1,839 total / 1,838 applicable and complete / 0 partial / 0 unmapped / 1 not applicable
- package and workspace version: `0.10.0`

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- `cargo test --workspace --tests --quiet`
- `cargo xtask release-check` (full release gate: Miri, policy/audit, parity, soak/chaos, reproducibility, footprint, artifact, E2E, and code-generation checks)
- `cargo run -p xtask -- interop-artifacts` with no artifact drift
- reference pins and self-test
- strict Python surface inventory
- SDK/ZMQ parity
- locked Cargo metadata
- `rnx e2e --timeout-secs 20`
- merged-main CI run `32731214377` and Verify run `32731214417`: success

## Publication boundary

This PR does not create `v0.10.0` or publish packages, images, signatures, provenance, Homebrew assets, or performance artifacts. After this PR is merged, tag only the exact merge commit and verify every tag-triggered workflow against that immutable tag. Physical carriers, public networks, third-party clients, and unsupported IFAC authentication remain separate evidence boundaries.
