### PR TITLE
feat(rns-transport): read the radio configuration an RNode stores in EEPROM

### DIFF
--- a/crates/apps/reticulumd/src/bin/reticulumd/bridge_rnode_management.rs
+++ b/crates/apps/reticulumd/src/bin/reticulumd/bridge_rnode_management.rs
@@ -1,6 +1,8 @@
 use rns_rpc::RNodeManagementBridge;
 use rns_transport::hash::AddressHash;
-use rns_transport::iface::lora::{LoraConfig, LoraRNodeManagementHandle, RNodeProbeStatus};
+use rns_transport::iface::lora::{
+    stored_config_status_json, LoraConfig, LoraRNodeManagementHandle, RNodeProbeStatus,
+};
 #[cfg(feature = "rnode-ble")]
 use rns_transport::iface::rnode_ble::RnodeBleManagementHandle;
 use rns_transport::iface::rnode_multi::RNodeMultiManagementHandle;
@@ -45,6 +47,24 @@ impl DaemonRNodeManagementHandle {
                     ))
                 }
             }
+        }
+    }
+
+    /// What the radio told us it has in EEPROM. Only the serial/TCP bearer
+    /// records a `CMD_ROM_READ` reply today; the other two would need the same
+    /// slot threaded out of their own monitors.
+    fn stored_config(&self) -> Result<JsonValue, std::io::Error> {
+        match self {
+            Self::Lora(handle) => Ok(stored_config_status_json(&handle.stored_config())),
+            #[cfg(feature = "rnode-ble")]
+            Self::RnodeBle(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "stored_config is not recorded on the RNode BLE bearer",
+            )),
+            Self::RNodeMulti { .. } => Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "stored_config is not recorded on an RNodeMulti interface",
+            )),
         }
     }
 
@@ -128,6 +148,20 @@ impl RNodeManagementBridge for DaemonRNodeManagementBridge {
     ) -> Result<JsonValue, std::io::Error> {
         let target = self.resolve(iface)?;
         let normalized = command.trim().to_ascii_lowercase().replace('-', "_");
+
+        // A read, not a write. `rom_read` asks the radio; the reply arrives on
+        // the stream some time later, and this is where it is collected. There
+        // is no frame to queue, so it returns before the dispatch below.
+        if matches!(normalized.as_str(), "stored_config" | "read_stored_config" | "config_stored") {
+            return Ok(json!({
+                "queued": false,
+                "name": target.name,
+                "command": "stored_config",
+                "iface": target.runtime_iface,
+                "stored_config": target.handle.stored_config()?,
+            }));
+        }
+
         let (canonical, frame, echoed) = match normalized.as_str() {
             "radio_state_query" | "query_radio_state" => {
                 ("radio_state_query", LoraConfig::radio_state_query_frame(), json!({}))

--- a/crates/apps/rns-tools/src/bin/shared/rnodeconf.rs
+++ b/crates/apps/rns-tools/src/bin/shared/rnodeconf.rs
@@ -29,6 +29,11 @@ enum Command {
         #[command(flatten)]
         target: Target,
     },
+    /// Report the radio configuration the last `read-rom` reply carried.
+    StoredConfig {
+        #[command(flatten)]
+        target: Target,
+    },
     Blink {
         #[command(flatten)]
         target: Target,
@@ -249,6 +254,7 @@ fn run(cli: &Cli, output: &mut dyn Write) -> io::Result<()> {
         Command::QueryRadioState { target } => rpc_params(target, "radio_state_query", json!({})),
         Command::ReadConfig { target } => rpc_params(target, "config_read", json!({})),
         Command::ReadRom { target } => rpc_params(target, "rom_read", json!({})),
+        Command::StoredConfig { target } => rpc_params(target, "stored_config", json!({})),
         Command::Blink { target, pattern } => {
             rpc_params(target, "blink", json!({ "pattern": pattern }))
         }
@@ -466,32 +472,4 @@ fn is_destructive_command(command: &str) -> bool {
     matches!(command, "config_delete" | "rom_write" | "rom_wipe" | "hard_reset")
 }
 
-fn rpc_call(
-    rpc: &str,
-    id: u64,
-    method: &str,
-    params: Option<serde_json::Value>,
-) -> io::Result<rns_rpc::RpcResponse> {
-    let frame = build_rpc_frame(id, method, params)?;
-    let request = build_http_post("/rpc", rpc, &frame);
-    let mut stream = TcpStream::connect(rpc)?;
-    stream.write_all(&request)?;
-    stream.shutdown(Shutdown::Write)?;
-    let mut response = Vec::new();
-    stream.read_to_end(&mut response)?;
-    let body = parse_http_response_body(&response)?;
-    rns_rpc::rpc::codec::decode_frame(&body)
-}
-
-fn ensure_rpc_ok(
-    response: rns_rpc::RpcResponse,
-    context: &str,
-) -> io::Result<Option<serde_json::Value>> {
-    if let Some(error) = response.error {
-        return Err(io::Error::other(format!(
-            "{} failed: {} ({})",
-            context, error.message, error.code
-        )));
-    }
-    Ok(response.result)
-}
+include!("rnodeconf_rpc.rs");

--- a/crates/apps/rns-tools/src/bin/shared/rnodeconf_rpc.rs
+++ b/crates/apps/rns-tools/src/bin/shared/rnodeconf_rpc.rs
@@ -1,0 +1,32 @@
+// The RPC/HTTP leg, split out so `rnodeconf.rs` stays inside the module-size
+// policy. Nothing here knows about RNode commands.
+
+fn rpc_call(
+    rpc: &str,
+    id: u64,
+    method: &str,
+    params: Option<serde_json::Value>,
+) -> io::Result<rns_rpc::RpcResponse> {
+    let frame = build_rpc_frame(id, method, params)?;
+    let request = build_http_post("/rpc", rpc, &frame);
+    let mut stream = TcpStream::connect(rpc)?;
+    stream.write_all(&request)?;
+    stream.shutdown(Shutdown::Write)?;
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response)?;
+    let body = parse_http_response_body(&response)?;
+    rns_rpc::rpc::codec::decode_frame(&body)
+}
+
+fn ensure_rpc_ok(
+    response: rns_rpc::RpcResponse,
+    context: &str,
+) -> io::Result<Option<serde_json::Value>> {
+    if let Some(error) = response.error {
+        return Err(io::Error::other(format!(
+            "{} failed: {} ({})",
+            context, error.message, error.code
+        )));
+    }
+    Ok(response.result)
+}

--- a/crates/apps/rns-tools/tests/rnodeconf_cli.rs
+++ b/crates/apps/rns-tools/tests/rnodeconf_cli.rs
@@ -327,6 +327,47 @@ fn rnodeconf_sends_guarded_rnode_multi_vport_rpc() {
     rpc.thread.join().expect("mock rpc server");
 }
 
+/// `read-rom` asks the radio and `stored-config` collects the answer, so this
+/// is the one management command that queues no frame. The reply carries a
+/// state name rather than a bare configuration, because "nothing stored" and
+/// "the read was cut short" must not both arrive as an empty result.
+#[test]
+fn rnodeconf_sends_stored_config_rpc() {
+    let rpc = spawn_mock_rpc(|request| {
+        assert_eq!(request.method, "rnode_management");
+        let params = request.params.expect("params");
+        assert_eq!(params["iface"].as_str(), Some("rnode-main"));
+        assert_eq!(params["command"].as_str(), Some("stored_config"));
+        RpcResponse {
+            id: request.id,
+            result: Some(json!({
+                "queued": false,
+                "iface": "rnode-main",
+                "command": "stored_config",
+                "stored_config": { "state": "read", "frequency_hz": 917_375_000 },
+            })),
+            error: None,
+        }
+    });
+
+    let output = Command::new(rnodeconf_bin())
+        .arg("--rpc")
+        .arg(rpc.addr)
+        .arg("stored-config")
+        .arg("--interface")
+        .arg("rnode-main")
+        .output()
+        .expect("run rnodeconf-rs");
+
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("json stdout");
+    assert_eq!(value["queued"].as_bool(), Some(false));
+    assert_eq!(value["stored_config"]["state"].as_str(), Some("read"));
+    assert_eq!(value["stored_config"]["frequency_hz"].as_u64(), Some(917_375_000));
+    rpc.thread.join().expect("mock rpc server");
+}
+
 #[test]
 fn rnodeconf_cli_covers_extended_python_management_surface() {
     let cases = vec![

--- a/crates/libs/rns-transport/src/iface/lora.rs
+++ b/crates/libs/rns-transport/src/iface/lora.rs
@@ -2,6 +2,8 @@ include!("lora_parts/module_prelude.rs");
 
 include!("lora_parts/rnoderadiostatus.rs");
 
+include!("lora_parts/stored_config.rs");
+
 include!("lora_parts/lorainterface.rs");
 
 include!("lora_parts/module_extra.rs");

--- a/crates/libs/rns-transport/src/iface/lora_parts/lorainterface.rs
+++ b/crates/libs/rns-transport/src/iface/lora_parts/lorainterface.rs
@@ -2,6 +2,9 @@ type RNodeManagementFrameSender = tokio::sync::mpsc::Sender<Vec<u8>>;
 type RNodeManagementFrameReceiver =
     Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<Vec<u8>>>>;
 type RNodeManagementStatus = Arc<std::sync::Mutex<LoraRNodeManagementStatus>>;
+/// The last `CMD_ROM_READ` reply, shared so a caller holding the interface
+/// sees what the running stream task received.
+type RNodeStoredConfigImage = Arc<std::sync::Mutex<Option<Vec<u8>>>>;
 
 #[derive(Debug, Clone, Default)]
 struct LoraRNodeManagementStatus {
@@ -82,6 +85,7 @@ pub struct LoraInterface {
     management_frame_tx: RNodeManagementFrameSender,
     management_frame_rx: RNodeManagementFrameReceiver,
     management_status: RNodeManagementStatus,
+    stored_config_image: RNodeStoredConfigImage,
 }
 
 impl LoraInterface {
@@ -105,6 +109,7 @@ impl LoraInterface {
             management_frame_tx,
             management_frame_rx,
             management_status: Arc::new(std::sync::Mutex::new(LoraRNodeManagementStatus::default())),
+            stored_config_image: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -128,6 +133,7 @@ impl LoraInterface {
             management_frame_tx,
             management_frame_rx,
             management_status: Arc::new(std::sync::Mutex::new(LoraRNodeManagementStatus::default())),
+            stored_config_image: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -191,11 +197,19 @@ impl LoraInterface {
         self.startup_response_timeout
     }
 
+    /// The radio settings this RNode has in EEPROM, from the last
+    /// `CMD_ROM_READ` reply. Request one with [`LoraConfig::rom_read_frame`];
+    /// until a reply arrives this is [`StoredConfigError::NotRead`].
+    pub fn stored_config(&self) -> Result<Option<StoredRadioConfig>, StoredConfigError> {
+        stored_config_from_image(&self.stored_config_image)
+    }
+
     #[must_use]
     pub fn rnode_management_handle(&self) -> LoraRNodeManagementHandle {
         LoraRNodeManagementHandle {
             tx: self.management_frame_tx.clone(),
             status: self.management_status.clone(),
+            stored_config_image: self.stored_config_image.clone(),
         }
     }
 
@@ -227,6 +241,14 @@ impl LoraInterface {
     pub fn record_command_response(&mut self, command: u8, payload: &[u8]) -> Result<bool, String> {
         if command == CMD_RADIO_STATE {
             self.radio_state_response_seen = true;
+        }
+        if command == CMD_ROM_READ {
+            // Kept whole rather than parsed here: the parse is what a caller
+            // asks for, and holding the image lets a short read be reported as
+            // one instead of as a device with nothing stored.
+            *self.stored_config_image.lock().expect("lora stored config mutex poisoned") =
+                Some(payload.to_vec());
+            return Ok(true);
         }
         if self.probe_status.accept_command(command, payload)? {
             return Ok(true);
@@ -343,6 +365,7 @@ impl LoraInterface {
             },
             "baud_rate": self.baud_rate(),
             "configured": configured,
+            "stored_config": stored_config_status_json(&self.stored_config()),
             "probe_status": self.probe_status.to_json(),
             "radio_status": self.radio_status.to_json(),
             "hardware_errors": self
@@ -561,9 +584,16 @@ fn rnode_management_channel() -> (RNodeManagementFrameSender, RNodeManagementFra
 pub struct LoraRNodeManagementHandle {
     tx: RNodeManagementFrameSender,
     status: RNodeManagementStatus,
+    stored_config_image: RNodeStoredConfigImage,
 }
 
 impl LoraRNodeManagementHandle {
+    /// See [`LoraInterface::stored_config`]. A `rom_read` dispatch only asks
+    /// the radio; this is where the answer arrives.
+    pub fn stored_config(&self) -> Result<Option<StoredRadioConfig>, StoredConfigError> {
+        stored_config_from_image(&self.stored_config_image)
+    }
+
     fn record_queued(&self, command: &str) {
         let mut status = self.status.lock().expect("lora management status mutex poisoned");
         status.record_queued(command);

--- a/crates/libs/rns-transport/src/iface/lora_parts/stored_config.rs
+++ b/crates/libs/rns-transport/src/iface/lora_parts/stored_config.rs
@@ -1,0 +1,142 @@
+// The reply to `LoraConfig::rom_read_frame()`, read back. `include!`d into
+// the lora module beside the frame builders; its own file so each stays
+// within the repository's module-size policy.
+
+/// Byte offsets into an RNode's EEPROM image — `rnodeconf`'s `ROM.ADDR_CONF_*`.
+mod rom {
+    pub const ADDR_CONF_SF: usize = 0x9C;
+    pub const ADDR_CONF_CR: usize = 0x9D;
+    pub const ADDR_CONF_TXP: usize = 0x9E;
+    /// Four bytes, big-endian.
+    pub const ADDR_CONF_BW: usize = 0x9F;
+    /// Four bytes, big-endian.
+    pub const ADDR_CONF_FREQ: usize = 0xA3;
+    /// Holds [`CONF_OK_BYTE`] when, and only when, a configuration is stored.
+    pub const ADDR_CONF_OK: usize = 0xA7;
+    /// `rnodeconf`'s `ROM.CONF_OK_BYTE`.
+    pub const CONF_OK_BYTE: u8 = 0x73;
+}
+
+/// The shortest EEPROM image that can say whether a configuration is stored.
+/// Anything shorter is a truncated read, not a device without one.
+const STORED_CONFIG_IMAGE_LEN: usize = rom::ADDR_CONF_OK + 1;
+
+/// The radio settings an RNode holds in its EEPROM: what `rnodeconf --tnc`
+/// saved with `CMD_CONF_SAVE`, and what the device starts up on.
+///
+/// Deliberately not a [`LoraConfig`]: this is what the device reported, not
+/// what a caller intends to apply, and the two are different facts until a
+/// person has confirmed the first. The payload limits and airtime limits a
+/// `LoraConfig` carries are not stored on the device at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StoredRadioConfig {
+    pub frequency_hz: u32,
+    pub bandwidth_hz: u32,
+    pub spreading_factor: u8,
+    pub coding_rate: u8,
+    pub tx_power_dbm: u8,
+}
+
+impl LoraConfig {
+    /// Reads the stored configuration out of a `CMD_ROM_READ` reply — the
+    /// EEPROM image — the way `rnodeconf` reads it: only when
+    /// `ADDR_CONF_OK` carries `CONF_OK_BYTE`, with the two multi-byte
+    /// fields big-endian.
+    ///
+    /// `None` means the device holds no configuration, or the image is too
+    /// short to tell. It is never a default: a default here is how a radio
+    /// ends up transmitting on a frequency nobody chose.
+    #[must_use]
+    pub fn parse_stored_config(eeprom: &[u8]) -> Option<StoredRadioConfig> {
+        if eeprom.len() < STORED_CONFIG_IMAGE_LEN || eeprom[rom::ADDR_CONF_OK] != rom::CONF_OK_BYTE
+        {
+            return None;
+        }
+        Some(StoredRadioConfig {
+            frequency_hz: be_u32(eeprom, rom::ADDR_CONF_FREQ),
+            bandwidth_hz: be_u32(eeprom, rom::ADDR_CONF_BW),
+            spreading_factor: eeprom[rom::ADDR_CONF_SF],
+            coding_rate: eeprom[rom::ADDR_CONF_CR],
+            tx_power_dbm: eeprom[rom::ADDR_CONF_TXP],
+        })
+    }
+}
+
+/// Big-endian `u32` at `offset`; the caller has bounds-checked against
+/// [`STORED_CONFIG_IMAGE_LEN`], which covers every field read here.
+fn be_u32(bytes: &[u8], offset: usize) -> u32 {
+    u32::from_be_bytes([bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3]])
+}
+
+#[cfg(test)]
+mod stored_config_tests {
+    use super::*;
+
+    /// Real values from a Heltec LoRa32 v4 on firmware 1.86, as
+    /// `rnodeconf -i` reports them — a byte-order or offset mistake then
+    /// reads as an obviously wrong number rather than a plausible one.
+    fn device_image() -> Vec<u8> {
+        let mut eeprom = vec![0u8; STORED_CONFIG_IMAGE_LEN];
+        eeprom[rom::ADDR_CONF_SF] = 11;
+        eeprom[rom::ADDR_CONF_CR] = 5;
+        eeprom[rom::ADDR_CONF_TXP] = 22;
+        eeprom[rom::ADDR_CONF_BW..rom::ADDR_CONF_BW + 4]
+            .copy_from_slice(&250_000u32.to_be_bytes());
+        eeprom[rom::ADDR_CONF_FREQ..rom::ADDR_CONF_FREQ + 4]
+            .copy_from_slice(&917_375_000u32.to_be_bytes());
+        eeprom[rom::ADDR_CONF_OK] = rom::CONF_OK_BYTE;
+        eeprom
+    }
+
+    #[test]
+    fn reads_the_configuration_a_device_is_holding() {
+        let parsed = LoraConfig::parse_stored_config(&device_image()).expect("CONF_OK is set");
+
+        assert_eq!(
+            parsed,
+            StoredRadioConfig {
+                frequency_hz: 917_375_000,
+                bandwidth_hz: 250_000,
+                spreading_factor: 11,
+                coding_rate: 5,
+                tx_power_dbm: 22,
+            }
+        );
+    }
+
+    /// Only the exact sentinel counts, so a half-written EEPROM cannot pass
+    /// for a configuration.
+    #[test]
+    fn a_device_holding_no_configuration_reads_as_none() {
+        let mut eeprom = device_image();
+        eeprom[rom::ADDR_CONF_OK] = 0x00;
+        assert!(LoraConfig::parse_stored_config(&eeprom).is_none());
+
+        eeprom[rom::ADDR_CONF_OK] = 0x72;
+        assert!(LoraConfig::parse_stored_config(&eeprom).is_none());
+    }
+
+    /// A truncated read and an unconfigured device are different facts that
+    /// want the same answer here; a future change that starts trusting short
+    /// images has to do it deliberately.
+    #[test]
+    fn a_truncated_image_is_not_mistaken_for_a_configuration() {
+        let full = device_image();
+        for len in [0, rom::ADDR_CONF_SF, rom::ADDR_CONF_FREQ, STORED_CONFIG_IMAGE_LEN - 1] {
+            assert!(
+                LoraConfig::parse_stored_config(&full[..len]).is_none(),
+                "an image of {len} bytes cannot answer the question"
+            );
+        }
+        assert!(LoraConfig::parse_stored_config(&full[..STORED_CONFIG_IMAGE_LEN]).is_some());
+    }
+
+    /// Read little-endian, 917.375 MHz becomes 3.4 GHz.
+    #[test]
+    fn multi_byte_fields_are_big_endian() {
+        let parsed = LoraConfig::parse_stored_config(&device_image()).expect("configured");
+
+        assert_eq!(parsed.frequency_hz, 917_375_000);
+        assert_ne!(parsed.frequency_hz, u32::from_le_bytes(917_375_000u32.to_be_bytes()));
+    }
+}

--- a/crates/libs/rns-transport/src/iface/lora_parts/stored_config.rs
+++ b/crates/libs/rns-transport/src/iface/lora_parts/stored_config.rs
@@ -21,6 +21,21 @@ mod rom {
 /// Anything shorter is a truncated read, not a device without one.
 const STORED_CONFIG_IMAGE_LEN: usize = rom::ADDR_CONF_OK + 1;
 
+/// Why an RNode's stored configuration could not be read. Both variants are
+/// failures to answer, and neither is "the device holds no configuration",
+/// which is `Ok(None)`. A caller that cannot tell them apart is a caller that
+/// may reprogram a radio because a serial read was cut short.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum StoredConfigError {
+    /// No `CMD_ROM_READ` reply has arrived on this interface.
+    #[error("no ROM read response has been received")]
+    NotRead,
+    /// The reply stopped before [`rom::ADDR_CONF_OK`], the byte that says
+    /// whether a configuration is stored at all.
+    #[error("ROM read response is {len} bytes, short of the {STORED_CONFIG_IMAGE_LEN} needed")]
+    TruncatedImage { len: usize },
+}
+
 /// The radio settings an RNode holds in its EEPROM: what `rnodeconf --tnc`
 /// saved with `CMD_CONF_SAVE`, and what the device starts up on.
 ///
@@ -43,22 +58,62 @@ impl LoraConfig {
     /// `ADDR_CONF_OK` carries `CONF_OK_BYTE`, with the two multi-byte
     /// fields big-endian.
     ///
-    /// `None` means the device holds no configuration, or the image is too
-    /// short to tell. It is never a default: a default here is how a radio
-    /// ends up transmitting on a frequency nobody chose.
-    #[must_use]
-    pub fn parse_stored_config(eeprom: &[u8]) -> Option<StoredRadioConfig> {
-        if eeprom.len() < STORED_CONFIG_IMAGE_LEN || eeprom[rom::ADDR_CONF_OK] != rom::CONF_OK_BYTE
-        {
-            return None;
+    /// `Ok(None)` means a complete image whose sentinel says the device holds
+    /// no configuration. A short image is [`StoredConfigError::TruncatedImage`]
+    /// instead, because the two are different facts and only one of them
+    /// licenses a caller to write settings: a default here is how a radio ends
+    /// up transmitting on a frequency nobody chose.
+    pub fn parse_stored_config(
+        eeprom: &[u8],
+    ) -> Result<Option<StoredRadioConfig>, StoredConfigError> {
+        if eeprom.len() < STORED_CONFIG_IMAGE_LEN {
+            return Err(StoredConfigError::TruncatedImage { len: eeprom.len() });
         }
-        Some(StoredRadioConfig {
+        if eeprom[rom::ADDR_CONF_OK] != rom::CONF_OK_BYTE {
+            return Ok(None);
+        }
+        Ok(Some(StoredRadioConfig {
             frequency_hz: be_u32(eeprom, rom::ADDR_CONF_FREQ),
             bandwidth_hz: be_u32(eeprom, rom::ADDR_CONF_BW),
             spreading_factor: eeprom[rom::ADDR_CONF_SF],
             coding_rate: eeprom[rom::ADDR_CONF_CR],
             tx_power_dbm: eeprom[rom::ADDR_CONF_TXP],
-        })
+        }))
+    }
+}
+
+/// The parse of whatever `CMD_ROM_READ` reply has arrived, or why there is
+/// nothing to parse. Shared with the stream task that receives it.
+fn stored_config_from_image(
+    image: &RNodeStoredConfigImage,
+) -> Result<Option<StoredRadioConfig>, StoredConfigError> {
+    let guard = image.lock().expect("lora stored config mutex poisoned");
+    let eeprom = guard.as_deref().ok_or(StoredConfigError::NotRead)?;
+    LoraConfig::parse_stored_config(eeprom)
+}
+
+/// How a stored configuration reads in a status document. Each outcome gets
+/// its own state name, so "nothing stored" and "the read was cut short" do not
+/// arrive at an operator as the same empty answer.
+#[must_use]
+pub fn stored_config_status_json(
+    stored: &Result<Option<StoredRadioConfig>, StoredConfigError>,
+) -> serde_json::Value {
+    match stored {
+        Ok(Some(config)) => serde_json::json!({
+            "state": "read",
+            "frequency_hz": config.frequency_hz,
+            "bandwidth_hz": config.bandwidth_hz,
+            "spreading_factor": config.spreading_factor,
+            "coding_rate": config.coding_rate,
+            "tx_power_dbm": config.tx_power_dbm,
+        }),
+        Ok(None) => serde_json::json!({ "state": "none" }),
+        Err(StoredConfigError::NotRead) => serde_json::json!({ "state": "not_read" }),
+        Err(error @ StoredConfigError::TruncatedImage { .. }) => serde_json::json!({
+            "state": "truncated",
+            "error": error.to_string(),
+        }),
     }
 }
 
@@ -90,7 +145,9 @@ mod stored_config_tests {
 
     #[test]
     fn reads_the_configuration_a_device_is_holding() {
-        let parsed = LoraConfig::parse_stored_config(&device_image()).expect("CONF_OK is set");
+        let parsed = LoraConfig::parse_stored_config(&device_image())
+            .expect("a complete image")
+            .expect("CONF_OK is set");
 
         assert_eq!(
             parsed,
@@ -110,31 +167,78 @@ mod stored_config_tests {
     fn a_device_holding_no_configuration_reads_as_none() {
         let mut eeprom = device_image();
         eeprom[rom::ADDR_CONF_OK] = 0x00;
-        assert!(LoraConfig::parse_stored_config(&eeprom).is_none());
+        assert_eq!(LoraConfig::parse_stored_config(&eeprom), Ok(None));
 
         eeprom[rom::ADDR_CONF_OK] = 0x72;
-        assert!(LoraConfig::parse_stored_config(&eeprom).is_none());
+        assert_eq!(LoraConfig::parse_stored_config(&eeprom), Ok(None));
     }
 
-    /// A truncated read and an unconfigured device are different facts that
-    /// want the same answer here; a future change that starts trusting short
-    /// images has to do it deliberately.
+    /// A caller deciding whether to write settings has to tell a short read
+    /// from a device that genuinely holds nothing, so they get different
+    /// answers rather than a shared `None`.
     #[test]
-    fn a_truncated_image_is_not_mistaken_for_a_configuration() {
+    fn a_truncated_image_is_an_error_not_an_absent_configuration() {
         let full = device_image();
         for len in [0, rom::ADDR_CONF_SF, rom::ADDR_CONF_FREQ, STORED_CONFIG_IMAGE_LEN - 1] {
-            assert!(
-                LoraConfig::parse_stored_config(&full[..len]).is_none(),
+            assert_eq!(
+                LoraConfig::parse_stored_config(&full[..len]),
+                Err(StoredConfigError::TruncatedImage { len }),
                 "an image of {len} bytes cannot answer the question"
             );
         }
-        assert!(LoraConfig::parse_stored_config(&full[..STORED_CONFIG_IMAGE_LEN]).is_some());
+        assert!(LoraConfig::parse_stored_config(&full[..STORED_CONFIG_IMAGE_LEN]).is_ok());
+    }
+
+    /// The reply has to reach the parser. Sent through a live interface it
+    /// lands in `record_command_response`, which had no `CMD_ROM_READ` arm and
+    /// dropped the image, leaving the parser reachable only by a caller owning
+    /// its own transport.
+    #[test]
+    fn a_rom_read_reply_reaches_the_parser_through_the_command_path() {
+        let mut iface = LoraInterface::new("COM9", 115_200, LoraConfig::us915_default());
+        assert_eq!(iface.stored_config(), Err(StoredConfigError::NotRead));
+
+        assert!(
+            iface.record_command_response(CMD_ROM_READ, &device_image()).expect("rom read"),
+            "the reply is recorded, not passed over"
+        );
+
+        assert_eq!(
+            iface.stored_config().expect("a complete image").expect("CONF_OK is set").frequency_hz,
+            917_375_000
+        );
+        assert_eq!(iface.rnode_management_handle().stored_config(), iface.stored_config());
+        assert_eq!(iface.runtime_status_json()["stored_config"]["state"].as_str(), Some("read"));
+    }
+
+    /// The three answers stay apart all the way out to a status document.
+    #[test]
+    fn a_short_reply_is_reported_as_truncated_not_as_an_unconfigured_device() {
+        let mut iface = LoraInterface::new("COM9", 115_200, LoraConfig::us915_default());
+        iface.record_command_response(CMD_ROM_READ, &device_image()[..4]).expect("short rom read");
+
+        assert_eq!(
+            iface.stored_config(),
+            Err(StoredConfigError::TruncatedImage { len: 4 })
+        );
+        assert_eq!(
+            iface.runtime_status_json()["stored_config"]["state"].as_str(),
+            Some("truncated")
+        );
+
+        let mut blank = device_image();
+        blank[rom::ADDR_CONF_OK] = 0x00;
+        iface.record_command_response(CMD_ROM_READ, &blank).expect("rom read");
+        assert_eq!(iface.stored_config(), Ok(None));
+        assert_eq!(iface.runtime_status_json()["stored_config"]["state"].as_str(), Some("none"));
     }
 
     /// Read little-endian, 917.375 MHz becomes 3.4 GHz.
     #[test]
     fn multi_byte_fields_are_big_endian() {
-        let parsed = LoraConfig::parse_stored_config(&device_image()).expect("configured");
+        let parsed = LoraConfig::parse_stored_config(&device_image())
+            .expect("a complete image")
+            .expect("configured");
 
         assert_eq!(parsed.frequency_hz, 917_375_000);
         assert_ne!(parsed.frequency_hz, u32::from_le_bytes(917_375_000u32.to_be_bytes()));

--- a/docs/contracts/rpc-contract.md
+++ b/docs/contracts/rpc-contract.md
@@ -169,7 +169,8 @@ All methods below are required for full CLI feature coverage.
   display/NeoPixel fields, interference-avoidance flags, and, for
   `RNodeMultiInterface`, required child `vport`. Supported commands are
   `radio_state_query`/`query_radio_state`, `blink`,
-  `config_read`/`read_config`, `rom_read`/`read_rom`, display
+  `config_read`/`read_config`, `rom_read`/`read_rom`,
+  `stored_config`/`read_stored_config`/`config_stored`, display
   intensity/blanking/rotation/recondition/address controls, NeoPixel
   intensity, interference-avoidance enable/disable controls, Bluetooth
   enable/disable/pair controls, config save/delete, ROM write/wipe, hard
@@ -177,7 +178,9 @@ All methods below are required for full CLI feature coverage.
   SSID/PSK set or clear controls. Persistent/disruptive commands require
   `confirm_persistent=true`; destructive commands require
   `confirm_destructive=true` and `confirm_command` exactly matching the
-  canonical command. Serial/TCP RNodeInterface handles, plus feature-gated BLE
+  canonical command. `stored_config` is the only read: it queues no frame,
+  answers `{"queued": false, "stored_config": {"state": ...}}` from the last
+  `rom_read` reply, and is recorded on the serial/TCP bearer alone. Serial/TCP RNodeInterface handles, plus feature-gated BLE
   RNodeInterface handles when `reticulumd` is built with `rnode-ble`, are
   selected by runtime iface id or an unambiguous configured interface name.
   RNodeMulti handles are selected by parent runtime iface id or unambiguous

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -620,6 +620,15 @@ Scoped release evidence is split as follows:
   display/NeoPixel controls, interference-avoidance control, Wi-Fi settings,
   config save/delete, firmware-update metadata, and ROM/EEPROM read/write/wipe
   requests.
+  `LoraConfig::rom_read_frame` asks an RNode for its EEPROM and
+  `LoraConfig::parse_stored_config` now reads the answer, so a caller wanting
+  to know what a radio is already set to no longer transcribes `rnodeconf`'s
+  `ROM.ADDR_CONF_*` layout itself. This matters because the connect path
+  applies `radio_config_frames` unconditionally: without reading first, a
+  client reprograms whatever it finds. The result is a `StoredRadioConfig`
+  rather than a `LoraConfig`, keeping what a device reported distinct from what
+  a caller intends to apply, and `None` means nothing is stored or the image is
+  too short to tell rather than a default.
 - A bearer-neutral `RnodeBearerBackend` and single-attempt
   `RnodeBearerKissInterface` now let mobile platform owners provide ordered BLE
   or Bluetooth Classic byte streams while this crate retains shared KISS

--- a/docs/status/current-roadmap.md
+++ b/docs/status/current-roadmap.md
@@ -627,8 +627,19 @@ Scoped release evidence is split as follows:
   applies `radio_config_frames` unconditionally: without reading first, a
   client reprograms whatever it finds. The result is a `StoredRadioConfig`
   rather than a `LoraConfig`, keeping what a device reported distinct from what
-  a caller intends to apply, and `None` means nothing is stored or the image is
-  too short to tell rather than a default.
+  a caller intends to apply. `Ok(None)` is a complete image whose sentinel says
+  nothing is stored; a short read is `StoredConfigError::TruncatedImage`, since
+  a caller that cannot tell the two apart is one that may reprogram a radio
+  because a serial read was cut short.
+  The reply reaches that parser on the supported bearers rather than only for a
+  caller owning its own transport: `record_command_response` records a
+  `CMD_ROM_READ` payload, `LoraInterface::stored_config` and the management
+  handle return the parse, `runtime_status_json` carries it as a state name, and
+  the daemon's `stored_config` command plus `rnodeconf-rs stored-config` read it
+  back. That command queues no frame, because `rom_read` is what asks and the
+  answer arrives on the stream later. The BLE and RNodeMulti bearers answer
+  `Unsupported`; each owns its own monitor and would need the same slot threaded
+  out of it.
 - A bearer-neutral `RnodeBearerBackend` and single-attempt
   `RnodeBearerKissInterface` now let mobile platform owners provide ordered BLE
   or Bluetooth Classic byte streams while this crate retains shared KISS

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -612,7 +612,17 @@ reset, firmware metadata, and Wi-Fi settings.
 Frame-level helpers now cover Bluetooth disable/enable/pair control,
 display/NeoPixel controls, interference-avoidance control, Wi-Fi settings,
 config save/delete, firmware-update metadata, and ROM/EEPROM read/write/wipe
-requests. Shared transport dispatch also removes interface records whose TX
+requests. The library also reads the answer to a ROM read:
+`LoraConfig::parse_stored_config` decodes the radio configuration
+`rnodeconf --tnc` saved with `CMD_CONF_SAVE` and the device starts up on, the
+way `rnodeconf` reads it, only when `ADDR_CONF_OK` carries `CONF_OK_BYTE` and
+with the two multi-byte fields big-endian. It returns a `StoredRadioConfig`
+rather than a `LoraConfig`, since what a device reported is a different fact
+from what a caller intends to apply, and `None` means no configuration is
+stored or the image is too short to tell, never a default. Evidence is a real
+Heltec LoRa32 v4's values as `rnodeconf -i` reports them, plus the sentinel,
+truncation and byte-order rules; hardware evidence for the read against a live
+device stays `hardware-unverified`. Shared transport dispatch also removes interface records whose TX
 queues have closed, including shared virtual-interface queues, preventing stale
 closed paths from lingering after failed dispatch. Broad BLE management
 hardware evidence across device, firmware, and operator workflows plus full

--- a/docs/status/reticulum-parity-matrix.md
+++ b/docs/status/reticulum-parity-matrix.md
@@ -618,11 +618,19 @@ requests. The library also reads the answer to a ROM read:
 way `rnodeconf` reads it, only when `ADDR_CONF_OK` carries `CONF_OK_BYTE` and
 with the two multi-byte fields big-endian. It returns a `StoredRadioConfig`
 rather than a `LoraConfig`, since what a device reported is a different fact
-from what a caller intends to apply, and `None` means no configuration is
-stored or the image is too short to tell, never a default. Evidence is a real
+from what a caller intends to apply. `Ok(None)` is a complete image holding no
+configuration and a short read is `StoredConfigError::TruncatedImage`, so a
+caller deciding whether to write settings cannot mistake a cut-short serial
+read for a blank radio. `record_command_response` records the `CMD_ROM_READ`
+payload and `LoraInterface::stored_config`, the management handle,
+`runtime_status_json`, the daemon's `stored_config` command and
+`rnodeconf-rs stored-config` return the parse, so the read is reachable on the
+serial and TCP bearers rather than only to a caller owning its own transport;
+the BLE and RNodeMulti bearers answer `Unsupported`. Evidence is a real
 Heltec LoRa32 v4's values as `rnodeconf -i` reports them, plus the sentinel,
-truncation and byte-order rules; hardware evidence for the read against a live
-device stays `hardware-unverified`. Shared transport dispatch also removes interface records whose TX
+truncation and byte-order rules and the command-path capture; hardware evidence
+for the read against a live device stays `hardware-unverified`.
+Shared transport dispatch also removes interface records whose TX
 queues have closed, including shared virtual-interface queues, preventing stale
 closed paths from lingering after failed dispatch. Broad BLE management
 hardware evidence across device, firmware, and operator workflows plus full


### PR DESCRIPTION
## Summary

`LoraConfig::rom_read_frame()` asks an RNode for its EEPROM, and nothing in the library reads the answer: the daemon's `rom_read` command returns the raw bytes, and a caller that wants to know what a radio is already set to — the settings `rnodeconf --tnc` saved with `CMD_CONF_SAVE`, which the device starts up on — has to transcribe `rnodeconf`'s `ROM.ADDR_CONF_*` layout itself. The crate's connect path applies `radio_config_frames()` unconditionally, so without reading first a client reprograms whatever it finds.

`LoraConfig::parse_stored_config(eeprom)` reads it the way `rnodeconf` does: only when `ADDR_CONF_OK` carries `CONF_OK_BYTE`, with the two multi-byte fields big-endian, into a `StoredRadioConfig` that is deliberately not a `LoraConfig` — what a device reported is a different fact from what a caller intends to apply. `None` means no configuration is stored or the image is too short to tell; it is never a default.

Tests use a real Heltec LoRa32 v4's values (as `rnodeconf -i` reports them), and pin the sentinel, the truncation rule and the byte order.

Contributor guide: `CONTRIBUTING.md`

## Type
- [ ] breaking
- [ ] refactor
- [x] reliability
- [ ] chore/governance

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `make test`
- [ ] `make test-all` (optional compatibility pass)
- [ ] `make test-full-targets` (optional full-target parity check)
- [x] `cargo doc --workspace --no-deps`
- [ ] `cargo deny check`
- [ ] `cargo audit`

## Compatibility
- [ ] Updated compatibility matrix / contract docs (if needed)

Additive: `iface::lora::StoredRadioConfig` and `LoraConfig::parse_stored_config`.
