### PR TITLE
fix(transport): block a routeless remote announce on every interface mode

### DIFF
--- a/crates/libs/rns-transport/src/iface_runtime.rs
+++ b/crates/libs/rns-transport/src/iface_runtime.rs
@@ -26,6 +26,17 @@ fn allows_announce_broadcast(
         return true;
     };
 
+    // Reference parity: `Transport.py`'s per-interface announce ladder opens
+    // with a rung that is not mode-specific — an announce for a destination
+    // this node does not own, with no next-hop interface on file, is blocked
+    // on every outgoing interface ("Blocking announce broadcast on <iface>
+    // since next hop interface doesn't exist"). Only `Roaming` and `Boundary`
+    // block a `None` next hop below, and they do it as a side effect of
+    // matching `Some(..)`, so the other four modes let it through today.
+    if !policy.local_destination && policy.next_hop_iface_mode.is_none() {
+        return false;
+    }
+
     match outgoing_mode {
         InterfaceMode::AccessPoint => false,
         InterfaceMode::Roaming => {

--- a/crates/libs/rns-transport/src/iface_tests.rs
+++ b/crates/libs/rns-transport/src/iface_tests.rs
@@ -833,6 +833,110 @@ mod tests {
         assert_eq!(rx.try_recv().expect("announce").packet, packet);
     }
 
+    /// A remote announce with no route on file is blocked on every mode, not just
+    /// the two whose `matches!(Some(..))` happens to reject `None`.
+    #[tokio::test]
+    async fn full_blocks_remote_announce_without_a_next_hop_interface() {
+        let mut mgr = InterfaceManager::new(16);
+        let mut rx = mgr
+            .new_channel_with_role_and_mode(16, IfaceRole::Unicast, InterfaceMode::Full)
+            .tx_channel;
+        let packet = announce_packet();
+        let trace = mgr
+            .send_with_announce_policy(
+                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: packet.clone() },
+                Some(AnnounceBroadcastPolicy {
+                    local_destination: false,
+                    next_hop_iface_mode: None,
+                }),
+            )
+            .await;
+        assert_eq!(trace.sent_ifaces, 0);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn gateway_blocks_remote_announce_without_a_next_hop_interface() {
+        let mut mgr = InterfaceManager::new(16);
+        let mut rx = mgr
+            .new_channel_with_role_and_mode(16, IfaceRole::Unicast, InterfaceMode::Gateway)
+            .tx_channel;
+        let packet = announce_packet();
+        let trace = mgr
+            .send_with_announce_policy(
+                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: packet.clone() },
+                Some(AnnounceBroadcastPolicy {
+                    local_destination: false,
+                    next_hop_iface_mode: None,
+                }),
+            )
+            .await;
+        assert_eq!(trace.sent_ifaces, 0);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn internal_blocks_remote_announce_without_a_next_hop_interface() {
+        let mut mgr = InterfaceManager::new(16);
+        let mut rx = mgr
+            .new_channel_with_role_and_mode(16, IfaceRole::Unicast, InterfaceMode::Internal)
+            .tx_channel;
+        let packet = announce_packet();
+        let trace = mgr
+            .send_with_announce_policy(
+                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: packet.clone() },
+                Some(AnnounceBroadcastPolicy {
+                    local_destination: false,
+                    next_hop_iface_mode: None,
+                }),
+            )
+            .await;
+        assert_eq!(trace.sent_ifaces, 0);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn point_to_point_blocks_remote_announce_without_a_next_hop_interface() {
+        let mut mgr = InterfaceManager::new(16);
+        let mut rx = mgr
+            .new_channel_with_role_and_mode(16, IfaceRole::Unicast, InterfaceMode::PointToPoint)
+            .tx_channel;
+        let packet = announce_packet();
+        let trace = mgr
+            .send_with_announce_policy(
+                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: packet.clone() },
+                Some(AnnounceBroadcastPolicy {
+                    local_destination: false,
+                    next_hop_iface_mode: None,
+                }),
+            )
+            .await;
+        assert_eq!(trace.sent_ifaces, 0);
+        assert!(rx.try_recv().is_err());
+    }
+
+    /// The guard is scoped to remote announces: this node's own destination has no
+    /// next hop by definition, and must still be announceable.
+    #[tokio::test]
+    async fn full_allows_local_announce_without_a_next_hop_interface() {
+        let mut mgr = InterfaceManager::new(16);
+        let mut rx = mgr
+            .new_channel_with_role_and_mode(16, IfaceRole::Unicast, InterfaceMode::Full)
+            .tx_channel;
+        let packet = announce_packet();
+        let trace = mgr
+            .send_with_announce_policy(
+                TxMessage { tx_type: TxMessageType::Broadcast(None), packet: packet.clone() },
+                Some(AnnounceBroadcastPolicy {
+                    local_destination: true,
+                    next_hop_iface_mode: None,
+                }),
+            )
+            .await;
+        assert_eq!(trace.sent_ifaces, 1);
+        assert_eq!(rx.try_recv().expect("announce").packet, packet);
+    }
+
     #[tokio::test]
     async fn remote_announces_are_queued_and_released_by_hop_priority() {
         let mut mgr = InterfaceManager::new(16);

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -334,6 +334,14 @@ Scoped release evidence is split as follows:
 - Pending ordinary announce rebroadcasts now complete early when a later
   incoming transport announce proves the rebroadcast has already been passed
   onward, while retaining cached announce material for known-path responses.
+- A remote announce with no next-hop interface on file is now blocked on every
+  outgoing interface mode, matching the rung `Transport.py`'s per-interface
+  announce ladder opens with ("Blocking announce broadcast on <iface> since next
+  hop interface doesn't exist"). Only roaming and boundary rejected a missing
+  next hop before, and they did it as a side effect of matching `Some(..)`, so
+  the other four modes carried it. The rung is scoped to remote announces: a
+  destination this node owns has no next hop by definition and stays
+  announceable.
 - Transport announce rebroadcasts now have deterministic handler-boundary
   and local transport-policy evidence that the learned next-hop interface mode
   drives Python-style outgoing mode policy, including access-point suppression

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -365,6 +365,11 @@ Cached remote path-response announces now carry `PacketContext::PathResponse`
 when scheduled from a known path, matching Python's `PATH_RESPONSE` treatment
 for direct path answers and keeping ordinary announce rebroadcast policy
 separate from path-response delivery.
+A remote announce with no next-hop interface on file is now blocked on every
+outgoing interface mode, matching the non-mode-specific rung Python's
+per-interface announce ladder opens with, where previously only roaming and
+boundary rejected it. The rung is scoped to remote announces, so a destination
+this node owns stays announceable.
 When an ordinary announce is already queued for the same destination, a due
 known-path `PATH_RESPONSE` now drains first and the ordinary announce
 rebroadcasts afterward, matching Python's `held_announces` ordering.


### PR DESCRIPTION
## Summary

Fixes #578, first of two.

`Transport.py`'s per-interface announce ladder opens with a rung that is
not mode-specific (1.5.0, `Transport.py:1413`):

    if not local_destination and from_interface == None:
        RNS.log("Blocking announce broadcast on "+str(interface)+
                " since next hop interface doesn't exist", ac_loglevel)
        should_transmit = False

`allows_announce_broadcast` has no equivalent. `Roaming` and `Boundary`
reject a `None` next hop, but only as a side effect of matching
`Some(..)`; `Full`, `PointToPoint`, `Gateway` and `Internal` return `true`
unconditionally. So an announce for a destination this node neither owns
nor has a route to is broadcast on any interface in one of those four
modes — and `Full` is the default.

The guard is scoped to remote announces. A locally-owned destination has
no next hop by definition, and the reference lets it through on the same
rung, so `local_destination` still short-circuits.

Four of the five new tests fail on the parent commit and pass here; the
fifth is the local-destination control and passes either way.

`cargo test --workspace` passes on Linux — CI's `test-nextest-unit` stage is
`cargo nextest run --workspace --lib --bins`, which includes the bin below,
and it is green. On **macOS** one test fails, `rns-tools --bin rngit`'s
`local_git_bundle_fetch_and_push_use_the_registered_request_paths`, and it
fails identically on a pristine `v0.10.0` checkout there — a platform
difference, not something this branch does. The `make test` box is left
unticked only because my own local run was the macOS one; CI is the authority
and it is green.

Verified against Reticulum 1.5.0, the pinned reference.

## Type
- [ ] breaking
- [ ] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `make test` — green in CI on Linux; 1 macOS-only failure locally, see above
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [x] `cargo doc --workspace --no-deps`
- [x] `cargo deny check`
- [x] `cargo audit`

Also run: `./tools/scripts/check-boundaries.sh` (ok), `make migration-checks` (ok).

## Compatibility
- [ ] Updated compatibility matrix / contract docs (if needed)

No public API changes; behaviour only.
