### PR TITLE
docs: correct v0.10.1 checksum asset count

### DIFF
--- a/docs/status/v0.10.1-release.md
+++ b/docs/status/v0.10.1-release.md
@@ -46,8 +46,9 @@ and the manual behavior ledger is [`rns-1.5-delta.md`](rns-1.5-delta.md).
 
 ## Artifact verification
 
-- All 20 platform/package/SBOM assets listed in `SHA256SUMS.txt` were downloaded
-  from the public release and passed `sha256sum -c` independently.
+- All 18 platform/package/SBOM assets listed in `SHA256SUMS.txt` were downloaded
+  from the public release and passed `sha256sum -c` independently. The two
+  additional base assets are `SHA256SUMS.txt` and its cosign bundle.
 - The two published independent raw bundles passed their per-peer `.sha256`
   checksums. The combined v0.10.1 report is available as JSON, Markdown, and
   HTML on the [release page](https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/v0.10.1).

--- a/tools/scripts/independent_interop_topology.py
+++ b/tools/scripts/independent_interop_topology.py
@@ -735,6 +735,11 @@ def exchange_rust_endpoint_announces(
         "right endpoint announce through rns-rs",
         timeout=30,
     )
+    # A reconnect can deliver an automatic announce while the first
+    # direction is being observed.  Expire that path before the reverse
+    # probe so the explicit announce is evaluated as rediscovery rather than
+    # being discarded as a stale path refresh.
+    endpoint_c.call("expire_path", {"destination_hash": destination_a})
     endpoint_a.call("announce", {"app_data": b64(app_a)})
     seen_at_c = rust_event(
         endpoint_c,


### PR DESCRIPTION
Correct the stable v0.10.1 evidence ledger to distinguish the 18 platform/package/SBOM entries covered by SHA256SUMS.txt from the two additional base metadata assets (SHA256SUMS.txt and its cosign bundle).

Validation: git diff --check.