### PR TITLE
fix(rnode): keep native reads single-owner

### DIFF
--- a/crates/libs/lxmf-runtime/src/delivery.rs
+++ b/crates/libs/lxmf-runtime/src/delivery.rs
@@ -340,13 +340,12 @@ pub(crate) fn request_link_attempts(request: &SendRequest, fallback: usize) -> u
     }
 }
 
-pub(crate) fn request_resource_timeout(request: &SendRequest, fallback: Duration) -> Duration {
-    if request.extensions.get(EXT_ACCEPTED_RESULT_ACK).and_then(JsonValue::as_bool).unwrap_or(false)
-    {
-        Duration::from_secs(8)
-    } else {
-        fallback
-    }
+pub(crate) fn request_resource_timeout(_request: &SendRequest, fallback: Duration) -> Duration {
+    // An accepted-result acknowledgement can exceed the direct packet budget
+    // and become a Resource. It must therefore inherit the backend's normal
+    // Resource bound: a short acknowledgement-specific timeout can abandon a
+    // live low-bitrate transfer and let the caller start a competing retry.
+    fallback
 }
 
 fn decode_required_base64(

--- a/crates/libs/lxmf-runtime/src/link_delivery.rs
+++ b/crates/libs/lxmf-runtime/src/link_delivery.rs
@@ -109,11 +109,12 @@ async fn cancel_resource(
     transport: &Transport,
     link_id: rns_transport::hash::AddressHash,
     resource_hash: rns_transport::hash::Hash,
-) {
-    // Preserve the original transfer failure as the caller-facing error. The
-    // transport cancellation is cleanup: it may already be absent if the
-    // resource manager emitted a terminal failure first.
-    let _ = transport.cancel_resource(&link_id, resource_hash).await;
+) -> Result<(), SdkError> {
+    transport.cancel_resource(&link_id, resource_hash).await.map(|_| ()).map_err(|error| {
+        transport_error(format!(
+            "resource cancellation failed link={link_id} hash={resource_hash}: {error}"
+        ))
+    })
 }
 
 pub(crate) async fn await_resource_completion_with_cancel<F>(
@@ -123,13 +124,19 @@ pub(crate) async fn await_resource_completion_with_cancel<F>(
     cancel: F,
 ) -> Result<(), SdkError>
 where
-    F: Future<Output = ()>,
+    F: Future<Output = Result<(), SdkError>>,
 {
     let result = await_resource_completion(events, resource_hash, timeout).await;
-    if result.is_err() {
-        cancel.await;
+    if let Err(transfer_error) = result {
+        return match cancel.await {
+            Ok(()) => Err(transfer_error),
+            Err(cancel_error) => Err(transport_error(format!(
+                "{}; cleanup failed: {}",
+                transfer_error.message, cancel_error.message
+            ))),
+        };
     }
-    result
+    Ok(())
 }
 
 pub(crate) async fn await_resource_completion(

--- a/crates/libs/lxmf-runtime/src/link_delivery.rs
+++ b/crates/libs/lxmf-runtime/src/link_delivery.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -40,7 +41,13 @@ pub(crate) async fn send_link_payload(
             .send_resource(&link_id, payload.to_vec(), None)
             .await
             .map_err(|err| transport_error(format!("resource send failed: {err:?}")))?;
-        await_resource_completion(&mut resource_events, resource_hash, resource_timeout).await?;
+        await_resource_completion_with_cancel(
+            &mut resource_events,
+            resource_hash,
+            resource_timeout,
+            cancel_resource(transport, link_id, resource_hash),
+        )
+        .await?;
         (DeliveryRepresentation::Resource, None)
     } else {
         match send_on_link(transport, &link, payload)
@@ -51,8 +58,14 @@ pub(crate) async fn send_link_payload(
                 (DeliveryRepresentation::Packet, Some(hex::encode(packet.hash().to_bytes())))
             }
             LinkSendResult::Resource(resource_hash) => {
-                await_resource_completion(&mut resource_events, resource_hash, resource_timeout)
-                    .await?;
+                let link_id = *link.lock().await.id();
+                await_resource_completion_with_cancel(
+                    &mut resource_events,
+                    resource_hash,
+                    resource_timeout,
+                    cancel_resource(transport, link_id, resource_hash),
+                )
+                .await?;
                 (DeliveryRepresentation::Resource, None)
             }
         }
@@ -90,6 +103,33 @@ async fn activate_link(
         "link activation failed: {}",
         last_error.map_or_else(|| "no attempts made".to_owned(), |error| error.to_string())
     )))
+}
+
+async fn cancel_resource(
+    transport: &Transport,
+    link_id: rns_transport::hash::AddressHash,
+    resource_hash: rns_transport::hash::Hash,
+) {
+    // Preserve the original transfer failure as the caller-facing error. The
+    // transport cancellation is cleanup: it may already be absent if the
+    // resource manager emitted a terminal failure first.
+    let _ = transport.cancel_resource(&link_id, resource_hash).await;
+}
+
+pub(crate) async fn await_resource_completion_with_cancel<F>(
+    events: &mut tokio::sync::broadcast::Receiver<rns_transport::resource::ResourceEvent>,
+    resource_hash: rns_transport::hash::Hash,
+    timeout: Duration,
+    cancel: F,
+) -> Result<(), SdkError>
+where
+    F: Future<Output = ()>,
+{
+    let result = await_resource_completion(events, resource_hash, timeout).await;
+    if result.is_err() {
+        cancel.await;
+    }
+    result
 }
 
 pub(crate) async fn await_resource_completion(

--- a/crates/libs/lxmf-runtime/src/tests.rs
+++ b/crates/libs/lxmf-runtime/src/tests.rs
@@ -1,4 +1,6 @@
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use lxmf_core::{MessageMethod, TransportMethod};
@@ -18,7 +20,7 @@ use crate::delivery::{
     forced_representation, request_link_attempts, request_link_timeout, request_resource_timeout,
     requested_method, resolve_destination,
 };
-use crate::link_delivery::await_resource_completion;
+use crate::link_delivery::{await_resource_completion, await_resource_completion_with_cancel};
 use crate::{
     InProcessBackend, InProcessBackendConfig, EXT_ACCEPTED_RESULT_ACK,
     EXT_DIRECT_PACKET_MAX_WIRE_BYTES, EXT_LINK_CONNECT_TIMEOUT_MS,
@@ -58,18 +60,68 @@ fn explicit_unknown_delivery_method_is_rejected() {
 }
 
 #[test]
-fn accepted_result_uses_short_link_timeout_unless_overridden() {
+fn accepted_result_uses_short_link_timeout_and_normal_resource_timeout() {
     let mut request = request();
     request.extensions.insert(EXT_ACCEPTED_RESULT_ACK.to_owned(), json!(true));
     assert_eq!(request_link_timeout(&request, Duration::from_secs(20)), Duration::from_secs(5));
     assert_eq!(request_link_attempts(&request, 3), 1);
     assert_eq!(
         request_resource_timeout(&request, Duration::from_secs(120)),
-        Duration::from_secs(8)
+        Duration::from_secs(120)
     );
 
     request.extensions.insert(EXT_LINK_CONNECT_TIMEOUT_MS.to_owned(), json!(75_000));
     assert_eq!(request_link_timeout(&request, Duration::from_secs(20)), Duration::from_secs(75));
+}
+
+#[tokio::test]
+async fn resource_wait_failure_runs_cancellation_before_returning() {
+    let (_sender, mut receiver) = broadcast::channel(2);
+    let expected_hash = Hash::new_from_slice(b"expected");
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let cancellation_observer = cancelled.clone();
+
+    let error = await_resource_completion_with_cancel(
+        &mut receiver,
+        expected_hash,
+        Duration::from_millis(10),
+        async move {
+            cancellation_observer.store(true, Ordering::SeqCst);
+        },
+    )
+    .await
+    .expect_err("timed-out resource must fail");
+
+    assert_eq!(error.category, lxmf_sdk::ErrorCategory::Transport);
+    assert!(cancelled.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn resource_wait_success_does_not_cancel_completed_transfer() {
+    let (sender, mut receiver) = broadcast::channel(2);
+    let expected_hash = Hash::new_from_slice(b"expected");
+    sender
+        .send(ResourceEvent {
+            hash: expected_hash,
+            link_id: AddressHash::new_from_slice(b"link"),
+            kind: ResourceEventKind::OutboundComplete,
+        })
+        .expect("queue completion");
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let cancellation_observer = cancelled.clone();
+
+    await_resource_completion_with_cancel(
+        &mut receiver,
+        expected_hash,
+        Duration::from_secs(1),
+        async move {
+            cancellation_observer.store(true, Ordering::SeqCst);
+        },
+    )
+    .await
+    .expect("matching completion succeeds");
+
+    assert!(!cancelled.load(Ordering::SeqCst));
 }
 
 #[tokio::test]

--- a/crates/libs/lxmf-runtime/src/tests.rs
+++ b/crates/libs/lxmf-runtime/src/tests.rs
@@ -87,6 +87,7 @@ async fn resource_wait_failure_runs_cancellation_before_returning() {
         Duration::from_millis(10),
         async move {
             cancellation_observer.store(true, Ordering::SeqCst);
+            Ok(())
         },
     )
     .await
@@ -116,12 +117,32 @@ async fn resource_wait_success_does_not_cancel_completed_transfer() {
         Duration::from_secs(1),
         async move {
             cancellation_observer.store(true, Ordering::SeqCst);
+            Ok(())
         },
     )
     .await
     .expect("matching completion succeeds");
 
     assert!(!cancelled.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn resource_wait_surfaces_cancellation_failure_with_transfer_error() {
+    let (_sender, mut receiver) = broadcast::channel(2);
+    let expected_hash = Hash::new_from_slice(b"expected");
+
+    let error = await_resource_completion_with_cancel(
+        &mut receiver,
+        expected_hash,
+        Duration::from_millis(10),
+        async { Err(crate::delivery::transport_error("cancel dispatch failed")) },
+    )
+    .await
+    .expect_err("failed cleanup must remain visible");
+
+    assert_eq!(error.category, lxmf_sdk::ErrorCategory::Transport);
+    assert!(error.message.contains("resource transfer timed out"));
+    assert!(error.message.contains("cleanup failed: cancel dispatch failed"));
 }
 
 #[tokio::test]

--- a/crates/libs/rns-transport/src/iface.rs
+++ b/crates/libs/rns-transport/src/iface.rs
@@ -24,6 +24,7 @@ pub mod rnode_ble;
 pub mod rnode_bearer;
 
 mod rnode_bearer_interface;
+mod rnode_bearer_status;
 
 pub mod rnode_spp;
 

--- a/crates/libs/rns-transport/src/iface/lora_parts/rnoderadiostatus.rs
+++ b/crates/libs/rns-transport/src/iface/lora_parts/rnoderadiostatus.rs
@@ -160,16 +160,19 @@ impl RNodeRadioStatus {
         config: LoraConfig,
         expected_radio_state: u8,
     ) -> Result<(), String> {
-        if let Some(frequency_hz) = self.frequency_hz {
-            let configured = i64::try_from(config.frequency_hz)
-                .expect("validated LoRa frequency fits signed comparison range");
-            let reported = i64::from(frequency_hz);
-            if (configured - reported).abs() > 100 {
-                return Err(format!(
-                    "rnode frequency mismatch configured={} reported={}",
-                    config.frequency_hz, frequency_hz
-                ));
+        match self.frequency_hz {
+            Some(frequency_hz) => {
+                let configured = i64::try_from(config.frequency_hz)
+                    .expect("validated LoRa frequency fits signed comparison range");
+                let reported = i64::from(frequency_hz);
+                if (configured - reported).abs() > 100 {
+                    return Err(format!(
+                        "rnode frequency mismatch configured={} reported={}",
+                        config.frequency_hz, frequency_hz
+                    ));
+                }
             }
+            None => return Err("rnode frequency response is missing".to_string()),
         }
         match self.bandwidth_hz {
             Some(value) if value == config.bandwidth_hz => {}

--- a/crates/libs/rns-transport/src/iface/rnode_bearer.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer.rs
@@ -34,7 +34,10 @@ pub trait RnodeBearerBackend {
 
     /// Read the next available chunk.
     ///
-    /// `Ok(None)` means no bytes are currently available. A closed or failed
+    /// `Ok(None)` means no bytes are currently available. The backend owns any
+    /// bounded wait used to produce that result; callers must not wrap this
+    /// future in a shorter timeout because platform implementations may use a
+    /// blocking worker to wait for native notifications. A closed or failed
     /// transport must return `Err` so the single-attempt interface can stop.
     async fn read(&mut self) -> Result<Option<Vec<u8>>, String>;
 
@@ -115,10 +118,6 @@ where
 
     pub async fn send_deferred_frames(&mut self) -> Result<(), RnodeBleKissError> {
         self.inner.send_deferred_frames().await
-    }
-
-    pub async fn retry_startup_sequence(&mut self) -> Result<(), RnodeBleKissError> {
-        self.inner.retry_startup_sequence().await
     }
 
     pub async fn send_id_beacon(&mut self) -> Result<(), RnodeBleKissError> {

--- a/crates/libs/rns-transport/src/iface/rnode_bearer.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer.rs
@@ -5,8 +5,8 @@
 //! this crate's shared protocol runtime.
 
 use super::rnode_ble::{
-    RnodeBleBackend, RnodeBleKissConfig, RnodeBleKissError, RnodeBleKissRuntime,
-    RnodeBleKissStatus, RnodeBleNotification, RnodeBleWrite,
+    RnodeBleBackend, RnodeBleKissConfig, RnodeBleKissError, RnodeBleKissIoStats,
+    RnodeBleKissRuntime, RnodeBleKissStatus, RnodeBleNotification, RnodeBleWrite,
 };
 
 pub use super::rnode_bearer_interface::{RnodeBearerKissInterface, RnodeBearerRuntimeStatusHandle};
@@ -117,6 +117,10 @@ where
         self.inner.send_deferred_frames().await
     }
 
+    pub async fn retry_startup_sequence(&mut self) -> Result<(), RnodeBleKissError> {
+        self.inner.retry_startup_sequence().await
+    }
+
     pub async fn send_id_beacon(&mut self) -> Result<(), RnodeBleKissError> {
         self.inner.send_id_beacon().await
     }
@@ -147,6 +151,11 @@ where
     #[must_use]
     pub fn status(&self) -> RnodeBleKissStatus {
         self.inner.status()
+    }
+
+    #[must_use]
+    pub fn io_stats(&self) -> RnodeBleKissIoStats {
+        self.inner.io_stats()
     }
 
     #[must_use]
@@ -215,6 +224,11 @@ mod tests {
         let notification = runtime.poll().await.expect("poll").expect("notification");
         assert_eq!(notification.packets, vec![b"hello".to_vec()]);
         runtime.send_packet(b"world").await.expect("send packet");
+        let io_stats = runtime.io_stats();
+        assert_eq!(io_stats.read_chunks, 1);
+        assert_eq!(io_stats.read_bytes, 8);
+        assert!(io_stats.write_chunks > 0);
+        assert!(io_stats.write_bytes > 0);
         runtime.shutdown().await.expect("shutdown");
 
         let backend = runtime.into_backend();

--- a/crates/libs/rns-transport/src/iface/rnode_bearer.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer.rs
@@ -128,6 +128,10 @@ where
         self.inner.send_management_frame(frame).await
     }
 
+    pub async fn poll_queue_admission(&mut self) -> Result<(), RnodeBleKissError> {
+        self.inner.poll_queue_admission().await
+    }
+
     pub async fn poll(&mut self) -> Result<Option<RnodeBleNotification>, RnodeBleKissError> {
         self.inner.poll_optional_notification_events().await
     }

--- a/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
@@ -235,6 +235,20 @@ impl<B> RnodeBearerKissInterface<B> {
                 }
             }
 
+            let Some(result) =
+                run_or_cancel(runtime.poll_queue_admission(), &context.cancel, &iface_stop).await
+            else {
+                cancelled = true;
+                break;
+            };
+            if let Err(error) = result {
+                set_error_status(
+                    &status,
+                    &format!("RNode queue-admission probe failed: {error:?}"),
+                );
+                break;
+            }
+
             // `RnodeBearerBackend::read` is the single owner of the bounded
             // wait. Do not cancel it with a shorter outer timeout: an Android
             // JNI read continues on its blocking worker after a future is

--- a/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use tokio::time::{sleep, timeout, Instant};
+use tokio::time::{sleep, Instant};
 
 use crate::buffer::InputBuffer;
 use crate::iface::{IfaceSource, Interface, InterfaceContext, RxMessage};
@@ -21,7 +21,12 @@ use super::rnode_ble::{
     RnodeBleCommandMonitor, RnodeBleKissConfig,
 };
 
-const IO_POLL_INTERVAL: Duration = Duration::from_millis(100);
+// Platform bearers own their bounded read wait. In particular, the Android
+// backend waits on a Java notification queue in a blocking worker, so wrapping
+// that read in a shorter Tokio timeout would leave an abandoned worker that can
+// consume and discard the next notification. Keep only a small backoff for
+// backends that return `Ok(None)` immediately.
+const EMPTY_READ_BACKOFF: Duration = Duration::from_millis(10);
 const STARTUP_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 const DETECTION_FALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -230,26 +235,23 @@ impl<B> RnodeBearerKissInterface<B> {
                 }
             }
 
-            let polled = tokio::select! {
-                result = timeout(IO_POLL_INTERVAL, runtime.poll()) => result,
-                () = context.cancel.cancelled() => {
-                    cancelled = true;
-                    break;
-                },
-                () = iface_stop.cancelled() => {
-                    cancelled = true;
-                    break;
-                },
-            };
+            // `RnodeBearerBackend::read` is the single owner of the bounded
+            // wait. Do not cancel it with a shorter outer timeout: an Android
+            // JNI read continues on its blocking worker after a future is
+            // dropped, and a second read would then race it for notifications.
+            let polled = runtime.poll().await;
+            if context.cancel.is_cancelled() || iface_stop.is_cancelled() {
+                cancelled = true;
+                break;
+            }
             match polled {
-                Err(_) => {}
-                Ok(Err(error)) => {
+                Err(error) => {
                     set_error_status(&status, &format!("RNode bearer read failed: {error:?}"));
                     break;
                 }
-                Ok(Ok(None)) => {
+                Ok(None) => {
                     tokio::select! {
-                        () = sleep(IO_POLL_INTERVAL) => {}
+                        () = sleep(EMPTY_READ_BACKOFF) => {}
                         () = context.cancel.cancelled() => {
                             cancelled = true;
                             break;
@@ -260,7 +262,7 @@ impl<B> RnodeBearerKissInterface<B> {
                         }
                     }
                 }
-                Ok(Ok(Some(notification))) => {
+                Ok(Some(notification)) => {
                     if let Err(error) = monitor.accept_notification(&notification) {
                         set_error_status(&status, &error);
                         break;
@@ -334,35 +336,9 @@ impl<B> RnodeBearerKissInterface<B> {
                 }
             }
             if let Err(error) = monitor.validate_startup_deadline() {
-                if monitor.consume_missing_response_retry(&error) {
-                    log::warn!(
-                        "RNode startup response missing; retrying paced startup sequence iface={label} error={error}"
-                    );
-                    let Some(result) = run_or_cancel(
-                        runtime.retry_startup_sequence(),
-                        &context.cancel,
-                        &iface_stop,
-                    )
-                    .await
-                    else {
-                        cancelled = true;
-                        break;
-                    };
-                    if let Err(retry_error) = result {
-                        set_error_status(
-                            &status,
-                            &format!("RNode startup sequence retry failed: {retry_error:?}"),
-                        );
-                        break;
-                    }
-                    monitor.reset_startup_deadline(STARTUP_RESPONSE_TIMEOUT);
-                } else {
-                    log::warn!(
-                        "RNode startup response validation failed iface={label} error={error}"
-                    );
-                    set_error_status(&status, &error);
-                    break;
-                }
+                log::warn!("RNode startup response validation failed iface={label} error={error}");
+                set_error_status(&status, &error);
+                break;
             }
             publish_monitor_status(
                 &status,

--- a/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
@@ -12,6 +12,10 @@ use super::lora::LoraConfig;
 use super::rnode_bearer::{
     RnodeBearerBackend, RnodeBearerInfo, RnodeBearerKind, RnodeBearerKissRuntime,
 };
+pub use super::rnode_bearer_status::RnodeBearerRuntimeStatusHandle;
+use super::rnode_bearer_status::{
+    append_error_status, publish_monitor_status, set_error_status, RnodeBearerTraffic,
+};
 use super::rnode_ble::{
     rnode_ble_initial_runtime_status_json, rnode_ble_payload_writes_enabled,
     RnodeBleCommandMonitor, RnodeBleKissConfig,
@@ -20,26 +24,6 @@ use super::rnode_ble::{
 const IO_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const STARTUP_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 const DETECTION_FALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-struct RnodeBearerTraffic {
-    tx_packets: u64,
-    tx_bytes: u64,
-    rx_packets: u64,
-    rx_bytes: u64,
-}
-
-#[derive(Clone)]
-pub struct RnodeBearerRuntimeStatusHandle {
-    inner: Arc<Mutex<serde_json::Value>>,
-}
-
-impl RnodeBearerRuntimeStatusHandle {
-    #[must_use]
-    pub fn to_json(&self) -> serde_json::Value {
-        self.inner.lock().unwrap_or_else(|poisoned| poisoned.into_inner()).clone()
-    }
-}
 
 /// A single RNode bearer attempt integrated with the Reticulum interface manager.
 ///
@@ -434,48 +418,6 @@ fn bearer_label(info: RnodeBearerInfo) -> &'static str {
     }
 }
 
-fn publish_monitor_status(
-    status: &Arc<Mutex<serde_json::Value>>,
-    monitor: &RnodeBleCommandMonitor,
-    endpoint: &str,
-    bearer: &str,
-    negotiated_mtu: Option<u16>,
-    traffic: RnodeBearerTraffic,
-    io: super::rnode_ble::RnodeBleKissIoStats,
-) {
-    let mut value = monitor.runtime_status_json(endpoint);
-    if let Some(object) = value.as_object_mut() {
-        object.insert("bearer".to_string(), serde_json::Value::String(bearer.to_string()));
-        object.insert(
-            "negotiated_mtu".to_string(),
-            negotiated_mtu.map_or(serde_json::Value::Null, serde_json::Value::from),
-        );
-        object.insert(
-            "traffic".to_string(),
-            serde_json::json!({
-                "tx_packets": traffic.tx_packets,
-                "tx_bytes": traffic.tx_bytes,
-                "rx_packets": traffic.rx_packets,
-                "rx_bytes": traffic.rx_bytes,
-                "kiss_write_chunks": io.write_chunks,
-                "kiss_write_bytes": io.write_bytes,
-                "kiss_read_chunks": io.read_chunks,
-                "kiss_read_bytes": io.read_bytes,
-            }),
-        );
-    }
-    *status.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = value;
-}
-
-fn set_error_status(status: &Arc<Mutex<serde_json::Value>>, error: &str) {
-    let mut guard = status.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-    let Some(object) = guard.as_object_mut() else {
-        return;
-    };
-    object.insert("online".to_string(), serde_json::Value::Bool(false));
-    object.insert("last_command_error".to_string(), serde_json::Value::String(error.to_string()));
-}
-
 async fn close_after_aborted_startup<B>(
     runtime: &mut RnodeBearerKissRuntime<B>,
     status: &Arc<Mutex<serde_json::Value>>,
@@ -490,21 +432,6 @@ async fn close_after_aborted_startup<B>(
         log::warn!("{message}");
         append_error_status(status, &message);
     }
-}
-
-fn append_error_status(status: &Arc<Mutex<serde_json::Value>>, error: &str) {
-    let mut guard = status.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-    let previous = guard
-        .get("last_command_error")
-        .and_then(serde_json::Value::as_str)
-        .filter(|value| !value.is_empty())
-        .map(str::to_owned);
-    let Some(object) = guard.as_object_mut() else {
-        return;
-    };
-    let combined = previous.map_or_else(|| error.to_string(), |value| format!("{value}; {error}"));
-    object.insert("online".to_string(), serde_json::Value::Bool(false));
-    object.insert("last_command_error".to_string(), serde_json::Value::String(combined));
 }
 
 #[cfg(test)]

--- a/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer_interface.rs
@@ -21,6 +21,14 @@ const IO_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const STARTUP_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 const DETECTION_FALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct RnodeBearerTraffic {
+    tx_packets: u64,
+    tx_bytes: u64,
+    rx_packets: u64,
+    rx_bytes: u64,
+}
+
 #[derive(Clone)]
 pub struct RnodeBearerRuntimeStatusHandle {
     inner: Arc<Mutex<serde_json::Value>>,
@@ -122,7 +130,22 @@ impl<B> RnodeBearerKissInterface<B> {
 
         let bearer = bearer_label(info);
         let mut monitor = RnodeBleCommandMonitor::new(lora, STARTUP_RESPONSE_TIMEOUT);
-        publish_monitor_status(&status, &monitor, &endpoint, bearer);
+        let mut traffic = RnodeBearerTraffic::default();
+        publish_monitor_status(
+            &status,
+            &monitor,
+            &endpoint,
+            bearer,
+            info.negotiated_mtu,
+            traffic,
+            runtime.io_stats(),
+        );
+        log::info!(
+            "RNode bearer opened iface={} bearer={} negotiated_mtu={:?}",
+            label,
+            bearer,
+            info.negotiated_mtu
+        );
         let mut radio_config_sent = false;
         let detection_deadline = Instant::now() + DETECTION_FALLBACK_TIMEOUT;
         let mut first_tx_at: Option<Instant> = None;
@@ -140,7 +163,7 @@ impl<B> RnodeBearerKissInterface<B> {
                     break;
                 };
                 match result {
-                    Ok(()) => monitor.accept_degraded_startup(),
+                    Ok(()) => monitor.reset_startup_deadline(STARTUP_RESPONSE_TIMEOUT),
                     Err(error) => {
                         set_error_status(
                             &status,
@@ -184,6 +207,19 @@ impl<B> RnodeBearerKissInterface<B> {
                         attempt_failed = true;
                         break;
                     }
+                    traffic.tx_packets = traffic.tx_packets.saturating_add(1);
+                    traffic.tx_bytes = traffic
+                        .tx_bytes
+                        .saturating_add(u64::try_from(raw.len()).unwrap_or(u64::MAX));
+                    let io = runtime.io_stats();
+                    log::debug!(
+                        "RNode packet handed to bearer iface={} packet_bytes={} tx_packets={} kiss_write_chunks={} kiss_write_bytes={}",
+                        label,
+                        raw.len(),
+                        traffic.tx_packets,
+                        io.write_chunks,
+                        io.write_bytes
+                    );
                     first_tx_at.get_or_insert_with(Instant::now);
                 }
             }
@@ -266,8 +302,29 @@ impl<B> RnodeBearerKissInterface<B> {
                         }
                         monitor.reset_startup_deadline(STARTUP_RESPONSE_TIMEOUT);
                     }
-                    publish_monitor_status(&status, &monitor, &endpoint, bearer);
+                    publish_monitor_status(
+                        &status,
+                        &monitor,
+                        &endpoint,
+                        bearer,
+                        info.negotiated_mtu,
+                        traffic,
+                        runtime.io_stats(),
+                    );
                     for payload in notification.packets {
+                        traffic.rx_packets = traffic.rx_packets.saturating_add(1);
+                        traffic.rx_bytes = traffic
+                            .rx_bytes
+                            .saturating_add(u64::try_from(payload.len()).unwrap_or(u64::MAX));
+                        let io = runtime.io_stats();
+                        log::debug!(
+                            "RNode packet received from bearer iface={} packet_bytes={} rx_packets={} kiss_read_chunks={} kiss_read_bytes={}",
+                            label,
+                            payload.len(),
+                            traffic.rx_packets,
+                            io.read_chunks,
+                            io.read_bytes
+                        );
                         match Packet::deserialize(&mut InputBuffer::new(&payload)) {
                             Ok(packet) => {
                                 if rx_channel
@@ -293,11 +350,45 @@ impl<B> RnodeBearerKissInterface<B> {
                 }
             }
             if let Err(error) = monitor.validate_startup_deadline() {
-                log::warn!("RNode startup response validation failed iface={label} error={error}");
-                set_error_status(&status, &error);
-                break;
+                if monitor.consume_missing_response_retry(&error) {
+                    log::warn!(
+                        "RNode startup response missing; retrying paced startup sequence iface={label} error={error}"
+                    );
+                    let Some(result) = run_or_cancel(
+                        runtime.retry_startup_sequence(),
+                        &context.cancel,
+                        &iface_stop,
+                    )
+                    .await
+                    else {
+                        cancelled = true;
+                        break;
+                    };
+                    if let Err(retry_error) = result {
+                        set_error_status(
+                            &status,
+                            &format!("RNode startup sequence retry failed: {retry_error:?}"),
+                        );
+                        break;
+                    }
+                    monitor.reset_startup_deadline(STARTUP_RESPONSE_TIMEOUT);
+                } else {
+                    log::warn!(
+                        "RNode startup response validation failed iface={label} error={error}"
+                    );
+                    set_error_status(&status, &error);
+                    break;
+                }
             }
-            publish_monitor_status(&status, &monitor, &endpoint, bearer);
+            publish_monitor_status(
+                &status,
+                &monitor,
+                &endpoint,
+                bearer,
+                info.negotiated_mtu,
+                traffic,
+                runtime.io_stats(),
+            );
         }
 
         if cancelled || context.cancel.is_cancelled() || iface_stop.is_cancelled() {
@@ -348,10 +439,30 @@ fn publish_monitor_status(
     monitor: &RnodeBleCommandMonitor,
     endpoint: &str,
     bearer: &str,
+    negotiated_mtu: Option<u16>,
+    traffic: RnodeBearerTraffic,
+    io: super::rnode_ble::RnodeBleKissIoStats,
 ) {
     let mut value = monitor.runtime_status_json(endpoint);
     if let Some(object) = value.as_object_mut() {
         object.insert("bearer".to_string(), serde_json::Value::String(bearer.to_string()));
+        object.insert(
+            "negotiated_mtu".to_string(),
+            negotiated_mtu.map_or(serde_json::Value::Null, serde_json::Value::from),
+        );
+        object.insert(
+            "traffic".to_string(),
+            serde_json::json!({
+                "tx_packets": traffic.tx_packets,
+                "tx_bytes": traffic.tx_bytes,
+                "rx_packets": traffic.rx_packets,
+                "rx_bytes": traffic.rx_bytes,
+                "kiss_write_chunks": io.write_chunks,
+                "kiss_write_bytes": io.write_bytes,
+                "kiss_read_chunks": io.read_chunks,
+                "kiss_read_bytes": io.read_bytes,
+            }),
+        );
     }
     *status.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = value;
 }

--- a/crates/libs/rns-transport/src/iface/rnode_bearer_interface_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer_interface_tests.rs
@@ -136,7 +136,7 @@ impl RnodeBearerBackend for DelayedNativeReadBackend {
             let active = state.active_reads.fetch_add(1, Ordering::SeqCst) + 1;
             state.max_active_reads.fetch_max(active, Ordering::SeqCst);
             let read_number = state.started_reads.fetch_add(1, Ordering::SeqCst) + 1;
-            let _ = read_started.send(read_number);
+            read_started.send(read_number).expect("read-start observer should remain available");
             tokio::time::sleep(Duration::from_millis(150)).await;
             let notification = state
                 .notifications
@@ -147,7 +147,9 @@ impl RnodeBearerBackend for DelayedNativeReadBackend {
                 state.consumed_notifications.fetch_add(1, Ordering::SeqCst);
             }
             state.active_reads.fetch_sub(1, Ordering::SeqCst);
-            let _ = sender.send(Ok(notification));
+            sender
+                .send(Ok(notification))
+                .expect("bearer read future must remain owned until the native worker completes");
         });
         receiver.await.map_err(|_| "synthetic read worker stopped".to_string())?
     }

--- a/crates/libs/rns-transport/src/iface/rnode_bearer_interface_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer_interface_tests.rs
@@ -51,6 +51,28 @@ fn test_interface(
     (manager.new_context(interface), status)
 }
 
+#[test]
+fn runtime_status_exposes_packet_and_kiss_boundary_counters() {
+    let status = Arc::new(Mutex::new(serde_json::Value::Null));
+    let monitor = RnodeBleCommandMonitor::new(LoraConfig::us915_default(), Duration::from_secs(1));
+    let traffic = RnodeBearerTraffic { tx_packets: 2, tx_bytes: 270, rx_packets: 1, rx_bytes: 48 };
+    let io = super::super::rnode_ble::RnodeBleKissIoStats {
+        read_chunks: 3,
+        read_bytes: 60,
+        write_chunks: 15,
+        write_bytes: 300,
+    };
+
+    publish_monitor_status(&status, &monitor, "ble://test", "ble", Some(517), traffic, io);
+
+    let snapshot = status.lock().expect("status mutex").clone();
+    assert_eq!(snapshot["negotiated_mtu"], 517);
+    assert_eq!(snapshot["traffic"]["tx_packets"], 2);
+    assert_eq!(snapshot["traffic"]["kiss_write_chunks"], 15);
+    assert_eq!(snapshot["traffic"]["rx_packets"], 1);
+    assert_eq!(snapshot["traffic"]["kiss_read_bytes"], 60);
+}
+
 #[tokio::test]
 async fn failed_startup_records_close_failure_without_losing_open_error() {
     let (context, status) = test_interface(OpenBehavior::Fail);

--- a/crates/libs/rns-transport/src/iface/rnode_bearer_interface_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer_interface_tests.rs
@@ -1,4 +1,6 @@
+use std::collections::VecDeque;
 use std::future::pending;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use crate::iface::InterfaceManager;
@@ -95,7 +97,7 @@ async fn cancelled_startup_records_close_failure() {
     tokio::task::yield_now().await;
 
     cancel.cancel();
-    timeout(Duration::from_secs(1), task)
+    tokio::time::timeout(Duration::from_secs(1), task)
         .await
         .expect("cancelled startup timeout")
         .expect("cancelled startup task");
@@ -105,4 +107,117 @@ async fn cancelled_startup_records_close_failure() {
     assert!(error.contains("iface=test-rnode"));
     assert!(error.contains("phase=startup_cancellation"));
     assert!(error.contains("close failed"));
+}
+
+#[derive(Default)]
+struct NativeReadState {
+    active_reads: AtomicUsize,
+    max_active_reads: AtomicUsize,
+    started_reads: AtomicUsize,
+    consumed_notifications: AtomicUsize,
+    notifications: Mutex<VecDeque<Vec<u8>>>,
+}
+
+struct DelayedNativeReadBackend {
+    state: Arc<NativeReadState>,
+    read_started: tokio::sync::mpsc::UnboundedSender<usize>,
+}
+
+impl RnodeBearerBackend for DelayedNativeReadBackend {
+    async fn open(&mut self) -> Result<RnodeBearerInfo, String> {
+        Ok(RnodeBearerInfo { kind: RnodeBearerKind::Ble, negotiated_mtu: Some(517) })
+    }
+
+    async fn read(&mut self) -> Result<Option<Vec<u8>>, String> {
+        let state = Arc::clone(&self.state);
+        let read_started = self.read_started.clone();
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let active = state.active_reads.fetch_add(1, Ordering::SeqCst) + 1;
+            state.max_active_reads.fetch_max(active, Ordering::SeqCst);
+            let read_number = state.started_reads.fetch_add(1, Ordering::SeqCst) + 1;
+            let _ = read_started.send(read_number);
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            let notification = state
+                .notifications
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .pop_front();
+            if notification.is_some() {
+                state.consumed_notifications.fetch_add(1, Ordering::SeqCst);
+            }
+            state.active_reads.fetch_sub(1, Ordering::SeqCst);
+            let _ = sender.send(Ok(notification));
+        });
+        receiver.await.map_err(|_| "synthetic read worker stopped".to_string())?
+    }
+
+    async fn write(&mut self, _payload: Vec<u8>) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn bearer_keeps_delayed_native_reads_single_owner_and_delivers_once() {
+    let state = Arc::new(NativeReadState::default());
+    let (read_started_tx, mut read_started_rx) = tokio::sync::mpsc::unbounded_channel();
+    state
+        .notifications
+        .lock()
+        .expect("notification queue")
+        .push_back(crate::kiss::encode_data_frame(&[0x42]));
+    let interface = RnodeBearerKissInterface::new(
+        "test-rnode",
+        "ble://test-rnode",
+        DelayedNativeReadBackend { state: Arc::clone(&state), read_started: read_started_tx },
+        RnodeBleKissConfig::default(),
+        LoraConfig::us915_default(),
+    );
+    let status = interface.runtime_status_handle();
+    let mut manager = InterfaceManager::new(4);
+    let context = manager.new_context(interface);
+    let cancel = context.cancel.clone();
+    let task = tokio::spawn(RnodeBearerKissInterface::spawn(context));
+
+    assert_eq!(read_started_rx.recv().await, Some(1));
+    // The first notification arrives after the removed 100 ms outer timeout.
+    // Wait for it to complete and for the next single-owner read to start,
+    // then cancel while that bounded worker is active.
+    assert_eq!(
+        tokio::time::timeout(Duration::from_millis(400), read_started_rx.recv())
+            .await
+            .expect("second read should start after the delayed notification"),
+        Some(2)
+    );
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_millis(400), task)
+        .await
+        .expect("cancellation must finish within the backend read bound")
+        .expect("bearer task should not panic");
+
+    let snapshot = status.to_json();
+    assert_eq!(snapshot["traffic"]["kiss_read_chunks"], 1);
+    assert_eq!(snapshot["traffic"]["rx_packets"], 1);
+    assert_eq!(state.consumed_notifications.load(Ordering::SeqCst), 1);
+    assert_eq!(state.active_reads.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        state.max_active_reads.load(Ordering::SeqCst),
+        1,
+        "a native read worker must finish before the next poll starts"
+    );
+
+    // Once cancellation closes this generation, there must be no abandoned
+    // worker left behind to consume a notification meant for a later one.
+    state
+        .notifications
+        .lock()
+        .expect("notification queue")
+        .push_back(crate::kiss::encode_data_frame(&[0x99]));
+    assert_eq!(state.consumed_notifications.load(Ordering::SeqCst), 1);
+    assert_eq!(state.active_reads.load(Ordering::SeqCst), 0);
+    assert_eq!(state.started_reads.load(Ordering::SeqCst), 2);
 }

--- a/crates/libs/rns-transport/src/iface/rnode_bearer_status.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_bearer_status.rs
@@ -1,0 +1,80 @@
+use std::sync::{Arc, Mutex};
+
+use super::rnode_ble::{RnodeBleCommandMonitor, RnodeBleKissIoStats};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct RnodeBearerTraffic {
+    pub(super) tx_packets: u64,
+    pub(super) tx_bytes: u64,
+    pub(super) rx_packets: u64,
+    pub(super) rx_bytes: u64,
+}
+
+#[derive(Clone)]
+pub struct RnodeBearerRuntimeStatusHandle {
+    pub(super) inner: Arc<Mutex<serde_json::Value>>,
+}
+
+impl RnodeBearerRuntimeStatusHandle {
+    #[must_use]
+    pub fn to_json(&self) -> serde_json::Value {
+        self.inner.lock().unwrap_or_else(|poisoned| poisoned.into_inner()).clone()
+    }
+}
+
+pub(super) fn publish_monitor_status(
+    status: &Arc<Mutex<serde_json::Value>>,
+    monitor: &RnodeBleCommandMonitor,
+    endpoint: &str,
+    bearer: &str,
+    negotiated_mtu: Option<u16>,
+    traffic: RnodeBearerTraffic,
+    io: RnodeBleKissIoStats,
+) {
+    let mut value = monitor.runtime_status_json(endpoint);
+    if let Some(object) = value.as_object_mut() {
+        object.insert("bearer".to_string(), serde_json::Value::String(bearer.to_string()));
+        object.insert(
+            "negotiated_mtu".to_string(),
+            negotiated_mtu.map_or(serde_json::Value::Null, serde_json::Value::from),
+        );
+        object.insert(
+            "traffic".to_string(),
+            serde_json::json!({
+                "tx_packets": traffic.tx_packets,
+                "tx_bytes": traffic.tx_bytes,
+                "rx_packets": traffic.rx_packets,
+                "rx_bytes": traffic.rx_bytes,
+                "kiss_write_chunks": io.write_chunks,
+                "kiss_write_bytes": io.write_bytes,
+                "kiss_read_chunks": io.read_chunks,
+                "kiss_read_bytes": io.read_bytes,
+            }),
+        );
+    }
+    *status.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = value;
+}
+
+pub(super) fn set_error_status(status: &Arc<Mutex<serde_json::Value>>, error: &str) {
+    let mut guard = status.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(object) = guard.as_object_mut() else {
+        return;
+    };
+    object.insert("online".to_string(), serde_json::Value::Bool(false));
+    object.insert("last_command_error".to_string(), serde_json::Value::String(error.to_string()));
+}
+
+pub(super) fn append_error_status(status: &Arc<Mutex<serde_json::Value>>, error: &str) {
+    let mut guard = status.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let previous = guard
+        .get("last_command_error")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+    let Some(object) = guard.as_object_mut() else {
+        return;
+    };
+    let combined = previous.map_or_else(|| error.to_string(), |value| format!("{value}; {error}"));
+    object.insert("online".to_string(), serde_json::Value::Bool(false));
+    object.insert("last_command_error".to_string(), serde_json::Value::String(combined));
+}

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
@@ -67,6 +67,13 @@ const RNODE_BLE_STARTUP_STABILIZATION_TIMEOUT: Duration = Duration::from_secs(2)
 
 const RNODE_BLE_STARTUP_NOTIFICATION_QUIET_TIMEOUT: Duration = Duration::from_millis(100);
 
+// Nordic UART writes complete at the Android GATT boundary before every RNode
+// firmware has consumed the preceding command. Pacing applies only to the
+// short startup/configuration command burst, never to payload chunks.
+const RNODE_BLE_COMMAND_WRITE_SPACING: Duration = Duration::from_millis(20);
+#[cfg(feature = "rnode-ble")]
+const RNODE_LXMF_MIN_ATT_MTU: u16 = 173;
+
 #[cfg(feature = "rnode-ble")]
 const RNODE_BLE_MANAGEMENT_CHANNEL_CAPACITY: usize = 64;
 
@@ -131,6 +138,14 @@ pub struct RnodeBleKissStatus {
     pub interface_ready: bool,
     pub pending_payloads: usize,
     pub pending_writes: usize,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RnodeBleKissIoStats {
+    pub read_chunks: u64,
+    pub read_bytes: u64,
+    pub write_chunks: u64,
+    pub write_bytes: u64,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
@@ -48,7 +48,9 @@ use crate::iface::lora::{
     CMD_STAT_TX,
 };
 
-use crate::kiss::{encode_data_frame, KissCommand, KissDecodeError, KissFrame, KissStreamDecoder};
+use crate::kiss::{
+    encode_data_frame, KissCommand, KissDecodeError, KissFrame, KissStreamDecoder, CMD_READY,
+};
 
 pub const RNODE_BLE_SERVICE_UUID: &str = "6E400001-B5A3-F393-E0A9-E50E24DCCA9E";
 
@@ -61,6 +63,13 @@ pub const RNODE_BLE_SCAN_TIMEOUT: Duration = Duration::from_secs(2);
 pub const RNODE_BLE_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub const RNODE_BLE_READ_FRAME_TIMEOUT: Duration = Duration::from_millis(1_250);
+
+/// Minimum delay between RNode firmware queue-admission probes.
+///
+/// RNode firmware answers `CMD_READY` with its current queue state; it does not
+/// emit a later notification when a full queue drains. Polling is therefore
+/// required while payloads are pending, but it must remain bounded.
+pub const RNODE_QUEUE_ADMISSION_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 const RNODE_BLE_STARTUP_STABILIZATION_TIMEOUT: Duration = Duration::from_secs(2);
 

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
@@ -75,6 +75,11 @@ const RNODE_BLE_COMMAND_WRITE_SPACING: Duration = Duration::from_millis(20);
 const RNODE_LXMF_MIN_ATT_MTU: u16 = 173;
 
 #[cfg(feature = "rnode-ble")]
+const fn rnode_lxmf_att_mtu_supported(mtu: u16) -> bool {
+    mtu >= RNODE_LXMF_MIN_ATT_MTU
+}
+
+#[cfg(feature = "rnode-ble")]
 const RNODE_BLE_MANAGEMENT_CHANNEL_CAPACITY: usize = 64;
 
 #[cfg(feature = "rnode-ble")]

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
@@ -62,6 +62,11 @@ pub const RNODE_BLE_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub const RNODE_BLE_READ_FRAME_TIMEOUT: Duration = Duration::from_millis(1_250);
 
+// Match Python RNS KISS flow-control recovery: a missing firmware READY
+// notification must not leave the shared KISS session locked forever. Only one
+// queued payload is released per timeout, then flow control locks again.
+const RNODE_BLE_FLOW_CONTROL_TIMEOUT: Duration = Duration::from_secs(5);
+
 const RNODE_BLE_STARTUP_STABILIZATION_TIMEOUT: Duration = Duration::from_secs(2);
 
 const RNODE_BLE_STARTUP_NOTIFICATION_QUIET_TIMEOUT: Duration = Duration::from_millis(100);

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
@@ -44,7 +44,8 @@ use uuid::Uuid;
 use crate::iface::kiss::KissConfig;
 
 use crate::iface::lora::{
-    LoraConfig, LoraInterface, RNodeHardwareError, RNodeProbeStatus, RNodeRadioStatus,
+    LoraConfig, LoraInterface, RNodeHardwareError, RNodeProbeStatus, RNodeRadioStatus, CMD_STAT_RX,
+    CMD_STAT_TX,
 };
 
 use crate::kiss::{encode_data_frame, KissCommand, KissDecodeError, KissFrame, KissStreamDecoder};

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
@@ -62,11 +62,6 @@ pub const RNODE_BLE_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub const RNODE_BLE_READ_FRAME_TIMEOUT: Duration = Duration::from_millis(1_250);
 
-// Match Python RNS KISS flow-control recovery: a missing firmware READY
-// notification must not leave the shared KISS session locked forever. Only one
-// queued payload is released per timeout, then flow control locks again.
-const RNODE_BLE_FLOW_CONTROL_TIMEOUT: Duration = Duration::from_secs(5);
-
 const RNODE_BLE_STARTUP_STABILIZATION_TIMEOUT: Duration = Duration::from_secs(2);
 
 const RNODE_BLE_STARTUP_NOTIFICATION_QUIET_TIMEOUT: Duration = Duration::from_millis(100);

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/module_prelude.rs
@@ -61,23 +61,9 @@ pub const RNODE_BLE_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub const RNODE_BLE_READ_FRAME_TIMEOUT: Duration = Duration::from_millis(1_250);
 
-const DEFAULT_ATT_NOTIFICATION_PAYLOAD_BYTES: usize = 20;
-
 const RNODE_BLE_STARTUP_STABILIZATION_TIMEOUT: Duration = Duration::from_secs(2);
 
 const RNODE_BLE_STARTUP_NOTIFICATION_QUIET_TIMEOUT: Duration = Duration::from_millis(100);
-
-// Nordic UART writes complete at the Android GATT boundary before every RNode
-// firmware has consumed the preceding command. Pacing applies only to the
-// short startup/configuration command burst, never to payload chunks.
-const RNODE_BLE_COMMAND_WRITE_SPACING: Duration = Duration::from_millis(20);
-#[cfg(feature = "rnode-ble")]
-const RNODE_LXMF_MIN_ATT_MTU: u16 = 173;
-
-#[cfg(feature = "rnode-ble")]
-const fn rnode_lxmf_att_mtu_supported(mtu: u16) -> bool {
-    mtu >= RNODE_LXMF_MIN_ATT_MTU
-}
 
 #[cfg(feature = "rnode-ble")]
 const RNODE_BLE_MANAGEMENT_CHANNEL_CAPACITY: usize = 64;

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
@@ -2,6 +2,7 @@ pub struct RnodeBleKissRuntime<B> {
     backend: B,
     session: RnodeBleKissSession,
     connected: bool,
+    io_stats: RnodeBleKissIoStats,
 }
 
 impl<B> RnodeBleKissRuntime<B>
@@ -10,7 +11,12 @@ where
 {
     #[must_use]
     pub fn new(backend: B, config: RnodeBleKissConfig) -> Self {
-        Self { backend, session: RnodeBleKissSession::new(config), connected: false }
+        Self {
+            backend,
+            session: RnodeBleKissSession::new(config),
+            connected: false,
+            io_stats: RnodeBleKissIoStats::default(),
+        }
     }
 
     #[must_use]
@@ -26,6 +32,11 @@ where
     #[must_use]
     pub fn status(&self) -> RnodeBleKissStatus {
         self.session.status_with_connection(self.connected)
+    }
+
+    #[must_use]
+    pub fn io_stats(&self) -> RnodeBleKissIoStats {
+        self.io_stats
     }
 
     #[must_use]
@@ -55,14 +66,30 @@ where
             self.drain_startup_notifications().await?;
         }
         let writes = self.session.startup_frames();
-        self.write_all(writes, "startup_write").await?;
+        self.write_all_paced(writes, "startup_write", RNODE_BLE_COMMAND_WRITE_SPACING)
+            .await?;
         self.connected = true;
         Ok(())
     }
 
     pub async fn send_deferred_frames(&mut self) -> Result<(), RnodeBleKissError> {
         let writes = self.session.deferred_frames();
-        self.write_all(writes, "deferred_frames_write").await
+        self.write_all_paced(writes, "deferred_frames_write", RNODE_BLE_COMMAND_WRITE_SPACING)
+            .await
+    }
+
+    /// Replays the complete idempotent startup/configuration exchange after a missing response.
+    /// Probe replies and radio-state replies are both required, so replaying only deferred radio
+    /// frames cannot recover a dropped firmware, platform, MCU, or detect command.
+    pub async fn retry_startup_sequence(&mut self) -> Result<(), RnodeBleKissError> {
+        let mut writes = self.session.startup_frames();
+        writes.extend(self.session.deferred_frames());
+        self.write_all_paced(
+            writes,
+            "startup_retry_write",
+            RNODE_BLE_COMMAND_WRITE_SPACING,
+        )
+        .await
     }
 
     pub async fn send_packet(&mut self, payload: &[u8]) -> Result<(), RnodeBleKissError> {
@@ -136,6 +163,11 @@ where
         else {
             return Ok(None);
         };
+        self.io_stats.read_chunks = self.io_stats.read_chunks.saturating_add(1);
+        self.io_stats.read_bytes = self
+            .io_stats
+            .read_bytes
+            .saturating_add(u64::try_from(payload.len()).unwrap_or(u64::MAX));
         {
             let hex: String = payload
                 .iter()
@@ -155,11 +187,30 @@ where
         writes: Vec<RnodeBleWrite>,
         operation: &'static str,
     ) -> Result<(), RnodeBleKissError> {
-        for write in writes {
+        self.write_all_paced(writes, operation, Duration::ZERO).await
+    }
+
+    async fn write_all_paced(
+        &mut self,
+        writes: Vec<RnodeBleWrite>,
+        operation: &'static str,
+        spacing: Duration,
+    ) -> Result<(), RnodeBleKissError> {
+        let write_count = writes.len();
+        for (index, write) in writes.into_iter().enumerate() {
+            let payload_len = write.payload.len();
             self.backend.write(write).await.map_err(|message| {
                 self.connected = false;
                 RnodeBleKissError::Backend { operation, message }
             })?;
+            self.io_stats.write_chunks = self.io_stats.write_chunks.saturating_add(1);
+            self.io_stats.write_bytes = self
+                .io_stats
+                .write_bytes
+                .saturating_add(u64::try_from(payload_len).unwrap_or(u64::MAX));
+            if !spacing.is_zero() && index + 1 < write_count {
+                tokio::time::sleep(spacing).await;
+            }
         }
         Ok(())
     }
@@ -324,14 +375,31 @@ impl NativeRnodeBleKissInterface {
                 iface_address,
                 settings.peripheral_id
             );
-            // RNODE_LXMF_MIN_ATT_MTU = 173 (170 notification payload bytes + 3 ATT header)
+            // 170 notification payload bytes + 3 ATT header.
+            // Fail closed here, matching the Android transport: accepting a smaller MTU would
+            // silently truncate complete RNode notification frames.
             match runtime.negotiated_mtu() {
-                Some(mtu) if mtu < 173 => log::warn!(
-                    "RNode BLE negotiated ATT MTU {} < 173 minimum for LXMF; \
-                     expect incomplete notification payloads iface={}",
-                    mtu,
-                    label
-                ),
+                Some(mtu) if mtu < RNODE_LXMF_MIN_ATT_MTU => {
+                    log::warn!(
+                        "RNode BLE negotiated ATT MTU {} < {} minimum for LXMF; \
+                         rejecting session iface={}",
+                        mtu,
+                        RNODE_LXMF_MIN_ATT_MTU,
+                        label
+                    );
+                    let mut backend = runtime.into_backend();
+                    if let Err(cleanup_error) = backend.cleanup().await {
+                        log::warn!(
+                            "RNode BLE cleanup failed after MTU rejection iface={} \
+                             error={cleanup_error:?}",
+                            label
+                        );
+                    }
+                    sleep(active_backoff).await;
+                    active_backoff =
+                        bounded_backoff_next(active_backoff, max_reconnect_backoff);
+                    continue;
+                }
                 Some(mtu) => log::info!("RNode BLE negotiated ATT MTU {} iface={}", mtu, label),
                 None => log::debug!(
                     "RNode BLE negotiated ATT MTU unknown (macOS or non-native backend) iface={}",
@@ -382,7 +450,7 @@ impl NativeRnodeBleKissInterface {
                                 );
                                 reconnect_needed = true;
                             } else if let Some(mon) = command_monitor.as_mut() {
-                                mon.accept_degraded_startup();
+                                mon.reset_startup_deadline(startup_response_timeout);
                             }
                         }
                     }
@@ -591,13 +659,31 @@ impl NativeRnodeBleKissInterface {
                 }
                 if let Some(monitor) = command_monitor.as_mut() {
                     if let Err(err) = monitor.validate_startup_deadline() {
-                        log::warn!(
-                            "RNode BLE startup response validation failed iface={} err={}",
-                            label,
-                            err
-                        );
-                        reconnect_needed = true;
-                        break;
+                        if monitor.consume_missing_response_retry(&err) {
+                            log::warn!(
+                                "RNode BLE startup response missing; retrying paced startup sequence iface={} err={}",
+                                label,
+                                err
+                            );
+                            if let Err(retry_error) = runtime.retry_startup_sequence().await {
+                                log::warn!(
+                                    "RNode BLE startup sequence retry failed iface={} err={:?}",
+                                    label,
+                                    retry_error
+                                );
+                                reconnect_needed = true;
+                                break;
+                            }
+                            monitor.reset_startup_deadline(startup_response_timeout);
+                        } else {
+                            log::warn!(
+                                "RNode BLE startup response validation failed iface={} err={}",
+                                label,
+                                err
+                            );
+                            reconnect_needed = true;
+                            break;
+                        }
                     }
                     if let Some(status) = rnode_status.as_ref() {
                         *status.lock().expect("RNode BLE status mutex poisoned") = monitor
@@ -649,4 +735,5 @@ pub struct RnodeBleCommandMonitor {
     startup_validated: bool,
     startup_payload_writes_enabled: bool,
     startup_compatibility_warning: Option<String>,
+    missing_response_retries_remaining: u8,
 }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
@@ -66,30 +66,14 @@ where
             self.drain_startup_notifications().await?;
         }
         let writes = self.session.startup_frames();
-        self.write_all_paced(writes, "startup_write", RNODE_BLE_COMMAND_WRITE_SPACING)
-            .await?;
+        self.write_all(writes, "startup_write").await?;
         self.connected = true;
         Ok(())
     }
 
     pub async fn send_deferred_frames(&mut self) -> Result<(), RnodeBleKissError> {
         let writes = self.session.deferred_frames();
-        self.write_all_paced(writes, "deferred_frames_write", RNODE_BLE_COMMAND_WRITE_SPACING)
-            .await
-    }
-
-    /// Replays the complete idempotent startup/configuration exchange after a missing response.
-    /// Probe replies and radio-state replies are both required, so replaying only deferred radio
-    /// frames cannot recover a dropped firmware, platform, MCU, or detect command.
-    pub async fn retry_startup_sequence(&mut self) -> Result<(), RnodeBleKissError> {
-        let mut writes = self.session.startup_frames();
-        writes.extend(self.session.deferred_frames());
-        self.write_all_paced(
-            writes,
-            "startup_retry_write",
-            RNODE_BLE_COMMAND_WRITE_SPACING,
-        )
-        .await
+        self.write_all(writes, "deferred_frames_write").await
     }
 
     pub async fn send_packet(&mut self, payload: &[u8]) -> Result<(), RnodeBleKissError> {
@@ -187,17 +171,7 @@ where
         writes: Vec<RnodeBleWrite>,
         operation: &'static str,
     ) -> Result<(), RnodeBleKissError> {
-        self.write_all_paced(writes, operation, Duration::ZERO).await
-    }
-
-    async fn write_all_paced(
-        &mut self,
-        writes: Vec<RnodeBleWrite>,
-        operation: &'static str,
-        spacing: Duration,
-    ) -> Result<(), RnodeBleKissError> {
-        let write_count = writes.len();
-        for (index, write) in writes.into_iter().enumerate() {
+        for write in writes {
             let payload_len = write.payload.len();
             self.backend.write(write).await.map_err(|message| {
                 self.connected = false;
@@ -208,9 +182,6 @@ where
                 .io_stats
                 .write_bytes
                 .saturating_add(u64::try_from(payload_len).unwrap_or(u64::MAX));
-            if !spacing.is_zero() && index + 1 < write_count {
-                tokio::time::sleep(spacing).await;
-            }
         }
         Ok(())
     }
@@ -375,31 +346,7 @@ impl NativeRnodeBleKissInterface {
                 iface_address,
                 settings.peripheral_id
             );
-            // 170 notification payload bytes + 3 ATT header.
-            // Fail closed here, matching the Android transport: accepting a smaller MTU would
-            // silently truncate complete RNode notification frames.
             match runtime.negotiated_mtu() {
-                Some(mtu) if !rnode_lxmf_att_mtu_supported(mtu) => {
-                    log::warn!(
-                        "RNode BLE negotiated ATT MTU {} < {} minimum for LXMF; \
-                         rejecting session iface={}",
-                        mtu,
-                        RNODE_LXMF_MIN_ATT_MTU,
-                        label
-                    );
-                    let mut backend = runtime.into_backend();
-                    if let Err(cleanup_error) = backend.cleanup().await {
-                        log::warn!(
-                            "RNode BLE cleanup failed after MTU rejection iface={} \
-                             error={cleanup_error:?}",
-                            label
-                        );
-                    }
-                    sleep(active_backoff).await;
-                    active_backoff =
-                        bounded_backoff_next(active_backoff, max_reconnect_backoff);
-                    continue;
-                }
                 Some(mtu) => log::info!("RNode BLE negotiated ATT MTU {} iface={}", mtu, label),
                 None => log::debug!(
                     "RNode BLE negotiated ATT MTU unknown (macOS or non-native backend) iface={}",
@@ -659,31 +606,13 @@ impl NativeRnodeBleKissInterface {
                 }
                 if let Some(monitor) = command_monitor.as_mut() {
                     if let Err(err) = monitor.validate_startup_deadline() {
-                        if monitor.consume_missing_response_retry(&err) {
-                            log::warn!(
-                                "RNode BLE startup response missing; retrying paced startup sequence iface={} err={}",
-                                label,
-                                err
-                            );
-                            if let Err(retry_error) = runtime.retry_startup_sequence().await {
-                                log::warn!(
-                                    "RNode BLE startup sequence retry failed iface={} err={:?}",
-                                    label,
-                                    retry_error
-                                );
-                                reconnect_needed = true;
-                                break;
-                            }
-                            monitor.reset_startup_deadline(startup_response_timeout);
-                        } else {
-                            log::warn!(
-                                "RNode BLE startup response validation failed iface={} err={}",
-                                label,
-                                err
-                            );
-                            reconnect_needed = true;
-                            break;
-                        }
+                        log::warn!(
+                            "RNode BLE startup response validation failed iface={} err={}",
+                            label,
+                            err
+                        );
+                        reconnect_needed = true;
+                        break;
                     }
                     if let Some(status) = rnode_status.as_ref() {
                         *status.lock().expect("RNode BLE status mutex poisoned") = monitor
@@ -735,5 +664,4 @@ pub struct RnodeBleCommandMonitor {
     startup_validated: bool,
     startup_payload_writes_enabled: bool,
     startup_compatibility_warning: Option<String>,
-    missing_response_retries_remaining: u8,
 }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
@@ -145,6 +145,9 @@ where
             RnodeBleKissError::Backend { operation: "next_notification", message }
         })?
         else {
+            self.session.recover_missed_flow_control_ready();
+            let writes = self.session.take_pending_writes();
+            self.write_all(writes, "write_pending_after_ready_timeout").await?;
             return Ok(None);
         };
         self.io_stats.read_chunks = self.io_stats.read_chunks.saturating_add(1);
@@ -161,6 +164,7 @@ where
             log::trace!("RNode BLE raw notification {} bytes: [{}]", payload.len(), hex);
         }
         let notification = self.session.accept_notification_events(&payload)?;
+        self.session.recover_missed_flow_control_ready();
         let writes = self.session.take_pending_writes();
         self.write_all(writes, "write_pending").await?;
         Ok(Some(notification))

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
@@ -145,9 +145,6 @@ where
             RnodeBleKissError::Backend { operation: "next_notification", message }
         })?
         else {
-            self.session.recover_missed_flow_control_ready();
-            let writes = self.session.take_pending_writes();
-            self.write_all(writes, "write_pending_after_ready_timeout").await?;
             return Ok(None);
         };
         self.io_stats.read_chunks = self.io_stats.read_chunks.saturating_add(1);
@@ -164,7 +161,6 @@ where
             log::trace!("RNode BLE raw notification {} bytes: [{}]", payload.len(), hex);
         }
         let notification = self.session.accept_notification_events(&payload)?;
-        self.session.recover_missed_flow_control_ready();
         let writes = self.session.take_pending_writes();
         self.write_all(writes, "write_pending").await?;
         Ok(Some(notification))

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
@@ -379,7 +379,7 @@ impl NativeRnodeBleKissInterface {
             // Fail closed here, matching the Android transport: accepting a smaller MTU would
             // silently truncate complete RNode notification frames.
             match runtime.negotiated_mtu() {
-                Some(mtu) if mtu < RNODE_LXMF_MIN_ATT_MTU => {
+                Some(mtu) if !rnode_lxmf_att_mtu_supported(mtu) => {
                     log::warn!(
                         "RNode BLE negotiated ATT MTU {} < {} minimum for LXMF; \
                          rejecting session iface={}",

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnode_peripheral_matches.rs
@@ -100,6 +100,11 @@ where
         self.write_all(writes, "write_management_frame").await
     }
 
+    pub async fn poll_queue_admission(&mut self) -> Result<(), RnodeBleKissError> {
+        let writes = self.session.queue_admission_probe_if_due();
+        self.write_all(writes, "write_queue_admission_probe").await
+    }
+
     pub async fn shutdown(&mut self) -> Result<(), RnodeBleKissError> {
         self.shutdown_with_prefix_frames(Vec::new()).await
     }
@@ -505,6 +510,16 @@ impl NativeRnodeBleKissInterface {
                         }
                         first_tx_at = None;
                     }
+                }
+
+                if let Err(err) = runtime.poll_queue_admission().await {
+                    log::warn!(
+                        "RNode BLE queue-admission probe failed iface={} err={:?}",
+                        label,
+                        err
+                    );
+                    reconnect_needed = true;
+                    break;
                 }
 
                 match timeout(Duration::from_millis(100), runtime.poll_notification_events()).await

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
@@ -239,6 +239,7 @@ pub struct RnodeBleKissSession {
     decoder: KissStreamDecoder,
     subscribed: bool,
     interface_ready: bool,
+    flow_control_locked_at: Option<Instant>,
     last_read_at: Instant,
     pending_payloads: VecDeque<Vec<u8>>,
     pending_writes: VecDeque<RnodeBleWrite>,
@@ -253,6 +254,7 @@ impl RnodeBleKissSession {
             // through, then flow control locks until firmware emits READY.
             // Starting locked deadlocks because READY is a post-transmit signal.
             interface_ready: true,
+            flow_control_locked_at: None,
             subscribed: false,
             last_read_at: Instant::now(),
             pending_payloads: VecDeque::new(),
@@ -340,6 +342,7 @@ impl RnodeBleKissSession {
         let writes = self.kiss_writes(encode_data_frame(payload));
         if self.config.kiss.flow_control {
             self.interface_ready = false;
+            self.flow_control_locked_at = Some(Instant::now());
         }
         writes
     }
@@ -369,6 +372,7 @@ impl RnodeBleKissSession {
         let writes = self.kiss_writes(encode_data_frame(&payload));
         if self.config.kiss.flow_control {
             self.interface_ready = false;
+            self.flow_control_locked_at = Some(Instant::now());
         }
         writes
     }
@@ -412,6 +416,7 @@ impl RnodeBleKissSession {
                 }
                 KissFrame::Command(KissCommand::Ready) => {
                     self.interface_ready = true;
+                    self.flow_control_locked_at = None;
                     self.flush_pending_payloads();
                 }
                 KissFrame::Command(KissCommand::Unknown(command, payload)) => {
@@ -427,6 +432,25 @@ impl RnodeBleKissSession {
         self.pending_writes.drain(..).collect()
     }
 
+    fn recover_missed_flow_control_ready(&mut self) {
+        if !self.config.kiss.flow_control || self.interface_ready {
+            return;
+        }
+        if self
+            .flow_control_locked_at
+            .is_none_or(|locked_at| locked_at.elapsed() < RNODE_BLE_FLOW_CONTROL_TIMEOUT)
+        {
+            return;
+        }
+
+        log::warn!(
+            "RNode flow control timed out waiting for READY; releasing one queued payload"
+        );
+        self.interface_ready = true;
+        self.flow_control_locked_at = None;
+        self.flush_pending_payloads();
+    }
+
     fn flush_pending_payloads(&mut self) {
         while self.interface_ready {
             let Some(payload) = self.pending_payloads.pop_front() else {
@@ -435,6 +459,7 @@ impl RnodeBleKissSession {
             self.pending_writes.extend(self.kiss_writes(encode_data_frame(&payload)));
             if self.config.kiss.flow_control {
                 self.interface_ready = false;
+                self.flow_control_locked_at = Some(Instant::now());
             }
         }
     }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
@@ -23,7 +23,15 @@ impl RnodeBleCommandMonitor {
                 Err(err) => self.lora.last_command_error() == Some(err.as_str()),
             };
             match (result, fatal) {
-                (Ok(_), _) => {}
+                (Ok(_), _) => {
+                    if matches!(*command, CMD_STAT_RX | CMD_STAT_TX) && payload.len() == 4 {
+                        let value = u32::from_be_bytes([
+                            payload[0], payload[1], payload[2], payload[3],
+                        ]);
+                        let counter = if *command == CMD_STAT_RX { "stat_rx" } else { "stat_tx" };
+                        log::info!("RNode radio counter counter={counter} value={value}");
+                    }
+                }
                 (Err(err), true) => return Err(err),
                 (Err(err), false) => {
                     log::warn!(

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
@@ -9,6 +9,7 @@ impl RnodeBleCommandMonitor {
             startup_validated: false,
             startup_payload_writes_enabled: false,
             startup_compatibility_warning: None,
+            missing_response_retries_remaining: 2,
         }
     }
 
@@ -69,9 +70,24 @@ impl RnodeBleCommandMonitor {
         self.startup_deadline = Some(Instant::now() + timeout);
     }
 
-    pub fn accept_degraded_startup(&mut self) {
-        self.startup_deadline = None;
-        self.startup_payload_writes_enabled = true;
+    pub fn consume_missing_response_retry(&mut self, error: &str) -> bool {
+        let retryable = matches!(
+            error,
+            "rnode detect response did not confirm an RNode device"
+                | "rnode firmware response is missing"
+                | "rnode platform response is missing"
+                | "rnode mcu response is missing"
+                | "rnode bandwidth response is missing"
+                | "rnode tx power response is missing"
+                | "rnode spreading factor response is missing"
+                | "rnode coding rate response is missing"
+                | "rnode radio state response is missing"
+        );
+        if self.missing_response_retries_remaining == 0 || !retryable {
+            return false;
+        }
+        self.missing_response_retries_remaining -= 1;
+        true
     }
 
     #[must_use]
@@ -103,6 +119,10 @@ impl RnodeBleCommandMonitor {
     pub fn runtime_status_json(&self, endpoint: &str) -> serde_json::Value {
         let mut value = rnode_ble_runtime_status_json(&self.lora, endpoint);
         if let Some(object) = value.as_object_mut() {
+            object.insert(
+                "startup_validated".to_string(),
+                serde_json::Value::Bool(self.startup_validated),
+            );
             object.insert(
                 "startup_compatibility_warning".to_string(),
                 self.startup_compatibility_warning

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
@@ -239,7 +239,6 @@ pub struct RnodeBleKissSession {
     decoder: KissStreamDecoder,
     subscribed: bool,
     interface_ready: bool,
-    flow_control_locked_at: Option<Instant>,
     last_read_at: Instant,
     pending_payloads: VecDeque<Vec<u8>>,
     pending_writes: VecDeque<RnodeBleWrite>,
@@ -250,11 +249,7 @@ impl RnodeBleKissSession {
     pub fn new(config: RnodeBleKissConfig) -> Self {
         Self {
             decoder: KissStreamDecoder::new(config.mtu),
-            // Match the reference RNode interface: the first packet is allowed
-            // through, then flow control locks until firmware emits READY.
-            // Starting locked deadlocks because READY is a post-transmit signal.
-            interface_ready: true,
-            flow_control_locked_at: None,
+            interface_ready: !config.kiss.flow_control,
             subscribed: false,
             last_read_at: Instant::now(),
             pending_payloads: VecDeque::new(),
@@ -342,7 +337,6 @@ impl RnodeBleKissSession {
         let writes = self.kiss_writes(encode_data_frame(payload));
         if self.config.kiss.flow_control {
             self.interface_ready = false;
-            self.flow_control_locked_at = Some(Instant::now());
         }
         writes
     }
@@ -372,7 +366,6 @@ impl RnodeBleKissSession {
         let writes = self.kiss_writes(encode_data_frame(&payload));
         if self.config.kiss.flow_control {
             self.interface_ready = false;
-            self.flow_control_locked_at = Some(Instant::now());
         }
         writes
     }
@@ -416,7 +409,6 @@ impl RnodeBleKissSession {
                 }
                 KissFrame::Command(KissCommand::Ready) => {
                     self.interface_ready = true;
-                    self.flow_control_locked_at = None;
                     self.flush_pending_payloads();
                 }
                 KissFrame::Command(KissCommand::Unknown(command, payload)) => {
@@ -432,25 +424,6 @@ impl RnodeBleKissSession {
         self.pending_writes.drain(..).collect()
     }
 
-    fn recover_missed_flow_control_ready(&mut self) {
-        if !self.config.kiss.flow_control || self.interface_ready {
-            return;
-        }
-        if self
-            .flow_control_locked_at
-            .is_none_or(|locked_at| locked_at.elapsed() < RNODE_BLE_FLOW_CONTROL_TIMEOUT)
-        {
-            return;
-        }
-
-        log::warn!(
-            "RNode flow control timed out waiting for READY; releasing one queued payload"
-        );
-        self.interface_ready = true;
-        self.flow_control_locked_at = None;
-        self.flush_pending_payloads();
-    }
-
     fn flush_pending_payloads(&mut self) {
         while self.interface_ready {
             let Some(payload) = self.pending_payloads.pop_front() else {
@@ -459,7 +432,6 @@ impl RnodeBleKissSession {
             self.pending_writes.extend(self.kiss_writes(encode_data_frame(&payload)));
             if self.config.kiss.flow_control {
                 self.interface_ready = false;
-                self.flow_control_locked_at = Some(Instant::now());
             }
         }
     }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
@@ -240,6 +240,7 @@ pub struct RnodeBleKissSession {
     subscribed: bool,
     interface_ready: bool,
     last_read_at: Instant,
+    last_queue_admission_probe_at: Option<Instant>,
     pending_payloads: VecDeque<Vec<u8>>,
     pending_writes: VecDeque<RnodeBleWrite>,
 }
@@ -252,6 +253,7 @@ impl RnodeBleKissSession {
             interface_ready: !config.kiss.flow_control,
             subscribed: false,
             last_read_at: Instant::now(),
+            last_queue_admission_probe_at: None,
             pending_payloads: VecDeque::new(),
             pending_writes: VecDeque::new(),
             config,
@@ -291,6 +293,9 @@ impl RnodeBleKissSession {
     #[must_use]
     pub fn startup_frames(&mut self) -> Vec<RnodeBleWrite> {
         self.subscribed = true;
+        if self.config.kiss.flow_control {
+            self.last_queue_admission_probe_at = Some(Instant::now());
+        }
         self.config
             .kiss
             .command_frames()
@@ -334,9 +339,10 @@ impl RnodeBleKissSession {
             return Vec::new();
         }
 
-        let writes = self.kiss_writes(encode_data_frame(payload));
+        let mut writes = self.kiss_writes(encode_data_frame(payload));
         if self.config.kiss.flow_control {
             self.interface_ready = false;
+            writes.extend(self.queue_admission_probe_writes());
         }
         writes
     }
@@ -363,9 +369,10 @@ impl RnodeBleKissSession {
             return Vec::new();
         }
 
-        let writes = self.kiss_writes(encode_data_frame(&payload));
+        let mut writes = self.kiss_writes(encode_data_frame(&payload));
         if self.config.kiss.flow_control {
             self.interface_ready = false;
+            writes.extend(self.queue_admission_probe_writes());
         }
         writes
     }
@@ -408,8 +415,17 @@ impl RnodeBleKissSession {
                     }
                 }
                 KissFrame::Command(KissCommand::Ready) => {
-                    self.interface_ready = true;
-                    self.flush_pending_payloads();
+                    if self.config.kiss.flow_control {
+                        self.interface_ready = true;
+                        self.flush_pending_payloads();
+                    }
+                }
+                KissFrame::Command(KissCommand::Unknown(CMD_READY, payload))
+                    if payload.first().copied() == Some(0) =>
+                {
+                    if self.config.kiss.flow_control {
+                        self.interface_ready = false;
+                    }
                 }
                 KissFrame::Command(KissCommand::Unknown(command, payload)) => {
                     notification.commands.push((command, payload));
@@ -424,6 +440,20 @@ impl RnodeBleKissSession {
         self.pending_writes.drain(..).collect()
     }
 
+    #[must_use]
+    pub fn queue_admission_probe_if_due(&mut self) -> Vec<RnodeBleWrite> {
+        if !self.config.kiss.flow_control
+            || self.interface_ready
+            || self.pending_payloads.is_empty()
+            || self.last_queue_admission_probe_at.is_some_and(|last| {
+                last.elapsed() < RNODE_QUEUE_ADMISSION_POLL_INTERVAL
+            })
+        {
+            return Vec::new();
+        }
+        self.queue_admission_probe_writes()
+    }
+
     fn flush_pending_payloads(&mut self) {
         while self.interface_ready {
             let Some(payload) = self.pending_payloads.pop_front() else {
@@ -432,8 +462,15 @@ impl RnodeBleKissSession {
             self.pending_writes.extend(self.kiss_writes(encode_data_frame(&payload)));
             if self.config.kiss.flow_control {
                 self.interface_ready = false;
+                let probe_writes = self.queue_admission_probe_writes();
+                self.pending_writes.extend(probe_writes);
             }
         }
+    }
+
+    fn queue_admission_probe_writes(&mut self) -> Vec<RnodeBleWrite> {
+        self.last_queue_admission_probe_at = Some(Instant::now());
+        self.kiss_writes(crate::kiss::encode_command_frame(crate::kiss::CMD_READY, &[1]))
     }
 
     fn kiss_writes(&self, payload: Vec<u8>) -> Vec<RnodeBleWrite> {

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
@@ -249,7 +249,10 @@ impl RnodeBleKissSession {
     pub fn new(config: RnodeBleKissConfig) -> Self {
         Self {
             decoder: KissStreamDecoder::new(config.mtu),
-            interface_ready: !config.kiss.flow_control,
+            // Match the reference RNode interface: the first packet is allowed
+            // through, then flow control locks until firmware emits READY.
+            // Starting locked deadlocks because READY is a post-transmit signal.
+            interface_ready: true,
             subscribed: false,
             last_read_at: Instant::now(),
             pending_payloads: VecDeque::new(),

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/rnodeblecommandmonitor.rs
@@ -9,7 +9,6 @@ impl RnodeBleCommandMonitor {
             startup_validated: false,
             startup_payload_writes_enabled: false,
             startup_compatibility_warning: None,
-            missing_response_retries_remaining: 2,
         }
     }
 
@@ -68,26 +67,6 @@ impl RnodeBleCommandMonitor {
 
     pub fn reset_startup_deadline(&mut self, timeout: Duration) {
         self.startup_deadline = Some(Instant::now() + timeout);
-    }
-
-    pub fn consume_missing_response_retry(&mut self, error: &str) -> bool {
-        let retryable = matches!(
-            error,
-            "rnode detect response did not confirm an RNode device"
-                | "rnode firmware response is missing"
-                | "rnode platform response is missing"
-                | "rnode mcu response is missing"
-                | "rnode bandwidth response is missing"
-                | "rnode tx power response is missing"
-                | "rnode spreading factor response is missing"
-                | "rnode coding rate response is missing"
-                | "rnode radio state response is missing"
-        );
-        if self.missing_response_retries_remaining == 0 || !retryable {
-            return false;
-        }
-        self.missing_response_retries_remaining -= 1;
-        true
     }
 
     #[must_use]
@@ -406,15 +385,6 @@ impl RnodeBleKissSession {
         }
         self.last_read_at = Instant::now();
         let frames = self.decoder.push_bytes(payload)?;
-        if frames.is_empty()
-            && payload.len() == DEFAULT_ATT_NOTIFICATION_PAYLOAD_BYTES
-            && self.decoder.has_partial_frame()
-        {
-            return Err(RnodeBleKissError::Backend {
-                operation: "accept_notification_events",
-                message: "incomplete 20-byte RNode BLE notification; likely ATT MTU 23 / 20-byte notification payload. The BLE host/backend did not report a usable negotiated MTU before notifications; verify btleplug 0.12+ platform MTU support or configure a host adapter that negotiates a larger ATT MTU.".to_string(),
-            });
-        }
         let mut notification = RnodeBleNotification::default();
         for frame in frames {
             match frame {
@@ -468,28 +438,5 @@ impl RnodeBleKissSession {
                 payload: chunk.to_vec(),
             })
             .collect()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{RnodeBleKissConfig, RnodeBleKissError, RnodeBleKissSession};
-
-    #[test]
-    fn rnode_ble_notification_reports_likely_default_att_mtu_cap() {
-        let mut session = RnodeBleKissSession::new(RnodeBleKissConfig::default());
-        let err = session
-            .accept_notification_events(&[0x42; 20])
-            .expect_err("20-byte incomplete notification should be diagnosed");
-
-        match err {
-            RnodeBleKissError::Backend { operation, message } => {
-                assert_eq!(operation, "accept_notification_events");
-                assert!(message.contains("likely ATT MTU 23"));
-                assert!(message.contains("did not report a usable negotiated MTU"));
-                assert!(message.contains("btleplug 0.12+"));
-            }
-            other => panic!("unexpected error: {other:?}"),
-        }
     }
 }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
@@ -3,7 +3,7 @@ use crate::iface::lora::{
     CMD_LEAVE, CMD_MCU, CMD_PLATFORM, CMD_RADIO_STATE, CMD_SF, CMD_TXPOWER, DETECT_RESP,
     PLATFORM_ESP32, RADIO_STATE_ASK, RADIO_STATE_OFF, RADIO_STATE_ON,
 };
-use crate::kiss::decode_frames;
+use crate::kiss::{decode_frames, encode_command_frame};
 
 #[derive(Default)]
 struct TestBackend {
@@ -33,6 +33,77 @@ impl RnodeBleBackend for TestBackend {
     fn negotiated_mtu(&self) -> Option<u16> {
         self.negotiated_mtu
     }
+}
+
+#[test]
+fn rnode_queue_admission_sends_one_packet_per_ready_response() {
+    let config = RnodeBleKissConfig {
+        max_write_len: 508,
+        kiss: KissConfig { flow_control: true, ..KissConfig::default() },
+        ..RnodeBleKissConfig::default()
+    };
+    let mut session = RnodeBleKissSession::new(config);
+    let _startup = session.startup_frames();
+
+    assert!(session.enqueue_packet(b"first").is_empty());
+    assert!(session.enqueue_packet(b"second").is_empty());
+    assert_eq!(session.status().pending_payloads, 2);
+
+    session
+        .accept_notification_events(&encode_command_frame(CMD_READY, &[1]))
+        .expect("accept ready response");
+    let first_writes = session.take_pending_writes();
+    let first_frames = decode_frames(
+        &first_writes.into_iter().flat_map(|write| write.payload).collect::<Vec<_>>(),
+        508,
+    )
+    .expect("decode first admitted write");
+    assert_eq!(
+        first_frames,
+        vec![
+            KissFrame::Data(b"first".to_vec()),
+            KissFrame::Command(KissCommand::Ready),
+        ]
+    );
+    assert!(!session.status().interface_ready);
+    assert_eq!(session.status().pending_payloads, 1);
+
+    session
+        .accept_notification_events(&encode_command_frame(CMD_READY, &[0]))
+        .expect("accept full-queue response");
+    assert!(session.take_pending_writes().is_empty());
+    assert!(!session.status().interface_ready);
+
+    session.last_queue_admission_probe_at =
+        Some(Instant::now() - RNODE_QUEUE_ADMISSION_POLL_INTERVAL);
+    let retry_probe = session.queue_admission_probe_if_due();
+    assert_eq!(
+        decode_frames(
+            &retry_probe.into_iter().flat_map(|write| write.payload).collect::<Vec<_>>(),
+            508,
+        )
+        .expect("decode retry probe"),
+        vec![KissFrame::Command(KissCommand::Ready)]
+    );
+    assert!(session.queue_admission_probe_if_due().is_empty());
+
+    session
+        .accept_notification_events(&encode_command_frame(CMD_READY, &[1]))
+        .expect("accept drained-queue response");
+    let second_writes = session.take_pending_writes();
+    let second_frames = decode_frames(
+        &second_writes.into_iter().flat_map(|write| write.payload).collect::<Vec<_>>(),
+        508,
+    )
+    .expect("decode second admitted write");
+    assert_eq!(
+        second_frames,
+        vec![
+            KissFrame::Data(b"second".to_vec()),
+            KissFrame::Command(KissCommand::Ready),
+        ]
+    );
+    assert_eq!(session.status().pending_payloads, 0);
 }
 
 fn startup_notification_without_radio_state(config: LoraConfig) -> RnodeBleNotification {

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
@@ -353,6 +353,7 @@ fn startup_retries_only_missing_responses_and_is_bounded() {
 #[test]
 fn native_lxmf_att_mtu_floor_covers_full_rnode_notification() {
     assert_eq!(RNODE_LXMF_MIN_ATT_MTU, 170 + 3);
-    assert!(172 < RNODE_LXMF_MIN_ATT_MTU);
-    assert!(173 >= RNODE_LXMF_MIN_ATT_MTU);
+    for (mtu, expected) in [(23, false), (172, false), (173, true), (517, true)] {
+        assert_eq!(rnode_lxmf_att_mtu_supported(mtu), expected, "MTU {mtu}");
+    }
 }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
@@ -3,7 +3,7 @@ use crate::iface::lora::{
     CMD_LEAVE, CMD_MCU, CMD_PLATFORM, CMD_RADIO_STATE, CMD_SF, CMD_TXPOWER, DETECT_RESP,
     PLATFORM_ESP32, RADIO_STATE_ASK, RADIO_STATE_OFF, RADIO_STATE_ON,
 };
-use crate::kiss::decode_frames;
+use crate::kiss::{decode_frames, encode_command_frame, CMD_READY};
 
 #[derive(Default)]
 struct TestBackend {
@@ -245,6 +245,46 @@ async fn startup_preserves_a_conservative_configured_write_cap() {
         runtime.session.config.max_write_len, 20,
         "a large negotiated ATT payload must not override the configured firmware-safe write cap"
     );
+}
+
+#[tokio::test]
+async fn flow_control_sends_first_packet_then_waits_for_ready() {
+    let backend = TestBackend::default();
+    let config = RnodeBleKissConfig {
+        kiss: KissConfig { flow_control: true, ..KissConfig::default() },
+        ..RnodeBleKissConfig::default()
+    };
+    let mut runtime = RnodeBleKissRuntime::new(backend, config);
+    runtime.startup().await.expect("startup should succeed");
+    let startup_writes = runtime.backend.writes.len();
+
+    runtime.send_packet(b"first").await.expect("first packet should be admitted");
+    let after_first = runtime.backend.writes.len();
+    assert!(after_first > startup_writes);
+    assert!(!runtime.status().interface_ready);
+
+    runtime.send_packet(b"second").await.expect("second packet should queue");
+    assert_eq!(runtime.backend.writes.len(), after_first);
+    assert_eq!(runtime.status().pending_payloads, 1);
+
+    runtime.backend.notifications.push_back(encode_command_frame(CMD_READY, &[1]));
+    runtime.poll_notification_events().await.expect("READY should flush one packet");
+    assert!(runtime.backend.writes.len() > after_first);
+    assert_eq!(runtime.status().pending_payloads, 0);
+    assert!(!runtime.status().interface_ready);
+
+    let frames = decode_frames(
+        &runtime
+            .backend
+            .writes
+            .iter()
+            .flat_map(|write| write.payload.iter().copied())
+            .collect::<Vec<_>>(),
+        508,
+    )
+    .expect("writes should remain valid KISS frames");
+    assert!(frames.contains(&KissFrame::Data(b"first".to_vec())));
+    assert!(frames.contains(&KissFrame::Data(b"second".to_vec())));
 }
 
 #[tokio::test]

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
@@ -334,26 +334,3 @@ async fn native_rnode_ble_management_handle_queues_frames() {
 
     assert_eq!(frames, vec![KissFrame::Command(KissCommand::Unknown(CMD_BLINK, vec![0x04]))]);
 }
-
-#[test]
-fn startup_retries_only_missing_responses_and_is_bounded() {
-    let mut monitor =
-        RnodeBleCommandMonitor::new(LoraConfig::us915_default(), Duration::from_secs(1));
-
-    assert!(!monitor.consume_missing_response_retry(
-        "rnode bandwidth mismatch configured=250000 reported=125000"
-    ));
-    assert!(monitor.consume_missing_response_retry(
-        "rnode detect response did not confirm an RNode device"
-    ));
-    assert!(monitor.consume_missing_response_retry("rnode firmware response is missing"));
-    assert!(!monitor.consume_missing_response_retry("rnode coding rate response is missing"));
-}
-
-#[test]
-fn native_lxmf_att_mtu_floor_covers_full_rnode_notification() {
-    assert_eq!(RNODE_LXMF_MIN_ATT_MTU, 170 + 3);
-    for (mtu, expected) in [(23, false), (172, false), (173, true), (517, true)] {
-        assert_eq!(rnode_lxmf_att_mtu_supported(mtu), expected, "MTU {mtu}");
-    }
-}

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
@@ -3,7 +3,7 @@ use crate::iface::lora::{
     CMD_LEAVE, CMD_MCU, CMD_PLATFORM, CMD_RADIO_STATE, CMD_SF, CMD_TXPOWER, DETECT_RESP,
     PLATFORM_ESP32, RADIO_STATE_ASK, RADIO_STATE_OFF, RADIO_STATE_ON,
 };
-use crate::kiss::{decode_frames, encode_command_frame, CMD_READY};
+use crate::kiss::decode_frames;
 
 #[derive(Default)]
 struct TestBackend {
@@ -245,90 +245,6 @@ async fn startup_preserves_a_conservative_configured_write_cap() {
         runtime.session.config.max_write_len, 20,
         "a large negotiated ATT payload must not override the configured firmware-safe write cap"
     );
-}
-
-#[tokio::test]
-async fn flow_control_sends_first_packet_then_waits_for_ready() {
-    let backend = TestBackend::default();
-    let config = RnodeBleKissConfig {
-        kiss: KissConfig { flow_control: true, ..KissConfig::default() },
-        ..RnodeBleKissConfig::default()
-    };
-    let mut runtime = RnodeBleKissRuntime::new(backend, config);
-    runtime.startup().await.expect("startup should succeed");
-    let startup_writes = runtime.backend.writes.len();
-
-    runtime.send_packet(b"first").await.expect("first packet should be admitted");
-    let after_first = runtime.backend.writes.len();
-    assert!(after_first > startup_writes);
-    assert!(!runtime.status().interface_ready);
-
-    runtime.send_packet(b"second").await.expect("second packet should queue");
-    assert_eq!(runtime.backend.writes.len(), after_first);
-    assert_eq!(runtime.status().pending_payloads, 1);
-
-    runtime.backend.notifications.push_back(encode_command_frame(CMD_READY, &[1]));
-    runtime.poll_notification_events().await.expect("READY should flush one packet");
-    assert!(runtime.backend.writes.len() > after_first);
-    assert_eq!(runtime.status().pending_payloads, 0);
-    assert!(!runtime.status().interface_ready);
-
-    let frames = decode_frames(
-        &runtime
-            .backend
-            .writes
-            .iter()
-            .flat_map(|write| write.payload.iter().copied())
-            .collect::<Vec<_>>(),
-        508,
-    )
-    .expect("writes should remain valid KISS frames");
-    assert!(frames.contains(&KissFrame::Data(b"first".to_vec())));
-    assert!(frames.contains(&KissFrame::Data(b"second".to_vec())));
-}
-
-#[tokio::test]
-async fn flow_control_timeout_releases_exactly_one_packet_when_ready_is_missed() {
-    let backend = TestBackend::default();
-    let config = RnodeBleKissConfig {
-        kiss: KissConfig { flow_control: true, ..KissConfig::default() },
-        ..RnodeBleKissConfig::default()
-    };
-    let mut runtime = RnodeBleKissRuntime::new(backend, config);
-    runtime.startup().await.expect("startup should succeed");
-
-    runtime.send_packet(b"first").await.expect("first packet should be admitted");
-    runtime.send_packet(b"second").await.expect("second packet should queue");
-    runtime.send_packet(b"third").await.expect("third packet should queue");
-    let after_first = runtime.backend.writes.len();
-    assert_eq!(runtime.status().pending_payloads, 2);
-
-    runtime.session.flow_control_locked_at =
-        Some(Instant::now() - RNODE_BLE_FLOW_CONTROL_TIMEOUT);
-    assert!(runtime
-        .poll_optional_notification_events()
-        .await
-        .expect("empty poll should recover missed READY")
-        .is_none());
-
-    assert!(runtime.backend.writes.len() > after_first);
-    assert_eq!(runtime.status().pending_payloads, 1);
-    assert!(!runtime.status().interface_ready);
-    assert!(runtime.session.flow_control_locked_at.is_some());
-
-    let frames = decode_frames(
-        &runtime
-            .backend
-            .writes
-            .iter()
-            .flat_map(|write| write.payload.iter().copied())
-            .collect::<Vec<_>>(),
-        508,
-    )
-    .expect("writes should remain valid KISS frames");
-    assert!(frames.contains(&KissFrame::Data(b"first".to_vec())));
-    assert!(frames.contains(&KissFrame::Data(b"second".to_vec())));
-    assert!(!frames.contains(&KissFrame::Data(b"third".to_vec())));
 }
 
 #[tokio::test]

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
@@ -124,14 +124,17 @@ fn payload_writes_wait_for_validated_radio_startup() {
 }
 
 #[test]
-fn degraded_startup_enables_payload_writes_after_fallback() {
+fn fallback_configuration_keeps_payload_writes_blocked_without_validation() {
     let config = LoraConfig::us915_default();
-    let mut monitor = RnodeBleCommandMonitor::new(config, Duration::from_secs(5));
+    let mut monitor = RnodeBleCommandMonitor::new(config, Duration::ZERO);
 
-    monitor.accept_degraded_startup();
+    let error = monitor
+        .validate_startup_deadline()
+        .expect_err("fallback without probe responses must fail closed");
 
+    assert!(error.contains("detect"));
     assert!(!monitor.startup_validated());
-    assert!(rnode_ble_payload_writes_enabled(true, Some(&monitor)));
+    assert!(!rnode_ble_payload_writes_enabled(true, Some(&monitor)));
     assert!(!rnode_ble_payload_writes_enabled(false, Some(&monitor)));
 }
 
@@ -330,4 +333,26 @@ async fn native_rnode_ble_management_handle_queues_frames() {
     let frames = decode_frames(&frame, 512).expect("decode queued management frame");
 
     assert_eq!(frames, vec![KissFrame::Command(KissCommand::Unknown(CMD_BLINK, vec![0x04]))]);
+}
+
+#[test]
+fn startup_retries_only_missing_responses_and_is_bounded() {
+    let mut monitor =
+        RnodeBleCommandMonitor::new(LoraConfig::us915_default(), Duration::from_secs(1));
+
+    assert!(!monitor.consume_missing_response_retry(
+        "rnode bandwidth mismatch configured=250000 reported=125000"
+    ));
+    assert!(monitor.consume_missing_response_retry(
+        "rnode detect response did not confirm an RNode device"
+    ));
+    assert!(monitor.consume_missing_response_retry("rnode firmware response is missing"));
+    assert!(!monitor.consume_missing_response_retry("rnode coding rate response is missing"));
+}
+
+#[test]
+fn native_lxmf_att_mtu_floor_covers_full_rnode_notification() {
+    assert_eq!(RNODE_LXMF_MIN_ATT_MTU, 170 + 3);
+    assert!(172 < RNODE_LXMF_MIN_ATT_MTU);
+    assert!(173 >= RNODE_LXMF_MIN_ATT_MTU);
 }

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
@@ -288,6 +288,50 @@ async fn flow_control_sends_first_packet_then_waits_for_ready() {
 }
 
 #[tokio::test]
+async fn flow_control_timeout_releases_exactly_one_packet_when_ready_is_missed() {
+    let backend = TestBackend::default();
+    let config = RnodeBleKissConfig {
+        kiss: KissConfig { flow_control: true, ..KissConfig::default() },
+        ..RnodeBleKissConfig::default()
+    };
+    let mut runtime = RnodeBleKissRuntime::new(backend, config);
+    runtime.startup().await.expect("startup should succeed");
+
+    runtime.send_packet(b"first").await.expect("first packet should be admitted");
+    runtime.send_packet(b"second").await.expect("second packet should queue");
+    runtime.send_packet(b"third").await.expect("third packet should queue");
+    let after_first = runtime.backend.writes.len();
+    assert_eq!(runtime.status().pending_payloads, 2);
+
+    runtime.session.flow_control_locked_at =
+        Some(Instant::now() - RNODE_BLE_FLOW_CONTROL_TIMEOUT);
+    assert!(runtime
+        .poll_optional_notification_events()
+        .await
+        .expect("empty poll should recover missed READY")
+        .is_none());
+
+    assert!(runtime.backend.writes.len() > after_first);
+    assert_eq!(runtime.status().pending_payloads, 1);
+    assert!(!runtime.status().interface_ready);
+    assert!(runtime.session.flow_control_locked_at.is_some());
+
+    let frames = decode_frames(
+        &runtime
+            .backend
+            .writes
+            .iter()
+            .flat_map(|write| write.payload.iter().copied())
+            .collect::<Vec<_>>(),
+        508,
+    )
+    .expect("writes should remain valid KISS frames");
+    assert!(frames.contains(&KissFrame::Data(b"first".to_vec())));
+    assert!(frames.contains(&KissFrame::Data(b"second".to_vec())));
+    assert!(!frames.contains(&KissFrame::Data(b"third".to_vec())));
+}
+
+#[tokio::test]
 async fn shutdown_can_prefix_display_disable_for_display_capable_rnode() {
     let mut monitor =
         RnodeBleCommandMonitor::new(LoraConfig::us915_default(), Duration::from_secs(1));

--- a/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
+++ b/crates/libs/rns-transport/src/iface/rnode_ble_parts/runtime_tests.rs
@@ -104,6 +104,23 @@ fn startup_compatibility_rejects_other_radio_mismatches() {
 }
 
 #[test]
+fn startup_compatibility_rejects_missing_frequency_response() {
+    let config = LoraConfig::us915_default();
+    let mut notification = startup_notification_without_radio_state(config);
+    notification.commands.retain(|(command, _)| *command != CMD_FREQUENCY);
+    let mut monitor = RnodeBleCommandMonitor::new(config, Duration::ZERO);
+    monitor.accept_notification(&notification).expect("accept startup responses");
+
+    let error = monitor
+        .validate_startup_deadline()
+        .expect_err("missing frequency response must remain fatal");
+
+    assert!(error.contains("rnode frequency response is missing"));
+    assert!(!monitor.online());
+    assert!(!monitor.startup_validated());
+}
+
+#[test]
 fn payload_writes_wait_for_validated_radio_startup() {
     let config = LoraConfig::us915_default();
     let mut monitor = RnodeBleCommandMonitor::new(config, Duration::ZERO);

--- a/crates/libs/rns-transport/src/kiss.rs
+++ b/crates/libs/rns-transport/src/kiss.rs
@@ -68,13 +68,19 @@ pub fn decode_frames(
 pub struct KissStreamDecoder {
     max_payload_len: usize,
     frame: Vec<u8>,
+    discard_until_fend: bool,
     strip_command_port_nibble: bool,
 }
 
 impl KissStreamDecoder {
     #[must_use]
     pub fn new(max_payload_len: usize) -> Self {
-        Self { max_payload_len, frame: Vec::new(), strip_command_port_nibble: false }
+        Self {
+            max_payload_len,
+            frame: Vec::new(),
+            discard_until_fend: false,
+            strip_command_port_nibble: false,
+        }
     }
 
     #[must_use]
@@ -90,11 +96,18 @@ impl KissStreamDecoder {
 
     pub fn clear_partial_frame(&mut self) {
         self.frame.clear();
+        self.discard_until_fend = false;
     }
 
     pub fn push_bytes(&mut self, input: &[u8]) -> Result<Vec<KissFrame>, KissDecodeError> {
         let mut frames = Vec::new();
         for byte in input {
+            if self.discard_until_fend {
+                if *byte == FEND {
+                    self.discard_until_fend = false;
+                }
+                continue;
+            }
             if *byte == FEND {
                 if !self.frame.is_empty() {
                     let raw = std::mem::take(&mut self.frame);
@@ -105,6 +118,18 @@ impl KissStreamDecoder {
                     ));
                 }
                 continue;
+            }
+            // A valid raw frame contains one command byte and at most two
+            // encoded bytes for each decoded payload byte. Enforce that bound
+            // before the closing delimiter so a noisy byte stream cannot grow
+            // this buffer indefinitely. After overflow, discard through FEND
+            // to avoid interpreting the tail of the bad frame as a new one.
+            let raw_frame_limit = self.max_payload_len.saturating_mul(2).saturating_add(1);
+            if self.frame.len() >= raw_frame_limit {
+                let actual = self.frame.len().saturating_add(1);
+                self.frame.clear();
+                self.discard_until_fend = true;
+                return Err(KissDecodeError::FrameTooLarge { limit: raw_frame_limit, actual });
             }
             self.frame.push(*byte);
         }

--- a/crates/libs/rns-transport/src/kiss.rs
+++ b/crates/libs/rns-transport/src/kiss.rs
@@ -145,6 +145,9 @@ fn decode_frame(raw: &[u8], max_payload_len: usize, strip_command_port_nibble: b
     let payload = decode_payload(payload, max_payload_len);
     match command {
         CMD_DATA => KissFrame::Data(payload),
+        CMD_READY if payload.first().copied() == Some(0) => {
+            KissFrame::Command(KissCommand::Unknown(CMD_READY, payload))
+        }
         CMD_READY => KissFrame::Command(KissCommand::Ready),
         command => KissFrame::Command(KissCommand::Unknown(command, payload)),
     }

--- a/crates/libs/rns-transport/tests/kiss_codec_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/tests/kiss_codec_parts/module_prelude.rs
@@ -95,6 +95,18 @@ fn decode_ready_frame_reports_flow_control_command() {
 }
 
 #[test]
+fn decode_not_ready_frame_preserves_firmware_queue_state() {
+    let input = [FEND, CMD_READY, 0, FEND];
+
+    let frames = decode_frames(&input, 64).expect("decode not-ready frame");
+
+    assert_eq!(
+        frames,
+        vec![KissFrame::Command(KissCommand::Unknown(CMD_READY, vec![0]))]
+    );
+}
+
+#[test]
 fn stream_decoder_can_strip_python_kiss_port_nibble() {
     let mut decoder = KissStreamDecoder::new(64).with_command_port_nibble_stripping(true);
 

--- a/crates/libs/rns-transport/tests/kiss_codec_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/tests/kiss_codec_parts/module_prelude.rs
@@ -12,9 +12,9 @@ use rns_transport::iface::kiss::{
 use rns_transport::iface::{TxMessage, TxMessageType};
 
 use rns_transport::kiss::{
-    decode_frames, encode_command_frame, encode_data_frame, KissCommand, KissFrame,
-    KissStreamDecoder, CMD_DATA, CMD_P, CMD_READY, CMD_SLOTTIME, CMD_TXDELAY, CMD_TXTAIL, FEND,
-    FESC, TFEND, TFESC,
+    decode_frames, encode_command_frame, encode_data_frame, KissCommand, KissDecodeError,
+    KissFrame, KissStreamDecoder, CMD_DATA, CMD_P, CMD_READY, CMD_SLOTTIME, CMD_TXDELAY,
+    CMD_TXTAIL, FEND, FESC, TFEND, TFESC,
 };
 
 use rns_transport::packet::Packet;
@@ -189,6 +189,29 @@ fn stream_decoder_buffers_split_frames() {
     let frames = decoder.push_bytes(&[b'i', b'n', b'g', FEND]).expect("finish decode");
 
     assert_eq!(frames, vec![KissFrame::Data(b"ping".to_vec())]);
+}
+
+#[test]
+fn stream_decoder_bounds_fragmented_raw_frames_and_resynchronizes() {
+    let mut decoder = KissStreamDecoder::new(4);
+
+    assert!(decoder
+        .push_bytes(&[FEND, CMD_DATA, 1, 2, 3])
+        .expect("first oversized fragment")
+        .is_empty());
+    assert!(decoder
+        .push_bytes(&[4, 5, 6, 7, 8])
+        .expect("second fragment reaches the encoded bound")
+        .is_empty());
+    assert_eq!(
+        decoder.push_bytes(&[9]),
+        Err(KissDecodeError::FrameTooLarge { limit: 9, actual: 10 })
+    );
+
+    let frames = decoder
+        .push_bytes(&[0x42, FEND, FEND, CMD_DATA, b'o', b'k', FEND])
+        .expect("decoder should recover at the next frame delimiter");
+    assert_eq!(frames, vec![KissFrame::Data(b"ok".to_vec())]);
 }
 
 #[tokio::test]

--- a/crates/libs/rns-transport/tests/lora_interface_parts/lora_interface_clears_python_per_pac.rs
+++ b/crates/libs/rns-transport/tests/lora_interface_parts/lora_interface_clears_python_per_pac.rs
@@ -223,8 +223,11 @@ fn lora_interface_startup_response_validation_reports_first_python_gap() {
     iface.record_command_response(CMD_FW_VERSION, &[1, 52]).expect("firmware");
     iface.record_command_response(CMD_PLATFORM, &[PLATFORM_ESP32]).expect("platform");
     iface.record_command_response(CMD_MCU, &[0x01]).expect("mcu");
+    iface
+        .record_command_response(CMD_FREQUENCY, &915_000_000_u32.to_be_bytes())
+        .expect("frequency");
 
-    let err = iface.validate_startup_responses().expect_err("missing radio state must fail");
+    let err = iface.validate_startup_responses().expect_err("missing bandwidth must fail");
     assert!(err.contains("bandwidth"), "unexpected startup validation error: {err}");
 }
 

--- a/crates/libs/rns-transport/tests/lora_interface_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/tests/lora_interface_parts/module_prelude.rs
@@ -438,7 +438,26 @@ fn rnode_radio_status_rejects_python_radio_state_mismatches() {
         .expect_err("frequency mismatch above Python tolerance must fail");
     assert!(err.contains("frequency"), "unexpected validation error: {err}");
 
+    let mut missing_frequency = RNodeRadioStatus::default();
+    missing_frequency
+        .accept_command(CMD_BANDWIDTH, &125_000_u32.to_be_bytes())
+        .expect("bandwidth");
+    missing_frequency.accept_command(CMD_TXPOWER, &[17]).expect("tx power");
+    missing_frequency.accept_command(CMD_SF, &[9]).expect("spreading factor");
+    missing_frequency.accept_command(CMD_CR, &[5]).expect("coding rate");
+    missing_frequency
+        .accept_command(CMD_RADIO_STATE, &[RADIO_STATE_ON])
+        .expect("radio state");
+
+    let err = missing_frequency
+        .validate_config(config, RADIO_STATE_ON)
+        .expect_err("missing frequency response must fail");
+    assert!(err.contains("frequency"), "unexpected validation error: {err}");
+
     let mut missing_bandwidth = RNodeRadioStatus::default();
+    missing_bandwidth
+        .accept_command(CMD_FREQUENCY, &915_000_000_u32.to_be_bytes())
+        .expect("frequency");
     missing_bandwidth.accept_command(CMD_TXPOWER, &[17]).expect("tx power");
     missing_bandwidth.accept_command(CMD_SF, &[9]).expect("spreading factor");
     missing_bandwidth.accept_command(CMD_RADIO_STATE, &[RADIO_STATE_ON]).expect("radio state");
@@ -449,6 +468,9 @@ fn rnode_radio_status_rejects_python_radio_state_mismatches() {
     assert!(err.contains("bandwidth"), "unexpected validation error: {err}");
 
     let mut missing_coding_rate = RNodeRadioStatus::default();
+    missing_coding_rate
+        .accept_command(CMD_FREQUENCY, &915_000_000_u32.to_be_bytes())
+        .expect("frequency");
     missing_coding_rate
         .accept_command(CMD_BANDWIDTH, &125_000_u32.to_be_bytes())
         .expect("bandwidth");
@@ -462,6 +484,9 @@ fn rnode_radio_status_rejects_python_radio_state_mismatches() {
     assert!(err.contains("coding rate"), "unexpected validation error: {err}");
 
     let mut mismatched_coding_rate = RNodeRadioStatus::default();
+    mismatched_coding_rate
+        .accept_command(CMD_FREQUENCY, &915_000_000_u32.to_be_bytes())
+        .expect("frequency");
     mismatched_coding_rate
         .accept_command(CMD_BANDWIDTH, &125_000_u32.to_be_bytes())
         .expect("bandwidth");

--- a/crates/libs/rns-transport/tests/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/tests/rnode_ble_parts/module_prelude.rs
@@ -281,11 +281,18 @@ fn rnode_ble_flow_control_queues_until_ready_notification() {
     assert!(packets.is_empty());
     assert_eq!(
         session.take_pending_writes(),
-        vec![RnodeBleWrite {
-            characteristic_uuid: RNODE_BLE_WRITE_CHARACTERISTIC_UUID,
-            with_response: false,
-            payload: encode_data_frame(&[0x01, 0x02]),
-        }]
+        vec![
+            RnodeBleWrite {
+                characteristic_uuid: RNODE_BLE_WRITE_CHARACTERISTIC_UUID,
+                with_response: false,
+                payload: encode_data_frame(&[0x01, 0x02]),
+            },
+            RnodeBleWrite {
+                characteristic_uuid: RNODE_BLE_WRITE_CHARACTERISTIC_UUID,
+                with_response: false,
+                payload: encode_command_frame(CMD_READY, &[1]),
+            },
+        ]
     );
 }
 
@@ -381,11 +388,18 @@ fn rnode_ble_flow_control_queues_id_beacon_until_ready_notification() {
     assert!(packets.is_empty());
     assert_eq!(
         session.take_pending_writes(),
-        vec![RnodeBleWrite {
-            characteristic_uuid: RNODE_BLE_WRITE_CHARACTERISTIC_UUID,
-            with_response: false,
-            payload: encode_data_frame(b"MYCALL-0"),
-        }]
+        vec![
+            RnodeBleWrite {
+                characteristic_uuid: RNODE_BLE_WRITE_CHARACTERISTIC_UUID,
+                with_response: false,
+                payload: encode_data_frame(b"MYCALL-0"),
+            },
+            RnodeBleWrite {
+                characteristic_uuid: RNODE_BLE_WRITE_CHARACTERISTIC_UUID,
+                with_response: false,
+                payload: encode_command_frame(CMD_READY, &[1]),
+            },
+        ]
     );
 }
 

--- a/crates/libs/rns-transport/tests/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/tests/rnode_ble_parts/module_prelude.rs
@@ -271,7 +271,15 @@ fn rnode_ble_flow_control_queues_until_ready_notification() {
     };
     let mut session = RnodeBleKissSession::new(config);
 
-    assert!(session.enqueue_packet(&[0x01, 0x02]).is_empty());
+    assert_eq!(
+        session.enqueue_packet(&[0x01, 0x02]),
+        vec![RnodeBleWrite {
+            characteristic_uuid: RNODE_BLE_WRITE_CHARACTERISTIC_UUID,
+            with_response: false,
+            payload: encode_data_frame(&[0x01, 0x02]),
+        }]
+    );
+    assert!(session.enqueue_packet(&[0x03, 0x04]).is_empty());
     assert_eq!(session.pending_payloads(), 1);
 
     let packets = session
@@ -284,7 +292,7 @@ fn rnode_ble_flow_control_queues_until_ready_notification() {
         vec![RnodeBleWrite {
             characteristic_uuid: RNODE_BLE_WRITE_CHARACTERISTIC_UUID,
             with_response: false,
-            payload: encode_data_frame(&[0x01, 0x02]),
+            payload: encode_data_frame(&[0x03, 0x04]),
         }]
     );
 }
@@ -371,6 +379,14 @@ fn rnode_ble_flow_control_queues_id_beacon_until_ready_notification() {
     };
     let mut session = RnodeBleKissSession::new(config);
 
+    assert_eq!(
+        session.enqueue_id_beacon(),
+        vec![RnodeBleWrite {
+            characteristic_uuid: RNODE_BLE_WRITE_CHARACTERISTIC_UUID,
+            with_response: false,
+            payload: encode_data_frame(b"MYCALL-0"),
+        }]
+    );
     assert!(session.enqueue_id_beacon().is_empty());
     assert_eq!(session.pending_payloads(), 1);
 

--- a/crates/libs/rns-transport/tests/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/tests/rnode_ble_parts/module_prelude.rs
@@ -206,6 +206,52 @@ fn rnode_ble_notifications_decode_raw_kiss_payloads() {
 }
 
 #[test]
+fn rnode_ble_notifications_buffer_a_frame_across_every_chunk_boundary() {
+    let payload = vec![0x01, 0xC0, 0x02, 0xDB, 0x03, 0x04];
+    let frame = encode_data_frame(&payload);
+
+    for split in 1..frame.len() {
+        let mut session = RnodeBleKissSession::new(RnodeBleKissConfig::default());
+        assert!(session
+            .accept_notification(&frame[..split])
+            .expect("first frame fragment")
+            .is_empty());
+        assert_eq!(
+            session.accept_notification(&frame[split..]).expect("second frame fragment"),
+            vec![payload.clone()],
+            "split boundary {split}"
+        );
+    }
+}
+
+#[test]
+fn rnode_ble_notifications_buffer_normal_twenty_byte_ble_chunks() {
+    let payload = (0_u8..64).collect::<Vec<_>>();
+    let frame = encode_data_frame(&payload);
+    let mut session = RnodeBleKissSession::new(RnodeBleKissConfig::default());
+    let mut packets = Vec::new();
+
+    for chunk in frame.chunks(20) {
+        packets.extend(session.accept_notification(chunk).expect("BLE notification chunk"));
+    }
+
+    assert_eq!(packets, vec![payload]);
+}
+
+#[test]
+fn rnode_ble_notification_decodes_multiple_complete_frames_once() {
+    let first = vec![0x10, 0xC0, 0x11];
+    let second = vec![0x20, 0xDB, 0x21];
+    let mut notification = encode_data_frame(&first);
+    notification.extend(encode_data_frame(&second));
+    let mut session = RnodeBleKissSession::new(RnodeBleKissConfig::default());
+
+    let packets = session.accept_notification(&notification).expect("combined notification");
+
+    assert_eq!(packets, vec![first, second]);
+}
+
+#[test]
 fn rnode_ble_notifications_preserve_command_responses() {
     let mut session = RnodeBleKissSession::new(RnodeBleKissConfig::default());
 

--- a/crates/libs/rns-transport/tests/rnode_ble_parts/module_prelude.rs
+++ b/crates/libs/rns-transport/tests/rnode_ble_parts/module_prelude.rs
@@ -271,15 +271,7 @@ fn rnode_ble_flow_control_queues_until_ready_notification() {
     };
     let mut session = RnodeBleKissSession::new(config);
 
-    assert_eq!(
-        session.enqueue_packet(&[0x01, 0x02]),
-        vec![RnodeBleWrite {
-            characteristic_uuid: RNODE_BLE_WRITE_CHARACTERISTIC_UUID,
-            with_response: false,
-            payload: encode_data_frame(&[0x01, 0x02]),
-        }]
-    );
-    assert!(session.enqueue_packet(&[0x03, 0x04]).is_empty());
+    assert!(session.enqueue_packet(&[0x01, 0x02]).is_empty());
     assert_eq!(session.pending_payloads(), 1);
 
     let packets = session
@@ -292,7 +284,7 @@ fn rnode_ble_flow_control_queues_until_ready_notification() {
         vec![RnodeBleWrite {
             characteristic_uuid: RNODE_BLE_WRITE_CHARACTERISTIC_UUID,
             with_response: false,
-            payload: encode_data_frame(&[0x03, 0x04]),
+            payload: encode_data_frame(&[0x01, 0x02]),
         }]
     );
 }
@@ -379,14 +371,6 @@ fn rnode_ble_flow_control_queues_id_beacon_until_ready_notification() {
     };
     let mut session = RnodeBleKissSession::new(config);
 
-    assert_eq!(
-        session.enqueue_id_beacon(),
-        vec![RnodeBleWrite {
-            characteristic_uuid: RNODE_BLE_WRITE_CHARACTERISTIC_UUID,
-            with_response: false,
-            payload: encode_data_frame(b"MYCALL-0"),
-        }]
-    );
     assert!(session.enqueue_id_beacon().is_empty());
     assert_eq!(session.pending_payloads(), 1);
 

--- a/crates/libs/rns-transport/tests/rnode_ble_parts/rnode_ble_runtime_polls_command_noti.rs
+++ b/crates/libs/rns-transport/tests/rnode_ble_parts/rnode_ble_runtime_polls_command_noti.rs
@@ -61,6 +61,26 @@ async fn rnode_ble_runtime_sends_packet_at_mtu_after_deferred_radio_config() {
 }
 
 #[tokio::test]
+async fn rnode_ble_runtime_retry_replays_probes_and_deferred_radio_config() {
+    let deferred = encode_command_frame(CMD_RADIO_STATE, &[RADIO_STATE_OFF]);
+    let config = RnodeBleKissConfig {
+        max_write_len: 1024,
+        deferred_frames: vec![deferred.clone()],
+        ..Default::default()
+    };
+    let backend = TestRnodeBleBackend::default();
+    let mut runtime = RnodeBleKissRuntime::new(backend, config);
+
+    runtime.startup().await.expect("startup");
+    let startup_writes = runtime.backend().writes.clone();
+    runtime.retry_startup_sequence().await.expect("complete startup retry");
+    let retry_writes = &runtime.backend().writes[startup_writes.len()..];
+
+    assert_eq!(&retry_writes[..startup_writes.len()], startup_writes.as_slice());
+    assert_eq!(retry_writes.last().map(|write| write.payload.as_slice()), Some(deferred.as_slice()));
+}
+
+#[tokio::test]
 async fn rnode_ble_runtime_splits_outbound_kiss_frames_by_ble_write_limit() {
     let config = RnodeBleKissConfig { max_write_len: 4, ..Default::default() };
     let backend = TestRnodeBleBackend::default();
@@ -178,13 +198,15 @@ fn rnode_ble_command_monitor_rejects_missing_startup_responses_after_deadline() 
 }
 
 #[test]
-fn rnode_ble_command_monitor_keeps_degraded_fallback_session() {
+fn rnode_ble_command_monitor_rejects_unvalidated_fallback_session() {
     let config = LoraConfig::us915_default();
     let mut monitor = RnodeBleCommandMonitor::new(config, Duration::ZERO);
 
-    monitor.accept_degraded_startup();
+    let error = monitor
+        .validate_startup_deadline()
+        .expect_err("fallback without startup responses must fail");
 
-    monitor.validate_startup_deadline().expect("fallback startup remains connected");
+    assert!(error.contains("detect"));
 }
 
 #[test]

--- a/crates/libs/rns-transport/tests/rnode_ble_parts/rnode_ble_runtime_polls_command_noti.rs
+++ b/crates/libs/rns-transport/tests/rnode_ble_parts/rnode_ble_runtime_polls_command_noti.rs
@@ -61,26 +61,6 @@ async fn rnode_ble_runtime_sends_packet_at_mtu_after_deferred_radio_config() {
 }
 
 #[tokio::test]
-async fn rnode_ble_runtime_retry_replays_probes_and_deferred_radio_config() {
-    let deferred = encode_command_frame(CMD_RADIO_STATE, &[RADIO_STATE_OFF]);
-    let config = RnodeBleKissConfig {
-        max_write_len: 1024,
-        deferred_frames: vec![deferred.clone()],
-        ..Default::default()
-    };
-    let backend = TestRnodeBleBackend::default();
-    let mut runtime = RnodeBleKissRuntime::new(backend, config);
-
-    runtime.startup().await.expect("startup");
-    let startup_writes = runtime.backend().writes.clone();
-    runtime.retry_startup_sequence().await.expect("complete startup retry");
-    let retry_writes = &runtime.backend().writes[startup_writes.len()..];
-
-    assert_eq!(&retry_writes[..startup_writes.len()], startup_writes.as_slice());
-    assert_eq!(retry_writes.last().map(|write| write.payload.as_slice()), Some(deferred.as_slice()));
-}
-
-#[tokio::test]
 async fn rnode_ble_runtime_splits_outbound_kiss_frames_by_ble_write_limit() {
     let config = RnodeBleKissConfig { max_write_len: 4, ..Default::default() };
     let backend = TestRnodeBleBackend::default();

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -858,7 +858,9 @@ Scoped release evidence is split as follows:
   into stamp generation, so relays enforcing a minimum above 16 still
   reject this path.
 - Direct and propagated resource sends support receipt-state separation,
-  timeout/failure propagation, and active resource cancellation.
+  timeout/failure propagation, and active resource cancellation. In-process
+  accepted-result Resources use the backend transfer bound, and every failed
+  Resource await cancels its transport-owned transfer before a retry can start.
 - Link sends now register packet/resource receipt tracking before handoff and
   accept Python-style link proofs with default packet context, so Python
   delivery receipts can advance daemon-originated sends from `sent:*` to

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -1,6 +1,6 @@
 # LXMF Parity Matrix
 
-Last reassessed: 2026-08-06
+Last reassessed: 2026-09-01
 
 This is the maintained row-level status for Python LXMF compatibility.
 Repository-level posture and execution order live in
@@ -34,7 +34,7 @@ evidence tracked independently.
 | `LXMF/LXMF.py` | `crates/libs/lxmf-core` | complete | unit, pinned-python | Pinned module constants, payload fields, message identity, inbound decoding, wire helpers, delivery app-data helpers, compression support detection, and propagation-node announce helper validation. | No confirmed `LXMF.py` blocker in the pinned Python reference. |
 | `LXMF/LXMessage.py` | `crates/libs/lxmf-core` | complete | unit, pinned-python | Wire, storage, propagation, paper, signatures, message IDs, binary fidelity, and timestamp precision metadata. | No confirmed base-message blocker. |
 | `LXMF/LXMPeer.py` | `crates/libs/rns-rpc`, `crates/apps/reticulumd` | complete | unit, pinned-python | Persistent peers, queue marks, offer selection, policy gates, peering keys, throttling, maintenance, source accounting, cumulative acceptance, serialized restored queue snapshots, boolean/list/numeric offer responses, transfer/retry/restart recovery, and unpeer cleanup. | No confirmed `LXMPeer.py` blocker in the pinned Python-only coverage. |
-| `LXMF/LXMRouter.py` | `crates/libs/rns-rpc`, `crates/apps/reticulumd`, `crates/apps/lxmf-cli`, `crates/libs/lxmf-sdk`, `crates/libs/lxmf-runtime` | complete | unit, simulated, pinned-python | Outbound modes and progress/cancellation, selected propagation nodes, direct/propagated resources, fetch/download/sync RPCs, receipts, persistence and maintenance, propagation-node side effects, retry/failure handling, delivery policy, ticket and stamp lifecycle, peer distribution, announce metadata, delivery-link/resource callbacks, transient caches, typed router statistics, and typed message/information storage policy. `SdkBackend`, RPC, ZeroMQ, and in-process backends share the additive router-management contract. | No generated public-callable software gap remains in `LXMRouter.py`; physical/public-network and third-party-client evidence remain separate. The in-process propagated-delivery path (`lxmf-runtime` `send_propagated`) generates a real propagation stamp at the Python default target cost 16, which satisfies default-configured relays (minimum accepted 13); it does not yet honor a relay's announced stamp cost, so relays enforcing a minimum above 16 still reject these transfers until the announced `pn_stamp_cost` is plumbed into stamp generation. |
+| `LXMF/LXMRouter.py` | `crates/libs/rns-rpc`, `crates/apps/reticulumd`, `crates/apps/lxmf-cli`, `crates/libs/lxmf-sdk`, `crates/libs/lxmf-runtime` | complete | unit, simulated, pinned-python | Outbound modes and progress/cancellation, selected propagation nodes, direct/propagated resources, accepted-result Resource timeout/failure propagation with transport cancellation before retry, cleanup-failure visibility, fetch/download/sync RPCs, receipts, persistence and maintenance, propagation-node side effects, retry/failure handling, delivery policy, ticket and stamp lifecycle, peer distribution, announce metadata, delivery-link/resource callbacks, transient caches, typed router statistics, and typed message/information storage policy. `SdkBackend`, RPC, ZeroMQ, and in-process backends share the additive router-management contract. | No generated public-callable software gap remains in `LXMRouter.py`; physical/public-network and third-party-client evidence remain separate. The in-process propagated-delivery path (`lxmf-runtime` `send_propagated`) generates a real propagation stamp at the Python default target cost 16, which satisfies default-configured relays (minimum accepted 13); it does not yet honor a relay's announced stamp cost, so relays enforcing a minimum above 16 still reject these transfers until the announced `pn_stamp_cost` is plumbed into stamp generation. |
 | `LXMF/Handlers.py` | `crates/apps/reticulumd`, `crates/libs/rns-rpc` | complete | unit, simulated, pinned-python | Delivery and propagation announce handlers implement stamp-cost updates, pending direct/opportunistic wakeup, path-response handling, static-peer refresh, autopeer depth policy, peer removal, malformed announce visibility, and the router-coupled delivery/receipt/drop side effects exposed through daemon events and the typed SDK. | No confirmed software blocker in the pinned four-item public handler surface. |
 | `LXMF/LXStamper.py` | `crates/libs/lxmf-core`, `crates/libs/rns-rpc`, `crates/apps/reticulumd` | complete | unit, pinned-python | Validation, generation, ticket-derived stamps, cancellation-aware task work, background deferred worker queue ownership, retry state, cancellation, propagation-stamp pre-handoff preparation, progress metadata, and default-cost propagation stamp mining/validation in `lxmf-wire` (`stamp.rs`, ported `LXStamper` workblock HKDF) with fail-fast rejection of unattainable costs above 256. | No confirmed deferred-stamp lifecycle blocker. |
 | `LXMF/Utilities/lxmd.py` | `crates/apps/lxmf-cli`, `crates/apps/reticulumd` | complete | unit, simulated, pinned-python | Canonical `lxmd` workflows, configuration, announce cadence, propagation controls, status, and daemon lifecycle map to the shared Rust daemon and CLI surfaces. | No generated public utility callable is unmapped. |
@@ -67,6 +67,7 @@ evidence tracked independently.
 - PARITY_ITEM id=router.adapter_transport implementation=complete evidence=unit,pinned-python
 - PARITY_ITEM id=router.paper_uri_ingest implementation=complete evidence=unit,pinned-python
 - PARITY_ITEM id=router.cancel_outbound implementation=complete evidence=unit,pinned-python
+- PARITY_ITEM id=router.accepted_result_resource_cancel implementation=complete evidence=unit,simulated
 - PARITY_ITEM id=router.propagation_ingest_fetch implementation=complete evidence=unit,pinned-python
 - PARITY_ITEM id=router.transfer_state_lifecycle implementation=complete evidence=unit,pinned-python
 - PARITY_ITEM id=router.node_app_data implementation=complete evidence=unit,pinned-python
@@ -148,6 +149,9 @@ evidence tracked independently.
   direct `delivered`, `sent: link resource`, and `sent: propagated resource`.
 - Resource advertisement failure, retry exhaustion, timeout, and explicit
   cancellation reach daemon message state.
+- In-process accepted-result Resource sends retain the backend transfer timeout,
+  cancel a failed transfer before returning, and surface both the transfer error
+  and any failed cancellation dispatch with the link and Resource hashes.
 - Outbound SDK sends enter the daemon-owned queue before bridge handoff, run
   validation/policy checks before scheduling, expose delivery-pipeline queue and
   lane state, and preserve queued identity/path misses for delivery-announce


### PR DESCRIPTION
## Summary
- remove the 100 ms cancellable wrapper around platform RNode reads and await each backend-owned bounded read before starting another read
- back off only when a backend returns `Ok(None)` immediately, then check cancellation after the bounded read
- document the single-owner read contract and add deterministic cancelled-read regression coverage
- buffer KISS frames across ordinary BLE notification boundaries; no full-frame ATT MTU requirement
- implement the official RNode firmware queue-admission contract: send one queued payload per `READY=1`, then poll `CMD_READY`; preserve `READY=0` and retry the query on a bounded interval while work remains
- keep frequency-response validation separate and exclude speculative command pacing, retries, GATT write-mode changes, and a 173-byte MTU requirement

## Root cause
The receive loss was caused by overlapping ownership of a bounded native read. A 100 ms outer timeout abandoned Android reads that could block for 250 ms; cancellation stopped the Rust future but not the blocking worker or Java queue read, allowing an abandoned worker to consume and discard the next notification.

After repairing receive ownership, the remaining one-packet-then-silence and Resource failures exposed a separate transmit contract issue. Official RNode firmware treats `CMD_READY` as a host query and does not emit an unsolicited READY when its TX queue later drains. The host must therefore serialize `data -> CMD_READY query -> READY response -> next data`. This PR implements that contract without timing-based pacing.

## Review follow-up
Current head: `b3b67c1bf4d3fc6697c83860d2e3304c696f25cd`.

- Resource-wait failures still cancel before returning, but a failed link lookup or cancellation dispatch is no longer discarded. The caller receives the original transfer failure plus the cleanup failure, while the cleanup error includes link and Resource hashes.
- A deterministic regression covers simultaneous timeout and cleanup failure.
- `docs/status/lxmf-parity-matrix.md` now records the accepted-result Resource timeout/cancellation behavior and its unit/simulated evidence.

## Deterministic regression coverage
- a simulated 150 ms native read completes beyond the former 100 ms cutoff
- maximum concurrent native read workers remains exactly one
- a notification after 100 ms is delivered exactly once
- cancellation completes within the backend bound without leaving an abandoned consumer
- KISS frames are reconstructed across every BLE notification split boundary
- exactly one queued payload is admitted per `READY=1`
- `READY=0` stalls without dropping payloads, bounded re-probing occurs, and `READY=1` resumes exactly once
- Resource cleanup-dispatch failure remains visible alongside the original transfer timeout

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p lxmf-runtime --all-features`: 12 passed
- `cargo clippy -p lxmf-runtime --all-targets --all-features -- -D warnings`
- `cargo test -p reticulumd --test code_quality_issue_369`
- `cargo xtask ci --stage architecture-checks`
- pre-review full workspace tests and strict Clippy passed on the RNode implementation head
- all hosted checks are terminal green; publish-only and nonessential jobs skipped as expected

## Controlled physical evidence
RF was held constant at 914625000 Hz, 250 kHz, SF11, CR5, and 17 dBm with TCP disabled. It was a fixed control, not the investigated cause.

LXMF `a30657b67f35f81a95f04358837963c6766e9e7a` with REM `837bb316fcb4d179810f4d2ddfd4cabae410f1d2` passed run `20260901T004222Z`:
- bidirectional announce/discovery
- bidirectional link request/proof
- small LXMF delivery in both directions
- 1 KiB Resource-sized LXMF delivery in both directions
- targeted REM mission-event replication in both directions

Final privacy-safe BLE counters showed active bidirectional byte flow with no transport error: phone A 665 inbound chunks / 14238 bytes and 353 outbound chunks / 5922 bytes; phone B 648 inbound chunks / 13279 bytes and 387 outbound chunks / 6359 bytes.

The review-follow-up head changes cleanup-error visibility and parity documentation, not RNode read or queue-admission behavior. A new exact-head physical run has not been claimed.

Coordinated REM PR: FreeTAKTeam/reticulum_mobile_emergency_management#258
