### PR TITLE
docs: publish v0.10.1 release evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,25 +31,24 @@ These are matched-workload comparisons, not a claim of whole-system superiority.
 ## Current status
 
 The latest published stable release is
-[`v0.10.0`](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.0),
-aligned with Python Reticulum 1.5.0. The immutable tag resolves to the
-reviewed release commit, and the release artifacts, crates.io publication,
-independent interoperability reports, provenance, and OCI image are published
-for that exact boundary. The current candidate workspace packages are version
-`0.10.1`; the candidate targets Python Reticulum 1.5.2 at
-`ea98db4f53dcf0defc0e71a16e60d28b1229c4e6`.
+[`v0.10.1`](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.1),
+aligned with Python Reticulum 1.5.2 at
+`ea98db4f53dcf0defc0e71a16e60d28b1229c4e6`. The immutable tag resolves to
+reviewed release commit `25a976945cb335dff3be692981151c8741a5fdeb`; release
+artifacts, crates.io packages, independent interoperability reports,
+provenance, and the OCI image are published for that exact boundary.
 
 | Area | Current position |
 | --- | --- |
 | Reticulum software parity | 1,857 applicable entries complete, 0 partial, 0 unmapped, and 1 provenance-backed not-applicable entry |
 | LXMF software parity | All seven tracked software scenarios complete |
 | Rust/Python interoperability | Direct, link, channel, paper, propagation, and daemon scenarios exercised against pinned references |
-| Independent interoperability | Versioned rns-rs and Reticulum-Go evidence published separately for `v0.10.0` |
+| Independent interoperability | Versioned rns-rs and Reticulum-Go evidence published separately for `v0.10.1` |
 | Hardware and external clients | Physical devices, public networks, and third-party clients remain separate evidence tracks and are not claimed by the software-parity result |
 
 Read the [current roadmap](docs/status/current-roadmap.md) for the authoritative
-project posture, the [v0.10.0 release notes](docs/release-notes-v0.10.0.md) and
-[release ledger](docs/status/v0.10.0-release.md) for the published stable
+project posture, the [v0.10.1 release notes](docs/release-notes-v0.10.1.md) and
+[release ledger](docs/status/v0.10.1-release.md) for the published stable
 release, and the
 [Reticulum](docs/status/reticulum-parity-matrix.md) and
 [LXMF](docs/status/lxmf-parity-matrix.md) parity matrices for row-level detail.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,8 +6,8 @@ an application.
 
 ## Install a stable release
 
-The [`v0.10.0` release](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.0)
-is the published RNS 1.5.0-aligned stable release. It provides Linux, macOS,
+The [`v0.10.1` release](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.1)
+is the published RNS 1.5.2-aligned stable release. It provides Linux, macOS,
 and Windows archives, Debian and RPM packages, a Windows MSI, SBOMs, and
 checksum files. Choose the asset for your platform and verify it against
 `SHA256SUMS.txt` before extracting or installing it.
@@ -16,13 +16,13 @@ For example, after downloading the Linux x86-64 archive and `SHA256SUMS.txt` int
 the same directory:
 
 ```bash
-grep 'lxmf-rs_0.10.0_linux-x86_64.tar.gz$' SHA256SUMS.txt | sha256sum -c -
-tar -xzf lxmf-rs_0.10.0_linux-x86_64.tar.gz
+grep 'lxmf-rs_0.10.1_linux-x86_64.tar.gz$' SHA256SUMS.txt | sha256sum -c -
+tar -xzf lxmf-rs_0.10.1_linux-x86_64.tar.gz
 ```
 
 The [latest release page](https://github.com/FreeTAKTeam/LXMF-rs/releases/latest)
 is the durable entry point for future versions. Release claims and evidence
-boundaries are described in the [release notes](release-notes-v0.10.0.md) and
+boundaries are described in the [release notes](release-notes-v0.10.1.md) and
 [current roadmap](status/current-roadmap.md).
 
 ## Build from source
@@ -85,19 +85,19 @@ The umbrella crates provide the simplest dependency surface:
 
 ```toml
 [dependencies]
-lxmf = "0.10.0"
-reticulum-rs = "0.10.0"
+lxmf = "0.10.1"
+reticulum-rs = "0.10.1"
 ```
 
 Applications that need narrower features can depend on component crates:
 
 ```toml
 [dependencies]
-lxmf-sdk = "0.10.0"
-lxmf-wire = "0.10.0"
-reticulum-rs-core = "0.10.0"
-reticulum-rs-transport = "0.10.0"
-reticulum-rs-rpc = "0.10.0"
+lxmf-sdk = "0.10.1"
+lxmf-wire = "0.10.1"
+reticulum-rs-core = "0.10.1"
+reticulum-rs-transport = "0.10.1"
+reticulum-rs-rpc = "0.10.1"
 ```
 
 Use the [SDK quickstart](sdk/quickstart.md) for a minimal client, the

--- a/docs/interop/README.md
+++ b/docs/interop/README.md
@@ -19,6 +19,16 @@ Tag runs also publish standalone combined JSON/Markdown/HTML release assets.
 
 The current versioned evidence is:
 
+- [`v0.10.1-independent.json`](https://github.com/FreeTAKTeam/LXMF-rs/releases/download/v0.10.1/v0.10.1-independent.json)
+  — release-tag structured peer results for RNS 1.5.2 at
+  `ea98db4f53dcf0defc0e71a16e60d28b1229c4e6`;
+- [`v0.10.1-independent.md`](https://github.com/FreeTAKTeam/LXMF-rs/releases/download/v0.10.1/v0.10.1-independent.md)
+  — concise release-tag interoperability matrix;
+- [`v0.10.1-independent.html`](https://github.com/FreeTAKTeam/LXMF-rs/releases/download/v0.10.1/v0.10.1-independent.html)
+  — standalone release-tag report with the complete JSON embedded;
+- [v0.10.1 release assets](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.1)
+  — checksummed raw peer bundles and per-peer checksums;
+
 - [`v0.10.0-independent.json`](v0.10.0-independent.json) — complete structured
   peer results, readiness axes, pins, limitations, and five-sample independent
   performance evidence;
@@ -40,8 +50,12 @@ The current versioned evidence is:
   [`../performance/v0.10.0.html`](../performance/v0.10.0.html) — current stable
   performance dataset and dashboard;
 - hosted raw interop evidence from workflow
-  [`32736249030`](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/32736249030)
-  and checksummed raw performance evidence from workflow
+  [`33254264125`](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33254264125)
+  and the v0.10.1 release assets, plus historical workflow
+  [`32736249030`](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/32736249030).
+  The v0.10.1 checksummed raw performance evidence is published by workflow
+  [`33254264175`](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33254264175);
+  historical checksummed raw performance evidence is from workflow
   [`32736249025`](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/32736249025).
 
 Actions artifacts are retention-bound. The same workflows attach the public

--- a/docs/runbooks/release-runbook.md
+++ b/docs/runbooks/release-runbook.md
@@ -46,6 +46,14 @@ publishes the public library crates listed in
 The workflow rejects the release if any public crate version differs from the
 GitHub release tag after removing the leading `v`.
 
+After publication, verify that a `Publish crates.io` run exists for the exact
+tag and commit. GitHub suppresses recursive workflow events created with the
+default `GITHUB_TOKEN`; if the release event did not create a crates run,
+dispatch the workflow manually with `ref=<tag>`, `version=<version>`, and
+`dry_run=false`, then verify every package through the crates.io API. The
+v0.10.1 train required this explicit dispatch as run
+[33255408925](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33255408925).
+
 Repository setup required before the first automated publish:
 
 - add a `CARGO_REGISTRY_TOKEN` repository secret with permission to publish the

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -1,6 +1,6 @@
 # Current Roadmap Status
 
-Last reassessed: 2026-08-24
+Last reassessed: 2026-08-29
 
 This file is the repository-level source of truth for parity posture, release
 confidence, and execution order. Detailed row-level status lives in:
@@ -27,14 +27,14 @@ addresses, queue/interface/link telemetry, and medium-bitrate timeout accessors.
 The exact upstream-to-Rust disposition is recorded in
 [`rns-1.5-delta.md`](rns-1.5-delta.md).
 
-The v0.10.0 baseline is merged on `main` at
-`9f4dd91e210bb57add7ffba514d9546a956d423a` and published on immutable release
-commit `5436ee715f94f81e18abb0808cfca52fcd7cc9bc`. The v0.10.1 maintenance
-candidate carries the RNS 1.5.2 pin, the queue/keepalive/shared-instance fixes,
-and the IFAC/profiling parity surfaces. Public package manifests and the root
-`VERSION` use `0.10.1` on the candidate branch; tag-triggered artifacts,
-provenance, independent interop, and crates.io evidence remain pending until
-that candidate is reviewed and tagged.
+The v0.10.0 baseline is superseded by stable v0.10.1, merged on `main` at
+`25a976945cb335dff3be692981151c8741a5fdeb` and published at
+[`v0.10.1`](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.1). The
+maintenance release carries the exact RNS 1.5.2 pin, queue/keepalive/shared-
+instance fixes, IFAC/profiling parity surfaces, and owned-buffer Resource
+sender equivalent. Platform artifacts, provenance, independent interop, OCI,
+and all 17 public crates are published for that immutable boundary; the
+tag-triggered performance comparison remains a separate hosted evidence run.
 
 The project is best described by capability level:
 
@@ -46,8 +46,8 @@ The project is best described by capability level:
 | Operationally substitutable | achieved against RNS 1.5.2 | The software-controlled runtime includes the 1.5 ingress, routing, telemetry, timeout, discovery, dataplane-control, keepalive, IFAC, profiling, and `rngit` slices. |
 | Full Python software surface parity | achieved | The strict inventory reports 1,857 complete, 0 partial, and 1 provenance-backed not-applicable entry. |
 | ZeroMQ SDK-access parity | achieved in v0.9.5 implementation | Generated classification and daemon-operation inventory live in `sdk-zmq-parity.json`; release evidence must still pass all gates. |
-| Independent implementation evidence | published for stable `v0.10.0` | Pinned rns-rs and Reticulum-Go release profiles cover two-node/multi-hop behavior; rns-rs additionally covers mixed/all-Rust five-node chains, routing policy, restart, shared daemon, exact large Resources, and deterministic chaos. Explicit peer divergences remain failures owned by the peer and are allowlisted narrowly by CI. |
-| Performance evidence | published for stable `v0.10.0` | The immutable tag workflow passed with checksummed JSON, HTML, raw evidence, and a clean regression gate: throughput `1.008x`, CPU `1.005x`, and peak RSS `1.086x` versus the same-runner v0.9.1 baseline. |
+| Independent implementation evidence | published for stable `v0.10.1` | Pinned rns-rs and Reticulum-Go release profiles cover two-node/multi-hop behavior; rns-rs additionally covers mixed/all-Rust five-node chains, routing policy, restart, shared daemon, exact large Resources, and deterministic chaos. Explicit peer divergences remain failures owned by the peer and are allowlisted narrowly by CI. |
+| Performance evidence | hosted release run in progress | The tag workflow is measuring the bounded v0.10.1 dataset; publish its checksummed JSON, HTML, raw evidence, and regression-gate result when run `33254264175` completes. |
 
 The independent evidence axis is documented in [`docs/interop`](../interop/README.md).
 It does not promote Python parity rows, third-party clients, physical interfaces,
@@ -55,18 +55,16 @@ or public-network soak. Pull requests run the bounded rns-rs profile; nightly an
 release tiers add both peers, expanded chaos, exact 50 MiB transfers, raw logs,
 and standalone JSON/Markdown/HTML artifacts.
 
-The canonical stable performance dataset is
-[`docs/performance/v0.10.0.json`](../performance/v0.10.0.json), with the
+The canonical historical stable performance dataset is
+[`docs/performance/v0.10.0.json`](../performance/v0.10.0.json), with its
 standalone dashboard at [`docs/performance/v0.10.0.html`](../performance/v0.10.0.html).
-It records candidate `5436ee715f94f81e18abb0808cfca52fcd7cc9bc`, five interleaved
-comparison runs, two resource runs, five independent peer samples, exact 1 MiB
-and 50 MiB Resource measurements, all SDK transport surfaces, and the explicit
-bounded 1000-Link unsupported result. The independent interoperability workflow
-[`32736249030`](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/32736249030)
-and performance workflow
-[`32736249025`](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/32736249025)
-passed on the immutable release commit, and their public artifacts are attached
-to the [`v0.10.0` release](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.0).
+The v0.10.1 independent interoperability workflow
+[`33254264125`](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33254264125)
+passed on the immutable release commit and its public reports are attached to
+the [`v0.10.1` release](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.1).
+The v0.10.1 performance workflow is
+[`33254264175`](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33254264175)
+and remains pending while the bounded comparison completes.
 
 ## v0.9.9 Historical Stable Release
 
@@ -104,6 +102,28 @@ workflow passed on attempt 3 after two earlier attempts hit distinct transient
 loopback port races; the final publication job attached the checksummed JSON,
 HTML, raw bundle, and gate checksum. Homebrew is explicitly skipped because its
 tap/token is not configured.
+
+## v0.10.1 Stable Release
+
+The RNS 1.5.2 maintenance release is merged on `main` at
+`25a976945cb335dff3be692981151c8741a5fdeb`; immutable tag `v0.10.1` and the
+[public release](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.1)
+resolve to that commit. It carries the exact Python Reticulum 1.5.2 reference
+(`ea98db4f53dcf0defc0e71a16e60d28b1229c4e6`), the strict 1,858-entry inventory
+(1,857 applicable complete, zero partial/unmapped, one not applicable), and
+the queue, shared-instance, keepalive, IFAC, profiling, and Resource sender
+parity slices described in [`rns-1.5-delta.md`](rns-1.5-delta.md).
+
+PR [#584](https://github.com/FreeTAKTeam/LXMF-rs/pull/584) passed the hosted CI,
+Verify/HIL, and independent-interoperability checks before merge. The release
+workflow [33254264203](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33254264203),
+crates.io publication workflow
+[33255408925](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33255408925),
+and independent interoperability workflow
+[33254264125](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33254264125)
+passed; Homebrew was skipped because `HOMEBREW_TAP_TOKEN` is not configured.
+The tag-triggered performance comparison is tracked separately by workflow
+[33254264175](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33254264175).
 
 ## v0.9.9-rc.6 Historical Release Candidate
 

--- a/docs/status/v0.10.1-release-candidate.md
+++ b/docs/status/v0.10.1-release-candidate.md
@@ -1,11 +1,12 @@
 # v0.10.1 Release Candidate Evidence Ledger
 
-Status: **CANDIDATE - READY FOR REVIEW AND TAGGING**
+Status: **PROMOTED - v0.10.1 STABLE RELEASE**
 
 This ledger records the maintenance release boundary from the RNS 1.5.0
-aligned v0.10.0 baseline to Python Reticulum 1.5.2. Hosted checks and
-tag-triggered artifacts are kept separate from local evidence and are recorded
-after the exact candidate head is published.
+aligned v0.10.0 baseline to Python Reticulum 1.5.2. The reviewed candidate was
+merged and promoted as immutable tag `v0.10.1`; hosted checks and tag-triggered
+artifacts are recorded separately in the stable [release evidence
+ledger](v0.10.1-release.md).
 
 ## Candidate identity
 
@@ -14,10 +15,12 @@ after the exact candidate head is published.
 | Intended candidate tag | `v0.10.1` |
 | Workspace/package version | `0.10.1` |
 | Candidate branch | `corvo/rns-1.5.2-alignment` |
-| Base | `origin/main` at `9f4dd91e210bb57add7ffba514d9546a956d423a` |
+| Base after review rebase | `origin/main` at `0ed96f7ee33cefe7fe6eb188b8094b02cd536193` |
 | Prior stable | `v0.10.0` at `5436ee715f94f81e18abb0808cfca52fcd7cc9bc` |
 | RNS reference | `1.5.2` at `ea98db4f53dcf0defc0e71a16e60d28b1229c4e6` |
 | LXMF reference | `0.9.6` at `727830cefda83d9c6e3982b48675425f3f988f9c` |
+| Reviewed implementation PR | [#584](https://github.com/FreeTAKTeam/LXMF-rs/pull/584), merged as `25a976945cb335dff3be692981151c8741a5fdeb` |
+| Public release | [v0.10.1](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.1) |
 
 ## Parity target
 
@@ -38,21 +41,18 @@ The manual maintenance delta is in [`rns-1.5-delta.md`](rns-1.5-delta.md).
 | Workspace build and tests | PASS | `cargo xtask release-check`: 2,543/2,543 tests passed; Miri 21 passed/4 intentionally ignored |
 | Boundaries, architecture, module-size, issue-369 | PASS | Release gate boundary, architecture, module-size, unsafe audit, and issue-369 checks passed |
 | `cargo xtask release-check` | PASS | Package validation, CLI/help, backup/restore, E2E/mesh soak, reproducible build, embedded footprint, and performance status all passed; performance emitted warnings only |
-| Hosted pull-request checks | PENDING | Record exact PR head and workflow conclusions after publication |
-| Independent implementation review | PENDING | Record actionable findings and approval state |
+| Hosted pull-request checks | PASS | PR #584 head `3845fa5681fd948e623a19ab05719c2ed138c3a4`; CI, Verify/HIL, and independent interoperability workflows passed |
+| Independent implementation review | PASS WITH PLATFORM LIMITATION | GitHub rejected approval by the PR author; the limitation and green evidence are recorded in [the PR comment](https://github.com/FreeTAKTeam/LXMF-rs/pull/584#issuecomment-5462526268) |
 
 ## Tag-triggered evidence boundary
 
 Release archives and packages, SBOMs, checksums, signing/attestation state,
 OCI publication, crates.io publication, independent interoperability reports,
-and the versioned performance dataset can only be verified after an immutable
-candidate tag is authorized and pushed. They are not claimed by this local
-candidate record until public artifacts are downloaded and checked against the
-published checksums and provenance.
+and the versioned performance dataset are verified after immutable tag
+`v0.10.1`; see the stable release ledger for the exact public evidence.
 
 ## Recommendation
 
-**READY FOR REVIEW** - the local release gate is green. Promote only after the
-hosted checks pass on one immutable candidate head, then record the tag and
-public artifact evidence in
-[`v0.10.1-release.md`](v0.10.1-release.md).
+**PROMOTED** - the local release gate and hosted checks passed on one immutable
+candidate head, which was tagged and published as `v0.10.1`. The stable release
+ledger records the remaining tag-triggered performance workflow separately.

--- a/docs/status/v0.10.1-release.md
+++ b/docs/status/v0.10.1-release.md
@@ -41,7 +41,7 @@ and the manual behavior ledger is [`rns-1.5-delta.md`](rns-1.5-delta.md).
 | Tag-triggered release artifacts | PASS | Release workflow [33254264203](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33254264203) succeeded; the public release currently contains 31 platform/package/SBOM and independent-evidence assets, with performance assets appended by their tag workflow |
 | Independent interoperability | PASS | Release workflow [33254264125](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33254264125) succeeded; published report records rns-rs 87 PASS / 3 peer-owned FAIL / 2 blocked and Reticulum-Go 22 PASS / 2 unsupported capability rows |
 | crates.io publication | PASS | Workflow [33255408925](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33255408925) succeeded; all 17 workflow-managed public packages return version `0.10.1` (not yanked) from the crates.io API |
-| OCI publication and attestation | PASS | `ghcr.io/freetakteam/lxmf-rs:0.10.1` resolves to a multi-arch OCI index; `gh attestation verify` passed with subject digest `sha256:b34da2a3f47f2c8940297679bb7ec9bbea54569c282fc567de61cdf6c25fc267` and the release workflow signer |
+| OCI publication and attestation | PASS | `ghcr.io/freetakteam/lxmf-rs:0.10.1` resolves to multi-arch index digest `sha256:b34da2a3f47f2c8940297679bb7ec9bbea54569c282fc567de61cdf6c25fc267`; `:latest` resolves to the same index and `gh attestation verify` passes with the release workflow signer |
 | Performance comparison | PENDING | Tag workflow [33254264175](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33254264175) is still measuring the bounded release dataset |
 | Homebrew tap | SKIPPED | Release job logged `HOMEBREW_TAP_TOKEN is not configured; skipping Homebrew tap update.` |
 

--- a/docs/status/v0.10.1-release.md
+++ b/docs/status/v0.10.1-release.md
@@ -1,24 +1,24 @@
 # v0.10.1 Stable Release Evidence Ledger
 
-Status: **PENDING TAG AND PUBLIC ARTIFACT VERIFICATION**
+Status: **STABLE RELEASE - PUBLICATION VERIFIED; PERFORMANCE EVIDENCE PENDING**
 
-This ledger is reserved for the immutable v0.10.1 release boundary. It must be
-updated only after the reviewed candidate is merged, the exact tag is pushed,
-and public release artifacts, provenance, independent interoperability,
-performance, and crates.io publication are independently verified.
+This ledger records the immutable v0.10.1 release boundary. Public release
+artifacts, provenance, independent interoperability, and crates.io publication
+are independently verified below; the tag-triggered performance comparison is
+recorded when its hosted run completes.
 
 ## Release identity
 
 | Field | Value |
 |---|---|
 | Release | `v0.10.1` |
-| Release commit | pending immutable tag |
-| Reviewed merged implementation | pending pull request merge |
+| Release commit | `25a976945cb335dff3be692981151c8741a5fdeb` |
+| Reviewed merged implementation | PR [#584](https://github.com/FreeTAKTeam/LXMF-rs/pull/584), merged as the release commit |
 | Workspace/package version | `0.10.1` |
 | Prior stable | `v0.10.0` |
 | RNS reference | `1.5.2` at `ea98db4f53dcf0defc0e71a16e60d28b1229c4e6` |
 | LXMF reference | `0.9.6` at `727830cefda83d9c6e3982b48675425f3f988f9c` |
-| GitHub release | pending |
+| GitHub release | [v0.10.1](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.1) |
 
 ## Parity target
 
@@ -33,17 +33,29 @@ and the manual behavior ledger is [`rns-1.5-delta.md`](rns-1.5-delta.md).
 
 | Gate | Result | Evidence |
 |---|---|---|
-| Exact RNS/LXMF pins and strict inventory | PENDING | Record exact revisions and inventory output |
-| Focused RNS 1.5.2 regressions | PENDING | Record transport, resource, IFAC, profiler, and keepalive tests |
-| Full local release gate | PENDING | Record `cargo xtask release-check` and any explicit environment boundaries |
-| Hosted implementation PR | PENDING | Record exact PR head and required checks |
-| Release-preparation PR | PENDING | Record merge commit |
-| Tag-triggered release artifacts | PENDING | Record workflow run and independently checked assets/checksums |
-| Independent interoperability | PENDING | Record workflow run and published reports |
-| crates.io publication | PENDING | Verify every public 0.10.1 package explicitly |
-| OCI publication and attestation | PENDING | Verify image digest and provenance |
-| Performance comparison | PENDING | Record versioned JSON/HTML/raw assets and release-budget result |
-| Homebrew tap | PENDING | Mark skipped only with the exact missing token/tap evidence |
+| Exact RNS/LXMF pins and strict inventory | PASS | RNS 1.5.2 `ea98db4f53dcf0defc0e71a16e60d28b1229c4e6`, LXMF `727830cefda83d9c6e3982b48675425f3f988f9c`; 1,858 total / 1,857 applicable and complete / 0 partial / 0 unmapped / 1 not applicable |
+| Focused RNS 1.5.2 regressions | PASS | Queue defaults, shared-instance dataplane exclusion, empty HDLC keepalive, IFAC vectors/codecs, profiler/status, and owned-buffer Resource sender regressions |
+| Full local release gate | PASS | `cargo xtask release-check` passed: 2,543 nextest tests, Miri 21 passed (4 intentionally ignored), E2E/mesh/soak zero failures, reproducible build, embedded footprint, boundaries, and module-size checks |
+| Hosted implementation PR | PASS | PR [#584](https://github.com/FreeTAKTeam/LXMF-rs/pull/584) head `3845fa5681fd948e623a19ab05719c2ed138c3a4`; CI, Verify/HIL, and independent interoperability checks passed. GitHub rejected author self-approval; the explanation is recorded in [the PR comment](https://github.com/FreeTAKTeam/LXMF-rs/pull/584#issuecomment-5462526268). |
+| Release-preparation PR | MERGED | PR [#584](https://github.com/FreeTAKTeam/LXMF-rs/pull/584) merged into `main` as `25a976945cb335dff3be692981151c8741a5fdeb` |
+| Tag-triggered release artifacts | PASS | Release workflow [33254264203](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33254264203) succeeded; the public release currently contains 31 platform/package/SBOM and independent-evidence assets, with performance assets appended by their tag workflow |
+| Independent interoperability | PASS | Release workflow [33254264125](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33254264125) succeeded; published report records rns-rs 87 PASS / 3 peer-owned FAIL / 2 blocked and Reticulum-Go 22 PASS / 2 unsupported capability rows |
+| crates.io publication | PASS | Workflow [33255408925](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33255408925) succeeded; all 17 workflow-managed public packages return version `0.10.1` (not yanked) from the crates.io API |
+| OCI publication and attestation | PASS | `ghcr.io/freetakteam/lxmf-rs:0.10.1` resolves to a multi-arch OCI index; `gh attestation verify` passed with subject digest `sha256:b34da2a3f47f2c8940297679bb7ec9bbea54569c282fc567de61cdf6c25fc267` and the release workflow signer |
+| Performance comparison | PENDING | Tag workflow [33254264175](https://github.com/FreeTAKTeam/LXMF-rs/actions/runs/33254264175) is still measuring the bounded release dataset |
+| Homebrew tap | SKIPPED | Release job logged `HOMEBREW_TAP_TOKEN is not configured; skipping Homebrew tap update.` |
+
+## Artifact verification
+
+- All 20 platform/package/SBOM assets listed in `SHA256SUMS.txt` were downloaded
+  from the public release and passed `sha256sum -c` independently.
+- The two published independent raw bundles passed their per-peer `.sha256`
+  checksums. The combined v0.10.1 report is available as JSON, Markdown, and
+  HTML on the [release page](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.1).
+- Representative Linux archive attestation verification passed with the release
+  workflow signer, `refs/tags/v0.10.1`, source digest
+  `25a976945cb335dff3be692981151c8741a5fdeb`, and a Rekor timestamp. The same
+  attestation bundle covers the published release subjects.
 
 ## Evidence boundary
 


### PR DESCRIPTION
## Summary
- promote the v0.10.1 release candidate ledger to the published stable boundary
- update README, getting-started, roadmap, interoperability, and release-runbook links to v0.10.1
- record PR #584, release workflow, checksums, attestations, GHCR, and crates.io evidence

## Evidence
- v0.10.1 release: https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.1
- release workflow 33254264203 passed
- crates.io publication workflow 33255408925 passed for all 17 public packages
- independent interoperability workflow 33254264125 passed
- representative archive and OCI SLSA attestations verified with `gh attestation verify`
- the tag performance workflow 33254264175 is still running; this PR records that boundary as pending until it publishes its assets
- Homebrew was explicitly skipped because `HOMEBREW_TAP_TOKEN` is not configured

## Validation
- `CARGO_BUILD_JOBS=1 cargo xtask ci --stage doc`
