### PR TITLE
docs(rns-core): document secure_storage instead of hiding it

### DIFF
--- a/crates/libs/rns-core/src/lib.rs
+++ b/crates/libs/rns-core/src/lib.rs
@@ -14,7 +14,6 @@ pub mod packet;
 pub mod ratchets;
 
 #[cfg(feature = "std")]
-#[doc(hidden)]
 pub mod secure_storage;
 pub mod serde;
 

--- a/crates/libs/rns-core/src/secure_storage.rs
+++ b/crates/libs/rns-core/src/secure_storage.rs
@@ -1,4 +1,12 @@
 //! Private filesystem persistence helpers.
+//!
+//! What the crate itself uses to keep key material on disk — `FileKeyManager`
+//! and the ratchet store both write through [`atomic_write_private`] — and
+//! what a consumer persisting an identity or a ratchet file wants for the
+//! same reasons: the file is created owner-only, written whole to a
+//! randomised sibling, synced, and renamed over the target, so a crash
+//! leaves either the old file or the new one and never a partial or a
+//! world-readable copy.
 
 use rand_core::{OsRng, RngCore};
 use std::fs::{self, File, OpenOptions};

--- a/crates/libs/rns-core/src/secure_storage.rs
+++ b/crates/libs/rns-core/src/secure_storage.rs
@@ -3,10 +3,15 @@
 //! What the crate itself uses to keep key material on disk — `FileKeyManager`
 //! and the ratchet store both write through [`atomic_write_private`] — and
 //! what a consumer persisting an identity or a ratchet file wants for the
-//! same reasons: the file is created owner-only, written whole to a
-//! randomised sibling, synced, and renamed over the target, so a crash
-//! leaves either the old file or the new one and never a partial or a
-//! world-readable copy.
+//! same reasons: the file is written whole to a randomised sibling, synced,
+//! and renamed over the target, so a crash leaves either the old file or the
+//! new one and never a partial.
+//!
+//! **The owner-only half is Unix.** The 0700/0600 modes below are behind
+//! `cfg(unix)`, and no Windows ACL is installed in their place, so there the
+//! temporary and final files inherit whatever their parent directory allows.
+//! A consumer on Windows that needs key material kept from other local users
+//! has to arrange the directory's permissions itself.
 
 use rand_core::{OsRng, RngCore};
 use std::fs::{self, File, OpenOptions};
@@ -19,7 +24,8 @@ const PRIVATE_DIRECTORY_MODE: u32 = 0o700;
 const PRIVATE_FILE_MODE: u32 = 0o600;
 const TEMP_CREATE_ATTEMPTS: usize = 128;
 
-/// Creates a directory and restricts it to its owner on Unix.
+/// Creates a directory, and on Unix restricts it to its owner. On Windows it
+/// keeps whatever permissions it inherits; see the module documentation.
 pub fn ensure_private_directory(path: &Path) -> io::Result<()> {
     fs::create_dir_all(path)?;
 
@@ -32,7 +38,9 @@ pub fn ensure_private_directory(path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-/// Atomically replaces a private file using a randomized, exclusively-created sibling.
+/// Atomically replaces a file using a randomized, exclusively-created sibling.
+/// Owner-only on Unix; see the module documentation for what Windows does not
+/// get.
 pub fn atomic_write_private(path: &Path, contents: &[u8]) -> io::Result<()> {
     if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
         ensure_private_directory(parent)?;


### PR DESCRIPTION
## Summary

`rns_core::secure_storage` is what the crate itself persists key material with — `FileKeyManager` and the ratchet store both write through `atomic_write_private` — but the module was `#[doc(hidden)]`, so a consumer keeping an identity file or a ratchet file beside its own data had no way to find it and re-implemented a weaker version. This drops the attribute and states, on the module, what the write guarantees: owner-only creation, a randomised exclusively-created sibling, sync, then rename, so a crash leaves the old file or the new one and never a partial or world-readable copy.

No code changes.

Contributor guide: `CONTRIBUTING.md`

## Type
- [ ] breaking
- [ ] refactor
- [ ] reliability
- [x] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `make test`
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [x] `cargo doc --workspace --no-deps`
- [ ] `cargo deny check`
- [ ] `cargo audit`

## Compatibility
- [ ] Updated compatibility matrix / contract docs (if needed)
