### PR TITLE
fix(transport): stop a passive node building a retransmission queue it never drains

### DIFF
--- a/crates/libs/rns-transport/src/transport/announce.rs
+++ b/crates/libs/rns-transport/src/transport/announce.rs
@@ -181,14 +181,47 @@ async fn process_announce<'a>(
             handler.single_out_destinations.insert(packet.destination, destination.clone());
         }
 
-        if handler.announce_limits.should_suppress_rebroadcast(packet, &shared_config) {
+        // Reference parity (`Transport.py:2267`): an announce is only filed for
+        // retransmission on a node that will actually retransmit it.
+        //
+        //     if (transport_enabled() or is_from_local_client) and context != PATH_RESPONSE:
+        //         if rate_blocked: RNS.log("Blocking rebroadcast ...")
+        //         else:            announce_table[destination_hash] = [...]
+        //
+        // The inner rate-limit branch was already here; the outer condition was
+        // not, so `map` — which only `drain_retransmissions` prunes, and which
+        // only the retransmit worker drains, and only when `transport_enabled`
+        // — grew without bound on a passive node, one cloned `Packet` per
+        // distinct destination for the life of the process.
+        //
+        // Everything that is not queued is still cached rather than dropped.
+        // Unlike the reference, this crate rebuilds a path entry's announce
+        // packet out of the announce table when persisting the path table
+        // (`save_reticulum_path_table` -> `cached_packet_for_destination`),
+        // where the reference stores a packet hash and keeps the packet in its
+        // own on-disk cache. Dropping it outright here would persist an empty
+        // path table on exactly the nodes this guard is meant to help. The
+        // cache is the bounded half of the table (`announce_cache_capacity`),
+        // which is what it is for.
+        let from_shared_instance =
+            { handler.iface_manager.lock().await.is_shared_instance(&route_iface) };
+        let queue_for_retransmission = (handler.config.transport_enabled || from_shared_instance)
+            && packet.context != PacketContext::PathResponse;
+        let rate_blocked =
+            handler.announce_limits.should_suppress_rebroadcast(packet, &shared_config);
+
+        if rate_blocked {
             log::debug!(
                 "tp({}): suppressing announce rebroadcast for {} due to announce_rate_target",
                 handler.config.name,
                 packet.destination
             );
-        } else {
+        }
+
+        if queue_for_retransmission && !rate_blocked {
             handler.announce_table.add(packet, dest_hash, route_iface);
+        } else {
+            handler.announce_table.add_cached(packet, dest_hash, route_iface);
         }
 
         let random_blobs = handler.path_table.random_blobs_for(&packet.destination);

--- a/crates/libs/rns-transport/src/transport/announce_table.rs
+++ b/crates/libs/rns-transport/src/transport/announce_table.rs
@@ -75,6 +75,21 @@ impl AnnounceCache {
     }
 
     pub fn insert(&mut self, destination: AddressHash, entry: AnnounceEntry) {
+        // Refreshing a destination the cache already holds does not grow it,
+        // so it must not cost an unrelated destination its entry.
+        if let Some(existing) = self.newer.as_mut().and_then(|newer| newer.get_mut(&destination)) {
+            *existing = entry;
+            return;
+        }
+
+        // Held in the older generation instead: take it back, so that one
+        // destination does not occupy two slots while `get` reads only one.
+        if self.older.as_mut().is_some_and(|older| older.remove(&destination).is_some())
+            && self.older.as_ref().is_some_and(|older| older.is_empty())
+        {
+            self.older = None;
+        }
+
         if self.capacity > 0 && self.len() >= self.capacity {
             self.evict_one();
         }
@@ -165,6 +180,23 @@ impl AnnounceTable {
         destination: AddressHash,
         received_from: AddressHash,
     ) {
+        // Every packet lookup reads the retransmission queue first, and both
+        // `observe_passed_rebroadcast` and `drain_retransmissions` copy a
+        // queued entry over the cache when it retires. Leaving one untouched
+        // here would keep serving the announce this one supersedes, after the
+        // path table has already accepted this one. Refresh it in place: the
+        // pending rebroadcast keeps its own schedule and context, being an
+        // ordinary announce this node still owes rather than the path response
+        // that refreshed it.
+        if let Some(queued) = self.map.get_mut(&destination) {
+            let context = queued.packet.context;
+            queued.packet = announce.clone();
+            queued.packet.context = context;
+            queued.hops = announce.header.hops;
+            queued.received_from = received_from;
+            return;
+        }
+
         let entry = AnnounceEntry {
             packet: announce.clone(),
             timeout: Instant::now(),

--- a/crates/libs/rns-transport/src/transport/announce_table.rs
+++ b/crates/libs/rns-transport/src/transport/announce_table.rs
@@ -261,6 +261,14 @@ impl AnnounceTable {
         false
     }
 
+    /// `(retransmission queue, bounded cache)` sizes. The two tiers are
+    /// private, and `packet_for_destination` cannot tell them apart, but which
+    /// one an announce lands in is the whole behaviour under test.
+    #[cfg(test)]
+    pub(crate) fn tier_sizes(&self) -> (usize, usize) {
+        (self.map.len(), self.cache.len())
+    }
+
     #[cfg(test)]
     pub(crate) fn pending_response_for_destination(
         &self,

--- a/crates/libs/rns-transport/src/transport/announce_table_tests.rs
+++ b/crates/libs/rns-transport/src/transport/announce_table_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::packet::PacketContext;
+use crate::packet::{PacketContext, PacketDataBuffer};
 use rand_core::OsRng;
 use std::thread;
 use std::time::Duration as StdDuration;
@@ -303,4 +303,105 @@ fn zero_capacity_announce_cache_is_unbounded() {
     }
 
     assert_eq!(table.cache.len(), 2);
+}
+
+/// The queued entry is what every packet lookup reads first, and what
+/// `observe_passed_rebroadcast` and `drain_retransmissions` copy over the
+/// cache when it retires. A newer announce that is only cached — a
+/// `PATH_RESPONSE`, or one the rate limiter blocked — has to reach those
+/// readers too, or the node persists and answers path requests with the
+/// announce the path table has already superseded.
+#[test]
+fn a_cached_announce_refreshes_the_queued_one_it_supersedes() {
+    let mut table = AnnounceTable::new(16, 1);
+    let destination = AddressHash::new_from_rand(OsRng);
+    let first_iface = AddressHash::new_from_rand(OsRng);
+    let second_iface = AddressHash::new_from_rand(OsRng);
+    let transport_id = AddressHash::new_from_rand(OsRng);
+
+    let queued = Packet {
+        header: Header { hops: 1, ..Packet::default().header },
+        destination,
+        context: PacketContext::None,
+        data: PacketDataBuffer::new_from_slice(b"superseded-announce"),
+        ..Packet::default()
+    };
+    let superseding = Packet {
+        header: Header { hops: 2, ..Packet::default().header },
+        destination,
+        context: PacketContext::PathResponse,
+        data: PacketDataBuffer::new_from_slice(b"accepted-announce"),
+        ..Packet::default()
+    };
+
+    table.add(&queued, destination, first_iface);
+    table.add_cached(&superseding, destination, second_iface);
+
+    assert_eq!(
+        table.tier_sizes(),
+        (1, 0),
+        "the newer announce refreshes the queued entry rather than becoming a second copy of the destination"
+    );
+    let persisted =
+        table.cached_packet_for_destination(&destination).expect("packet for the accepted path");
+    assert_eq!(
+        persisted.data, superseding.data,
+        "path persistence must read the announce the path table accepted"
+    );
+    assert_eq!(
+        persisted.context,
+        PacketContext::None,
+        "the rebroadcast this node still owes is an ordinary announce, not the path response that refreshed it"
+    );
+
+    table.map.get_mut(&destination).unwrap().timeout = Instant::now() - Duration::from_millis(1);
+    let messages = table.drain_retransmissions(&transport_id);
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].packet.data, superseding.data, "and it rebroadcasts the newer announce");
+    assert_eq!(messages[0].packet.header.hops, 2);
+    assert!(
+        matches!(messages[0].tx_type, TxMessageType::Broadcast(Some(iface)) if iface == second_iface),
+        "held back from the interface the accepted announce arrived on"
+    );
+
+    table.map.get_mut(&destination).unwrap().timeout = Instant::now() - Duration::from_millis(1);
+    table.drain_retransmissions(&transport_id);
+    assert_eq!(table.tier_sizes(), (0, 1), "the retired entry moves to the cache");
+    assert_eq!(
+        table.cached_packet_for_destination(&destination).expect("cached packet").data,
+        superseding.data,
+        "retiring the queue must not put the superseded announce back in the cache"
+    );
+
+    assert!(table.add_response(destination, first_iface, 2));
+    assert_eq!(
+        table.responses.get(&destination).expect("response entry inserted").packet.data,
+        superseding.data,
+        "a later path request answers with the same announce the path table holds"
+    );
+}
+
+/// Refreshing a destination the cache already holds does not grow it, so it
+/// must not cost an unrelated destination its entry — and with it the path
+/// that destination could still be persisted or answered from.
+#[test]
+fn refreshing_a_cached_destination_does_not_evict_another() {
+    let mut table = AnnounceTable::new(2, 1);
+    let received_from = AddressHash::new_from_rand(OsRng);
+    let lowest = AddressHash::new([0x01; 16]);
+    let refreshed = AddressHash::new([0x02; 16]);
+    let announce = |destination| Packet { destination, ..Packet::default() };
+
+    table.add_cached(&announce(lowest), lowest, received_from);
+    table.add_cached(&announce(refreshed), refreshed, received_from);
+    assert_eq!(table.tier_sizes(), (0, 2), "the cache is at capacity");
+
+    table.add_cached(&announce(refreshed), refreshed, received_from);
+
+    assert_eq!(table.tier_sizes(), (0, 2), "a refresh consumes no capacity");
+    assert!(table.packet_for_destination(&refreshed).is_some());
+    assert!(
+        table.packet_for_destination(&lowest).is_some(),
+        "an unrelated destination must survive its neighbour being refreshed"
+    );
 }

--- a/crates/libs/rns-transport/src/transport/tests.rs
+++ b/crates/libs/rns-transport/src/transport/tests.rs
@@ -17,6 +17,7 @@ include!("tests_parts/roaming_path_response_suppression.rs");
 include!("tests_parts/announce_identity_drift.rs");
 
 include!("tests_parts/announce_broadcast_policy.rs");
+include!("tests_parts/announce_table_retransmission_gate.rs");
 
 include!("tests_parts/encrypted_resource_control_packet.rs");
 

--- a/crates/libs/rns-transport/src/transport/tests_parts/announce_table_retransmission_gate.rs
+++ b/crates/libs/rns-transport/src/transport/tests_parts/announce_table_retransmission_gate.rs
@@ -1,0 +1,133 @@
+async fn feed_announce(transport: &Transport, iface: crate::hash::AddressHash, aspect: &str) -> Packet {
+    let mut destination = SingleInputDestination::new(
+        PrivateIdentity::new_from_rand(OsRng),
+        DestinationName::new("lxmf", aspect),
+    );
+    let announce = destination.announce(OsRng, None).expect("announce");
+    handle_announce(
+        &announce,
+        transport.get_handler().lock().await,
+        iface,
+        crate::iface::IfaceSource::None,
+    )
+    .await;
+    announce
+}
+
+async fn tier_sizes(transport: &Transport) -> (usize, usize) {
+    transport.get_handler().lock().await.announce_table.tier_sizes()
+}
+
+/// A node that will never retransmit must not accumulate a retransmission
+/// queue. `map` is pruned only by `drain_retransmissions`, and the retransmit
+/// worker calls that only when `transport_enabled` — so before this gate,
+/// every announce a passive node heard stayed in `map` for the life of the
+/// process, one cloned `Packet` per distinct destination.
+///
+/// The reference does not have the problem because it never inserts:
+/// `Transport.py`'s `if (transport_enabled() or is_from_local_client) and
+/// context != PATH_RESPONSE:` guards the insert itself.
+#[tokio::test]
+async fn passive_transport_caches_announces_instead_of_queueing_them() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("passive", &identity, false));
+    let iface = transport.iface_manager().lock().await.new_channel(16).address;
+
+    for aspect in ["one", "two", "three"] {
+        feed_announce(&transport, iface, aspect).await;
+    }
+
+    let (queued, cached) = tier_sizes(&transport).await;
+    assert_eq!(queued, 0, "a passive node must not queue announces for a retransmission it will never send");
+    assert_eq!(cached, 3, "they belong in the bounded cache instead, which is what the path table reads back");
+}
+
+/// The control. Same three announces, same code path, `transport_enabled` on:
+/// they are queued, because this node really will rebroadcast them. Without
+/// this, the assertion above would also pass if `handle_announce` had simply
+/// stopped working.
+#[tokio::test]
+async fn transport_enabled_still_queues_announces_for_retransmission() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let mut config = TransportConfig::new("relay", &identity, false);
+    config.set_transport_enabled(true);
+    let transport = Transport::new(config);
+    let iface = transport.iface_manager().lock().await.new_channel(16).address;
+
+    for aspect in ["one", "two", "three"] {
+        feed_announce(&transport, iface, aspect).await;
+    }
+
+    let (queued, cached) = tier_sizes(&transport).await;
+    assert_eq!(queued, 3, "a transport node must still queue what it is going to rebroadcast");
+    assert_eq!(cached, 0, "and must not divert them to the cache");
+}
+
+/// Reference parity for the clause this crate models from the other side: an
+/// announce arriving over a shared-instance link is queued even on a passive
+/// node, matching `or is_from_local_client`.
+#[tokio::test]
+async fn a_shared_instance_iface_still_queues_on_a_passive_node() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("passive-shared", &identity, false));
+    let iface = transport.iface_manager().lock().await.new_channel(16).address;
+    assert!(transport.iface_manager().lock().await.set_shared_instance(iface, true));
+
+    feed_announce(&transport, iface, "local-client").await;
+
+    let (queued, cached) = tier_sizes(&transport).await;
+    assert_eq!(queued, 1, "the reference queues a local client's announce even when not transport-enabled");
+    assert_eq!(cached, 0);
+}
+
+/// The third clause of the same reference condition. A path response is a
+/// directed reply, not something to rebroadcast, so it is cached rather than
+/// queued even on a transport node.
+#[tokio::test]
+async fn a_path_response_announce_is_never_queued_for_retransmission() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let mut config = TransportConfig::new("relay-path-response", &identity, false);
+    config.set_transport_enabled(true);
+    let transport = Transport::new(config);
+    let iface = transport.iface_manager().lock().await.new_channel(16).address;
+
+    let mut destination = SingleInputDestination::new(
+        PrivateIdentity::new_from_rand(OsRng),
+        DestinationName::new("lxmf", "path-response"),
+    );
+    let mut announce = destination.announce(OsRng, None).expect("announce");
+    announce.context = PacketContext::PathResponse;
+    handle_announce(
+        &announce,
+        transport.get_handler().lock().await,
+        iface,
+        crate::iface::IfaceSource::None,
+    )
+    .await;
+
+    let (queued, cached) = tier_sizes(&transport).await;
+    assert_eq!(queued, 0, "a path response is a directed reply, not a rebroadcast candidate");
+    assert_eq!(cached, 1);
+}
+
+/// The reason nothing is simply dropped. This crate rebuilds a path entry's
+/// announce packet out of the announce table when persisting the path table,
+/// where the reference stores a packet hash and keeps the packet in its own
+/// on-disk cache. A passive node that dropped the packet here would persist an
+/// empty path table — so the cached copy has to remain findable.
+#[tokio::test]
+async fn a_cached_announce_is_still_findable_for_path_table_persistence() {
+    let identity = PrivateIdentity::new_from_rand(OsRng);
+    let transport = Transport::new(TransportConfig::new("passive-persist", &identity, false));
+    let iface = transport.iface_manager().lock().await.new_channel(16).address;
+
+    let announce = feed_announce(&transport, iface, "persisted").await;
+
+    let handler_arc = transport.get_handler();
+    let handler = handler_arc.lock().await;
+    let found = handler.announce_table.cached_packet_for_destination(&announce.destination);
+    assert!(
+        found.is_some(),
+        "save_reticulum_path_table drops any path entry whose announce packet it cannot find"
+    );
+}

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -345,6 +345,21 @@ Scoped release evidence is split as follows:
   transport-policy evidence for Python-style per-interface holding and
   lowest-hop release, so bursty unknown announce traffic on one ingress no
   longer stands in for all interfaces in the parity matrix.
+- A node that will not retransmit no longer files the announces it hears into
+  the retransmission queue, matching `Transport.py:2267`'s
+  `(transport_enabled() or is_from_local_client) and context != PATH_RESPONSE`
+  guard on the `announce_table` insert. Those announces are cached rather than
+  dropped, because this crate rebuilds a path entry's announce packet from the
+  announce table when persisting where Python stores a packet hash. A cached
+  announce that supersedes a queued one refreshes it in place, so persistence
+  and later path responses read the announce the path table accepted, and
+  refreshing a destination the cache already holds no longer evicts an
+  unrelated one. Measured against a public hub over six minutes, the queue grew
+  14 -> 317 and never decremented; it now stays at 0 while the bounded cache
+  holds the same routes. Python's local-client announce timing
+  (`retransmit_timeout = now`, `retries = PATHFINDER_R`) is not implemented, and
+  the shared-instance condition reads the receiving interface rather than
+  Python's parent-interface `is_local_client_interface`.
 - Restored Reticulum path-table announces are now cache-only lookup material at
   startup, not fresh rebroadcast work, while still serving known-path response
   requests from the restored cache.

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -63,7 +63,7 @@ negotiation, runtime feature checks, or the separate hardware-evidence axis.
 | `RNS/Identity.py` | `crates/libs/rns-core` | complete | unit, pinned-python | Identity material, hashing, signing, encryption, recall, and key conversion. | No confirmed parity blocker. |
 | `RNS/Destination.py` | `crates/libs/rns-core`, `crates/libs/rns-transport` | complete | unit, pinned-python | Destination hashing, descriptors, announces, proof generation and validation, ratchets, known-key stability checks, and bounded request/response enforcement. Single-destination Data delivery proofs are correlated through the packet cache before identity verification. | No generated callable software gap remains; broader scenario and external-client evidence is tracked independently. |
 | `RNS/Packet.py` | `crates/libs/rns-core`, `crates/libs/rns-transport` | complete | unit, pinned-python | Framing, serialization, contexts, proofs, receipts, public post-encryption packet-hash correlation, explicit and implicit proof-destination correlation, Python-default link proof context, and header semantics. | No confirmed parity blocker. |
-| `RNS/Transport.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | complete | unit, simulated, pinned-python | Path and announce handling, bounded four-class priority ingress, early filtering, protocol accounting, same-destination request batching, gravity-aware replacement, dynamic path rebalancing, boundary path requests, path replacement/state/await semantics, routed links/resources/receipts/tunnels, next-hop formulas, interface lifecycle, discovery and blackhole state, persistence, runtime jobs, graceful shutdown, and focused scoped-request, pacing, duplicate-suppression, MTU, restore/restart, and transport-disabled evidence. | No generated 1.5.0 callable software gap remains; multi-device, public-network, and broader scenario evidence remains separate. |
+| `RNS/Transport.py` | `crates/libs/rns-transport`, `crates/apps/reticulumd` | complete | unit, simulated, pinned-python | Path and announce handling, bounded four-class priority ingress, early filtering, protocol accounting, same-destination request batching, gravity-aware replacement, dynamic path rebalancing, boundary path requests, path replacement/state/await semantics, routed links/resources/receipts/tunnels, next-hop formulas, interface lifecycle, discovery and blackhole state, persistence, runtime jobs, graceful shutdown, and focused scoped-request, pacing, duplicate-suppression, MTU, restore/restart, transport-disabled, and announce-table-admission evidence. | No generated 1.5.0 callable software gap remains; multi-device, public-network, and broader scenario evidence remains separate. Python's local-client announce timing (immediate single retransmit) is not implemented, and the shared-instance condition reads the receiving interface rather than Python's parent-interface `is_local_client_interface`. |
 | `RNS/Link.py` | `crates/libs/rns-transport` | complete | unit, pinned-python | Establishment, proof validation, bounded request/response correlation, bound-interface enforcement for data/channel fan-out, RTT-derived liveness, protocol close, cleanup, and the focused dynamic path-rebalancing slice. | No generated callable software gap remains; cross-implementation and external-client evidence is separate. |
 | `RNS/Resource.py` | `crates/libs/rns-transport` | complete | unit, simulated, pinned-python | Bounded receive allocation, advertisement validation, retries, receiver-minimum collision-guard serving window, window-local hashmap exhaustion gating, bz2 compression, adaptive fragment scheduling, timeout/failure events, cancellation, cleanup, split-resource sequencing, ordered reassembly, per-segment metadata, and whole-resource completion. | Serving-window software contract is complete; collision-list regeneration and cross-implementation transfer evidence are narrower follow-ups. |
 | `RNS/Channel.py` | `crates/libs/rns-transport` | complete | unit, pinned-python | Channel packet handling, retry scheduling, negotiated full-link MDU, buffering, ordered receive delivery, callback ordering/short-circuit/panic containment, delivery-on-proof, timeout retry, exhaustion cleanup, and live Rust/Python channel sequence tests. | No confirmed channel parity blocker. |
@@ -448,6 +448,18 @@ reappearing tunnel cannot replace a fresher active route unless the existing
 path is expired or the tunnel path is at least as fresh under Python's
 timebase rules, with active-preservation and fresher-tunnel replacement
 evidence.
+A node that will not retransmit no longer files the announces it hears into the
+retransmission queue, matching Python's
+`(transport_enabled() or is_from_local_client) and context != PATH_RESPONSE`
+guard on the `announce_table` insert. Those announces are cached rather than
+dropped, since path-table persistence rebuilds the announce packet from the
+announce table instead of from a packet hash, and a cached announce that
+supersedes a queued one refreshes it in place so persistence and later path
+responses read the announce the path table accepted. Refreshing a destination
+the cache already holds no longer evicts an unrelated one. Python's local-client
+announce timing remains unimplemented, and the shared-instance condition reads
+the receiving interface rather than Python's parent-interface
+`is_local_client_interface`.
 
 Enabled unknown interface kinds still parse so operators can see them in daemon
 status, but daemon startup marks them as failed with explicit


### PR DESCRIPTION
## Summary

Fixes #581. Independent of #579 and #580 — different file, no overlap, mergeable
in any order.

Adds the outer condition `transport/announce.rs` dropped when porting
`Transport.py:2267`. The inner rate-limit branch was already there; the guard
around it was not, so a node that will never retransmit still filed every
announce it heard into a queue only `drain_retransmissions` prunes — and the
retransmit worker calls that only when `transport_enabled`.

### Not queued is not dropped

The obvious one-line guard would regress path persistence, so this does
something slightly different and it is the part worth reviewing.

This crate rebuilds a path entry's announce packet out of the announce table
when persisting (`save_reticulum_path_table` → `cached_packet_for_destination`)
and **skips any entry whose packet it cannot find**. The reference persists a
packet *hash* and keeps the packet in its own on-disk cache
(`Transport.py:3776`), so it has no such coupling. Simply not inserting would
therefore make a passive node write an empty path table.

So anything not queued goes to the bounded `cache` tier instead of the unbounded
`map` — the tier `announce_cache_capacity` already exists to bound, and which
`cached_packet_for_destination` already consults. `a_cached_announce_is_still_findable_for_path_table_persistence`
covers exactly that regression.

### Measured

Same public hub, six minutes, 15-second samples, before and after:

| | `map` (retransmit queue) | `cache` (bounded) |
|---|---|---|
| `v0.10.0` | 14 → **317**, never decremented | **0** throughout |
| this branch | **0** throughout | 0 → 248 |

Relay behaviour is unchanged in both runs — 272 third-party announces arrived
and only the node's own announce left on a second interface.

### Tests

Two of the five fail on the parent commit and pass here: the passive-node case,
and the `PATH_RESPONSE` clause. The other three are the invariants this must not
break — a transport node still queues, a shared-instance interface still queues
on a passive node, and a cached announce stays findable for persistence — and
pass either way, which is what makes them worth having rather than decoration.

### One judgement call I would like checked

The reference's `is_from_local_client` asks whether the *receiving interface's
parent* is a local shared instance (`Transport.is_local_client_interface`). This
crate models that relationship from the other side: `set_shared_instance` is set
on the link **to** a shared instance, and `inherit_runtime_config` propagates it
to accepted children.

I used `is_shared_instance` on the receiving interface, on the reasoning that it
can only ever queue *more* than the reference would and never less, so it cannot
regress a shared-instance deployment. If that is the wrong end for your intent,
it is one condition and I will change it.

Note this does not implement the reference's local-client *timing* (announce
immediately, once — `retransmit_timeout = now`, `retries = PATHFINDER_R`).
`AnnounceTable::add` has no parameters for it, that behaviour is unchanged from
today, and it felt like a separate concern from the leak.

## Type
- [ ] breaking
- [ ] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `make test` — green in CI on Linux; 1 macOS-only failure locally, see below
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [x] `cargo doc --workspace --no-deps`
- [x] `cargo deny check`
- [x] `cargo audit`

Also run: `cargo xtask ci --stage architecture-checks` equivalent (boundary and
module-size), and `make migration-checks` — both ok.

`cargo test --workspace` is 2829 passing locally with one failure,
`rns-tools --bin rngit`'s
`local_git_bundle_fetch_and_push_use_the_registered_request_paths`, which is
**macOS-only**: it fails identically on a pristine `v0.10.0` checkout, and CI's
`test-nextest-unit` covers the same bin on Linux and passes.

## Compatibility
- [ ] Updated compatibility matrix / contract docs (if needed)

No public API change. `AnnounceTable::tier_sizes` is `#[cfg(test)]`, mirroring
the existing `pending_response_for_destination`.
