### PR TITLE
fix(lxmf-runtime): send an opportunistic packet without its destination prefix

### DIFF
--- a/crates/libs/lxmf-runtime/src/delivery.rs
+++ b/crates/libs/lxmf-runtime/src/delivery.rs
@@ -122,13 +122,27 @@ pub(crate) async fn send(
     }
 }
 
+/// What an opportunistic packet carries: the packed message without its
+/// leading destination hash, which the packet's own destination field
+/// already names — `LXMessage.send` packs `self.packed[DESTINATION_LENGTH:]`,
+/// and a receiver puts its own hash back before unpacking.
+pub(crate) fn opportunistic_packet_data<'a>(wire: &'a [u8], destination: &AddressHash) -> &'a [u8] {
+    let mut destination_bytes = [0u8; 16];
+    destination_bytes.copy_from_slice(destination.as_slice());
+    rns_transport::delivery::strip_destination_prefix(wire, &destination_bytes)
+}
+
 async fn send_opportunistic(
     transport: &Transport,
     destination: AddressHash,
     wire: &[u8],
     message_id: MessageId,
 ) -> Result<InProcessSendReport, SdkError> {
-    let packet = data_packet(destination, PropagationType::Transport, wire)?;
+    let packet = data_packet(
+        destination,
+        PropagationType::Transport,
+        opportunistic_packet_data(wire, &destination),
+    )?;
     let receipt_hash = hex::encode(packet.hash().to_bytes());
     let outcome =
         ensure_sent(transport.send_packet_with_outcome(packet).await, "opportunistic send")?;

--- a/crates/libs/lxmf-runtime/src/tests.rs
+++ b/crates/libs/lxmf-runtime/src/tests.rs
@@ -318,3 +318,24 @@ async fn in_process_backend_implements_typed_router_management_contract() {
     assert!(policy.retain_node_lxms);
     assert_eq!(backend.router_stats().expect("stats").storage_policy, policy);
 }
+
+/// `LXMessage.send` packs `self.packed[DESTINATION_LENGTH:]` into an
+/// opportunistic packet: the destination rides in the packet header, and a
+/// receiver prepends its own hash before unpacking. Sending the whole wire
+/// gave the receiver the hash twice, and nothing it could verify.
+#[test]
+fn an_opportunistic_packet_carries_the_wire_without_its_destination_prefix() {
+    let destination = rns_transport::hash::AddressHash::new([0x11; 16]);
+    let mut wire = destination.as_slice().to_vec();
+    wire.extend_from_slice(&[0x22; 16]);
+    wire.extend_from_slice(b"signature and payload");
+
+    assert_eq!(super::delivery::opportunistic_packet_data(&wire, &destination), &wire[16..]);
+
+    let other = rns_transport::hash::AddressHash::new([0x33; 16]);
+    assert_eq!(
+        super::delivery::opportunistic_packet_data(&wire, &other),
+        &wire[..],
+        "a wire that does not start with the destination is left alone"
+    );
+}

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -839,6 +839,15 @@ Scoped release evidence is split as follows:
   fields, so direct-chat links/body text do not get JSON-stringified.
 - Delivery modes are honored by the daemon; the old claim that requested modes
   are ignored is obsolete.
+- In-process opportunistic sends reach the far side. `LXMessage.send` packs
+  `self.packed[DESTINATION_LENGTH:]` into an opportunistic packet because the
+  destination rides in the packet header and the receiving router prepends its
+  own hash before unpacking; `lxmf-runtime`'s `send_opportunistic` handed the
+  whole wire to `data_packet`, so a receiver saw the destination hash twice and
+  a message it could not verify, and every such send was dropped silently. It
+  strips the prefix with `rns_transport::delivery::strip_destination_prefix`,
+  the same helper the daemon uses, and a test pins the packet data to the wire
+  without its leading destination.
 - RPC daemon `lxmf.delivery` announce ingestion now wakes stored pending
   direct/default-direct and opportunistic outbound messages for the announced
   destination while leaving propagated, paper, terminal, already-sending, and

--- a/docs/status/lxmf-parity-matrix.md
+++ b/docs/status/lxmf-parity-matrix.md
@@ -130,6 +130,16 @@ evidence tracked independently.
 ### Delivery and receipts
 
 - Direct, opportunistic, propagated, and paper modes are distinct.
+- An opportunistic packet carries the wire without its leading destination
+  hash, as `LXMessage.send` packs `self.packed[DESTINATION_LENGTH:]`: the
+  destination rides in the packet header and the receiving router prepends its
+  own hash before unpacking (`LXMRouter.delivery_packet` into
+  `LXMessage.unpack_from_bytes`). `lxmf-runtime`'s `send_opportunistic` handed
+  over the whole wire, so a receiver saw the destination twice and a message it
+  could not verify, and every opportunistic send from the in-process backend
+  was dropped silently on the far side. It strips the prefix with
+  `rns_transport::delivery::strip_destination_prefix`, as the daemon's
+  `bridge_helpers::opportunistic_payload` already did.
 - Opportunistic Single/Data delivery now generates receiver-policy-controlled
   proofs on the ingress interface; explicit proof validation requires the
   packet-cache correlation for the proved destination and rejects signatures


### PR DESCRIPTION
## Summary

`LXMessage.send` packs `self.packed[DESTINATION_LENGTH:]` into an opportunistic packet: the destination rides in the packet header, and the receiving router prepends its own hash before unpacking (`LXMRouter.delivery_packet` → `LXMessage.unpack_from_bytes`). `reticulumd`'s `bridge_helpers::opportunistic_payload` strips the prefix the same way.

`lxmf-runtime::delivery::send_opportunistic` handed the whole wire to `data_packet`, so a receiver saw the destination hash twice and a message it could not verify — every opportunistic send from the in-process backend was dropped silently on the far side.

The runtime now strips the prefix with `rns_transport::delivery::strip_destination_prefix`, as the daemon does; a test pins the packet data to the wire without its leading destination.

Contributor guide: `CONTRIBUTING.md`

## Type
- [ ] breaking
- [ ] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `make test`
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [x] `cargo doc --workspace --no-deps`
- [ ] `cargo deny check`
- [ ] `cargo audit`

## Compatibility
- [ ] Updated compatibility matrix / contract docs (if needed)
